### PR TITLE
fix: add GH_TOKEN to GitHub-Beads sync workflow

### DIFF
--- a/.github/workflows/github-to-beads.yml
+++ b/.github/workflows/github-to-beads.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Run sync
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           SYNC_ACTION: ${{ github.event.action }}


### PR DESCRIPTION
## Summary

Hotfix: The `gh` CLI calls inside the Node sync script (`findSyncComment`, `createOrEditComment`) need `GH_TOKEN` in the environment. Without it, the workflow fails immediately with:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

**Root cause**: The "Run sync" step had `GITHUB_EVENT_PATH`, `GITHUB_REPOSITORY`, `SYNC_ACTION`, and `BEADS_SYNC_CONFIG` but was missing `GH_TOKEN`.

**Fix**: Added `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the env block.

**Discovered during**: Live testing of issue #74 after merging PR #73.

## Test Plan
- [x] Re-run issue #74 sync after merge to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — single-line, low-risk fix that corrects a clear authentication failure.
- The change is minimal and unambiguously correct. The `gh` CLI requires `GH_TOKEN` in the environment when running inside GitHub Actions, and it was simply omitted from the env block. The same token is already used in the checkout step, and the workflow's declared permissions cover the required scopes. No logic or security concerns.
- No files require special attention.
</details>

<sub>Last reviewed commit: ["fix: add GH_TOKEN to..."](https://github.com/harshanandak/forge/commit/d8ca9fec8fac38501ab14c8ecc33aaf852091019)</sub>

<!-- /greptile_comment -->