### PR TITLE
feat: GitHub ↔ Beads sync — setup, reverse sync, docs (PR 2/2)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -73,6 +73,8 @@ Related to beads-yyy
 - Closes #
 - Related to #
 
+> **Note**: `Closes #N` closes the GitHub issue on merge. If GitHub-Beads sync is enabled, the linked Beads issue is auto-closed too.
+
 ---
 
 ## ✅ Merge Criteria (All Must Be Met)

--- a/.github/workflows/beads-to-github.yml
+++ b/.github/workflows/beads-to-github.yml
@@ -1,0 +1,50 @@
+name: Beads → GitHub Issue Sync
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.beads/**'
+
+# Serialize with forward-sync to prevent race conditions
+concurrency:
+  group: beads-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  reverse-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard — skip loop commits
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [[ "$COMMIT_MSG" == chore\(beads\):* ]]; then
+            echo "Loop guard: skipping chore(beads): commit"
+            echo "SKIP=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Checkout current
+        if: env.SKIP != 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect and close
+        if: env.SKIP != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get old and new versions of .beads/issues.jsonl
+          OLD_CONTENT=$(git show HEAD~1:.beads/issues.jsonl 2>/dev/null || echo "")
+          NEW_CONTENT=$(cat .beads/issues.jsonl 2>/dev/null || echo "")
+
+          # Export via temp files to avoid shell injection
+          printf '%s' "$OLD_CONTENT" > /tmp/old-issues.jsonl
+          printf '%s' "$NEW_CONTENT" > /tmp/new-issues.jsonl
+
+          node scripts/github-beads-sync/reverse-sync-cli.mjs /tmp/old-issues.jsonl /tmp/new-issues.jsonl

--- a/.github/workflows/beads-to-github.yml
+++ b/.github/workflows/beads-to-github.yml
@@ -32,15 +32,21 @@ jobs:
         if: env.SKIP != 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect and close
         if: env.SKIP != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           # Get old and new versions of .beads/issues.jsonl
-          OLD_CONTENT=$(git show HEAD~1:.beads/issues.jsonl 2>/dev/null || echo "")
+          # Use github.event.before (pre-push SHA) to catch multi-commit pushes
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE_SHA" ]; then
+            OLD_CONTENT=""
+          else
+            OLD_CONTENT=$(git show "$BEFORE_SHA":.beads/issues.jsonl 2>/dev/null || echo "")
+          fi
           NEW_CONTENT=$(cat .beads/issues.jsonl 2>/dev/null || echo "")
 
           # Export via temp files to avoid shell injection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,8 @@ Task 2: Validation logic
 
 ## State Management (Single Source of Truth)
 
+> GitHub issue lifecycle may sync to Beads via CI -- see [docs/BEADS_GITHUB_SYNC.md](docs/BEADS_GITHUB_SYNC.md).
+
 **All workflow state stored in Beads metadata** (survives compaction):
 
 ```json

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -47,6 +47,7 @@ const VERSION = packageJson.version;
 
 // Load PluginManager for discoverable agent architecture
 const PluginManager = require('../lib/plugin-manager');
+const { scaffoldGithubBeadsSync } = require('../lib/setup');
 
 // Load enhanced onboarding modules
 const contextMerge = require(path.join(packageDir, 'lib', 'context-merge'));
@@ -1742,6 +1743,19 @@ async function configureExternalServices(rl, question, selectedAgents = [], proj
   // Write all tokens to .env.local (preserving existing values)
   const { added, preserved } = writeEnvTokens(tokens, true);
   displayEnvTokenResults(added, preserved);
+
+  // GitHub-Beads issue sync setup
+  console.log('');
+  const enableSync = await askYesNo(question, 'Enable GitHub ↔ Beads issue sync?', true);
+  if (enableSync) {
+    const result = await scaffoldGithubBeadsSync(projectRoot, packageDir);
+    for (const f of result.created) {
+      console.log(`  Created: ${f}`);
+    }
+    for (const f of result.skipped) {
+      console.log(`  Skipped: ${f} (already exists)`);
+    }
+  }
 }
 
 // Display the Forge banner

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -1748,12 +1748,16 @@ async function configureExternalServices(rl, question, selectedAgents = [], proj
   console.log('');
   const enableSync = await askYesNo(question, 'Enable GitHub ↔ Beads issue sync?', true);
   if (enableSync) {
-    const result = await scaffoldGithubBeadsSync(projectRoot, packageDir);
-    for (const f of result.created) {
-      console.log(`  Created: ${f}`);
-    }
-    for (const f of result.skipped) {
-      console.log(`  Skipped: ${f} (already exists)`);
+    try {
+      const result = await scaffoldGithubBeadsSync(projectRoot, packageDir);
+      for (const f of result.created) {
+        console.log(`  Created: ${f}`);
+      }
+      for (const f of result.skipped) {
+        console.log(`  Skipped: ${f} (already exists)`);
+      }
+    } catch (err) {
+      console.error(`  Error scaffolding GitHub-Beads sync: ${err.message}`);
     }
   }
 }

--- a/docs/BEADS_GITHUB_SYNC.md
+++ b/docs/BEADS_GITHUB_SYNC.md
@@ -1,0 +1,251 @@
+# GitHub <-> Beads Issue Sync
+
+Automatic synchronization between GitHub Issues and Beads issue tracking.
+
+**GitHub Issues** = human/team/public interface.
+**Beads** = AI agent engine (`bd ready`, `bd close`).
+
+Neither side needs to know about the other. Contributors file issues on GitHub; AI agents pick up work via Beads. Status changes propagate automatically.
+
+---
+
+## Architecture
+
+### Phase 1: GitHub -> Beads (CI-driven)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant GH as GitHub Issues
+    participant WF as GitHub Actions
+    participant BD as Beads CLI
+    participant Repo as .beads/ + mapping
+
+    U->>GH: Opens issue #42
+    GH->>WF: issues.opened trigger
+    WF->>WF: Guard checks (bot? skip label? no-beads?)
+    WF->>WF: Idempotency check (existing bot comment?)
+    WF->>BD: bd create --title "..." --type bug --priority 1
+    BD->>Repo: Write .beads/issues.jsonl
+    WF->>Repo: Write .github/beads-mapping.json {"42": "forge-abc"}
+    WF->>GH: Post bot comment <!-- beads-sync:42 -->
+    WF->>Repo: git commit + push
+
+    U->>GH: Closes issue #42
+    GH->>WF: issues.closed trigger
+    WF->>Repo: Read mapping: "42" -> "forge-abc"
+    WF->>BD: bd close forge-abc --reason "Closed via GitHub #42"
+    WF->>Repo: git commit + push
+```
+
+### Phase 2: Beads -> GitHub (push-triggered)
+
+```mermaid
+sequenceDiagram
+    participant AI as AI Agent
+    participant BD as Beads CLI
+    participant Repo as .beads/
+    participant WF as GitHub Actions
+    participant GH as GitHub Issues
+
+    AI->>BD: bd close forge-abc
+    BD->>Repo: Update issues.jsonl
+    AI->>Repo: git push
+    Repo->>WF: push trigger (paths: .beads/**)
+    WF->>WF: Guard: skip if commit msg starts with "chore(beads):"
+    WF->>Repo: Diff issues.jsonl for closed transitions
+    WF->>GH: gh api PATCH /issues/42 state=closed
+```
+
+### Loop Prevention
+
+Three guards prevent infinite ping-pong:
+
+1. **Bot detection** -- workflows skip events from `github-actions[bot]`
+2. **Commit message prefix** -- Phase 2 workflow skips commits starting with `chore(beads):`
+3. **Opt-out label** -- `skip-beads-sync` label on any issue disables sync entirely
+
+---
+
+## Setup
+
+### Via Forge Setup (recommended)
+
+```bash
+bunx forge setup
+# During interactive prompts:
+# "Enable GitHub <-> Beads sync? (y/n)" -> y
+```
+
+This scaffolds:
+- `.github/workflows/github-to-beads.yml`
+- `.github/workflows/beads-to-github.yml` (Phase 2)
+- `.github/beads-mapping.json`
+- `scripts/github-beads-sync/` (Node modules)
+- `scripts/github-beads-sync.config.json`
+
+### Manual Setup
+
+1. Copy workflow files from `templates/` into `.github/workflows/`
+2. Copy `scripts/github-beads-sync/` and `scripts/github-beads-sync.config.json`
+3. Create `.github/beads-mapping.json` with `{}`
+4. Ensure Beads is initialized: `bd init`
+5. Commit and push to enable the workflows
+
+---
+
+## Configuration Reference
+
+All settings live in `scripts/github-beads-sync.config.json`.
+
+### Label and Type Mapping
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `labelToType` | `object` | `{"bug":"bug", "enhancement":"feature", "documentation":"task", "question":"task"}` | Maps GitHub labels to Beads issue types. First matching label wins. |
+| `labelToPriority` | `object` | `{"P0":0, "critical":0, "P1":1, "high":1, "P2":2, "medium":2, "P3":3, "low":3, "P4":4, "backlog":4}` | Maps GitHub labels to Beads priority levels (0-4). First matching label wins. |
+| `defaultType` | `string` | `"task"` | Beads type when no label matches `labelToType`. |
+| `defaultPriority` | `number` | `2` | Beads priority when no label matches `labelToPriority`. |
+| `mapAssignee` | `boolean` | `true` | Whether to copy GitHub assignee to Beads issue on creation. |
+
+### Security Gates (Public Repos)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `publicRepoGate` | `string` | `"none"` | Access control for public repos. See [Security](#security) section. |
+| `gateLabelName` | `string` | `"beads-track"` | Required label when `publicRepoGate` is `"label"`. |
+| `gateAssociations` | `string[]` | `["MEMBER", "COLLABORATOR", "OWNER"]` | Allowed author associations when `publicRepoGate` is `"author_association"`. |
+
+### Example: Custom Configuration
+
+```json
+{
+  "labelToType": {
+    "bug": "bug",
+    "feature": "feature",
+    "chore": "chore",
+    "spike": "task"
+  },
+  "labelToPriority": {
+    "urgent": 0,
+    "important": 1,
+    "normal": 2,
+    "nice-to-have": 3
+  },
+  "defaultType": "task",
+  "defaultPriority": 2,
+  "mapAssignee": true,
+  "publicRepoGate": "author_association",
+  "gateAssociations": ["MEMBER", "COLLABORATOR", "OWNER"]
+}
+```
+
+---
+
+## Security
+
+### Public Repo Gate
+
+On public repos, anyone can open an issue -- which triggers a commit to your default branch via the sync workflow. The `publicRepoGate` setting controls who can trigger sync:
+
+| Value | Behavior | Recommended For |
+|-------|----------|-----------------|
+| `"none"` | All issues sync (default). | Private repos, trusted teams. |
+| `"author_association"` | Only issues from authors in `gateAssociations` sync. | Public repos with known contributors. |
+| `"label"` | Only issues with the `gateLabelName` label sync. A maintainer must add the label. | Public repos accepting external issues. |
+
+### Input Sanitization
+
+- Issue titles and bodies are **never interpolated in shell commands**. The sync scripts use Node `execFile` with array arguments (no shell).
+- Workflow files pass event data via `env:` blocks, never via `${{ }}` in `run:` blocks (prevents GitHub Actions injection).
+- Only title, URL, mapped type, and priority are stored in Beads -- raw issue body is not committed.
+
+### SHA-Pinned Actions
+
+All third-party actions in the workflow files are pinned to full commit SHAs, not tags. This prevents supply-chain attacks via tag mutation.
+
+```yaml
+# Good: SHA-pinned
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+
+# Bad: tag-only (never used)
+- uses: actions/checkout@v4
+```
+
+---
+
+## Opt-Out
+
+Two ways to prevent an issue from syncing:
+
+1. **Label**: Add `skip-beads-sync` to the GitHub issue. The workflow checks labels before processing.
+2. **Body keyword**: Include `no-beads` anywhere in the issue body. Useful for quick one-off exclusions.
+
+Both are checked at the `issues.opened` trigger. If added after creation, they prevent close-sync but not the already-created Beads issue.
+
+---
+
+## Troubleshooting
+
+### Sync not triggering
+
+- **Check workflow is enabled**: Go to Actions tab in GitHub, verify `github-to-beads` workflow exists and is active.
+- **Check branch**: Workflows must exist on the default branch (usually `main` or `master`).
+- **Check permissions**: The workflow needs `contents: write` and `issues: write` permissions.
+
+### Duplicate Beads issues
+
+- The workflow checks for an existing `<!-- beads-sync:N -->` bot comment before creating. If the comment was deleted, a duplicate may be created.
+- Fix: Check `.github/beads-mapping.json` for the existing mapping and manually remove the duplicate Beads issue with `bd delete`.
+
+### Loop detection firing incorrectly
+
+- If legitimate commits starting with `chore(beads):` are being skipped by the Phase 2 workflow, rename the commit prefix in the workflow file.
+- The bot-actor check uses `github.actor` -- ensure your CI bot user matches the expected name.
+
+### Mapping file conflicts
+
+- If two issues are created simultaneously, the `git push` for the second may fail due to a stale mapping file.
+- The workflow retries with `git pull --rebase` up to 3 times. If it still fails, the workflow run will show as failed -- re-run it manually.
+
+### `bd` command not found in CI
+
+- The workflow installs Beads fresh each run: `bun add -g @beads/bd`.
+- If this fails, check that the workflow uses a runner with Node/Bun available.
+
+---
+
+## Fork Behavior
+
+Sync does **not** work in forks. The `GITHUB_TOKEN` provided to forked repo workflows is scoped to the fork and cannot write to the upstream repo's `.beads/` directory or post comments on upstream issues.
+
+When a fork PR uses `Closes #N`, GitHub closes the issue on the **upstream** repo on merge. This triggers the upstream's `issues.closed` workflow, which handles the Beads close normally.
+
+---
+
+## GitHub Projects Integration
+
+This plugin creates well-labeled GitHub issues but does **not** manage GitHub Projects boards. Use GitHub's built-in automation instead:
+
+### Setting Up Auto-Add to Project
+
+1. Go to your GitHub Project (Projects tab on your profile or org)
+2. Click the `...` menu, then **Workflows**
+3. Enable **"Auto-add to project"**
+4. Set the filter, for example: `is:issue is:open label:bug,enhancement`
+5. All matching issues (including those created by the sync) will auto-appear on your board
+
+### Recommended Project Views
+
+- **Board view**: Columns for `Open`, `In Progress`, `Done` -- map to Beads statuses
+- **Table view**: Add `Labels`, `Assignees`, `Priority` fields for triage
+- **Filter by label**: Use the labels mapped in your config to create focused views
+
+This approach is more flexible than automating board placement -- you control the filters and views entirely within GitHub's UI.
+
+---
+
+## Related Documentation
+
+- [Design doc](plans/2026-03-21-github-beads-sync-design.md) -- full design decisions, OWASP analysis, and edge cases
+- [Toolchain reference](TOOLCHAIN.md) -- Beads CLI commands, installation, and troubleshooting

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -109,10 +109,66 @@ async function markStepComplete(projectPath, stepName) {
   await saveSetupState(projectPath, state);
 }
 
+/**
+ * Scaffold GitHub-Beads sync files into a target project.
+ * Copies workflow, config, and mapping template — never overwrites existing files.
+ *
+ * @param {string} projectPath - Target project root
+ * @param {string} pkgDir - Forge package directory (source of template files)
+ * @returns {Promise<{created: string[], skipped: string[]}>}
+ */
+async function scaffoldGithubBeadsSync(projectPath, pkgDir) {
+  const created = [];
+  const skipped = [];
+
+  const files = [
+    {
+      src: path.join(pkgDir, '.github', 'workflows', 'github-to-beads.yml'),
+      dest: path.join('.github', 'workflows', 'github-to-beads.yml'),
+    },
+    {
+      src: path.join(pkgDir, 'scripts', 'github-beads-sync.config.json'),
+      dest: path.join('scripts', 'github-beads-sync.config.json'),
+    },
+    {
+      src: null, // generated in-place (empty mapping template)
+      dest: path.join('.github', 'beads-mapping.json'),
+      content: '{}',
+    },
+  ];
+
+  for (const file of files) {
+    const destPath = path.join(projectPath, file.dest);
+
+    // Never overwrite existing files — preserve user customizations
+    if (fs.existsSync(destPath)) {
+      skipped.push(file.dest);
+      continue;
+    }
+
+    // Ensure parent directory exists
+    const destDir = path.dirname(destPath);
+    await fs.promises.mkdir(destDir, { recursive: true });
+
+    if (file.src) {
+      // Copy from template
+      await fs.promises.copyFile(file.src, destPath);
+    } else {
+      // Write generated content
+      await fs.promises.writeFile(destPath, file.content, 'utf-8');
+    }
+
+    created.push(file.dest);
+  }
+
+  return { created, skipped };
+}
+
 module.exports = {
   saveSetupState,
   loadSetupState,
   isSetupComplete,
   getNextStep,
-  markStepComplete
+  markStepComplete,
+  scaffoldGithubBeadsSync
 };

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -121,10 +121,23 @@ async function scaffoldGithubBeadsSync(projectPath, pkgDir) {
   const created = [];
   const skipped = [];
 
+  // Sync script modules that workflows depend on at runtime
+  const syncScripts = [
+    'config.mjs', 'mapping.mjs', 'comment.mjs', 'github-api.mjs',
+    'sanitize.mjs', 'run-bd.mjs', 'label-mapper.mjs', 'index.mjs',
+    'reverse-sync.mjs', 'reverse-sync-cli.mjs',
+  ];
+
   const files = [
+    // Phase 1: GitHub → Beads
     {
       src: path.join(pkgDir, '.github', 'workflows', 'github-to-beads.yml'),
       dest: path.join('.github', 'workflows', 'github-to-beads.yml'),
+    },
+    // Phase 2: Beads → GitHub
+    {
+      src: path.join(pkgDir, '.github', 'workflows', 'beads-to-github.yml'),
+      dest: path.join('.github', 'workflows', 'beads-to-github.yml'),
     },
     {
       src: path.join(pkgDir, 'scripts', 'github-beads-sync.config.json'),
@@ -135,6 +148,11 @@ async function scaffoldGithubBeadsSync(projectPath, pkgDir) {
       dest: path.join('.github', 'beads-mapping.json'),
       content: '{}',
     },
+    // Sync script modules
+    ...syncScripts.map((name) => ({
+      src: path.join(pkgDir, 'scripts', 'github-beads-sync', name),
+      dest: path.join('scripts', 'github-beads-sync', name),
+    })),
   ];
 
   for (const file of files) {

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -236,10 +236,10 @@ export function handleClosed(event, options = {}) {
     return { skipped: true, reason: `closed as ${stateReason}` };
   }
 
-  // 4. Read mapping
+  // 5. Read mapping
   let beadsId = getBeadsId(mappingPath, issueNumber);
 
-  // 5. Fallback: find via sync comment
+  // 6. Fallback: find via sync comment
   if (!beadsId) {
     const comment = findSyncComment(owner, repo, issueNumber);
     if (comment) {
@@ -251,12 +251,12 @@ export function handleClosed(event, options = {}) {
     }
   }
 
-  // 6. No beads link found
+  // 7. No beads link found
   if (!beadsId) {
     return { skipped: true, reason: 'no beads link found' };
   }
 
-  // 7. Check if already closed
+  // 8. Check if already closed
   const status = bdShow(beadsId);
   if (status === null) {
     return { skipped: true, reason: 'could not determine beads status' };
@@ -265,10 +265,10 @@ export function handleClosed(event, options = {}) {
     return { skipped: true, reason: 'already closed' };
   }
 
-  // 8. Close beads issue
+  // 9. Close beads issue
   bdClose(beadsId, `Closed via GitHub issue #${issueNumber}`);
 
-  // 9. Return success
+  // 10. Return success
   return { success: true, beadsId, issueNumber };
 }
 

--- a/scripts/github-beads-sync/reverse-sync-cli.mjs
+++ b/scripts/github-beads-sync/reverse-sync-cli.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for Beads → GitHub reverse sync.
+ * Usage: node reverse-sync-cli.mjs <old-jsonl-path> <new-jsonl-path>
+ *
+ * @module scripts/github-beads-sync/reverse-sync-cli
+ */
+
+import { readFileSync } from 'node:fs';
+import { handleBeadsClosed } from './reverse-sync.mjs';
+
+const oldPath = process.argv[2];
+const newPath = process.argv[3];
+
+if (!oldPath || !newPath) {
+  console.error('Usage: node reverse-sync-cli.mjs <old-jsonl-path> <new-jsonl-path>');
+  process.exit(1);
+}
+
+const oldContent = readFileSync(oldPath, 'utf-8');
+const newContent = readFileSync(newPath, 'utf-8');
+
+const result = handleBeadsClosed(oldContent, newContent);
+console.log(JSON.stringify(result, null, 2));
+
+if (result.errors.length > 0) {
+  console.error(`${result.errors.length} issue(s) failed to close on GitHub`);
+  process.exit(1);
+}
+
+console.log(`Closed ${result.closed.length} GitHub issue(s), skipped ${result.skipped.length}`);

--- a/scripts/github-beads-sync/reverse-sync.mjs
+++ b/scripts/github-beads-sync/reverse-sync.mjs
@@ -1,0 +1,138 @@
+/**
+ * Reverse sync: Beads → GitHub.
+ * When a Beads issue is closed (via git push updating .beads/),
+ * close the linked GitHub issue.
+ *
+ * @module scripts/github-beads-sync/reverse-sync
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Parse JSONL lines into an array of objects, skipping empty/malformed lines.
+ * @param {string[]} lines - Array of JSONL strings
+ * @returns {Array<{id: string, status: string, description?: string}>}
+ */
+function parseJsonlLines(lines) {
+  const results = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed);
+      if (obj && obj.id) results.push(obj);
+    } catch (_err) {
+      // Skip malformed lines
+    }
+  }
+  return results;
+}
+
+/**
+ * Detect Beads issues that transitioned to "closed" status.
+ * Only detects transitions: issue must exist in oldLines as non-closed,
+ * and appear in newLines as "closed".
+ *
+ * @param {string[]} oldLines - JSONL lines from previous .beads/issues.jsonl
+ * @param {string[]} newLines - JSONL lines from current .beads/issues.jsonl
+ * @returns {Array<{id: string, description: string}>} Issues that transitioned to closed
+ */
+export function detectClosedIssues(oldLines, newLines) {
+  const oldMap = new Map();
+  for (const issue of parseJsonlLines(oldLines)) {
+    oldMap.set(issue.id, issue.status);
+  }
+
+  const closed = [];
+  for (const issue of parseJsonlLines(newLines)) {
+    if (issue.status !== 'closed') continue;
+    const oldStatus = oldMap.get(issue.id);
+    // Must have existed before and not been closed already
+    if (oldStatus == null || oldStatus === 'closed') continue;
+    closed.push({ id: issue.id, description: issue.description || '' });
+  }
+  return closed;
+}
+
+/**
+ * Extract GitHub owner, repo, and issue number from a description string
+ * containing a GitHub issue URL.
+ *
+ * @param {string|null|undefined} description - Text that may contain a GitHub issue URL
+ * @returns {{owner: string, repo: string, issueNumber: number}|null}
+ */
+export function extractGitHubUrl(description) {
+  if (!description) return null;
+  const match = description.match(
+    /https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/,
+  );
+  if (!match) return null;
+  return {
+    owner: match[1],
+    repo: match[2],
+    issueNumber: parseInt(match[3], 10),
+  };
+}
+
+/**
+ * Close a GitHub issue using the `gh api` CLI.
+ * Uses execFileSync with array args (no shell).
+ *
+ * @param {string} owner - Repository owner
+ * @param {string} repo - Repository name
+ * @param {number|string} issueNumber - Issue number
+ */
+export function closeGitHubIssue(owner, repo, issueNumber) {
+  execFileSync('gh', [
+    'api',
+    `repos/${owner}/${repo}/issues/${issueNumber}`,
+    '-X', 'PATCH',
+    '-f', 'state=closed',
+  ], { encoding: 'utf-8' });
+}
+
+/**
+ * Handle Beads-to-GitHub reverse sync.
+ * Detects issues that transitioned to closed in .beads/issues.jsonl
+ * and closes the linked GitHub issues.
+ *
+ * @param {string} oldContent - Previous .beads/issues.jsonl content
+ * @param {string} newContent - Current .beads/issues.jsonl content
+ * @param {object} [deps] - Dependency injection
+ * @param {Function} [deps.closeGitHubIssue] - Override for testing
+ * @returns {{closed: Array, skipped: Array, errors: Array}}
+ */
+export function handleBeadsClosed(oldContent, newContent, deps = {}) {
+  const closeFn = deps.closeGitHubIssue ?? closeGitHubIssue;
+
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+
+  const transitions = detectClosedIssues(oldLines, newLines);
+
+  const closed = [];
+  const skipped = [];
+  const errors = [];
+
+  for (const issue of transitions) {
+    const parsed = extractGitHubUrl(issue.description);
+    if (!parsed) {
+      skipped.push({ beadsId: issue.id, reason: 'no GitHub URL' });
+      continue;
+    }
+
+    try {
+      closeFn(parsed.owner, parsed.repo, parsed.issueNumber);
+      closed.push({
+        beadsId: issue.id,
+        owner: parsed.owner,
+        repo: parsed.repo,
+        issueNumber: parsed.issueNumber,
+      });
+    } catch (err) {
+      errors.push({ beadsId: issue.id, error: err.message });
+    }
+  }
+
+  return { closed, skipped, errors };
+}

--- a/test/scripts/dep-guard.test.js
+++ b/test/scripts/dep-guard.test.js
@@ -2,7 +2,10 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
-const { describe, test, expect, beforeAll, afterAll } = require('bun:test');
+const { describe, test, expect, beforeAll, afterAll, setDefaultTimeout } = require('bun:test');
+
+// bash + mock script spawning can exceed default 5s on Windows CI
+setDefaultTimeout(15000);
 
 /**
  * Tests for scripts/dep-guard.sh
@@ -162,7 +165,7 @@ describe('scripts/dep-guard.sh', () => {
     });
   });
 
-  describe('check-ripple', { timeout: 15000 }, () => {
+  describe('check-ripple', () => {
     /** @type {string[]} */
     const mockFiles = [];
     /** @type {string[]} */
@@ -198,7 +201,7 @@ describe('scripts/dep-guard.sh', () => {
       const result = runDepGuard(['check-ripple', 'forge-nonexistent'], { BD_CMD: mock });
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/not found|Failed|Error/i);
-    }, 15000);
+    });
 
     test('warns and skips when title extraction fails', () => {
       // Mock bd: show returns JSON with no title field
@@ -214,7 +217,7 @@ describe('scripts/dep-guard.sh', () => {
       const result = runDepGuard(['check-ripple', 'forge-xyz'], { BD_CMD: mock });
       expect(result.status).toBe(0);
       expect(result.stderr).toContain('could not extract title');
-    }, 15000);
+    });
 
     test('warns and skips when bd list returns empty', () => {
       const mock = createMockBd(`
@@ -229,7 +232,7 @@ describe('scripts/dep-guard.sh', () => {
       const result = runDepGuard(['check-ripple', 'forge-xyz'], { BD_CMD: mock });
       expect(result.status).toBe(0);
       expect(result.stderr).toContain('could not fetch active issue list');
-    }, 15000);
+    });
 
     test('no conflicts when source is the only active issue', () => {
       // Mock bd: show returns JSON for the source, list returns only the source
@@ -253,7 +256,7 @@ ENDJSON
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('No conflicts detected');
       expect(result.stdout).toContain('forge-abc');
-    }, 15000);
+    });
 
     test('keyword overlap found between source and another issue', () => {
       // Mock bd: two issues with overlapping keywords "dependency" and "plan"
@@ -280,7 +283,7 @@ ENDJSON
       expect(result.stdout).toContain('forge-other');
       expect(result.stdout).toContain('dependency');
       expect(result.stdout).toContain('Confidence: LOW');
-    }, 15000);
+    });
 
     test('overlap report includes actionable options', () => {
       // Reuse the overlapping mock from previous test
@@ -306,7 +309,7 @@ ENDJSON
       // Should contain the options section
       expect(result.stdout).toContain('bd dep add forge-src forge-other');
       expect(result.stdout).toContain('bd show forge-other');
-    }, 15000);
+    });
 
     test('no overlap when terms are too short or all stop words', () => {
       // Issues share only stop words / short terms: "add", "the", "is", "to"
@@ -330,7 +333,7 @@ ENDJSON
       const result = runDepGuard(['check-ripple', 'forge-aaa'], { BD_CMD: mock });
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('No conflicts detected');
-    }, 15000);
+    });
 
     test('prints structured analyzer output from Beads JSON and task-file context', () => {
       const repositoryRoot = createTempRepo({
@@ -402,7 +405,7 @@ ENDJSON
       expect(result.stdout).toContain('forge-other depends on forge-src');
       expect(result.stdout).toContain('Pros:');
       expect(result.stdout).toContain('Cons:');
-    }, 15000);
+    });
 
     test('falls back to keyword-only report when the analyzer cannot run', () => {
       const repositoryRoot = createTempRepo({
@@ -458,7 +461,7 @@ ENDJSON
       expect(result.stdout).toContain('Potential overlap');
       expect(result.stdout).toContain('Confidence: LOW');
       expect(result.stdout).toContain('bd dep add forge-src forge-other');
-    }, 15000);
+    });
   });
 
   describe('extract-contracts', () => {

--- a/test/scripts/dep-guard.test.js
+++ b/test/scripts/dep-guard.test.js
@@ -198,7 +198,7 @@ describe('scripts/dep-guard.sh', () => {
       const result = runDepGuard(['check-ripple', 'forge-nonexistent'], { BD_CMD: mock });
       expect(result.status).toBe(1);
       expect(result.stderr).toMatch(/not found|Failed|Error/i);
-    });
+    }, 15000);
 
     test('warns and skips when title extraction fails', () => {
       // Mock bd: show returns JSON with no title field
@@ -229,7 +229,7 @@ describe('scripts/dep-guard.sh', () => {
       const result = runDepGuard(['check-ripple', 'forge-xyz'], { BD_CMD: mock });
       expect(result.status).toBe(0);
       expect(result.stderr).toContain('could not fetch active issue list');
-    });
+    }, 15000);
 
     test('no conflicts when source is the only active issue', () => {
       // Mock bd: show returns JSON for the source, list returns only the source
@@ -253,7 +253,7 @@ ENDJSON
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('No conflicts detected');
       expect(result.stdout).toContain('forge-abc');
-    });
+    }, 15000);
 
     test('keyword overlap found between source and another issue', () => {
       // Mock bd: two issues with overlapping keywords "dependency" and "plan"
@@ -306,7 +306,7 @@ ENDJSON
       // Should contain the options section
       expect(result.stdout).toContain('bd dep add forge-src forge-other');
       expect(result.stdout).toContain('bd show forge-other');
-    });
+    }, 15000);
 
     test('no overlap when terms are too short or all stop words', () => {
       // Issues share only stop words / short terms: "add", "the", "is", "to"
@@ -330,7 +330,7 @@ ENDJSON
       const result = runDepGuard(['check-ripple', 'forge-aaa'], { BD_CMD: mock });
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('No conflicts detected');
-    });
+    }, 15000);
 
     test('prints structured analyzer output from Beads JSON and task-file context', () => {
       const repositoryRoot = createTempRepo({
@@ -402,7 +402,7 @@ ENDJSON
       expect(result.stdout).toContain('forge-other depends on forge-src');
       expect(result.stdout).toContain('Pros:');
       expect(result.stdout).toContain('Cons:');
-    });
+    }, 15000);
 
     test('falls back to keyword-only report when the analyzer cannot run', () => {
       const repositoryRoot = createTempRepo({
@@ -458,7 +458,7 @@ ENDJSON
       expect(result.stdout).toContain('Potential overlap');
       expect(result.stdout).toContain('Confidence: LOW');
       expect(result.stdout).toContain('bd dep add forge-src forge-other');
-    });
+    }, 15000);
   });
 
   describe('extract-contracts', () => {

--- a/test/scripts/github-beads-sync/reverse-sync-cli.test.js
+++ b/test/scripts/github-beads-sync/reverse-sync-cli.test.js
@@ -1,0 +1,111 @@
+const { describe, it, expect, beforeEach, afterEach } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const CLI_PATH = path.resolve(__dirname, '../../../scripts/github-beads-sync/reverse-sync-cli.mjs');
+
+function runCli(args, opts = {}) {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 10000,
+    ...opts,
+  });
+}
+
+/** Extract the pretty-printed JSON object from CLI stdout (ignoring trailing summary line) */
+function parseResult(stdout) {
+  const lastBrace = stdout.lastIndexOf('}');
+  return JSON.parse(stdout.slice(0, lastBrace + 1));
+}
+
+describe('reverse-sync-cli.mjs', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reverse-sync-cli-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should exit 1 with usage when no args provided', () => {
+    try {
+      runCli([]);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err.status).toBe(1);
+      expect(err.stderr.toString()).toContain('Usage:');
+    }
+  });
+
+  it('should exit 1 with usage when only one arg provided', () => {
+    const oldFile = path.join(tmpDir, 'old.jsonl');
+    fs.writeFileSync(oldFile, '');
+    try {
+      runCli([oldFile]);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err.status).toBe(1);
+      expect(err.stderr.toString()).toContain('Usage:');
+    }
+  });
+
+  it('should exit 0 with empty files (no transitions)', () => {
+    const oldFile = path.join(tmpDir, 'old.jsonl');
+    const newFile = path.join(tmpDir, 'new.jsonl');
+    fs.writeFileSync(oldFile, '');
+    fs.writeFileSync(newFile, '');
+
+    const stdout = runCli([oldFile, newFile]);
+    const result = parseResult(stdout);
+    expect(result.closed).toEqual([]);
+    expect(result.skipped).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should detect a closure transition and output JSON result', () => {
+    const oldFile = path.join(tmpDir, 'old.jsonl');
+    const newFile = path.join(tmpDir, 'new.jsonl');
+
+    const issue = { id: 'forge-abc', title: 'Test', status: 'open', description: 'https://github.com/test/repo/issues/5' };
+    const closedIssue = { ...issue, status: 'closed' };
+
+    fs.writeFileSync(oldFile, JSON.stringify(issue) + '\n');
+    fs.writeFileSync(newFile, JSON.stringify(closedIssue) + '\n');
+
+    // Will fail because gh CLI is not available in test, but it should attempt the close
+    // and report an error (exit 1), not a usage error
+    try {
+      const stdout = runCli([oldFile, newFile]);
+      // If gh is available, it would attempt to close — either way, result should have structure
+      const result = parseResult(stdout);
+      expect(result).toHaveProperty('closed');
+      expect(result).toHaveProperty('errors');
+    } catch (err) {
+      // gh CLI not found = error in closing, not a crash
+      expect(err.status).toBe(1);
+      expect(err.stderr.toString()).toContain('failed to close');
+    }
+  });
+
+  it('should skip issues without GitHub URL in description', () => {
+    const oldFile = path.join(tmpDir, 'old.jsonl');
+    const newFile = path.join(tmpDir, 'new.jsonl');
+
+    const issue = { id: 'forge-xyz', title: 'No URL', status: 'open', description: 'just text' };
+    const closedIssue = { ...issue, status: 'closed' };
+
+    fs.writeFileSync(oldFile, JSON.stringify(issue) + '\n');
+    fs.writeFileSync(newFile, JSON.stringify(closedIssue) + '\n');
+
+    const stdout = runCli([oldFile, newFile]);
+    const result = parseResult(stdout);
+    expect(result.skipped.length).toBe(1);
+    expect(result.closed).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/test/scripts/github-beads-sync/reverse-sync.test.js
+++ b/test/scripts/github-beads-sync/reverse-sync.test.js
@@ -214,17 +214,23 @@ describe('handleBeadsClosed', () => {
   });
 });
 
-// --- Loop guard ---
+// --- Loop guard (validated against actual workflow YAML) ---
 
 describe('loop guard', () => {
-  test('commit message starting with chore(beads): should be detected as loop', () => {
-    // This tests the logic the workflow YAML uses — we verify the pattern here
-    const commitMsg = 'chore(beads): sync from GitHub issue #42';
-    expect(commitMsg.startsWith('chore(beads):')).toBe(true);
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const workflowPath = path.resolve(__dirname, '../../../.github/workflows/beads-to-github.yml');
+  const workflowContent = fs.readFileSync(workflowPath, 'utf-8');
+
+  test('workflow YAML contains chore(beads): loop guard pattern', () => {
+    expect(workflowContent).toContain('chore\\(beads\\):');
   });
 
-  test('non-sync commit message is not a loop', () => {
-    const commitMsg = 'feat: close beads issue forge-abc';
-    expect(commitMsg.startsWith('chore(beads):')).toBe(false);
+  test('workflow skips execution when SKIP is true', () => {
+    expect(workflowContent).toContain("if: env.SKIP != 'true'");
+  });
+
+  test('workflow uses github.event.before for pre-push comparison', () => {
+    expect(workflowContent).toContain('github.event.before');
   });
 });

--- a/test/scripts/github-beads-sync/reverse-sync.test.js
+++ b/test/scripts/github-beads-sync/reverse-sync.test.js
@@ -1,0 +1,230 @@
+import { describe, test, expect } from 'bun:test';
+
+import {
+  detectClosedIssues,
+  extractGitHubUrl,
+  handleBeadsClosed,
+} from '../../../scripts/github-beads-sync/reverse-sync.mjs';
+
+// --- detectClosedIssues ---
+
+describe('detectClosedIssues', () => {
+  test('detects issue that transitioned from open to closed', () => {
+    const oldLines = [
+      '{"id":"forge-abc","status":"open","description":"https://github.com/owner/repo/issues/42"}',
+    ];
+    const newLines = [
+      '{"id":"forge-abc","status":"closed","description":"https://github.com/owner/repo/issues/42"}',
+    ];
+    const result = detectClosedIssues(oldLines, newLines);
+    expect(result).toEqual([
+      { id: 'forge-abc', description: 'https://github.com/owner/repo/issues/42' },
+    ]);
+  });
+
+  test('ignores issues that were already closed', () => {
+    const oldLines = [
+      '{"id":"forge-abc","status":"closed","description":"https://github.com/owner/repo/issues/42"}',
+    ];
+    const newLines = [
+      '{"id":"forge-abc","status":"closed","description":"https://github.com/owner/repo/issues/42"}',
+    ];
+    const result = detectClosedIssues(oldLines, newLines);
+    expect(result).toEqual([]);
+  });
+
+  test('ignores issues that are still open', () => {
+    const oldLines = [
+      '{"id":"forge-abc","status":"open","description":"https://github.com/owner/repo/issues/42"}',
+    ];
+    const newLines = [
+      '{"id":"forge-abc","status":"open","description":"https://github.com/owner/repo/issues/42"}',
+    ];
+    const result = detectClosedIssues(oldLines, newLines);
+    expect(result).toEqual([]);
+  });
+
+  test('detects multiple closed issues', () => {
+    const oldLines = [
+      '{"id":"forge-a","status":"open","description":"https://github.com/o/r/issues/1"}',
+      '{"id":"forge-b","status":"open","description":"https://github.com/o/r/issues/2"}',
+      '{"id":"forge-c","status":"open","description":"https://github.com/o/r/issues/3"}',
+    ];
+    const newLines = [
+      '{"id":"forge-a","status":"closed","description":"https://github.com/o/r/issues/1"}',
+      '{"id":"forge-b","status":"open","description":"https://github.com/o/r/issues/2"}',
+      '{"id":"forge-c","status":"closed","description":"https://github.com/o/r/issues/3"}',
+    ];
+    const result = detectClosedIssues(oldLines, newLines);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('forge-a');
+    expect(result[1].id).toBe('forge-c');
+  });
+
+  test('handles newly added closed issue (not in old)', () => {
+    const oldLines = [];
+    const newLines = [
+      '{"id":"forge-new","status":"closed","description":"https://github.com/o/r/issues/5"}',
+    ];
+    // New issue that appears already closed — no transition, skip it
+    const result = detectClosedIssues(oldLines, newLines);
+    expect(result).toEqual([]);
+  });
+
+  test('handles empty lines and malformed JSON gracefully', () => {
+    const oldLines = ['', 'not-json', '{"id":"forge-a","status":"open","description":"url"}'];
+    const newLines = ['', 'not-json', '{"id":"forge-a","status":"closed","description":"url"}'];
+    const result = detectClosedIssues(oldLines, newLines);
+    expect(result).toEqual([{ id: 'forge-a', description: 'url' }]);
+  });
+
+  test('handles tombstone status — not treated as closure', () => {
+    const oldLines = [
+      '{"id":"forge-t","status":"open","description":"https://github.com/o/r/issues/9"}',
+    ];
+    const newLines = [
+      '{"id":"forge-t","status":"tombstone","description":"https://github.com/o/r/issues/9"}',
+    ];
+    const result = detectClosedIssues(oldLines, newLines);
+    expect(result).toEqual([]);
+  });
+});
+
+// --- extractGitHubUrl ---
+
+describe('extractGitHubUrl', () => {
+  test('extracts owner, repo, and issue number from standard URL', () => {
+    const result = extractGitHubUrl('https://github.com/myorg/myrepo/issues/42');
+    expect(result).toEqual({ owner: 'myorg', repo: 'myrepo', issueNumber: 42 });
+  });
+
+  test('extracts from URL embedded in longer description', () => {
+    const desc = 'Linked: https://github.com/foo/bar/issues/7 — see above';
+    const result = extractGitHubUrl(desc);
+    expect(result).toEqual({ owner: 'foo', repo: 'bar', issueNumber: 7 });
+  });
+
+  test('returns null for non-GitHub URL', () => {
+    expect(extractGitHubUrl('https://gitlab.com/o/r/issues/1')).toBeNull();
+  });
+
+  test('returns null for empty or undefined description', () => {
+    expect(extractGitHubUrl('')).toBeNull();
+    expect(extractGitHubUrl(undefined)).toBeNull();
+    expect(extractGitHubUrl(null)).toBeNull();
+  });
+
+  test('returns null for GitHub URL without issues path', () => {
+    expect(extractGitHubUrl('https://github.com/o/r/pull/5')).toBeNull();
+  });
+
+  test('handles URL with trailing slash', () => {
+    const result = extractGitHubUrl('https://github.com/a/b/issues/99/');
+    expect(result).toEqual({ owner: 'a', repo: 'b', issueNumber: 99 });
+  });
+});
+
+// --- handleBeadsClosed ---
+
+describe('handleBeadsClosed', () => {
+  test('closes GitHub issue for each newly-closed beads issue', () => {
+    const closedCalls = [];
+    const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
+
+    const oldContent = '{"id":"forge-x","status":"open","description":"https://github.com/org/proj/issues/10"}';
+    const newContent = '{"id":"forge-x","status":"closed","description":"https://github.com/org/proj/issues/10"}';
+
+    const result = handleBeadsClosed(oldContent, newContent, {
+      closeGitHubIssue: mockCloseGitHubIssue,
+    });
+
+    expect(closedCalls).toHaveLength(1);
+    expect(closedCalls[0]).toEqual({ owner: 'org', repo: 'proj', num: 10 });
+    expect(result.closed).toHaveLength(1);
+    expect(result.closed[0].beadsId).toBe('forge-x');
+  });
+
+  test('skips issues without valid GitHub URL in description', () => {
+    const closedCalls = [];
+    const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
+
+    const oldContent = '{"id":"forge-y","status":"open","description":"no-url-here"}';
+    const newContent = '{"id":"forge-y","status":"closed","description":"no-url-here"}';
+
+    const result = handleBeadsClosed(oldContent, newContent, {
+      closeGitHubIssue: mockCloseGitHubIssue,
+    });
+
+    expect(closedCalls).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('no GitHub URL');
+  });
+
+  test('returns empty results when no transitions detected', () => {
+    const closedCalls = [];
+    const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
+
+    const content = '{"id":"forge-z","status":"open","description":"https://github.com/o/r/issues/1"}';
+
+    const result = handleBeadsClosed(content, content, {
+      closeGitHubIssue: mockCloseGitHubIssue,
+    });
+
+    expect(closedCalls).toHaveLength(0);
+    expect(result.closed).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  test('handles multi-line JSONL content', () => {
+    const closedCalls = [];
+    const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
+
+    const oldContent = [
+      '{"id":"forge-a","status":"open","description":"https://github.com/o/r/issues/1"}',
+      '{"id":"forge-b","status":"open","description":"https://github.com/o/r/issues/2"}',
+    ].join('\n');
+    const newContent = [
+      '{"id":"forge-a","status":"closed","description":"https://github.com/o/r/issues/1"}',
+      '{"id":"forge-b","status":"closed","description":"https://github.com/o/r/issues/2"}',
+    ].join('\n');
+
+    const result = handleBeadsClosed(oldContent, newContent, {
+      closeGitHubIssue: mockCloseGitHubIssue,
+    });
+
+    expect(closedCalls).toHaveLength(2);
+    expect(result.closed).toHaveLength(2);
+  });
+
+  test('reports errors without throwing when closeGitHubIssue fails', () => {
+    const mockCloseGitHubIssue = () => {
+      throw new Error('API failure');
+    };
+
+    const oldContent = '{"id":"forge-e","status":"open","description":"https://github.com/o/r/issues/3"}';
+    const newContent = '{"id":"forge-e","status":"closed","description":"https://github.com/o/r/issues/3"}';
+
+    const result = handleBeadsClosed(oldContent, newContent, {
+      closeGitHubIssue: mockCloseGitHubIssue,
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].beadsId).toBe('forge-e');
+    expect(result.errors[0].error).toBe('API failure');
+  });
+});
+
+// --- Loop guard ---
+
+describe('loop guard', () => {
+  test('commit message starting with chore(beads): should be detected as loop', () => {
+    // This tests the logic the workflow YAML uses — we verify the pattern here
+    const commitMsg = 'chore(beads): sync from GitHub issue #42';
+    expect(commitMsg.startsWith('chore(beads):')).toBe(true);
+  });
+
+  test('non-sync commit message is not a loop', () => {
+    const commitMsg = 'feat: close beads issue forge-abc';
+    expect(commitMsg.startsWith('chore(beads):')).toBe(false);
+  });
+});

--- a/test/setup-github-sync.test.js
+++ b/test/setup-github-sync.test.js
@@ -1,0 +1,136 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { scaffoldGithubBeadsSync } = require('../lib/setup');
+
+describe('GitHub-Beads sync setup integration', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'forge-sync-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('scaffoldGithubBeadsSync', () => {
+    test('creates expected files when enabled', async () => {
+      const packageDir = path.join(__dirname, '..');
+
+      await scaffoldGithubBeadsSync(tmpDir, packageDir);
+
+      // Workflow file
+      const workflowPath = path.join(tmpDir, '.github', 'workflows', 'github-to-beads.yml');
+      expect(fs.existsSync(workflowPath)).toBe(true);
+
+      // Config file
+      const configPath = path.join(tmpDir, 'scripts', 'github-beads-sync.config.json');
+      expect(fs.existsSync(configPath)).toBe(true);
+
+      // Mapping file
+      const mappingPath = path.join(tmpDir, '.github', 'beads-mapping.json');
+      expect(fs.existsSync(mappingPath)).toBe(true);
+
+      // Mapping file should be empty JSON object
+      const mappingContent = JSON.parse(fs.readFileSync(mappingPath, 'utf-8'));
+      expect(mappingContent).toEqual({});
+    });
+
+    test('does not overwrite existing config files', async () => {
+      const packageDir = path.join(__dirname, '..');
+
+      // Pre-create config with custom content
+      const scriptsDir = path.join(tmpDir, 'scripts');
+      await fs.promises.mkdir(scriptsDir, { recursive: true });
+      const configPath = path.join(scriptsDir, 'github-beads-sync.config.json');
+      const customConfig = '{"custom": true}';
+      await fs.promises.writeFile(configPath, customConfig, 'utf-8');
+
+      // Pre-create mapping with custom content
+      const githubDir = path.join(tmpDir, '.github');
+      await fs.promises.mkdir(githubDir, { recursive: true });
+      const mappingPath = path.join(githubDir, 'beads-mapping.json');
+      const customMapping = '{"issue-1": "beads-1"}';
+      await fs.promises.writeFile(mappingPath, customMapping, 'utf-8');
+
+      await scaffoldGithubBeadsSync(tmpDir, packageDir);
+
+      // Config should retain custom content
+      const configContent = fs.readFileSync(configPath, 'utf-8');
+      expect(configContent).toBe(customConfig);
+
+      // Mapping should retain custom content
+      const mappingContent = fs.readFileSync(mappingPath, 'utf-8');
+      expect(mappingContent).toBe(customMapping);
+    });
+
+    test('creates directories as needed', async () => {
+      const packageDir = path.join(__dirname, '..');
+
+      await scaffoldGithubBeadsSync(tmpDir, packageDir);
+
+      expect(fs.existsSync(path.join(tmpDir, '.github', 'workflows'))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, 'scripts'))).toBe(true);
+    });
+
+    test('returns list of created files', async () => {
+      const packageDir = path.join(__dirname, '..');
+
+      const result = await scaffoldGithubBeadsSync(tmpDir, packageDir);
+
+      expect(result.created.length).toBeGreaterThan(0);
+      expect(result.skipped.length).toBe(0);
+    });
+
+    test('returns skipped files when they already exist', async () => {
+      const packageDir = path.join(__dirname, '..');
+
+      // Pre-create all files
+      const dirs = [
+        path.join(tmpDir, '.github', 'workflows'),
+        path.join(tmpDir, 'scripts'),
+      ];
+      for (const dir of dirs) {
+        await fs.promises.mkdir(dir, { recursive: true });
+      }
+      await fs.promises.writeFile(
+        path.join(tmpDir, '.github', 'workflows', 'github-to-beads.yml'), 'existing', 'utf-8'
+      );
+      await fs.promises.writeFile(
+        path.join(tmpDir, 'scripts', 'github-beads-sync.config.json'), '{}', 'utf-8'
+      );
+      await fs.promises.writeFile(
+        path.join(tmpDir, '.github', 'beads-mapping.json'), '{}', 'utf-8'
+      );
+
+      const result = await scaffoldGithubBeadsSync(tmpDir, packageDir);
+
+      expect(result.created.length).toBe(0);
+      expect(result.skipped.length).toBe(3);
+    });
+  });
+
+  describe('forge.js integration', () => {
+    const forgePath = path.join(__dirname, '..', 'bin', 'forge.js');
+    const content = fs.readFileSync(forgePath, 'utf-8');
+
+    test('--quick mode skips sync setup (no prompt)', () => {
+      // quickSetup should NOT call scaffoldGithubBeadsSync or prompt for it
+      const quickSection = content.substring(
+        content.indexOf('async function quickSetup'),
+        content.indexOf('async function quickSetup') + 2000
+      );
+      // Quick mode should not contain the sync prompt
+      expect(quickSection).not.toContain('GitHub');
+    });
+
+    test('configureExternalServices includes sync prompt', () => {
+      // The external services config should reference the sync setup
+      expect(content).toContain('GitHub');
+      expect(content).toContain('Beads issue sync');
+      expect(content).toContain('scaffoldGithubBeadsSync');
+    });
+  });
+});

--- a/test/setup-github-sync.test.js
+++ b/test/setup-github-sync.test.js
@@ -21,21 +21,23 @@ describe('GitHub-Beads sync setup integration', () => {
 
       await scaffoldGithubBeadsSync(tmpDir, packageDir);
 
-      // Workflow file
-      const workflowPath = path.join(tmpDir, '.github', 'workflows', 'github-to-beads.yml');
-      expect(fs.existsSync(workflowPath)).toBe(true);
+      // Phase 1 workflow
+      expect(fs.existsSync(path.join(tmpDir, '.github', 'workflows', 'github-to-beads.yml'))).toBe(true);
+
+      // Phase 2 workflow
+      expect(fs.existsSync(path.join(tmpDir, '.github', 'workflows', 'beads-to-github.yml'))).toBe(true);
 
       // Config file
-      const configPath = path.join(tmpDir, 'scripts', 'github-beads-sync.config.json');
-      expect(fs.existsSync(configPath)).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, 'scripts', 'github-beads-sync.config.json'))).toBe(true);
 
       // Mapping file
       const mappingPath = path.join(tmpDir, '.github', 'beads-mapping.json');
       expect(fs.existsSync(mappingPath)).toBe(true);
+      expect(JSON.parse(fs.readFileSync(mappingPath, 'utf-8'))).toEqual({});
 
-      // Mapping file should be empty JSON object
-      const mappingContent = JSON.parse(fs.readFileSync(mappingPath, 'utf-8'));
-      expect(mappingContent).toEqual({});
+      // Sync script modules (spot-check key files)
+      expect(fs.existsSync(path.join(tmpDir, 'scripts', 'github-beads-sync', 'index.mjs'))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, 'scripts', 'github-beads-sync', 'reverse-sync-cli.mjs'))).toBe(true);
     });
 
     test('does not overwrite existing config files', async () => {
@@ -95,8 +97,12 @@ describe('GitHub-Beads sync setup integration', () => {
       for (const dir of dirs) {
         await fs.promises.mkdir(dir, { recursive: true });
       }
+      // Pre-create all expected files
       await fs.promises.writeFile(
         path.join(tmpDir, '.github', 'workflows', 'github-to-beads.yml'), 'existing', 'utf-8'
+      );
+      await fs.promises.writeFile(
+        path.join(tmpDir, '.github', 'workflows', 'beads-to-github.yml'), 'existing', 'utf-8'
       );
       await fs.promises.writeFile(
         path.join(tmpDir, 'scripts', 'github-beads-sync.config.json'), '{}', 'utf-8'
@@ -104,11 +110,22 @@ describe('GitHub-Beads sync setup integration', () => {
       await fs.promises.writeFile(
         path.join(tmpDir, '.github', 'beads-mapping.json'), '{}', 'utf-8'
       );
+      // Pre-create script modules
+      const syncDir = path.join(tmpDir, 'scripts', 'github-beads-sync');
+      await fs.promises.mkdir(syncDir, { recursive: true });
+      const scriptNames = [
+        'config.mjs', 'mapping.mjs', 'comment.mjs', 'github-api.mjs',
+        'sanitize.mjs', 'run-bd.mjs', 'label-mapper.mjs', 'index.mjs',
+        'reverse-sync.mjs', 'reverse-sync-cli.mjs',
+      ];
+      for (const name of scriptNames) {
+        await fs.promises.writeFile(path.join(syncDir, name), 'existing', 'utf-8');
+      }
 
       const result = await scaffoldGithubBeadsSync(tmpDir, packageDir);
 
       expect(result.created.length).toBe(0);
-      expect(result.skipped.length).toBe(3);
+      expect(result.skipped.length).toBe(14);
     });
   });
 


### PR DESCRIPTION
## Summary

PR 2/2 for the GitHub ↔ Beads bidirectional issue sync epic (`forge-d2cl`). Builds on the core sync engine from PR #71.

- **T10: Forge setup integration** — `scaffoldGithubBeadsSync()` in `lib/setup.js`, interactive prompt in `bin/forge.js` during `configureExternalServices`. Copies workflow YAML, config JSON, and mapping template. Never overwrites existing files. Skipped in `--quick`/`--skip-external` modes.
- **T11: Beads→GitHub reverse sync** — Phase 2 of the sync: when `.beads/` changes on push to master, detects issues that transitioned to `closed` and closes the linked GitHub issue via `gh api`. Loop guard prevents infinite cycles. New workflow: `.github/workflows/beads-to-github.yml`.
- **T12: Documentation** — `docs/BEADS_GITHUB_SYNC.md` (architecture, setup, config reference, security, troubleshooting, fork behavior), PR template update, AGENTS.md pointer.
- **Pre-existing test fix** — Increased timeout for `dep-guard.sh check-ripple` tests that flaked on Windows CI.

## Design Doc
See: `docs/plans/2026-03-21-github-beads-sync-design.md`

## Beads Issue
Related: `forge-d2cl` (GitHub ↔ Beads bidirectional issue sync)

## Key Decisions
1. **Create-only sync (Option D)** — No field updates after creation, avoids conflict resolution entirely
2. **Belt-and-suspenders mapping (Option C)** — Bot comment (human-visible) + mapping file (fast lookup, debuggable)
3. **Configurable label mapping** — `sync-config.json` with user-customizable label→type/priority maps
4. **Fail-closed config validation** — Invalid `publicRepoGate` values throw errors (not silently default)
5. **Convention over configuration** — Works with zero setup via GitHub's native auto-add-to-project

## TDD Test Coverage
- Unit tests: 86 tests across 7 modules (config, mapping, comment, github-api, sanitize, run-bd, label-mapper)
- Integration tests: 7 tests with fixture payloads (opened, closed, malicious, auth gate)
- Orchestration tests: 12 tests for handleOpened/handleClosed
- Workflow validation: 27 tests for YAML security constraints
- Reverse sync tests: 20 tests for Phase 2 detection/closing
- Setup tests: 7 tests for scaffold function
- **Total: 159 new tests, all passing ✓**

## Security Review
- OWASP Top 10: Full analysis in `docs/plans/2026-03-21-issue-sync-owasp-analysis.md`
- A03 Injection: `execFileSync` with array args, `sanitizeTitle`/`sanitizeBody` strip shell metacharacters
- A05 Misconfiguration: Fail-closed `validateConfig()` with "did you mean?" suggestions
- A08 Data Integrity: `concurrency` group prevents mapping file corruption
- SHA-pinned third-party Actions (checkout, setup-bun)
- No `${{ }}` interpolation of untrusted data in `run:` blocks

## Test Plan
- [x] Lint passing (0 errors, 0 warnings)
- [x] Tests passing (1887 pass, 0 fail)
- [x] Security audit clean
- [x] OWASP review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — prior scaffold gap is resolved, logic is sound, and the only remaining item is a minor path-trigger scoping suggestion.
- The primary blocker from the previous review (missing Phase 2 workflow + script modules in scaffold) is addressed. The reverse-sync implementation handles all significant edge cases (empty old content, initial push, per-issue error isolation, loop guard). Test coverage is comprehensive (20 unit tests for reverse sync, 7 for scaffold). The single P2 comment (`.beads/**` vs `.beads/issues.jsonl`) is a non-blocking efficiency improvement that doesn't affect correctness.
- No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `bin/forge.js`, line 110-117 ([link](https://github.com/harshanandak/forge/blob/1bca335149b7859d332cc3f1fe9ad76f9fe8d59f/bin/forge.js#L110-L117)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing error handling around scaffold**

   `scaffoldGithubBeadsSync` calls `fs.promises.copyFile(file.src, destPath)` for each template file. If any source file is absent (e.g. a partial npm install), the function throws `ENOENT` and propagates uncaught through `configureExternalServices`, crashing the setup flow with no user-friendly message. Wrapping in a try-catch lets you surface a clear error instead:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: bin/forge.js
   Line: 110-117

   Comment:
   **Missing error handling around scaffold**

   `scaffoldGithubBeadsSync` calls `fs.promises.copyFile(file.src, destPath)` for each template file. If any source file is absent (e.g. a partial npm install), the function throws `ENOENT` and propagates uncaught through `configureExternalServices`, crashing the setup flow with no user-friendly message. Wrapping in a try-catch lets you surface a clear error instead:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `test/scripts/github-beads-sync/reverse-sync.test.js`, line 1079-1088 ([link](https://github.com/harshanandak/forge/blob/1bca335149b7859d332cc3f1fe9ad76f9fe8d59f/test/scripts/github-beads-sync/reverse-sync.test.js#L1079-L1088)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Loop guard tests don't exercise the actual shell pattern**

   The tests in this block verify a JavaScript `String.prototype.startsWith` call, not the bash glob pattern `[[ "$COMMIT_MSG" == chore\(beads\):* ]]` from the workflow. The comment "This tests the logic the workflow YAML uses" is misleading — if the bash pattern in `.github/workflows/beads-to-github.yml` were changed or broken, these tests would still pass.

   Consider either:
   - Removing these trivial JS tests (they add no real coverage), or
   - Adding a shellcheck/workflow-validation test against the actual YAML file, similar to the existing workflow validation tests mentioned in the PR description, to make it harder for the shell pattern to silently diverge.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/scripts/github-beads-sync/reverse-sync.test.js
   Line: 1079-1088

   Comment:
   **Loop guard tests don't exercise the actual shell pattern**

   The tests in this block verify a JavaScript `String.prototype.startsWith` call, not the bash glob pattern `[[ "$COMMIT_MSG" == chore\(beads\):* ]]` from the workflow. The comment "This tests the logic the workflow YAML uses" is misleading — if the bash pattern in `.github/workflows/beads-to-github.yml` were changed or broken, these tests would still pass.

   Consider either:
   - Removing these trivial JS tests (they add no real coverage), or
   - Adding a shellcheck/workflow-validation test against the actual YAML file, similar to the existing workflow validation tests mentioned in the PR description, to make it harder for the shell pattern to silently diverge.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `.github/workflows/beads-to-github.yml`, line 4-7 ([link](https://github.com/harshanandak/forge/blob/3d3bff45b1ee691465b71ba97071b4b5ac67a8fd/.github/workflows/beads-to-github.yml#L4-L7)) 

   **Path trigger broader than necessary**

   The `paths` filter catches all changes to `.beads/**`, but the reverse-sync logic only ever reads `.beads/issues.jsonl`. Any other file written under `.beads/` (e.g., settings, metadata) will kick off a full checkout + Node.js run that immediately produces `{"closed":[],"skipped":[],"errors":[]}` and exits 0 — wasting runner minutes for every such change.

   Narrowing the trigger means the workflow only fires when the file it actually processes changes:

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/beads-to-github.yml
Line: 4-7

Comment:
**Path trigger broader than necessary**

The `paths` filter catches all changes to `.beads/**`, but the reverse-sync logic only ever reads `.beads/issues.jsonl`. Any other file written under `.beads/` (e.g., settings, metadata) will kick off a full checkout + Node.js run that immediately produces `{"closed":[],"skipped":[],"errors":[]}` and exits 0 — wasting runner minutes for every such change.

Narrowing the trigger means the workflow only fires when the file it actually processes changes:

```suggestion
    paths:
      - '.beads/issues.jsonl'
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: add scaffold er..."](https://github.com/harshanandak/forge/commit/3d3bff45b1ee691465b71ba97071b4b5ac67a8fd)</sub>

<!-- /greptile_comment -->