### PR TITLE
docs: sync docs with forge-uto agent cleanup

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -178,11 +178,9 @@ This workflow works with ALL major AI coding agents:
 | Cursor | .cursorrules | .cursor/rules/ | .cursor/skills/ |
 | Kilo Code | AGENTS.md | .kilocode/workflows/ | .kilocode/skills/ |
 | OpenCode | AGENTS.md | .opencode/commands/ | .opencode/skills/ |
-| Cline | .clinerules | AGENTS.md | .cline/skills/ |
-| Roo Code | .clinerules | .roo/commands/ | - |
-| Continue | .continuerules | .continue/prompts/ | .continue/skills/ |
 | GitHub Copilot | .github/copilot-instructions.md | .github/prompts/ | - |
 | Codex CLI | AGENTS.md | - | - |
+| Goose | AGENTS.md | - | - |
 
 ## License
 

--- a/.clinerules
+++ b/.clinerules
@@ -182,6 +182,7 @@ This workflow works with ALL major AI coding agents:
 | Roo Code | .clinerules | .roo/commands/ | - |
 | Continue | .continuerules | .continue/prompts/ | .continue/skills/ |
 | GitHub Copilot | .github/copilot-instructions.md | .github/prompts/ | - |
+| Codex CLI | AGENTS.md | - | - |
 
 ## License
 

--- a/.clinerules
+++ b/.clinerules
@@ -17,28 +17,27 @@ Check branch name for context:
 
 ---
 
-# Forge - 9-Stage TDD Workflow
+# Forge - 7-Stage TDD Workflow
 
 A TDD-first workflow for AI coding agents. Ship features with confidence.
 
-## Commands (9 Stages)
+## Commands (7 Stages)
 
 | Stage | Command | Description |
 | ----- | ------- | ----------- |
-| 1 | `/status` | Check current context, active work, recent completions |
-| 2 | `/research` | Deep research with web search, document to docs/research/ |
-| 3 | `/plan` | Create implementation plan, branch, OpenSpec if strategic |
-| 4 | `/dev` | TDD development (RED-GREEN-REFACTOR cycles) |
-| 5 | `/check` | Validation (type/lint/security/tests) |
-| 6 | `/ship` | Create PR with full documentation |
-| 7 | `/review` | Address ALL PR feedback |
-| 8 | `/merge` | Update docs, merge PR, cleanup |
-| 9 | `/verify` | Final documentation verification |
+| utility | `/status` | Check current context, active work, recent completions |
+| 1 | `/plan` | Design intent → research → branch + worktree + task list |
+| 2 | `/dev` | Subagent-driven TDD per task (spec + quality review) |
+| 3 | `/validate` | Type check, lint, code review, security, tests |
+| 4 | `/ship` | Create PR with documentation |
+| 5 | `/review` | Address ALL PR feedback |
+| 6 | `/premerge` | Complete docs on feature branch, hand off PR |
+| 7 | `/verify` | Post-merge health check (CI on main) |
 
 ## Workflow Flow
 
 ```text
-/status → /research → /plan → /dev → /check → /ship → /review → /merge → /verify
+/plan → /dev → /validate → /ship → /review → /premerge → /verify
 ```
 
 ## Core Principles
@@ -52,47 +51,34 @@ A TDD-first workflow for AI coding agents. Ship features with confidence.
 
 - Git, GitHub CLI (`gh`)
 - Beads (recommended): `bun add -g @beads/bd && bd init`
-- OpenSpec (optional): `bun add -g @fission-ai/openspec && openspec init`
 
 ## Quick Start
 
 1. `/status` - Check where you are
-2. `/research <feature-name>` - Research the feature
-3. `/plan <feature-slug>` - Create formal plan
-4. `/dev` - Implement with TDD
-5. `/check` - Validate everything
-6. `/ship` - Create PR
+2. `/plan <feature-slug>` - Design Q&A → research → branch + task list
+3. `/dev` - Implement with TDD
+4. `/validate` - Validate everything
+5. `/ship` - Create PR
 
 ## Stage Details
 
