### PR TITLE
fix: quality gate honesty + CI path filter gaps (#68)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,20 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "master" ]
+    paths:
+      - 'bin/**'
+      - 'lib/**'
+      - 'scripts/**'
+      - 'packages/**'
+      - '.github/workflows/**'
   pull_request:
     branches: [ "master" ]
+    paths:
+      - 'bin/**'
+      - 'lib/**'
+      - 'scripts/**'
+      - 'packages/**'
+      - '.github/workflows/**'
   schedule:
     - cron: '19 20 * * 4'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ on:
       - 'scripts/**'
       - 'packages/**'
       - '.github/workflows/**'
+      - '.forge/hooks/**'
   pull_request:
     branches: [ "master" ]
     paths:
@@ -28,6 +29,7 @@ on:
       - 'scripts/**'
       - 'packages/**'
       - '.github/workflows/**'
+      - '.forge/hooks/**'
   schedule:
     - cron: '19 20 * * 4'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,8 @@ name: 'Dependency review'
 on:
   pull_request:
     branches: [ "master" ]
+    paths:
+      - 'package.json'
 
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,9 @@ on:
     branches: [ "master" ]
     paths:
       - 'package.json'
+      - 'bun.lock'
+      - 'packages/**/package.json'
+      - 'packages/**/bun.lock'
 
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,11 +12,28 @@ name: ESLint
 on:
   push:
     branches: [ "master" ]
+    paths:
+      - 'bin/**'
+      - 'lib/**'
+      - 'scripts/**'
+      - 'test/**'
+      - 'packages/**'
+      - 'package.json'
+      - '.github/workflows/**'
+      - '*.js'
+      - '.claude/**/*.js'
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "master" ]
-  schedule:
-    - cron: '39 2 * * 0'
+    paths:
+      - 'bin/**'
+      - 'lib/**'
+      - 'scripts/**'
+      - 'test/**'
+      - 'packages/**'
+      - 'package.json'
+      - '.github/workflows/**'
+      - '*.js'
+      - '.claude/**/*.js'
 
 jobs:
   eslint:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -22,6 +22,7 @@ on:
       - '.github/workflows/**'
       - '*.js'
       - '.claude/**/*.js'
+      - '.forge/hooks/**'
   pull_request:
     branches: [ "master" ]
     paths:
@@ -34,6 +35,7 @@ on:
       - '.github/workflows/**'
       - '*.js'
       - '.claude/**/*.js'
+      - '.forge/hooks/**'
 
 jobs:
   eslint:

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -3,8 +3,18 @@ name: Package Size Monitor
 on:
   push:
     branches: [main, master]
+    paths:
+      - 'package.json'
+      - 'bin/**'
+      - 'lib/**'
+      - 'packages/**'
   pull_request:
     branches: [main, master]
+    paths:
+      - 'package.json'
+      - 'bin/**'
+      - 'lib/**'
+      - 'packages/**'
 
 jobs:
   size-check:

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -8,6 +8,14 @@ on:
       - 'bin/**'
       - 'lib/**'
       - 'packages/**'
+      - 'skills/**'
+      - 'docs/*.md'
+      - '.claude/**'
+      - '.forge/hooks/**'
+      - '.github/prompts/**'
+      - 'install.sh'
+      - 'AGENTS.md'
+      - 'lefthook.yml'
   pull_request:
     branches: [main, master]
     paths:
@@ -15,6 +23,14 @@ on:
       - 'bin/**'
       - 'lib/**'
       - 'packages/**'
+      - 'skills/**'
+      - 'docs/*.md'
+      - '.claude/**'
+      - '.forge/hooks/**'
+      - '.github/prompts/**'
+      - 'install.sh'
+      - 'AGENTS.md'
+      - 'lefthook.yml'
 
 jobs:
   size-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - 'scripts/**'
       - 'test/**'
       - 'test-env/**'
+      - 'packages/**'
       - 'package.json'
       - '.github/workflows/**'
   pull_request:
@@ -18,6 +19,7 @@ on:
       - 'scripts/**'
       - 'test/**'
       - 'test-env/**'
