### PR TITLE
docs: update stale ESLint references after forge-y8z closure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ This project uses the **Professional Git Workflow** with Lefthook for automated 
 
 **Pre-push hooks** (automatic):
 - Branch protection: Blocks direct push to main/master
-- ESLint check: Blocks on errors (warnings allowed for now - see forge-y8z)
+- ESLint check: Blocks on errors and warnings (strict mode, `--max-warnings 0`)
 - Test suite: All tests must pass
 
 **Pull Request workflow**:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,9 +27,7 @@ pre-push:
       run: node scripts/branch-protection.js
       tags: protection
 
-    # 2. ESLint check (blocks on errors, warnings allowed)
-    # To enable strict mode (errors + warnings): add --max-warnings 0
-    # See Beads issue: forge-y8z for cleanup tracking
+    # 2. ESLint check (strict mode: blocks on errors and warnings)
     lint:
       run: |
         echo "🔍 Running ESLint..."


### PR DESCRIPTION
## Summary

- Updated CLAUDE.md: ESLint description now reflects strict mode (`--max-warnings 0`) instead of "warnings allowed for now"
- Updated lefthook.yml: Removed stale comments referencing forge-y8z tracking and old behavior

Post-merge verification fix from PR #34 (pre-PR5 cleanup).

## Test plan

- [x] Documentation-only change, no code impact
- [x] ESLint and tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Documentation cleanup to reflect actual ESLint behavior after forge-y8z issue closure. Both `CLAUDE.md` and `lefthook.yml` now accurately describe strict ESLint mode with `--max-warnings 0` instead of outdated "warnings allowed" language.

**Changes:**
- `CLAUDE.md:170` - Updated pre-push hook description to specify strict mode enforcement
- `lefthook.yml:30` - Removed stale comments referencing forge-y8z tracking issue
- No code or behavior changes, documentation-only update
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is completely safe to merge with zero risk
- Documentation-only changes that correct stale references to match existing implementation. No code, logic, or configuration changes. Both files now accurately describe the ESLint strict mode that was already enforced in `lefthook.yml:34`.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CLAUDE.md | Updated ESLint description to accurately reflect strict mode (`--max-warnings 0`), removing stale reference to forge-y8z |
| lefthook.yml | Cleaned up comments to remove stale forge-y8z tracking and clarify strict ESLint mode behavior |

</details>


</details>


<sub>Last reviewed commit: de9f957</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->