-### 1. Status (`/status`)
+### Status (`/status`) — Utility
 
 Check current context before starting work:
 
 - Active issues (via Beads if installed)
 - Recent completions
 - Current branch state
-- OpenSpec proposals in progress
 
-### 2. Research (`/research <feature-name>`)
+### 1. Plan (`/plan <feature-slug>`)
 
-Research before building:
+Design intent → research → branch + worktree + task list:
 
-- Web search for best practices
-- Security analysis (OWASP Top 10)
-- Existing patterns in codebase
-- Document to `docs/research/<feature>.md`
+- One-question-at-a-time Q&A captures design intent
+- Research best practices, OWASP Top 10
+- Create feature branch and task list
 
-### 3. Plan (`/plan <feature-slug>`)
-
-Create implementation plan:
-
-- Create feature branch
-- Define scope and approach
-- Create tracking issue (Beads)
-- OpenSpec proposal if strategic
-
-### 4. Development (`/dev`)
+### 2. Development (`/dev`)
 
 TDD implementation:
 
@@ -101,7 +87,7 @@ TDD implementation:
 - REFACTOR: Clean up
 - Commit after each GREEN cycle
 
-### 5. Check (`/check`)
+### 3. Validate (`/validate`)
 
 Validate everything:
 
@@ -111,16 +97,16 @@ Validate everything:
 - Integration tests
 - Security scan
 
-### 6. Ship (`/ship`)
+### 4. Ship (`/ship`)
 
 Create pull request:
 
 - Push branch
 - Create PR with documentation
-- Link to research doc
+- Link to design doc
 - List test coverage
 
-### 7. Review (`/review`)
+### 5. Review (`/review`)
 
 Address ALL feedback:
 
@@ -129,23 +115,21 @@ Address ALL feedback:
 - Security scan issues
 - Automated tool feedback
 
-### 8. Merge (`/merge`)
+### 6. Premerge (`/premerge`)
 
-Complete the work:
+Complete docs on feature branch:
 
 - Update documentation
-- Squash merge PR
-- Archive OpenSpec (if used)
+- Hand off PR to user for merge
+- Never auto-merges
+
+### 7. Verify (`/verify`)
+
+Post-merge health check:
+
+- CI passing on main
+- Deployments healthy
 - Close tracking issues
-
-### 9. Verify (`/verify`)
-
-Final documentation check:
-
-- All docs updated
-- Cross-references valid
-- Examples work
-- README current
 
 ## Directory Structure
 

--- a/.clinerules
+++ b/.clinerules
@@ -146,8 +146,6 @@ your-project/
 ├── .cursor/rules/               # Cursor rules
 ├── .kilocode/workflows/         # Kilo Code workflows
 ├── .opencode/commands/          # OpenCode commands
-├── .continue/prompts/           # Continue prompts
-├── .roo/commands/               # Roo Code commands
 │
 └── docs/
     ├── planning/
@@ -164,8 +162,6 @@ The `forge-workflow` skill is installed to all supporting agents:
 - `.claude/skills/forge-workflow/SKILL.md`
 - `.cursor/skills/forge-workflow/SKILL.md`
 - `.kilocode/skills/forge-workflow/SKILL.md`
-- `.cline/skills/forge-workflow/SKILL.md`
-- `.continue/skills/forge-workflow/SKILL.md`
 - `.opencode/skills/forge-workflow/SKILL.md`
 
 ## Supported Agents

--- a/.clinerules
+++ b/.clinerules
@@ -138,7 +138,6 @@ your-project/
 ├── AGENTS.md                    # This file (universal)
 ├── CLAUDE.md                    # Claude Code
 ├── .cursorrules                 # Cursor
-├── .clinerules                  # Cline/Roo Code
 ├── .github/
 │   └── copilot-instructions.md  # GitHub Copilot
 │

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ship features with confidence using a 7-stage TDD-first workflow for AI coding a
 
 ✅ **TDD-First**: Write tests before code
 ✅ **Design-First**: One-question-at-a-time Q&A captures intent upfront
