### PR TITLE
fix: resolve Greptile Quality Gate race condition

### DIFF
--- a/.github/workflows/greptile-quality-gate.yml
+++ b/.github/workflows/greptile-quality-gate.yml
@@ -3,6 +3,7 @@ name: Greptile Quality Gate
 on:
   pull_request_review:
     types: [submitted]
+    branches: ["master"]
 
 jobs:
   quality-gate:
@@ -17,11 +18,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Only run for Greptile reviews
+            // Only run for Greptile reviews (exact match)
             const reviewer = context.payload.review?.user?.login || '';
             console.log(`Review submitted by: ${reviewer}`);
 
-            if (!reviewer.includes('greptile')) {
+            if (reviewer !== 'greptile-apps[bot]') {
               console.log('⏭️ Skipping: Not a Greptile review');
               return;
             }

--- a/.github/workflows/greptile-quality-gate.yml
+++ b/.github/workflows/greptile-quality-gate.yml
@@ -3,12 +3,12 @@ name: Greptile Quality Gate
 on:
   pull_request_review:
     types: [submitted]
-    branches: ["master"]
 
 jobs:
   quality-gate:
     name: Greptile Quality Gate (≥4/5)
     runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'master'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/greptile-quality-gate.yml
+++ b/.github/workflows/greptile-quality-gate.yml
@@ -1,8 +1,8 @@
 name: Greptile Quality Gate
 
 on:
-  pull_request:
-    branches: ["master"]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   quality-gate:
@@ -17,11 +17,20 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Only run for Greptile reviews
+            const reviewer = context.payload.review?.user?.login || '';
+            console.log(`Review submitted by: ${reviewer}`);
+
+            if (!reviewer.includes('greptile')) {
+              console.log('⏭️ Skipping: Not a Greptile review');
+              return;
+            }
+
             // Get PR details
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: context.payload.pull_request.number
             });
 
             const prBody = pr.body || '';
@@ -31,7 +40,7 @@ jobs:
             const scoreMatch = prBody.match(/Confidence Score:\s*(\d+(?:\.\d+)?)\s*(?:\/|out of)\s*5/i);
 
             if (!scoreMatch) {
-              console.log('⚠️ No Greptile score found - allowing merge');
+              core.setFailed('❌ No Greptile confidence score found in PR description');
               return;
             }
 
@@ -42,7 +51,7 @@ jobs:
             console.log(`🎯 Required: ${minScore}/5`);
 
             if (score < minScore) {
-              core.setFailed(`Greptile score ${score}/5 < ${minScore}/5`);
+              core.setFailed(`❌ Greptile score ${score}/5 is below minimum ${minScore}/5`);
             } else {
               console.log(`✅ PASSED: Score ${score}/5 meets threshold!`);
             }


### PR DESCRIPTION
## Summary

Fixes the race condition in Greptile Quality Gate that was allowing PRs with low scores (<4.0) to bypass the quality check.

## Problem

The quality gate was running **BEFORE** Greptile finished posting its review:
- ⏰ 10:15:23 - Quality Gate starts
- 🔍 Checks PR body - **no score found**
- ✅ 10:15:30 - Quality Gate passes (allows merge)
- 📝 10:17:09 - Greptile posts review with score

**Result:** PRs with 3/5 scores were passing the quality gate

## Solution

Changed workflow trigger from `pull_request` to `pull_request_review`:

### Changes
- ✅ Triggers on `pull_request_review` instead of `pull_request`
- ✅ Only runs when Greptile submits a review (filters by reviewer)
- ✅ Fails (not passes) when no score found in PR description
- ✅ Uses correct PR number from review context
- ✅ Better error messages with emojis

### How It Works Now
1. PR is opened/updated
2. Greptile reviews the code (~2 minutes)
3. Greptile posts review with "Confidence Score: X/5" in PR body
4. **Quality Gate triggers** (after Greptile finishes)
5. Quality Gate reads score from PR body
6. Blocks merge if score < 4.0

## Testing

This fix will be tested when Greptile reviews this PR:
- Expected: Quality gate runs after Greptile posts review
- Expected: Score is found and properly evaluated

## Impact

- ✅ Closes the bypass vulnerability
- ✅ PR #20 would now correctly fail (3/5 score)
- ✅ All future PRs will be properly gated by score

## Related

- Addresses issue discovered in PR #20 analysis
- Fixes bypass vulnerability identified by Greptile

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the Greptile Quality Gate workflow to run on `pull_request_review` (submitted) events instead of `pull_request`, adds a job-level branch restriction to `master`, and attempts to only enforce the gate when the Greptile bot submits a review. The workflow then fetches the PR, parses a `Confidence Score: X/5` from the PR body, and fails the check when the score is missing or below 4.0.
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

- Not safe to merge as-is; the gate may silently skip or error instead of enforcing the threshold.
- The workflow currently (1) references `core.setFailed` without ensuring `core` is available in `actions/github-script`, which can cause runtime failures, and (2) likely uses an incorrect bot login string, which would skip Greptile reviews and prevent the quality gate from running at all.
- .github/workflows/greptile-quality-gate.yml
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/greptile-quality-gate.yml | Switches the quality gate to run on `pull_request_review` submissions and filters to Greptile bot reviews, then parses the PR body for a confidence score and fails if missing/too low (note: bot username match may be incorrect and `core` is referenced without import). |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Greptile as Greptile App
  participant GH as GitHub
  participant WF as Greptile Quality Gate Workflow
  participant API as GitHub REST API

  Greptile->>GH: Submit PR review (pull_request_review:submitted)
  GH-->>WF: Trigger workflow run
  WF->>WF: If base.ref != 'master' then skip
  WF->>WF: If reviewer != 'greptile-apps[bot]' then skip
  WF->>API: pulls.get(pull_number from payload)
  API-->>WF: PR body
  WF->>WF: Regex match "Confidence Score: X/5"
  alt Score missing
    WF-->>GH: Mark check failed (setFailed/throw)
  else Score < 4.0
    WF-->>GH: Mark check failed
  else Score >= 4.0
    WF-->>GH: Mark check success
  end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->