+      - 'packages/**'
       - 'package.json'
       - '.github/workflows/**'
   workflow_dispatch:  # Allow manual workflow runs

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/docs/plans/2026-03-20-quality-gates-decisions.md
+++ b/docs/plans/2026-03-20-quality-gates-decisions.md
@@ -1,0 +1,6 @@
+# Decisions Log: Quality Gate Honesty + CI Path Filter Gaps
+
+**Issue**: forge-twiw
+**Branch**: feat/quality-gates
+
+No decisions logged yet.

--- a/docs/plans/2026-03-20-quality-gates-design.md
+++ b/docs/plans/2026-03-20-quality-gates-design.md
@@ -1,0 +1,102 @@
+# Design: Quality Gate Honesty + CI Path Filter Gaps
+
+- **Feature**: quality-gates
+- **Date**: 2026-03-20
+- **Status**: approved
+- **Beads**: forge-mr0l, forge-ypeh (combined PR)
+
+## Purpose
+
+The local quality gate (validate.sh) misleads developers by reporting "Type check passed" when no type checking occurs. CI workflows have path filter gaps that cause unnecessary runs on docs-only PRs and miss runs on workspace package changes.
+
+## Success Criteria
+
+1. `validate.sh` step 1 prints "SKIPPED (no TypeScript)" instead of "passed"
+2. `test.yml` triggers on `packages/**` changes
+3. `eslint.yml` has path filters scoped to JS/config files, weekly schedule removed
+4. `codeql.yml` has code-only path filters on push/PR, weekly schedule retained
+5. `size-check.yml` has package-relevant path filters
+6. `dependency-review.yml` scoped to `package.json`
+7. `yaml-lint.yml` uses `setup-bun@v2`
+8. All existing CI tests still pass
+
+## Out of Scope
+
+- Adding real TypeScript type checking (no TS in project yet)
+- Creating a cross-platform `validate.js` Node script (future work)
+- Documenting local gate in CONTRIBUTING (separate issue)
+- Modifying lefthook.yml or pre-push hooks
+- Changing mutation testing schedule or config
+
+## Approach Selected
+
+Direct edits to validate.sh and 6 workflow YAML files. No new files created. Minimal, targeted changes per file.
+
+### validate.sh
+- Change step 1 from `bun run typecheck` (which is just an echo) to an honest skip message using `print_warning`
+- Keep the 4-step numbering so the slot is ready when TypeScript is added
+
+### test.yml
+- Add `packages/**` to both push and pull_request path filters
+
+### eslint.yml
+- Add path filters: `bin/**`, `lib/**`, `scripts/**`, `test/**`, `packages/**`, `package.json`, `.github/workflows/**`, `*.js` (root config files), `.claude/**/*.js`
+- Remove weekly `schedule` trigger (redundant — runs on every PR already)
+
+### codeql.yml
+- Add path filters on push/PR: `bin/**`, `lib/**`, `scripts/**`, `packages/**`, `.github/workflows/**`
+- Keep weekly schedule for full security scans
+
+### size-check.yml
+- Add path filters: `package.json`, `bin/**`, `lib/**`, `packages/**`
+
+### dependency-review.yml
+- Add path filter: `package.json`
+
+### yaml-lint.yml
+- Bump `setup-bun@v1` to `@v2`
+
+## Constraints
+
+- No new files — edits only
+- Path filters must be additive (never remove existing valid paths)
+- Weekly CodeQL schedule must be preserved
+- All changes must be valid YAML
+
+## Edge Cases
+
+- **Root-level JS files** (e.g., `eslint.config.js`): included in eslint.yml path filters via `*.js` glob
+- **`.claude/**/*.js` scripts**: included in eslint.yml paths since ESLint scans them
+- **Workflow file changes**: already in test.yml paths (`.github/workflows/**`), added to eslint/codeql too
+
+## Ambiguity Policy
+
+Use rubric scoring against success criteria. If an unexpected issue scores below 70% alignment with success criteria, pause and ask the user. Otherwise, make a conservative fix and document in the commit.
+
+## Technical Research
+
+### OWASP Top 10 Analysis
+
+This PR touches CI config and a local shell script — minimal attack surface:
+- **A05:2021 Security Misconfiguration**: Path filters could accidentally exclude security-relevant paths. Mitigation: CodeQL keeps weekly full scan; path filters are additive only.
+- **A08:2021 Software and Data Integrity**: CI workflow changes could weaken the quality gate. Mitigation: no checks are removed, only triggers are refined.
+- Other OWASP categories not applicable (no user input, no auth, no data handling).
+
+### TDD Test Scenarios
+
+1. **Happy path**: validate.sh runs, step 1 prints skip warning, steps 2-4 execute normally
+2. **CI trigger test**: PR touching only `packages/skills/index.js` triggers test.yml (currently doesn't)
+3. **CI skip test**: PR touching only `docs/README.md` does NOT trigger eslint.yml (currently does)
+4. **YAML validity**: All modified workflow files parse as valid YAML
+5. **Path filter completeness**: Every `.js` file in the repo is covered by at least one CI workflow's path filter
+
+### DRY Check
+
+No new code or abstractions being created — all changes are edits to existing files. DRY gate cleared.
+
+### Blast Radius
+
+Changes touch:
+- `scripts/validate.sh` (local dev only)
+- 6 workflow files in `.github/workflows/` (CI only)
+- No runtime code, no dependencies, no exports

--- a/docs/plans/2026-03-20-quality-gates-tasks.md
+++ b/docs/plans/2026-03-20-quality-gates-tasks.md
@@ -1,0 +1,154 @@
+# Task List: Quality Gate Honesty + CI Path Filter Gaps
+
+**Issue**: forge-twiw (covers forge-mr0l + forge-ypeh)
+**Branch**: feat/quality-gates
+**Design**: docs/plans/2026-03-20-quality-gates-design.md
+**Baseline**: 1544 pass, 12 fail (pre-existing), 9 errors (pre-existing)
+
+## Parallel Wave Structure
+
+```
+Wave 1 (independent — all in parallel):
+  Task 1: validate.sh typecheck honesty
+  Task 2: test.yml add packages/** path
+  Task 3: eslint.yml path filters + remove schedule
+  Task 4: codeql.yml path filters on push/PR
+  Task 5: size-check.yml path filters
+  Task 6: dependency-review.yml path filter
+  Task 7: yaml-lint.yml bump setup-bun v2
+
+Wave 2 (depends on all Wave 1):
+  Task 8: YAML validity check + test baseline
+```
+
+---
+
+## Task 1: validate.sh — honest typecheck skip
+
+**File(s)**: `scripts/validate.sh`
+**What to implement**: Replace step 1 `bun run typecheck` call with a `print_warning` that says "Type Check — SKIPPED (no TypeScript in project)". Keep the 4-step numbering.
+
+**TDD steps**:
+1. Write test: Not applicable (shell script — validated manually)
+2. Implement: Change lines 52-59 to use `print_warning` instead of calling `bun run typecheck`
+3. Verify: Run `bash scripts/validate.sh` — step 1 should print yellow warning, not green pass
+4. Commit: `fix: validate.sh typecheck step honestly reports skip`
+
+**Expected output**: Step 1 prints "Step 1/4: Type Check" header then yellow "SKIPPED (no TypeScript in project)"
+
+---
+
+## Task 2: test.yml — add packages/** path filter
+
+**File(s)**: `.github/workflows/test.yml`
+**What to implement**: Add `- 'packages/**'` to both the `push.paths` and `pull_request.paths` arrays.
+
+**TDD steps**:
+1. Write test: YAML parse validation (Task 8)
+2. Implement: Add `- 'packages/**'` after `- 'test-env/**'` in both path arrays (lines ~11 and ~20)
+3. Verify: YAML parses correctly
+4. Commit: `fix: test.yml add packages/** to path filters`
+
+**Expected output**: PRs touching workspace packages now trigger the test suite
+
+---
+
+## Task 3: eslint.yml — add path filters, remove schedule
+
+**File(s)**: `.github/workflows/eslint.yml`
+**What to implement**:
+- Add `paths` filter to both `push` and `pull_request` triggers: `bin/**`, `lib/**`, `scripts/**`, `test/**`, `packages/**`, `package.json`, `.github/workflows/**`, `*.js`, `.claude/**/*.js`
+- Remove the `schedule` section (lines 18-19)
+
+**TDD steps**:
+1. Write test: YAML parse validation (Task 8)
+2. Implement: Add path arrays, remove schedule cron
+3. Verify: YAML parses correctly, no schedule trigger present
+4. Commit: `fix: eslint.yml add path filters and remove redundant schedule`
+
+**Expected output**: ESLint CI only runs when code files change, not on docs-only PRs
+
+---
+
+## Task 4: codeql.yml — add path filters on push/PR
+
+**File(s)**: `.github/workflows/codeql.yml`
+**What to implement**:
+- Add `paths` filter to `push` trigger: `bin/**`, `lib/**`, `scripts/**`, `packages/**`, `.github/workflows/**`
+- Add `paths` filter to `pull_request` trigger: same paths
+- Keep the weekly `schedule` trigger unchanged
+
+**TDD steps**:
+1. Write test: YAML parse validation (Task 8)
+2. Implement: Add path arrays to push and pull_request sections
+3. Verify: YAML parses correctly, schedule section still present
+4. Commit: `fix: codeql.yml add code-only path filters, keep weekly schedule`
+
+**Expected output**: CodeQL push/PR runs scoped to code changes; weekly full scan preserved
+
+---
+
+## Task 5: size-check.yml — add path filters
+
+**File(s)**: `.github/workflows/size-check.yml`
+**What to implement**:
+- Add `paths` filter to both `push` and `pull_request` triggers: `package.json`, `bin/**`, `lib/**`, `packages/**`
+
+**TDD steps**:
+1. Write test: YAML parse validation (Task 8)
+2. Implement: Add path arrays to both trigger sections
+3. Verify: YAML parses correctly
+4. Commit: `fix: size-check.yml add package-relevant path filters`
+
+**Expected output**: Size check only runs when package-impacting files change
+
+---
+
+## Task 6: dependency-review.yml — scope to package.json
+
+**File(s)**: `.github/workflows/dependency-review.yml`
+**What to implement**:
+- Add `paths` filter to `pull_request` trigger: `package.json`
+
+**TDD steps**:
+1. Write test: YAML parse validation (Task 8)
+2. Implement: Add paths array to pull_request section
+3. Verify: YAML parses correctly
+4. Commit: `fix: dependency-review.yml scope to package.json changes`
+
+**Expected output**: Dependency review only runs when package.json changes
+
+---
+
+## Task 7: yaml-lint.yml — bump setup-bun version
+
+**File(s)**: `.github/workflows/yaml-lint.yml`
+**What to implement**:
+- Change `uses: oven-sh/setup-bun@v1` to `uses: oven-sh/setup-bun@v2`
+
+**TDD steps**:
+1. Write test: YAML parse validation (Task 8)
+2. Implement: Change v1 to v2 on line 28
+3. Verify: YAML parses correctly
+4. Commit: `fix: yaml-lint.yml bump setup-bun v1 to v2`
+
+**Expected output**: Consistent setup-bun version across all workflows
+
+---
+
+## Task 8: YAML validity + test baseline (Wave 2)
+
+**File(s)**: All modified workflow files
+**What to implement**: Validate all modified YAML files parse correctly. Run test suite to confirm no regressions.
+
+**TDD steps**:
+1. Run: `bun x js-yaml .github/workflows/test.yml`
+2. Run: `bun x js-yaml .github/workflows/eslint.yml`
+3. Run: `bun x js-yaml .github/workflows/codeql.yml`
+4. Run: `bun x js-yaml .github/workflows/size-check.yml`
+5. Run: `bun x js-yaml .github/workflows/dependency-review.yml`
+6. Run: `bun x js-yaml .github/workflows/yaml-lint.yml`
+7. Run: `bun test` — confirm same baseline (1544 pass, 12 pre-existing fail)
+8. Commit: final commit if any fixes needed
+
+**Expected output**: All YAML files parse without error, test count unchanged

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -51,12 +51,7 @@ echo -e "${BLUE}╚════════════════════�
 
 # Step 1: Type Check
 print_header "1/4: Type Check"
-if bun run typecheck; then
-  print_warning "Type check completed (no TypeScript configured yet)"
-else
-  print_error "Type check failed"
-  exit 1
-fi
+print_warning "SKIPPED (no TypeScript in project)"
 
 # Step 2: Lint
 print_header "2/4: Lint"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -51,12 +51,7 @@ echo -e "${BLUE}╚════════════════════�
 
 # Step 1: Type Check
 print_header "1/4: Type Check"
-if bun run typecheck; then
-  print_success "Type check passed"
-else
-  print_error "Type check failed"
-  exit 1
-fi
+print_warning "SKIPPED (no TypeScript in project)"
 
 # Step 2: Lint
 print_header "2/4: Lint"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -51,7 +51,12 @@ echo -e "${BLUE}╚════════════════════�
 
 # Step 1: Type Check
 print_header "1/4: Type Check"
-print_warning "SKIPPED (no TypeScript in project)"
+if bun run typecheck; then
+  print_warning "Type check completed (no TypeScript configured yet)"
+else
+  print_error "Type check failed"
+  exit 1
+fi
 
 # Step 2: Lint
 print_header "2/4: Lint"

--- a/test/check-script.test.js
+++ b/test/check-script.test.js
@@ -38,10 +38,10 @@ describe('scripts/validate.sh', () => {
     test('should run checks in correct order', () => {
       const content = fs.readFileSync(checkScriptPath, 'utf-8');
 
-      // Check that commands appear in order
-      const typecheckIndex = content.indexOf('typecheck');
-      const lintIndex = content.indexOf('lint');
-      const testIndex = content.indexOf('test');
+      // Check that step headers appear in order
+      const typecheckIndex = content.indexOf('Type Check');
+      const lintIndex = content.indexOf('Lint');
+      const testIndex = content.indexOf('Tests');
 
       expect(typecheckIndex > 0).toBeTruthy();
       expect(lintIndex > typecheckIndex).toBeTruthy();

--- a/test/scripts/dep-guard.test.js
+++ b/test/scripts/dep-guard.test.js
@@ -280,7 +280,7 @@ ENDJSON
       expect(result.stdout).toContain('forge-other');
       expect(result.stdout).toContain('dependency');
       expect(result.stdout).toContain('Confidence: LOW');
-    });
+    }, 15000);
 
     test('overlap report includes actionable options', () => {
       // Reuse the overlapping mock from previous test


### PR DESCRIPTION
## Summary
- **validate.sh**: Step 1 honestly reports "SKIPPED (no TypeScript)" instead of falsely claiming type check passed
- **CI workflows**: Add missing path filters to 5 workflows, remove redundant ESLint schedule, bump yaml-lint setup-bun v1→v2
- **test.yml**: Add `packages/**` so workspace package changes trigger CI tests

## Design Doc
See: [docs/plans/2026-03-20-quality-gates-design.md](docs/plans/2026-03-20-quality-gates-design.md)

## Beads Issues
Closes forge-mr0l (validate.sh typecheck stub & cross-platform)
Closes forge-ypeh (CI path filter gaps, mutation noise)
Tracking: forge-twiw

## Changes by File

| File | Change |
|------|--------|
| `scripts/validate.sh` | Step 1: honest skip instead of false "passed" |
| `.github/workflows/test.yml` | Add `packages/**` to path filters |
| `.github/workflows/eslint.yml` | Add code-only path filters, remove weekly schedule |
| `.github/workflows/codeql.yml` | Add code-only path filters on push/PR (weekly kept) |
| `.github/workflows/size-check.yml` | Add package-relevant path filters |
| `.github/workflows/dependency-review.yml` | Scope to `package.json` only |
| `.github/workflows/yaml-lint.yml` | Bump `setup-bun@v1` → `@v2` |

## Key Decisions
1. **Keep 4-step numbering in validate.sh** — slot stays ready for when TypeScript is added
2. **Remove ESLint weekly schedule** — redundant since it runs on every PR already
3. **Keep CodeQL weekly schedule** — weekly full scans catch things path-filtered PR runs miss
4. **ESLint paths include `*.js` and `.claude/**/*.js`** — covers root config files and agent scripts

## Security Review
- OWASP A05 (Security Misconfiguration): Path filters are additive only, no checks removed. CodeQL weekly preserved.
- OWASP A08 (Data Integrity): No quality gates weakened, only triggers refined.
- `bun audit`: No vulnerabilities found

## Test Plan
- [x] Type check: exit 0 (no TS — skipped)
- [x] Lint: exit 0, 0 errors, 0 warnings
- [x] Security audit: No vulnerabilities
- [x] Tests: 1667 pass, 9 fail (pre-existing), no regressions
- [x] All 6 modified YAML files parse correctly
- [x] validate.sh prints honest skip message

Decision gates fired: 0 (plan quality: Excellent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge; all quality gates are preserved or improved, with only minor style inconsistencies.
- The changes are surgical and well-scoped. Path filters are strictly additive, no security checks are weakened, and the weekly CodeQL scan is preserved as a full-coverage backstop. The two flagged issues (final banner wording and shallow docs glob) are cosmetic/minor and don't affect CI correctness or security posture.
- scripts/validate.sh (final banner wording), .github/workflows/size-check.yml (docs/*.md shallow glob)
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `scripts/validate.sh`, line 88-91 ([link](https://github.com/harshanandak/forge/blob/7d714a930f8fd89429aa97c1c336ecd75e69a2de/scripts/validate.sh#L88-L91)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Final banner says "All Checks Passed" when Step 1 was skipped**

   After the PR's change, Step 1 is explicitly skipped (with a `print_warning`), yet the closing banner still declares `✓ All Checks Passed Successfully`. A developer running the script could mistake this to mean type-checking actually ran and passed, which is the exact false impression the PR aims to fix.

   A small wording tweak would keep the banner honest:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/validate.sh
   Line: 88-91

   Comment:
   **Final banner says "All Checks Passed" when Step 1 was skipped**

   After the PR's change, Step 1 is explicitly skipped (with a `print_warning`), yet the closing banner still declares `✓ All Checks Passed Successfully`. A developer running the script could mistake this to mean type-checking actually ran and passed, which is the exact false impression the PR aims to fix.

   A small wording tweak would keep the banner honest:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `scripts/validate.sh`, line 54-59 ([link](https://github.com/harshanandak/forge/blob/cf14623bb62c3beb5abc494ca22fd2a492b03475/scripts/validate.sh#L54-L59)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Typecheck command still runs despite "SKIPPED" intent**

   The PR description, design doc, and task list all state the goal is to replace the `bun run typecheck` call with an unconditional skip message — "instead of calling `bun run typecheck`" (quote from the task doc). However, the implementation still executes `bun run typecheck` inside the `if` condition. The warning only prints when the command **succeeds**, which means:

   1. If someone later wires a real `tsc` call into `package.json`'s `typecheck` script, this gate will run a type check but then misleadingly print "Type check completed (no TypeScript configured yet)" on success — silently masking real failures under an "honest skip" message.
   2. A failed `typecheck` exits through the `else` branch with `exit 1` and "Type check failed", not a graceful skip.

   The intended implementation per the design doc is to remove the command entirely and unconditionally emit the warning:

   ``markdown
   This is a comment left during a code review.
   Path: scripts/validate.sh
   Line: 54-59

   Comment:
   **Typecheck command still runs despite "SKIPPED" intent**

   The PR description, design doc, and task list all state the goal is to replace the `bun run typecheck` call with an unconditional skip message — "instead of calling `bun run typecheck`" (quote from the task doc). However, the implementation still executes `bun run typecheck` inside the `if` condition. The warning only prints when the command **succeeds**, which means:

   1. If someone later wires a real `tsc` call into `package.json`'s `typecheck` script, this gate will run a type check but then misleadingly print "Type check completed (no TypeScript configured yet)" on success — silently masking real failures under an "honest skip" message.
   2. A failed `typecheck` exits through the `else` branch with `exit 1` and "Type check failed", not a graceful skip.

   The intended implementation per the design doc is to remove the command entirely and unconditionally emit the warning:

   ``
   </details>

3. `scripts/validate.sh`, line 54-59 ([link](https://github.com/harshanandak/forge/blob/9386d16a4bd0c39e85f36047207e4da31d7bf786/scripts/validate.sh#L54-L59)) 

   **Typecheck still executes — not actually skipped**

   The implementation changes the success message from green to yellow, but `bun run typecheck` is still called. The PR description and design doc both say the intent is to *replace* the `bun run typecheck` call with a `print_warning` that says "SKIPPED (no TypeScript in project)" — bypassing execution entirely.

   As written, the warning only appears when `bun run typecheck` exits 0. If the `typecheck` script in `package.json` is ever updated to actually invoke `tsc` (which is the stated future use case), the warning path is silently replaced by real typecheck behaviour without any other change to `validate.sh` — which is fine — but until then the command is being needlessly run. More critically, the displayed message ("Type check completed…") conflicts with the PR description, the design doc expected output ("SKIPPED (no TypeScript in project)"), and the test plan ("[x] Type check: exit 0 (no TS — skipped)").

   To match the documented intent:

   

   This removes the dependency on `bun run typecheck` and matches the success criteria stated in the design doc. When TypeScript is eventually added the block can be swapped back to the real check.

4. `.github/workflows/size-check.yml`, line 12-13 ([link](https://github.com/harshanandak/forge/blob/9386d16a4bd0c39e85f36047207e4da31d7bf786/.github/workflows/size-check.yml#L12-L13)) 

   **`docs/*.md` glob misses subdirectory docs**

   The pattern `docs/*.md` uses a single `*` which only matches Markdown files directly inside `docs/`, not in any subdirectory. This PR itself adds three new files under `docs/plans/` (`2026-03-20-quality-gates-decisions.md`, `2026-03-20-quality-gates-design.md`, `2026-03-20-quality-gates-tasks.md`). Those files are included in the measured package size (the `du` command does not exclude `docs/`), but changes to them will never trigger the size-check workflow.

   

   Same fix applies to the identical pattern on the `pull_request` trigger (line 27).

5. `scripts/validate.sh`, line 89-91 ([link](https://github.com/harshanandak/forge/blob/847483546a4cc2b3619eb8358efd9cc8da62a067/scripts/validate.sh#L89-L91)) 

   **Final banner contradicts the PR's honesty goal**

   The PR's stated goal is quality gate honesty — step 1 now correctly reports "SKIPPED". However, the final success banner unconditionally prints "All Checks Passed Successfully" even though step 1 was skipped rather than passing. This is a small but direct contradiction of the honesty intent.

   Consider updating the banner to reflect that some steps were skipped:


6. `.github/workflows/size-check.yml`, line 12 ([link](https://github.com/harshanandak/forge/blob/847483546a4cc2b3619eb8358efd9cc8da62a067/.github/workflows/size-check.yml#L12)) 

   **Shallow glob won't match nested docs (e.g. `docs/plans/`)**

   The `docs/*.md` pattern only matches top-level markdown files directly under `docs/` (e.g., `docs/README.md`). Files in subdirectories like `docs/plans/*.md` — including the three new plan documents added by this very PR — won't trigger the size check. If generated or design docs in subdirectories grow large and end up included in the published package, the size check will silently miss them.

   If the intent is to monitor any markdown under `docs/` that gets shipped, consider:

   

   If the intent is explicitly to track only root-level docs, a comment clarifying this would prevent future confusion.

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/validate.sh
Line: 89-91

Comment:
**Final banner contradicts the PR's honesty goal**

The PR's stated goal is quality gate honesty — step 1 now correctly reports "SKIPPED". However, the final success banner unconditionally prints "All Checks Passed Successfully" even though step 1 was skipped rather than passing. This is a small but direct contradiction of the honesty intent.

Consider updating the banner to reflect that some steps were skipped:

```suggestion
echo -e "${GREEN}╔═══════════════════════════════════════════╗${NC}"
echo -e "${GREEN}║   ✓ All Active Checks Passed Successfully ║${NC}"
echo -e "${GREEN}╚═══════════════════════════════════════════╝${NC}"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/size-check.yml
Line: 12

Comment:
**Shallow glob won't match nested docs (e.g. `docs/plans/`)**

The `docs/*.md` pattern only matches top-level markdown files directly under `docs/` (e.g., `docs/README.md`). Files in subdirectories like `docs/plans/*.md` — including the three new plan documents added by this very PR — won't trigger the size check. If generated or design docs in subdirectories grow large and end up included in the published package, the size check will silently miss them.

If the intent is to monitor any markdown under `docs/` that gets shipped, consider:

```suggestion
      - 'docs/**/*.md'
```

If the intent is explicitly to track only root-level docs, a comment clarifying this would prevent future confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: validate.sh unc..."](https://github.com/harshanandak/forge/commit/847483546a4cc2b3619eb8358efd9cc8da62a067)</sub>

<!-- /greptile_comment -->