-✅ **Multi-Agent**: Universal AGENTS.md works with 11 agents
+✅ **Multi-Agent**: Universal AGENTS.md works with 7+ agents
 
 ---
 
@@ -93,7 +93,7 @@ bunx forge setup
 
 ## Supported AI Agents
 
-Works with **8 AI coding agents** via universal AGENTS.md:
+Works with **7 AI coding agents** via universal AGENTS.md:
 
 ### Tier 1 (Primary Support)
 
@@ -103,7 +103,7 @@ Works with **8 AI coding agents** via universal AGENTS.md:
 | **GitHub Copilot** | Enterprise support, .github/copilot-instructions.md | 30 seconds |
 | **Kilo Code** | Auto failure recovery, .kilo.md | 30 seconds |
 | **Cursor** | Native modes (Plan/Ask/Debug), .cursor/rules/ | 30 seconds |
-| **Aider** | Git-integrated, terminal-native, .aider.conf.yml | 30 seconds |
+| **Codex CLI** | OpenAI terminal agent, AGENTS.md | 30 seconds |
 
 ### Tier 2 (Optional Support)
 
@@ -111,7 +111,6 @@ Works with **8 AI coding agents** via universal AGENTS.md:
 |-------|----------|------------|
 | **OpenCode** | Flexible, opencode.json | 30 seconds |
 | **Goose** | Model flexibility, open-source | 30 seconds |
-| **Antigravity** | Google-backed, early preview | 30 seconds |
 
 **Quick setup** (auto-detects agents):
 ```bash
@@ -123,7 +122,7 @@ bunx forge setup
 bunx forge setup --agent=copilot     # GitHub Copilot
 bunx forge setup --agent=cursor      # Cursor IDE
 bunx forge setup --agent=kilo        # Kilo Code
-bunx forge setup --agent=aider       # Aider
+bunx forge setup --agent=codex       # Codex CLI
 ```
 
 **Setup for all Tier 1 agents**:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ship features with confidence using a 7-stage TDD-first workflow for AI coding a
 
 ✅ **TDD-First**: Write tests before code
 ✅ **Design-First**: One-question-at-a-time Q&A captures intent upfront
-✅ **Multi-Agent**: Universal AGENTS.md works with 7+ agents
+✅ **Multi-Agent**: Universal AGENTS.md works with 7 agents
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ship features with confidence using a 7-stage TDD-first workflow for AI coding a
 ```bash
 /plan login-button        # Design Q&A → research → branch + task list
 /dev                      # TDD: RED → GREEN → REFACTOR cycles
-/validate                    # Type check + lint + tests + security scan
+/validate                 # Type check + lint + tests + security scan
 /ship                     # Create PR with full documentation
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -127,6 +127,21 @@ Copilot reads instructions from `.github/copilot-instructions.md`.
 
 ---
 
+### Codex CLI
+
+**Files created**:
+- `AGENTS.md` → Primary instructions
+
+**Usage**:
+Codex CLI reads `AGENTS.md` and follows the documented workflow.
+
+**Example**:
+```
+codex "Let's follow the Forge workflow. Start with /plan login-button."
+```
+
+---
+
 ### Kilo Code, OpenCode, Continue, Cline, Roo Code
 
 **Files created**:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -30,8 +30,7 @@ bunx forge setup
 **Interactive prompts**:
 1. Which agents do you use?
 2. Install Beads? (y/n) - Git-backed issue tracking
-3. Install OpenSpec? (y/n) - Spec-driven development
-4. Configure external services? (optional)
+3. Configure external services? (optional)
 
 **What gets created**:
 - `AGENTS.md` - Universal instructions (always)
@@ -42,7 +41,7 @@ bunx forge setup
 
 ```bash
 # Install for specific agents
-bunx forge setup --agents claude,cursor,windsurf
+bunx forge setup --agents claude,cursor,codex
 
 # Install for all agents
 bunx forge setup --all
