### PR TITLE
fix: PR #69 follow-up — --yes --quick combo, progress output, test accuracy (#70)

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -3713,17 +3713,9 @@ async function executeSetup(config) {
     ? loadAndSetupClaudeCommands(agents)
     : loadClaudeCommands(agents);
 
-  // Setup non-claude agents — claude is already set up by loadAndSetupClaudeCommands above
-  // For non-claude-selected runs, all agents go through setupAgent normally
-  const remainingAgents = agents.includes('claude')
-    ? agents.filter(a => a !== 'claude')
-    : agents;
-  remainingAgents.forEach(agentKey => {
-    setupAgent(agentKey, claudeCommands);
-  });
-
-  console.log('');
-  console.log('Agent configuration complete!');
+  // Setup agents with progress output (setupSelectedAgents skips claude internally
+  // since loadAndSetupClaudeCommands already handled it above)
+  setupSelectedAgents(agents, claudeCommands);
 
   // Install git hooks for TDD enforcement
   console.log('');
@@ -3821,8 +3813,8 @@ async function main() {
 
     // Quick mode
     if (flags.quick) {
-      // If no agents specified in quick mode, use all
-      if (selectedAgents.length === 0) {
+      // If no explicit agents specified, use all (--yes default doesn't count)
+      if (selectedAgents.length === 0 || (flags.yes && !flags.agents)) {
         selectedAgents = Object.keys(AGENTS);
       }
       await quickSetup(selectedAgents, flags.skipExternal);

--- a/test/setup-shared-helper.test.js
+++ b/test/setup-shared-helper.test.js
@@ -51,9 +51,9 @@ describe('executeSetup shared helper (forge-cpnj)', () => {
       nextFunc2 > -1 ? nextFunc2 : Infinity
     );
     const funcBody = content.substring(funcStart, funcEnd);
-    // Should call setupAgent
-    expect(funcBody).toContain('setupAgent(');
-    // Should NOT have the claude exclusion guard
+    // Should call setupSelectedAgents for consistent progress output
+    expect(funcBody).toContain('setupSelectedAgents(');
+    // Should NOT have the bare claude exclusion guard
     expect(funcBody).not.toContain("agentKey !== 'claude'");
   });
 
@@ -78,7 +78,7 @@ describe('executeSetup shared helper (forge-cpnj)', () => {
     expect(funcBody).toContain('handleExternalServices');
   });
 
-  test('executeSetup accepts config object with agents, skipExternal, yes properties', () => {
+  test('executeSetup accepts config object with agents and skipExternal properties', () => {
     const funcStart = content.indexOf('async function executeSetup(');
     expect(funcStart).toBeGreaterThan(-1);
     const funcBody = content.substring(funcStart, funcStart + 200);


### PR DESCRIPTION
## Summary

Follow-up fixes for 3 review comments on PR #69 that were not addressed before merge.

1. **--yes --quick combo**: `--yes` was overriding `--quick`'s "all agents" default. Now `--quick` overrides `--yes` default when no explicit `--agents` given.
2. **Progress output**: `executeSetup` now uses `setupSelectedAgents()` instead of bare `forEach`, giving consistent `[1/N] Setting up...` progress output across all setup paths.
3. **Test description**: Updated `setup-shared-helper.test.js` to accurately describe `executeSetup` config (`agents`, `skipExternal` only — `yes` is not passed through).

## Beads Issue
Closes forge-2irr

## Test Plan
- [x] All 38 PR-specific tests pass
- [x] Lint: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — all three fixes are correct, well-scoped, and backed by updated tests.
- The changes are small and targeted. The `--yes --quick` flag logic is correct across all edge cases, the `setupSelectedAgents` delegation works correctly because the function already internally guards against double-claude-setup, and the test updates accurately reflect the implementation. No regressions or new issues introduced.
- No files require special attention.
</details>

<sub>Last reviewed commit: ["fix: PR #69 follow-u..."](https://github.com/harshanandak/forge/commit/1b69272b6cdcde5e8d135703c5f9d240d639d3e7)</sub>

<!-- /greptile_comment -->