### PR TITLE
docs: post-merge verification for PR6

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,17 @@ forge-validate dev       # Validate before /dev stage
 forge-validate ship      # Validate before /ship stage
 ```
 
-### 5. Plugin Architecture (v1.5.0)
-11 agent plugins with specialized capabilities:
-- Each agent defined by JSON configuration
-- Community contributions welcome
-- Backwards compatible
+### 5. Smart Tool Recommendations (v1.7.0)
+Intelligent plugin catalog with 30+ curated tools:
+- **Auto-detection**: Scans your project for frameworks, databases, auth, payments, and more
+- **Budget modes**: free, open-source, startup, professional, custom
+- **CLI-first**: Prefers CLI tools over MCPs for portability
+- **Free alternatives**: Every paid tool shows free alternatives
+
+```bash
+bunx forge recommend                  # Recommendations for your project
+bunx forge recommend --budget free    # Only free tools
+```
 
 → [Validation docs](docs/VALIDATION.md) | [Plugin docs](lib/agents/README.md)
 


### PR DESCRIPTION
## Summary

- Updated README.md section 5: replaced outdated "Plugin Architecture (v1.5.0)" with "Smart Tool Recommendations (v1.7.0)"
- Added `forge recommend` usage examples to README

## Context

Post-merge `/verify` step for PR #41 (Plugin Architecture). Cross-checked all documentation and found README was referencing the old 11-agent plugin system instead of the new catalog/recommender.

## Test Plan

- [x] Docs-only change, no code modified
- [x] `forge recommend` command works on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updated README section 5 to replace outdated "Plugin Architecture (v1.5.0)" content with new "Smart Tool Recommendations" feature added in PR #41.

**Changes:**
- Replaced description of 11-agent plugin system with smart recommendations catalog (30+ tools)
- Added key features: auto-detection, budget modes, CLI-first approach, free alternatives
- Added usage examples for `forge recommend` command with budget flag

**Issue found:**
- Version label says v1.7.0 but package.json is at v1.6.0 (mismatch)
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after fixing version label mismatch
- Documentation change accurately describes the new feature implementation from PR #41. The `forge recommend` command exists and is correctly documented. Only issue is a version label inconsistency (v1.7.0 in README vs v1.6.0 in package.json) that should be corrected before merge.
- README.md requires version label correction at line 183
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| README.md | Updated section 5 to reflect new smart recommendations feature, replacing outdated plugin architecture content. Version label (v1.7.0) doesn't match package.json (v1.6.0). |

</details>


</details>


<sub>Last reviewed commit: c6783af</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->