@@ -57,7 +56,6 @@ curl -fsSL https://raw.githubusercontent.com/harshanandak/forge/main/install.sh 
 **Interactive prompts**:
 1. Which agents do you use?
 2. Install Beads? (y/n)
-3. Install OpenSpec? (y/n)
 
 ### Option 4: bun
 
@@ -74,21 +72,21 @@ bunx forge setup
 
 **Files created**:
 - `CLAUDE.md` → Linked to `AGENTS.md`
-- `.claude/commands/` → 9 slash commands
+- `.claude/commands/` → 7 slash commands
 - `.claude/rules/workflow.md` → Workflow rules
 - `.claude/skills/forge-workflow/` → Skill files
 
 **Usage**:
 ```bash
 /status
-/research feature-name
 /plan feature-name
 /dev
+/validate
 # ... etc
 ```
 
 **Skills available**:
-- `forge-workflow` - All 9 stages
+- `forge-workflow` - All 7 stages
 - `parallel-web-search` - Quick web research (if PARALLEL_API_KEY configured)
 - `parallel-deep-research` - Deep analysis (if PARALLEL_API_KEY configured)
 - `sonarcloud-analysis` - Code quality (if SONARCLOUD_TOKEN configured)
@@ -103,7 +101,7 @@ bunx forge setup
 - `.cursor/skills/forge-workflow/` → Skill files
 
 **Usage**:
-Cursor reads `.cursorrules` and follows the 9-stage workflow.
+Cursor reads `.cursorrules` and follows the 7-stage workflow.
 
 **Commands**:
 Use Composer or Chat to reference stages:
@@ -124,7 +122,7 @@ Copilot reads instructions from `.github/copilot-instructions.md`.
 
 **In Copilot Chat**:
 ```
-@workspace I'm starting a new feature, help me with the /research stage
+@workspace I'm starting a new feature, help me with the /plan stage
 ```
 
 ---
@@ -141,7 +139,7 @@ All agents read `AGENTS.md` and follow the documented workflow.
 **Example (any agent)**:
 ```
 "Let's follow the Forge workflow. I want to add a login button.
-Start with the /research stage."
+Start with the /plan stage."
 ```
 
 ---
@@ -164,7 +162,7 @@ git --version
 
 #### GitHub CLI
 
-**Required for** `/ship`, `/review`, `/merge` commands.
+**Required for** `/ship`, `/review`, `/premerge` commands.
 
 ```bash
 # macOS
@@ -221,38 +219,6 @@ bd list
 
 ---
 
-### Optional
-
-#### OpenSpec - Spec-Driven Development
-
-**Use for**: Architecture changes, breaking changes, multi-session features
-
-**Requirements**: Node.js 20.19+
-
-```bash
-# Check Node version
-node --version
-
-# Install globally
-bun install -g @fission-ai/openspec
-
-# Initialize in project
-cd your-project
-openspec init
-
-# Verify
-openspec list
-```
-
-**What it does**:
-- Proposal system for architecture changes
-- Generates planning docs automatically
-- Task tracking with delta specs
-
-[Full OpenSpec guide in TOOLCHAIN.md](TOOLCHAIN.md#openspec---spec-driven-development)
-
----
-
 ## Toolchain Setup
 
 ### Beads Configuration
@@ -293,25 +259,6 @@ bd init --prefix MYPROJ
 **Stealth mode** (local only, don't commit):
 ```bash
 bd init --stealth
-```
-
----
-
-### OpenSpec Configuration
-
-After `openspec init`, customize `openspec.config.json`:
-
-```json
-{
-  "specsDir": "openspec/specs",
-  "changesDir": "openspec/changes",
-  "archiveDir": "openspec/archive",
-  "templates": {
-    "proposal": "default",
-    "design": "default",
-    "tasks": "default"
-  }
-}
 ```
 
 ---
@@ -477,7 +424,7 @@ bunx sonarqube-scanner
 
 #### Parallel AI (Optional - Paid)
 
-**Used in** `/research` stage for deep web research.
+**Used in** `/plan` stage for deep web research.
 
 ```bash
 # 1. Get API key from https://platform.parallel.ai
