### PR TITLE
docs: clean up stale workflow refs in agent commands

### DIFF
--- a/.claude/commands/premerge.md
+++ b/.claude/commands/premerge.md
@@ -77,7 +77,7 @@ Check each of the following and update if the feature affects it. Be selective �
 ...update only between these markers...
 <!-- USER:END -->
 ```
-⚠️  NEVER touch `<!-- OPENSPEC:START/END -->` or other managed blocks.
+⚠️  NEVER touch other managed blocks (e.g., `<!-- AGENT:START/END -->`).
 
 **F. `AGENTS.md`** (if agent config, skills, or cross-agent workflow changed):
 - Update relevant sections describing agent capabilities or workflow
@@ -160,7 +160,7 @@ After you merge, run /verify
 ## Rules
 
 - **NEVER run `gh pr merge`** — blocked by PreToolUse hook in `.claude/settings.json`
-- **CLAUDE.md USER section only** — never touch managed blocks (`OPENSPEC:START/END`)
+- **CLAUDE.md USER section only** — never touch other managed blocks
 - **Warn if branch is behind** — tell user to rebase before doc updates
 - **Re-check CI after doc push** — doc commits re-trigger full CI pipeline
 - **One PR, complete** — code + tests + docs merged together, no follow-up doc PRs

--- a/.claude/commands/premerge.md
+++ b/.claude/commands/premerge.md
@@ -46,11 +46,21 @@ If the feature branch is behind `master`, tell the user to rebase first:
 
 Check each of the following and update if the feature affects it. Be selective — only update what genuinely changed.
 
-**A. `docs/planning/PROGRESS.md`** (always):
-- Add feature entry to completed section:
-  - Feature name, completion date, Beads ID, PR number, design doc link
-  - Key deliverables and files changed
-- Note: `docs/planning/` is gitignored — update locally only, no commit needed
+**A. `CHANGELOG.md`** (always):
+- Add entry under `## [Unreleased]` heading (create heading if not present)
+- Use [Keep a Changelog](https://keepachangelog.com/) categories:
+  - **Added**: New features
+  - **Changed**: Changes to existing functionality
+  - **Fixed**: Bug fixes
+  - **Removed**: Removed features
+- Include: feature name, PR number, Beads ID
+- Example:
+  ```markdown
+  ## [Unreleased]
+
+  ### Added
+  - Authentication refresh tokens (PR #89, forge-a3f8)
+  ```
 
 **B. `README.md`** (if user-facing changes):
 - Features list, configuration options, usage examples
@@ -78,7 +88,7 @@ Check each of the following and update if the feature affects it. Be selective �
 **Commit doc updates to feature branch**:
 
 ```bash
-git add README.md docs/ AGENTS.md CLAUDE.md
+git add CHANGELOG.md README.md docs/ AGENTS.md CLAUDE.md
 git commit -m "docs: update documentation for <feature-name>
 
 - Updated: [list files changed]
@@ -132,7 +142,7 @@ Do NOT suggest merging.
 ✓ CI checks: All passing
 ✓ Branch: Up to date with master
 ✓ Documentation updated:
-  - PROGRESS.md: Feature entry added (local only)
+  - CHANGELOG.md: Entry added under [Unreleased]
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh

--- a/.claude/commands/rollback.md
+++ b/.claude/commands/rollback.md
@@ -330,17 +330,14 @@ git commit -m "feat: add payment integration"
 bunx forge rollback
 # Select: 1. Rollback last commit
 
-# 4. Research better approach
+# 4. Plan with security in mind
 /plan payment-integration
 
-# 5. Plan with security in mind
-/plan payment-integration
-
-# 6. Implement correctly
+# 5. Implement correctly
 /dev
 # ... proper implementation with security ...
 
-# 7. Verify and ship
+# 6. Verify and ship
 /validate → /ship
 ```
 

--- a/.claude/commands/rollback.md
+++ b/.claude/commands/rollback.md
@@ -306,12 +306,12 @@ No changes made (dry run).
 
 ```bash
 # Standard workflow
-/status → /research → /plan → /dev → /validate → /ship → /review → /premerge → /verify
+/status → /plan → /dev → /validate → /ship → /review → /premerge → /verify
 
 # Recovery workflow
 /dev → (issues discovered) → bunx forge rollback → /dev (retry)
 /ship → (CI fails) → bunx forge rollback → /dev (fix) → /ship
-/premerge → (production issues) → bunx forge rollback → /plan (redesign)
+/verify → (production issues) → bunx forge rollback → /plan (redesign)
 ```
 
 ### Example: Failed Feature Implementation
@@ -331,7 +331,7 @@ bunx forge rollback
 # Select: 1. Rollback last commit
 
 # 4. Research better approach
-/research payment-integration
+/plan payment-integration
 
 # 5. Plan with security in mind
 /plan payment-integration

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -16,21 +16,17 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
-### Step 1: Read Current Progress
+### Step 1: Check Project Health
 ```bash
-cat docs/planning/PROGRESS.md
+bd stats
 ```
-- What's completed?
-- What's the next priority?
-- Which week/milestone are we in?
+- How many open / in-progress / completed issues?
+- Any blocked issues?
 
 ### Step 2: Check Active Work
 ```bash
 # Active Beads issues
 bd list --status in_progress
-
-# Active OpenSpec proposals
-openspec list --active
 ```
 
 ### Step 3: Review Recent Work
@@ -40,9 +36,6 @@ git log --oneline -10
 
 # Recently completed Beads
 bd list --status completed --limit 5
-
-# Archived OpenSpec proposals
-openspec list --archived --limit 3
 ```
 
 ### Step 4: Determine Context
@@ -53,24 +46,22 @@ openspec list --archived --limit 3
 ## Example Output
 
 ```
-✓ Current Stage: Week 7, AI Integration 100% complete
-✓ Next Priority: Week 8 - Billing & Testing
+✓ Project Health: 3 open, 1 in-progress, 12 completed
 
 Active Work:
-  - No in-progress Beads issues
-  - No active OpenSpec proposals
+  - forge-ctc: Clean up stale workflow refs (in_progress)
 
 Recent Completions:
-  - bd-a3f8: BlockSuite simplification (merged 2 days ago)
-  - bd-k2m5: Auth RLS policies (merged 5 days ago)
+  - forge-uto: Sync AGENTS.md with agent cleanup (closed 2 days ago)
+  - forge-abc: Auth refresh tokens (closed 5 days ago)
 
 Context: Ready for new feature
 
-Next: /research <feature-name>
+Next: /plan <feature-name>
 ```
 
 ## Next Steps
 
-- **If starting new work**: Run `/research <feature-name>`
+- **If starting new work**: Run `/plan <feature-name>`
 - **If continuing work**: Resume with appropriate phase command
 - **If reviewing**: Run `/review <pr-number>` or `/premerge <pr-number>`

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -55,9 +55,9 @@ Recent Completions:
   - forge-uto: Sync AGENTS.md with agent cleanup (closed 2 days ago)
   - forge-abc: Auth refresh tokens (closed 5 days ago)
 
-Context: Ready for new feature
+Context: Continuing work
 
-Next: /plan <feature-name>
+Next: Resume with /dev or /validate (check issue status)
 ```
 
 ## Next Steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Stale workflow refs**: Cleaned up references to removed tools and orphaned files in agent commands (PR #56, forge-ctc)
+  - `status.md`: Replaced openspec/PROGRESS.md commands with Beads equivalents, fixed /research → /plan
+  - `rollback.md`: Updated workflow diagrams to correct 7-stage pipeline (removed /research)
+  - `premerge.md`: Replaced PROGRESS.md reference with CHANGELOG.md maintenance step
+  - Fixed inconsistent example output in status.md (in-progress work vs "Ready for new feature")
+
 ## [1.5.0] - 2026-02-03
 
 ### Added

--- a/docs/plans/2026-03-10-stale-workflow-refs-decisions.md
+++ b/docs/plans/2026-03-10-stale-workflow-refs-decisions.md
@@ -1,0 +1,8 @@
+# Decisions Log: stale-workflow-refs
+
+**Beads**: forge-ctc
+**Branch**: feat/stale-workflow-refs
+
+---
+
+(No decision gates fired — all changes were fully specified in the design doc)

--- a/docs/plans/2026-03-10-stale-workflow-refs-design.md
+++ b/docs/plans/2026-03-10-stale-workflow-refs-design.md
@@ -1,0 +1,50 @@
+# Design: Clean up stale workflow refs in agent commands
+
+- **Feature**: stale-workflow-refs
+- **Date**: 2026-03-10
+- **Status**: approved
+- **Beads**: forge-ctc
+
+## Purpose
+
+Three `.claude/commands/` files reference removed tools (openspec), orphaned files (PROGRESS.md), and a dropped workflow stage (/research). This causes confusion when agents execute these commands and hit nonexistent resources. Additionally, `/premerge` has no CHANGELOG.md maintenance step, so the changelog has fallen behind (last updated 2026-02-03).
+
+## Success Criteria
+
+1. `status.md` — no references to openspec, PROGRESS.md, or /research; replaced with Beads equivalents
+2. `rollback.md` — workflow flow shows correct 7-stage pipeline (no /research)
+3. `premerge.md` — PROGRESS.md reference replaced with Beads equivalent; CHANGELOG.md update step added
+4. All workflow flow diagrams in touched files match: `/status → /plan → /dev → /validate → /ship → /review → /premerge → /verify`
+5. No functional/code changes — docs-only PR
+
+## Out of Scope
+
+- Documentation link checker (tracked separately — Beads issue to be created)
+- Fixing stale refs in files outside `.claude/commands/` (e.g., package.json, QUICKSTART.md, docs/EXAMPLES.md)
+- Changes to `research.md` (already a proper legacy alias redirect)
+
+## Approach Selected
+
+**Approach A: Minimal fix** — Update only the 3 command files to fix stale refs and add CHANGELOG step. Docs-only, no code changes.
+
+Rationale: This is a docs cleanup task. Link checker infrastructure is a separate feature with its own Beads issue.
+
+## Constraints
+
+- Docs-only — no source code, no tests, no new dependencies
+- Must preserve the existing structure/format of each command file
+- CHANGELOG step in premerge should use Keep a Changelog format (already established in CHANGELOG.md)
+
+## Edge Cases
+
+1. **Stale ref found in a file we're already editing**: Fix inline, document in commit message
+2. **CHANGELOG.md format**: Follow existing Keep a Changelog format already in the file
+3. **Beads commands in status.md**: Use real `bd` commands that actually work (`bd list`, `bd stats`)
+
+## Ambiguity Policy
+
+Fix inline and document in commit. Low-risk for docs-only changes.
+
+## Related Work
+
+- **Link checker** (new Beads issue): Local Lefthook pre-push hook preferred over GitHub Action, to catch broken internal markdown links before they hit PRs. Reference workflow from user's other repo saved in issue description.

--- a/docs/plans/2026-03-10-stale-workflow-refs-design.md
+++ b/docs/plans/2026-03-10-stale-workflow-refs-design.md
@@ -45,6 +45,36 @@ Rationale: This is a docs cleanup task. Link checker infrastructure is a separat
 
 Fix inline and document in commit. Low-risk for docs-only changes.
 
+## Technical Research
+
+### Stale Reference Inventory
+
+| File | Line | Stale Reference | Replacement |
+|------|------|----------------|-------------|
+| status.md | 21 | `cat docs/planning/PROGRESS.md` | `bd list --status completed --limit 5` |
+| status.md | 33 | `openspec list --active` | Remove (no replacement needed) |
+| status.md | 45 | `openspec list --archived --limit 3` | Remove |
+| status.md | 69 | `Next: /research <feature-name>` | `Next: /plan <feature-name>` |
+| status.md | 74 | `Run /research <feature-name>` | `Run /plan <feature-name>` |
+| rollback.md | 309 | `/status → /research → /plan → ...` | `/status → /plan → /dev → ...` |
+| rollback.md | 334 | `/research payment-integration` | `/plan payment-integration` |
+| premerge.md | 49 | `docs/planning/PROGRESS.md` | Replace with CHANGELOG.md step |
+| premerge.md | 135 | `PROGRESS.md: Feature entry added` | `CHANGELOG.md: Entry added` |
+
+### OWASP Top 10 Analysis
+
+Not applicable — docs-only changes with no code, no user input, no authentication, no data storage.
+
+### TDD Test Scenarios
+
+1. **Happy path**: All 3 files updated, grep for stale terms returns 0 matches (excluding research.md legacy alias)
+2. **Workflow consistency**: All workflow diagrams in touched files show identical 7-stage flow
+3. **CHANGELOG format**: New premerge step references Keep a Changelog format consistent with existing CHANGELOG.md
+
+### DRY Check
+
+No existing "replace stale workflow refs" logic exists. This is a manual docs edit — no abstraction needed.
+
 ## Related Work
 
 - **Link checker** (new Beads issue): Local Lefthook pre-push hook preferred over GitHub Action, to catch broken internal markdown links before they hit PRs. Reference workflow from user's other repo saved in issue description.

--- a/docs/plans/2026-03-10-stale-workflow-refs-tasks.md
+++ b/docs/plans/2026-03-10-stale-workflow-refs-tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Clean up stale workflow refs in agent commands
+
+**Beads**: forge-ctc
+**Branch**: feat/stale-workflow-refs
+**Design**: docs/plans/2026-03-10-stale-workflow-refs-design.md
+
+---
+
+## Task 1: Fix status.md — remove openspec, PROGRESS.md, /research
+
+**File(s)**: `.claude/commands/status.md`
+
+**What to implement**:
+- Line 21: Replace `cat docs/planning/PROGRESS.md` with `bd stats` and `bd list --status completed --limit 5`
+- Lines 33-34: Remove `openspec list --active` block entirely
+- Lines 44-46: Remove `openspec list --archived --limit 3` block entirely
+- Line 69: Change `Next: /research <feature-name>` → `Next: /plan <feature-name>`
+- Line 74: Change `Run /research <feature-name>` → `Run /plan <feature-name>`
+- Update example output to reflect Beads-only tracking (no OpenSpec)
+- Update "Next Steps" section to reference `/plan` not `/research`
+
+**TDD steps**:
+1. Run: `grep -c 'openspec\|PROGRESS\.md\|/research' .claude/commands/status.md` → expect 5+ matches
+2. Make edits
+3. Run: `grep -c 'openspec\|PROGRESS\.md\|/research' .claude/commands/status.md` → expect 0 matches
+4. Verify workflow flow (if present) matches 7-stage
+5. Commit: `docs: fix stale refs in status.md — remove openspec, PROGRESS.md, /research`
+
+**Expected output**: status.md references only Beads (`bd`) for tracking, `/plan` for next steps
+
+---
+
+## Task 2: Fix rollback.md — update workflow flow diagrams
+
+**File(s)**: `.claude/commands/rollback.md`
+
+**What to implement**:
+- Line 309: Change `/status → /research → /plan → /dev → /validate → /ship → /review → /premerge → /verify` → `/status → /plan → /dev → /validate → /ship → /review → /premerge → /verify`
+- Line 314: Same fix for the recovery workflow line if it has /research
+- Line 334: Change `/research payment-integration` → `/plan payment-integration`
+- Check for any other stale refs in the file
+
+**TDD steps**:
+1. Run: `grep -c '/research' .claude/commands/rollback.md` → expect 2+ matches
+2. Make edits
+3. Run: `grep -c '/research' .claude/commands/rollback.md` → expect 0 matches
+4. Verify all workflow flows show correct 7-stage
+5. Commit: `docs: fix stale workflow refs in rollback.md — remove /research stage`
+
+**Expected output**: All workflow diagrams in rollback.md show 7-stage pipeline
+
+---
+
+## Task 3: Fix premerge.md — replace PROGRESS.md with CHANGELOG.md step
+
+**File(s)**: `.claude/commands/premerge.md`
+
+**What to implement**:
+- Line 49: Replace `docs/planning/PROGRESS.md` section with CHANGELOG.md update step:
+  - Add entry under correct version heading using Keep a Changelog format
+  - Categories: Added, Changed, Fixed, Removed (match existing CHANGELOG.md style)
+  - Include: feature name, PR number, Beads ID
+- Line 135: Update example output to show CHANGELOG.md instead of PROGRESS.md
+- Keep the note about `docs/planning/` being gitignored if PROGRESS.md section is fully replaced
+
+**TDD steps**:
+1. Run: `grep -c 'PROGRESS\.md' .claude/commands/premerge.md` → expect 2 matches
+2. Make edits
+3. Run: `grep -c 'PROGRESS\.md' .claude/commands/premerge.md` → expect 0 matches
+4. Run: `grep -c 'CHANGELOG' .claude/commands/premerge.md` → expect 1+ matches
+5. Commit: `docs: replace PROGRESS.md with CHANGELOG.md step in premerge`
+
+**Expected output**: premerge.md instructs agents to update CHANGELOG.md before merge handoff
+
+---
+
+## Task 4: Final verification — grep for all stale terms across touched files
+
+**File(s)**: All 3 files
+
+**What to implement**:
+- Run grep for `openspec`, `PROGRESS.md`, `/research` across all `.claude/commands/` (excluding `research.md` legacy alias)
+- Verify 0 matches
+- Run grep for consistent workflow flow in all touched files
+
+**TDD steps**:
+1. Run: `grep -l 'openspec\|PROGRESS\.md' .claude/commands/status.md .claude/commands/rollback.md .claude/commands/premerge.md` → expect 0 matches
+2. Run: `grep '/research' .claude/commands/status.md .claude/commands/rollback.md .claude/commands/premerge.md` → expect 0 matches
+3. Verify each file's workflow diagram (if present) matches the canonical 7-stage flow
+4. No commit needed — verification only


### PR DESCRIPTION
## Summary
- Remove stale references to `openspec`, `docs/planning/PROGRESS.md`, and `/research` from 3 command files
- Add CHANGELOG.md maintenance step to `/premerge` (replaces orphaned PROGRESS.md tracking)
- Fix duplicate example step in `rollback.md` after `/research` removal

## Design Doc
See: [docs/plans/2026-03-10-stale-workflow-refs-design.md](docs/plans/2026-03-10-stale-workflow-refs-design.md)

## Decisions Log
See: [docs/plans/2026-03-10-stale-workflow-refs-decisions.md](docs/plans/2026-03-10-stale-workflow-refs-decisions.md) (no decision gates fired)

## Beads Issue
Closes: forge-ctc

## Files Changed

| File | Changes |
|------|---------|
| `.claude/commands/status.md` | Replace PROGRESS.md with `bd stats`, remove openspec refs, `/research` → `/plan` |
| `.claude/commands/rollback.md` | Remove `/research` from workflow flows, fix duplicate example step |
| `.claude/commands/premerge.md` | Replace PROGRESS.md section with CHANGELOG.md maintenance (Keep a Changelog format) |

## Key Decisions
1. **Beads replaces PROGRESS.md** — `bd stats` and `bd list` are the source of truth for project tracking
2. **CHANGELOG.md added to /premerge** — Keep a Changelog format with `[Unreleased]` heading, includes PR number and Beads ID
3. **research.md left as legacy alias** — already properly redirects to `/plan`, no changes needed

## Validation
- [x] Type check: N/A (no TypeScript)
- [x] Lint: 0 errors, 0 warnings
- [x] Tests: 1272/1272 passing
- [x] Security: N/A (docs-only, no code changes)
- [x] Grep verification: 0 matches for `openspec`, `PROGRESS.md`, `/research` across all 3 files

## Related
- Created Beads issue `forge-30k` for future documentation link checker (Lefthook pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is a focused docs-only cleanup that removes stale references to three deprecated resources — `openspec`, `docs/planning/PROGRESS.md`, and the `/research` workflow stage — across three agent command files, and adds a `CHANGELOG.md` maintenance step to `/premerge` to replace the orphaned PROGRESS.md tracking.

**Changes by file:**
- **`status.md`**: Step 1 replaced `cat docs/planning/PROGRESS.md` with `bd stats`; Step 2 dropped `openspec list --active`; Step 3 dropped `openspec list --archived`; "Next Steps" now points to `/plan` instead of `/research`; example output updated to reflect Beads-only tracking (previous review comment about the inconsistent "Ready for new feature" context was also resolved)
- **`rollback.md`**: Standard workflow diagram drops `/research` stage (9→8 stages matching the canonical 7+utility model); recovery workflow line corrected from `/premerge →` to `/verify →` for post-merge production issues; example steps renumbered cleanly after removing the `/research payment-integration` step
- **`premerge.md`**: Section A replaced PROGRESS.md entry instructions with a CHANGELOG.md Keep-a-Changelog step including format guidance and example; `git add` command updated to include `CHANGELOG.md`; example output and rules section updated; `OPENSPEC:START/END` block warning updated to generic managed-block guidance
- **`CHANGELOG.md`**: New `[Unreleased]` section added with a `### Fixed` entry for this cleanup (PR #56, forge-ctc), following the established Keep a Changelog format
- **`docs/plans/`**: Three new plan files (design, decisions, tasks) documenting the intent, constraints, stale-ref inventory, and TDD verification steps for this change
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it is docs-only with no code, tests, or configuration changes, and all stale references verified removed.
- All targeted stale references (`openspec`, `PROGRESS.md`, `/research`) have been removed from the three command files per the design doc's inventory. The CHANGELOG step in premerge is additive and consistent with the existing CHANGELOG.md format. The recovery workflow correction in rollback.md (`/premerge` → `/verify`) is semantically accurate. No logic regressions are introduced. The previous review comment about the inconsistent example context in status.md was already addressed in a prior commit.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .claude/commands/status.md | Replaced PROGRESS.md and openspec commands with Beads equivalents (bd stats / bd list), removed /research references, updated example output — changes are accurate and internally consistent |
| .claude/commands/rollback.md | Removed /research from standard workflow diagram and example; corrected recovery workflow line from /premerge to /verify (correct stage for post-merge production issues); renumbered example steps cleanly |
| .claude/commands/premerge.md | Replaced PROGRESS.md section with CHANGELOG.md maintenance step using Keep a Changelog format; updated git add command, example output, and rules section to match; removed OPENSPEC block reference |
| CHANGELOG.md | New [Unreleased] entry added under the Fixed category with PR number and Beads ID; follows existing Keep a Changelog format; historical PROGRESS.md references in older entries left correctly intact |
| docs/plans/2026-03-10-stale-workflow-refs-design.md | New design doc with clear purpose, success criteria, stale-reference inventory table, and OWASP/TDD analysis sections; all inventory items verified as addressed in the PR |
| docs/plans/2026-03-10-stale-workflow-refs-decisions.md | Minimal decisions log noting no decision gates fired; appropriate for a fully-specified docs-only cleanup |
| docs/plans/2026-03-10-stale-workflow-refs-tasks.md | Task breakdown with TDD grep verification steps for each of the 3 command files; all 4 tasks map directly to changes made in the PR |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/status\n(bd stats + bd list)"] --> B["/plan\n(design + branch + tasks)"]
    B --> C["/dev\n(TDD implementation)"]
    C --> D["/validate\n(lint + tests + security)"]
    D --> E["/ship\n(push + create PR)"]
    E --> F["/review\n(CI + Greptile + SonarCloud)"]
    F --> G["/premerge\n(update CHANGELOG.md + docs\nhand off to user)"]
    G --> H["User merges in GitHub UI"]
    H --> I["/verify\n(post-merge CI check)"]

    I -->|production issues| J["bunx forge rollback"]
    J --> B

    C -->|issues discovered| J
    E -->|CI fails| J
    J -->|retry| C

    style A fill:#e8f4fd,stroke:#2196F3
    style G fill:#e8f5e9,stroke:#4CAF50
    style I fill:#fff3e0,stroke:#FF9800
    style J fill:#fce4ec,stroke:#E91E63
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `.claude/commands/premerge.md`, line 80 ([link](https://github.com/harshanandak/forge/blob/08267a76621d831c674d1dd0dde98eea7e5621ab/.claude/commands/premerge.md#L80)) 

   **Stale `OPENSPEC:START/END` block reference — blocks no longer exist in `CLAUDE.md`**

   `CLAUDE.md` no longer contains any `<!-- OPENSPEC:START/END -->` markers (confirmed by grep). This warning now points to a nonexistent block structure and may confuse agents looking for markers to avoid. The PR's grep verification used a case-sensitive pattern (`openspec`) and missed this uppercase `OPENSPEC` reference.

   The same stale reference also appears in the **Rules** section at line 163:
   > `CLAUDE.md USER section only — never touch managed blocks (OPENSPEC:START/END)`

   Both occurrences should be updated to reference whichever managed blocks actually exist in `CLAUDE.md` today (e.g., `<!-- AGENT:START/END -->`, or simply drop the specific marker name in favour of "other managed blocks").

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .claude/commands/premerge.md
   Line: 80

   Comment:
   **Stale `OPENSPEC:START/END` block reference — blocks no longer exist in `CLAUDE.md`**

   `CLAUDE.md` no longer contains any `<!-- OPENSPEC:START/END -->` markers (confirmed by grep). This warning now points to a nonexistent block structure and may confuse agents looking for markers to avoid. The PR's grep verification used a case-sensitive pattern (`openspec`) and missed this uppercase `OPENSPEC` reference.

   The same stale reference also appears in the **Rules** section at line 163:
   > `CLAUDE.md USER section only — never touch managed blocks (OPENSPEC:START/END)`

   Both occurrences should be updated to reference whichever managed blocks actually exist in `CLAUDE.md` today (e.g., `<!-- AGENT:START/END -->`, or simply drop the specific marker name in favour of "other managed blocks").

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `.claude/commands/premerge.md`, line 80 ([link](https://github.com/harshanandak/forge/blob/f70734a0850dc825e393712494dfe7604888e0ff/.claude/commands/premerge.md#L80)) 

   **Residual `OPENSPEC` references not addressed by this PR**

   This PR explicitly targets removing stale `openspec` references, yet two remain in this file unchanged:

   - Line 80: `⚠️  NEVER touch '<!-- OPENSPEC:START/END -->' or other managed blocks.`
   - Line 163: `**CLAUDE.md USER section only** — never touch managed blocks (\`OPENSPEC:START/END\`)`

   If `CLAUDE.md` no longer contains `<!-- OPENSPEC:START -->` / `<!-- OPENSPEC:END -->` managed blocks (because the openspec tool has been fully removed), these warnings are stale and could confuse agents looking for markers that don't exist. If the blocks do still exist in `CLAUDE.md`, the references are still valid and no change is needed — but it's worth verifying intentionality since the PR description states it removes openspec refs from `premerge.md`.

3. `.claude/commands/premerge.md`, line 80 ([link](https://github.com/harshanandak/forge/blob/192c939213e803a7aa215fc48dcc850c7676fccb/.claude/commands/premerge.md#L80)) 

   **Surviving `OPENSPEC` reference contradicts grep verification claim**

   The PR description states "Grep verification: 0 matches for `openspec` … across all 3 files," but line 80 still contains `<!-- OPENSPEC:START/END -->`. The validation grep was almost certainly run case-sensitively (`openspec` lowercase), so it silently missed the uppercase variant.

   If OpenSpec has been fully retired from this project, the managed-block markers (`<!-- OPENSPEC:START/END -->`) no longer exist in `CLAUDE.md`, making this warning both misleading and unreachable. Consider updating the line to reference only the generic managed-block pattern:

   

   If the OPENSPEC markers *do* still exist in `CLAUDE.md`, they should be removed separately and this line updated to reflect whatever markers remain.
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: a6c8c0d</sub>

<!-- /greptile_comment -->