@@ -563,17 +510,13 @@ your-project/
 ├── .clinerules                  # If Cline/Roo selected
 │
 ├── .claude/                     # Claude Code files
-│   ├── commands/                # 9 workflow commands
+│   ├── commands/                # 7 workflow commands
 │   ├── rules/workflow.md
 │   ├── skills/forge-workflow/
 │   └── scripts/load-env.sh
 │
 ├── .cursor/                     # Cursor files
 │   ├── rules/forge-workflow.mdc
-│   └── skills/forge-workflow/
-│
-├── .windsurf/                   # Windsurf files
-│   ├── workflows/
 │   └── skills/forge-workflow/
 │
 ├── docs/
@@ -588,11 +531,6 @@ your-project/
 │   ├── issues.jsonl
 │   ├── config.yaml
 │   └── .gitignore
-│
-├── openspec/                    # If OpenSpec installed
-│   ├── specs/
-│   ├── changes/
-│   └── archive/
 │
 └── .env.local                   # Your configuration (add to .gitignore!)
 ```
@@ -629,18 +567,6 @@ bun install -g @beads/bd
 
 # Verify
 bd --version
-```
-
-### "OpenSpec requires Node.js 20.19+"
-
-```bash
-# Check version
-node --version
-
-# Upgrade Node.js
-# macOS: brew upgrade node
-# Windows: Download from nodejs.org
-# Linux: Use nvm
 ```
 
 ### "SonarQube connection refused"

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -142,7 +142,7 @@ codex "Let's follow the Forge workflow. Start with /plan login-button."
 
 ---
 
-### Kilo Code, OpenCode, Continue, Cline, Roo Code
+### Kilo Code, OpenCode, Goose
 
 **Files created**:
 - Agent-specific config pointing to `AGENTS.md`
@@ -522,7 +522,6 @@ your-project/
 ├── AGENTS.md                    # Universal (always created)
 ├── CLAUDE.md                    # If Claude selected
 ├── .cursorrules                 # If Cursor selected
-├── .clinerules                  # If Cline/Roo selected
 │
 ├── .claude/                     # Claude Code files
 │   ├── commands/                # 7 workflow commands


### PR DESCRIPTION
## Summary
- Remove stale Aider, Antigravity, Windsurf, and OpenSpec references from README.md, .clinerules, and docs/SETUP.md
- Update .clinerules from old 9-stage workflow to current 7-stage workflow
- Add Codex CLI to supported agents list in README.md
- Fix agent count and setup examples

## Context
Follow-up to PR #54 (forge-uto) which was merged without running `/premerge`. These doc updates would normally have been included in the feature branch.

## Files Changed
- **README.md**: Agent table (remove Aider/Antigravity, add Codex CLI), fix count, update setup examples
- **.clinerules**: Full 9-stage → 7-stage rewrite (stage table, flow, details, remove OpenSpec)
- **docs/SETUP.md**: Remove Windsurf directory, OpenSpec sections, fix stage refs

## Test plan
- [ ] Verify no remaining references to Aider, Antigravity, Windsurf, or 9-stage in changed files
- [ ] Verify Codex CLI appears in README agent table
- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is a documentation-only follow-up to PR #54 (`forge-uto`), syncing `README.md`, `.clinerules`, and `docs/SETUP.md` with the cleaned-up agent list and updated 7-stage workflow that was merged without running `/premerge`. The changes are internally consistent and correctly propagate the new stage names and agent roster across all three files.

**Key changes:**
- `README.md`: Aider removed from Tier 1, Codex CLI added; Antigravity removed from Tier 2; agent count corrected from 11→7 (feature badge) and 8→7 (body text); `--agent=aider` flag updated to `--agent=codex`
- `.clinerules`: Full 9-stage → 7-stage rewrite — stage table, workflow diagram, and stage detail sections all updated; OpenSpec, Cline, Roo Code, and Continue references removed; Codex CLI and Goose added to the supported agents table
- `docs/SETUP.md`: OpenSpec removed from interactive prompts, configuration, and troubleshooting sections; Windsurf directory removed from file structure diagram; Codex CLI agent section added; all stage command references updated (`/check` → `/validate`, `/merge` → `/premerge`, `/research` → `/plan`)

**Note:** `.clinerules` removes itself from its own directory structure listing and from the supported agents table. This is intentional — the directory listing describes what `bunx forge setup` generates for end users, and Cline/Roo Code are no longer supported targets. However, the file itself continues to exist as a meta-development context for contributors who use Cline to work on the forge repo. This dual purpose is not documented anywhere in the file, which could cause confusion for contributors encountering the file for the first time.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — documentation-only changes with no functional code impact.
- All three files are docs only. Stage names, agent counts, and command references are updated consistently across all changed files. No stale references to removed tools (Aider, Antigravity, Windsurf, OpenSpec, Cline, Roo Code, Continue) remain in the changed files. The PR's own test plan criteria are satisfied.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .clinerules | Full 9→7 stage rewrite: updated stage table, workflow flow, stage details, removed OpenSpec, Cline, Roo Code, and Continue agent references; added Codex CLI and Goose; self-reference to .clinerules removed from directory structure (intentional since forge no longer generates it for end users). |
| README.md | Agent table updated: Aider removed, Codex CLI added to Tier 1; Antigravity removed from Tier 2; agent count corrected (11→7 in feature badge, 8→7 in body text); --agent=aider flag updated to --agent=codex; /validate alignment fixed in Quick Example. |
| docs/SETUP.md | OpenSpec removed from interactive prompts and all configuration sections; Windsurf directory and .clinerules removed from directory structure; Codex CLI agent section added; stage references updated (9→7, /check→/validate, /merge→/premerge, /research→/plan); Parallel AI updated to reference /plan stage. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    S(["/status (utility)"]):::utility
    P["/plan\nDesign Q&A → research → branch + task list"]:::stage
    D["/dev\nSubagent-driven TDD per task"]:::stage
    V["/validate\nType check, lint, tests, security"]:::stage
    SH["/ship\nCreate PR with documentation"]:::stage
    R["/review\nAddress ALL PR feedback"]:::stage
    PM["/premerge\nComplete docs, hand off PR"]:::stage
    VE["/verify\nPost-merge health check on main"]:::stage

    S -.->|"optional context check"| P
    P --> D
    D --> V
    V --> SH
    SH --> R
    R --> PM
    PM --> VE

    classDef utility fill:#f0f0f0,stroke:#999,stroke-dasharray:5 5
    classDef stage fill:#d4edda,stroke:#28a745
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (7)</h3></summary>

1. `docs/SETUP.md`, line 130-143 ([link](https://github.com/harshanandak/forge/blob/64ccb2d6599030a6149794f5981591b9e0e43562/docs/SETUP.md#L130-L143)) 

   **Codex CLI missing from Agent-Specific Setup section**

   Codex CLI was just elevated to Tier 1 in `README.md` with a dedicated `--agent=codex` setup flag, but `docs/SETUP.md` has no corresponding agent entry. Every other Tier 1 agent (Claude Code, Cursor, GitHub Copilot, Kilo Code) has at least a brief setup block describing what files get created and how to invoke the workflow.

   A user following this doc to set up Codex CLI would find it completely absent — they'd have no guidance on which files are created or how to reference stages in the Codex CLI interface.

   Consider adding a minimal section, for example:

   ```markdown
   ### Codex CLI

   **Files created**:
   - `AGENTS.md` → Primary instructions

   **Usage**:
   Codex CLI reads `AGENTS.md` and follows the documented workflow.

   **Example**:
   ```
   codex "Let's follow the Forge workflow. Start with /plan login-button."
   ```
   ```

2. `.clinerules`, line 175-184 ([link](https://github.com/harshanandak/forge/blob/6b806c6aadbc6819d889dda1e30fa01d5e0ecf27/.clinerules#L175-L184)) 

   **Codex CLI missing from Supported Agents table**

   This PR promotes Codex CLI to a Tier 1 supported agent in `README.md` and adds a dedicated setup section in `docs/SETUP.md`, but the `Supported Agents` table in `.clinerules` (which was not modified in this PR) still does not include Codex CLI. This leaves an inconsistency: any Cline/Roo agent reading `.clinerules` for the agent compatibility matrix would not find Codex CLI listed.

3. `README.md`, line 22 ([link](https://github.com/harshanandak/forge/blob/a939365743877083d9bf0774452c62278b0f3c6d/README.md#L22)) 

   **Agent count inconsistency with `.clinerules` table**

   The README states `"7 agents"`, which tallies Tier 1 (5) + Tier 2 (2) = 7. However, the updated `.clinerules` "Supported Agents" table (lines 175–185) lists **9** agents — it additionally includes **Cline**, **Roo Code**, and **Continue** that are absent from both the Tier 1 and Tier 2 README tables.

   Before this PR the README claimed "11 agents"; this PR drops it to "7". If those three agents are still officially supported (they're documented in `.clinerules`), the count should reflect them. If they are intentionally being phased out of the supported list, they should also be removed from the `.clinerules` table for consistency.

   
   *(or alternatively remove Cline, Roo Code, and Continue from the `.clinerules` supported agents table)*

4. `README.md`, line 33 ([link](https://github.com/harshanandak/forge/blob/a939365743877083d9bf0774452c62278b0f3c6d/README.md#L33)) 

   **Inconsistent alignment on `/validate` line**

   The `/validate` command has extra spaces before its inline comment compared to the surrounding commands, breaking the visual column alignment in the Quick Example block.

   

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

5. `.clinerules`, line 140-170 ([link](https://github.com/harshanandak/forge/blob/2bad2867e616a7e54e19051adf783fda4b392da1/.clinerules#L140-L170)) 

   **Stale agent references in Directory Structure and Skills sections**

   The supported agents table was updated to remove Cline, Roo Code, and Continue, but the `Directory Structure` and `Skills` sections were not updated accordingly. This leaves misleading references to agents that are no longer supported:

   **Directory Structure** (lines ~140-150):
   - `.clinerules  # Cline/Roo Code` — Cline and Roo Code were removed from the agent table
   - `.continue/prompts/  # Continue prompts` — Continue was removed
   - `.roo/commands/  # Roo Code commands` — Roo Code was removed

   **Skills section** (lines ~163-170):
   - `.cline/skills/forge-workflow/SKILL.md` — Cline no longer listed as supported
   - `.continue/skills/forge-workflow/SKILL.md` — Continue no longer listed as supported

   These stale entries contradict the updated agent table and could confuse users looking at the directory structure guide or the skills installation list.

6. `docs/SETUP.md`, line 145 ([link](https://github.com/harshanandak/forge/blob/2bad2867e616a7e54e19051adf783fda4b392da1/docs/SETUP.md#L145)) 

   **Section header still references removed agents**

   This section heading still includes `Continue`, `Cline`, and `Roo Code`, which were removed from the supported agents table as part of this cleanup. The heading now contradicts the updated agent lists in `README.md` and `.clinerules`.

7. `.clinerules`, line 141 ([link](https://github.com/harshanandak/forge/blob/426b622391ecfdda13674c123a0cb8a0d5a9e850/.clinerules#L141)) 

   **Stale `.clinerules` entry in Directory Structure**

   The Directory Structure section still lists `.clinerules # Cline/Roo Code`, but both Cline and Roo Code were removed from the Supported Agents table in this very PR. Notably, `docs/SETUP.md` was correctly updated in this PR to remove the `.clinerules` entry from its own directory structure listing — the same change was missed here.
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 1fa6769</sub>

<!-- /greptile_comment -->