### PR TITLE
fix: correct README & docs inaccuracies — versions, OWASP, profiles, links, stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **Note**: `/check` was renamed to `/validate` and `/merge` was renamed to `/premerge` in v0.0.3. Historical entries below may use the old names.
+
 ## [Unreleased]
 
 ### Fixed

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -69,7 +69,7 @@ bunx forge setup --agents claude,cursor,cline
 
 Let's add a health check endpoint to demonstrate the full workflow.
 
-### Stage 1: Check Status
+### Utility: Check Status
 
 ```bash
 $ bunx forge /status
@@ -92,7 +92,7 @@ Ready to start!
 
 ---
 
-### Stage 2: Plan
+### Stage 1: Plan
 
 ```bash
 $ bunx forge /plan health-check-endpoint
@@ -105,9 +105,9 @@ $ bunx forge /plan health-check-endpoint
 
 **Output:**
 ```
-✓ Design doc: docs/plans/health-check-endpoint-design.md
 ✓ Created branch: feat/health-check-endpoint
-✓ Task list: docs/plans/health-check-endpoint-tasks.md (4 tasks)
+✓ Created issue: forge-abc1 (in_progress)
+✓ Design Q&A complete, research done, task list ready
 
 Next: /dev to start TDD implementation
 ```
@@ -116,7 +116,7 @@ Next: /dev to start TDD implementation
 
 ---
 
-### Stage 3: Development (TDD)
+### Stage 2: Development (TDD)
 
 ```bash
 $ bunx forge /dev
@@ -165,7 +165,7 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
 
 ---
 
-### Stage 4: Validate
+### Stage 3: Validate
 
 ```bash
 $ bunx forge /validate
@@ -185,7 +185,7 @@ Running security scan... ✓ (no vulnerabilities)
 
 ---
 
-### Stage 5: Ship
+### Stage 4: Ship
 
 ```bash
 $ bunx forge /ship
@@ -203,7 +203,7 @@ $ bunx forge /ship
 - Minimal information disclosure
 
 ## Research
-See: docs/plans/health-check-endpoint-design.md
+See: design doc from /plan phase
 
 ## Test Coverage
 - 1 unit test (health endpoint returns 200 OK)
@@ -226,7 +226,7 @@ Next: /review to address feedback
 
 ---
 
-### Stage 6: Review (if needed)
+### Stage 5: Review (if needed)
 
 ```bash
 $ bunx forge /review 42
@@ -242,7 +242,7 @@ Fix issues, commit, push - PR updates automatically.
 
 ---
 
-### Stage 7: Premerge
+### Stage 6: Premerge
 
 ```bash
 $ bunx forge /premerge 42
@@ -269,7 +269,7 @@ Back on main branch. Ready for next feature!
 
 ---
 
-### Stage 8: Verify
+### Stage 7: Verify
 
 ```bash
 $ bunx forge /verify
@@ -304,12 +304,11 @@ In **5 minutes**, you:
 
 **Simple feature** (like you just did):
 ```bash
-/research → /plan → /dev → /validate → /ship
+/plan → /dev → /validate → /ship
 ```
 
 **Bug fix with security**:
 ```bash
-/research sql-injection-fix
 /plan sql-injection-fix
 /dev  # Fix + tests
 /validate  # Security scan critical
@@ -318,8 +317,7 @@ In **5 minutes**, you:
 
 **Architecture change** (uses design doc):
 ```bash
-/research user-authentication
-/plan user-authentication  # Creates design doc + branch
+/plan user-authentication  # Design Q&A + research + branch
 /dev
 /validate
 /ship
@@ -364,8 +362,7 @@ bd ready  # Find work to do
 
 ```bash
 /status       # Check current state
-/research X   # Research feature X
-/plan X       # Create plan for X
+/plan X       # Design Q&A + research + branch + task list
 /dev          # TDD development
 /validate        # Validate everything
 /ship         # Create PR
@@ -401,4 +398,4 @@ Get approval on design before implementing.
 /status
 ```
 
-Then start with `/research <your-feature-name>` 🚀
+Then start with `/plan <your-feature-name>`

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -92,53 +92,31 @@ Ready to start!
 
 ---
 
-### Stage 2: Research
-
-```bash
-$ bunx forge /research health-check-endpoint
-```
-
-**What happens**:
-1. AI searches web for health check best practices
-2. Analyzes your codebase for existing patterns
-3. OWASP Top 10 security analysis
-4. Documents findings in `docs/research/health-check-endpoint.md`
-
-**Research doc includes**:
-- Best practices (REST conventions, status codes)
-- Security considerations (information disclosure risks)
-- Existing patterns in your codebase
-- TDD test scenarios identified upfront
-
-**Time**: ~2 minutes
-
----
-
-### Stage 3: Plan
+### Stage 2: Plan
 
 ```bash
 $ bunx forge /plan health-check-endpoint
 ```
 
 **What happens**:
-1. Creates feature branch: `feat/health-check-endpoint`
-2. Creates tracking issue (if Beads installed)
-3. Creates implementation plan
+1. Design Q&A captures intent (Phase 1)
+2. AI researches best practices, OWASP Top 10 analysis (Phase 2)
+3. Creates feature branch, tracking issue, and task list (Phase 3)
 
 **Output:**
 ```
+✓ Design doc: docs/plans/health-check-endpoint-design.md
 ✓ Created branch: feat/health-check-endpoint
-✓ Created issue: PROJ-42
-✓ Plan ready in: docs/planning/health-check-endpoint.md
+✓ Task list: docs/plans/health-check-endpoint-tasks.md (4 tasks)
 
 Next: /dev to start TDD implementation
 ```
 
-**Time**: ~30 seconds
+**Time**: ~3 minutes
 
 ---
 
-### Stage 4: Development (TDD)
+### Stage 3: Development (TDD)
 
 ```bash
 $ bunx forge /dev
@@ -187,7 +165,7 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
 
 ---
 
-### Stage 5: Validate
+### Stage 4: Validate
 
 ```bash
 $ bunx forge /validate
@@ -207,7 +185,7 @@ Running security scan... ✓ (no vulnerabilities)
 
 ---
 
-### Stage 6: Ship
+### Stage 5: Ship
 
 ```bash
 $ bunx forge /ship
@@ -225,7 +203,7 @@ $ bunx forge /ship
 - Minimal information disclosure
 
 ## Research
-See: docs/research/health-check-endpoint.md
+See: docs/plans/health-check-endpoint-design.md
 
 ## Test Coverage
 - 1 unit test (health endpoint returns 200 OK)
@@ -248,7 +226,7 @@ Next: /review to address feedback
 
 ---
 
-### Stage 7: Review (if needed)
+### Stage 6: Review (if needed)
 
 ```bash
 $ bunx forge /review 42
@@ -264,7 +242,7 @@ Fix issues, commit, push - PR updates automatically.
 
 ---
 
-### Stage 8: Premerge
+### Stage 7: Premerge
 
 ```bash
 $ bunx forge /premerge 42
@@ -291,7 +269,7 @@ Back on main branch. Ready for next feature!
 
 ---
 
-### Stage 9: Verify
+### Stage 8: Verify
 
 ```bash
 $ bunx forge /verify

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ forge-preflight ship      # Validate before /ship stage
 ```
 
 ### 5. Smart Tool Recommendations
-Curated plugin catalog across 7 workflow stages — research, dev, validate, ship, review, and more:
+Curated plugin catalog across 7 workflow stages — plan, dev, validate, ship, review, and more:
 - **Auto-detection**: Scans your project for frameworks, databases, auth, payments, and more
 - **Budget modes**: free, open-source, startup, professional, custom
 - **Portability-first**: MCPs included only when they add clear value over CLI alternatives

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Ship features with confidence using a 7-stage TDD-first workflow for AI coding a
 **With Forge** (systematic):
 - Tests written BEFORE code (TDD)
 - Research-backed decisions
-- OWASP Top 10 analysis built-in
+- OWASP Top 10 analysis in every /plan
 - Documentation at every stage
 
 → [See complete walkthrough in QUICKSTART.md](QUICKSTART.md)
@@ -163,7 +163,7 @@ One workflow, works with ALL major AI agents:
 
 Switch agents anytime without changing your workflow.
 
-### 4. Built-in TDD Enforcement (v1.5.0)
+### 4. Built-in TDD Enforcement
 Git hooks automatically enforce TDD practices:
 - **Pre-commit**: Blocks source commits without tests
 - **Pre-push**: Runs full test suite before push
@@ -177,11 +177,11 @@ forge-preflight dev       # Validate before /dev stage
 forge-preflight ship      # Validate before /ship stage
 ```
 
-### 5. Smart Tool Recommendations (v1.7.0)
-Intelligent plugin catalog with 30+ curated tools:
+### 5. Smart Tool Recommendations
+Curated plugin catalog across 7 workflow stages — research, dev, validate, ship, review, and more:
 - **Auto-detection**: Scans your project for frameworks, databases, auth, payments, and more
 - **Budget modes**: free, open-source, startup, professional, custom
-- **CLI-first**: Prefers CLI tools over MCPs for portability
+- **Portability-first**: MCPs included only when they add clear value over CLI alternatives
 - **Free alternatives**: Every paid tool shows free alternatives
 
 ```bash
@@ -189,9 +189,9 @@ bunx forge recommend                  # Recommendations for your project
 bunx forge recommend --budget free    # Only free tools
 ```
 
-→ [Validation docs](docs/VALIDATION.md) | [Plugin docs](lib/agents/README.md)
+→ [Validation docs](docs/VALIDATION.md) | [Plugin docs](docs/TOOLCHAIN.md)
 
-### 6. Enhanced Onboarding (v1.6.0) 🆕
+### 6. Enhanced Onboarding
 Smart setup that adapts to your project:
 
 **Intelligent File Merging**
@@ -210,11 +210,13 @@ bunx forge setup --merge=smart    # Intelligent merge
 - Saves to `.forge/context.json`
 
 **Workflow Profiles**
-- Adapts workflow based on work type:
-  - `feature`: Full 7-stage workflow (auto-escalates to critical for auth/payment)
-  - `fix`: Streamlined 5-stage workflow (auto-escalates to hotfix for production)
+- Adapts workflow based on work type (3-8 stages):
+  - `critical`: Full 8-stage workflow (auth, payments, security-sensitive)
+  - `standard`: 7-stage workflow (typical features)
   - `refactor`: Behavior-preserving 5-stage workflow
-  - `chore`: Minimal 3-stage workflow (docs/deps/config)
+  - `simple`: Streamlined 4-stage workflow
+  - `hotfix`: Minimal 3-stage workflow (production fixes)
+  - `docs`: Minimal 3-stage workflow (documentation/config)
 ```bash
 bunx forge setup --type=critical    # Set workflow manually
 ```

--- a/docs/GREPTILE_SETUP.md
+++ b/docs/GREPTILE_SETUP.md
@@ -372,7 +372,7 @@ A: Yes, via `.greptile/config.yml` configuration file.
 - **Greptile Documentation**: https://docs.greptile.com
 - **GitHub App Settings**: https://github.com/settings/installations
 - **Branch Protection Guide**: [../.github/BRANCH_PROTECTION_GUIDE.md](../.github/BRANCH_PROTECTION_GUIDE.md)
-- **Your PR #13** (example): https://github.com/harshanandak/forge/pull/13
+- **Your PRs**: Check the [pull requests page](https://github.com/harshanandak/forge/pulls) for examples
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,8 +3,8 @@
 **Comprehensive implementation plan for transforming Forge into a fully automated, orchestrated workflow system.**
 
 **Plan Created**: 2026-02-10
-**Status**: Phase 2 complete. PR5/PR6 research done, ready for planning.
-**Timeline**: 3-4 weeks total
+**Status**: Phase 2 complete. PRs 0-6 merged, PR7-PR8 pending.
+**Timeline**: Originally 3-4 weeks; Phases 0-2 complete as of March 2026.
 **Strategy**: Quick wins first → Build testing foundation → Add automation → Enable extensibility
 
 ---
@@ -87,8 +87,8 @@ PR0 (Simplification) → PR1 (Fixes) → PR2 (Security) → PR3 (Test Infra)
 | PR5 | PR4 | PR5.5 | ✅ MERGED (2026-02-20, PR #40) |
 | PR5.5 | PR5 | PR6 | ✅ MERGED (2026-02-23, PR #43) |
 | PR6 | PR5.5 | PR7 | ✅ MERGED (2026-02-21, PR #41) |
-| PR7 | PR6 | PR8 | Blocked |
-| PR8 | PR7 | None | Blocked |
+| PR7 | PR6 | PR8 | Planned |
+| PR8 | PR7 | None | Planned |
 
 ---
 

--- a/docs/plans/2026-03-22-docs-accuracy-decisions.md
+++ b/docs/plans/2026-03-22-docs-accuracy-decisions.md
@@ -2,5 +2,46 @@
 
 **Epic**: forge-e3qj
 **Date**: 2026-03-22
+**Decision gates fired during /dev**: 0 (plan quality: Excellent)
 
-No decisions logged yet.
+## Design-Phase Decisions (from Phase 1 Q&A)
+
+### Decision 1
+**Task**: Task 1 — Version tags
+**Choice**: Remove version tags entirely rather than using correct 0.0.3
+**Rationale**: Avoids maintenance burden; features exist but aren't versioned releases
+
+### Decision 2
+**Task**: Task 2 — OWASP claim
+**Choice**: Soften to "in every /plan" rather than removing entirely
+**Rationale**: Honest about manual nature while preserving the value message
+
+### Decision 3
+**Task**: Task 3 — Tool catalog framing
+**Choice**: Reframe around workflow stage categories, not raw count
+**Rationale**: Value is breadth of coverage; stays accurate as catalog grows/shrinks
+
+### Decision 4
+**Task**: Task 4 — CLI-first wording
+**Choice**: "Portability-first" over "CLI-first"
+**Rationale**: Matches actual mcpJustified filtering logic in plugin-recommender.js
+
+### Decision 5
+**Task**: Task 5 — Plugin docs link
+**Choice**: Point to docs/TOOLCHAIN.md
+**Rationale**: Best UX — users want setup info, not agent architecture source code
+
+### Decision 6
+**Task**: Task 7 — CHANGELOG rename note
+**Choice**: Add note at top, don't rewrite history
+**Rationale**: Preserves historical record while preventing confusion
+
+### Decision 7
+**Task**: Task 8 — Paid alternatives enforcement
+**Choice**: No action needed — test already exists and passes
+**Rationale**: Existing test at test/plugin-catalog.test.js:148 covers this
+
+### Decision 8
+**Task**: Task 9 — QUICKSTART stage numbering
+**Choice**: /status as "Utility", stages 1-7 match canonical workflow
+**Rationale**: Consistent with README table and AGENTS.md stage definitions

--- a/docs/plans/2026-03-22-docs-accuracy-decisions.md
+++ b/docs/plans/2026-03-22-docs-accuracy-decisions.md
@@ -1,0 +1,6 @@
+# Decisions Log: docs-accuracy
+
+**Epic**: forge-e3qj
+**Date**: 2026-03-22
+
+No decisions logged yet.

--- a/docs/plans/2026-03-22-docs-accuracy-design.md
+++ b/docs/plans/2026-03-22-docs-accuracy-design.md
@@ -58,14 +58,14 @@ Make reasonable choice and document it. All changes are doc-only (except one tes
 | 4 | "Portability-first" over "CLI-first" | Matches actual mcpJustified filtering logic |
 | 5 | Plugin docs → docs/TOOLCHAIN.md | Best UX — users want setup info, not source code |
 | 6 | CHANGELOG note at top, not rewrite | Preserves historical record while preventing confusion |
-| 7 | Add enforcement test for paid alternatives | Prevents future regressions; all paid tools already comply |
+| 7 | Paid-alternatives test already exists | Existing test at test/plugin-catalog.test.js:148 passes — no action needed |
 | 8 | Acknowledge profile stage range | Honest about varying workflows without complexity |
 
 ## Technical Research
 
 ### OWASP Analysis
 
-Not applicable — this PR is doc fixes + one test. No user input, no auth, no API, no data processing. Zero security risk surface.
+Not applicable — this PR is doc-only fixes. No user input, no auth, no API, no data processing. Zero security risk surface.
 
 ### Blast-Radius Search
 
@@ -83,12 +83,12 @@ Only README.md lines 166, 180, 194 are in scope for this PR.
 | Item | README Claim | Actual Code | File |
 |------|-------------|-------------|------|
 | Version | v1.5.0, v1.6.0, v1.7.0 | 0.0.3 | package.json:3 |
-| Tool count | "30+ curated tools" | 15 tool entries | lib/plugin-catalog.js |
+| Tool count | "30+ curated tools" | 29 tool entries | lib/plugin-catalog.js |
 | CLI-first | "Prefers CLI over MCPs" | Skips MCPs unless mcpJustified=true | lib/plugin-recommender.js:117-124 |
 | OWASP | "built-in" | Manual checklist in /plan Phase 2 | .claude/commands/plan.md:206 |
 | Plugin docs | lib/agents/README.md | Should be docs/TOOLCHAIN.md | README.md:192 |
 | Profiles | "7-stage" universal | 6 profiles, 3-8 stages | lib/workflow-profiles.js |
-| Paid alts | "Every paid tool shows free alternatives" | parallel-deep-research missing alternatives | lib/plugin-catalog.js:78 |
+| Paid alts | "Every paid tool shows free alternatives" | All paid tools have alternatives (test passes) | test/plugin-catalog.test.js:148 |
 | CHANGELOG | /check in v1.4.0 section | Should be /validate | CHANGELOG.md:381 |
 
 ### TDD Test Scenarios

--- a/docs/plans/2026-03-22-docs-accuracy-design.md
+++ b/docs/plans/2026-03-22-docs-accuracy-design.md
@@ -23,10 +23,10 @@ README.md and supporting docs contain multiple factual inaccuracies vs the actua
 
 ## Out of Scope
 
-- Roadmap/planned-features section (deferred to separate issue)
 - Bumping package.json version
 - Adding automated OWASP gate (separate feature)
 - Fixing other epics (CI alignment, validate contracts, onboarding)
+- ENHANCED_ONBOARDING.md / AGENT_INSTALL_PROMPT.md (belong to forge-z1ft epic)
 
 ## Approach Selected
 

--- a/docs/plans/2026-03-22-docs-accuracy-design.md
+++ b/docs/plans/2026-03-22-docs-accuracy-design.md
@@ -30,7 +30,7 @@ README.md and supporting docs contain multiple factual inaccuracies vs the actua
 
 ## Approach Selected
 
-Doc-only fixes for 7 of 8 issues. One small test addition (forge-b1ai) to enforce paid tools always have free alternatives in the catalog. No production code changes.
+Doc-only fixes for all issues. The paid-alternatives enforcement test (forge-b1ai) already exists in the codebase and passes — no new test or code changes needed.
 
 ## Constraints
 

--- a/docs/plans/2026-03-22-docs-accuracy-design.md
+++ b/docs/plans/2026-03-22-docs-accuracy-design.md
@@ -1,0 +1,62 @@
+# Design Doc: README & Documentation Accuracy
+
+**Feature**: docs-accuracy
+**Date**: 2026-03-22
+**Status**: approved
+**Epic**: forge-e3qj
+
+## Purpose
+
+README.md and supporting docs contain multiple factual inaccuracies vs the actual codebase — wrong versions, wrong flag names, wrong paths, overclaimed features. This erodes trust on first contact. Fix all 8 identified inaccuracies in a single PR.
+
+## Success Criteria
+
+1. No version tags (v1.5, v1.6, v1.7) appear in README feature headers
+2. OWASP claim reworded to reflect manual checklist, not automated gate
+3. Tool catalog framed around category breadth, not raw count
+4. "CLI-first" replaced with portability-first wording matching actual MCP filtering logic
+5. Plugin docs link points to docs/TOOLCHAIN.md
+6. CHANGELOG has note at top about /check -> /validate and /merge -> /premerge rename
+7. Test exists enforcing paid catalog entries always have free alternatives
+8. README workflow profiles section acknowledges varying stage counts (3-8)
+9. All tests pass, lint clean
+
+## Out of Scope
+
+- Roadmap/planned-features section (deferred to separate issue)
+- Bumping package.json version
+- Adding automated OWASP gate (separate feature)
+- Fixing other epics (CI alignment, validate contracts, onboarding)
+
+## Approach Selected
+
+Doc-only fixes for 7 of 8 issues. One small test addition (forge-b1ai) to enforce paid tools always have free alternatives in the catalog. No production code changes.
+
+## Constraints
+
+- README must remain accurate to current codebase state (0.0.3)
+- CHANGELOG is historical — add clarifying note, don't rewrite history
+- No feature additions — only corrections and clarifications
+
+## Edge Cases
+
+- Profile stage counts vary (3-8) — README should mention the range without overwhelming the reader
+- "30+ tools" → reframe around categories, not count, so it stays accurate as catalog grows/shrinks
+- OWASP wording must sound valuable while being honest about manual nature
+
+## Ambiguity Policy
+
+Make reasonable choice and document it. All changes are doc-only (except one test), so risk is minimal.
+
+## Decisions Log
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | Remove version tags from feature headers | Version 0.0.3 makes v1.5+ tags misleading; features exist but aren't versioned releases |
+| 2 | Soften OWASP to "in every /plan" | Accurate — it's a manual checklist in Phase 2, not an automated gate |
+| 3 | Reframe tool count around categories | Value is breadth of coverage, not raw number |
+| 4 | "Portability-first" over "CLI-first" | Matches actual mcpJustified filtering logic |
+| 5 | Plugin docs → docs/TOOLCHAIN.md | Best UX — users want setup info, not source code |
+| 6 | CHANGELOG note at top, not rewrite | Preserves historical record while preventing confusion |
+| 7 | Add enforcement test for paid alternatives | Prevents future regressions; all paid tools already comply |
+| 8 | Acknowledge profile stage range | Honest about varying workflows without complexity |

--- a/docs/plans/2026-03-22-docs-accuracy-design.md
+++ b/docs/plans/2026-03-22-docs-accuracy-design.md
@@ -60,3 +60,39 @@ Make reasonable choice and document it. All changes are doc-only (except one tes
 | 6 | CHANGELOG note at top, not rewrite | Preserves historical record while preventing confusion |
 | 7 | Add enforcement test for paid alternatives | Prevents future regressions; all paid tools already comply |
 | 8 | Acknowledge profile stage range | Honest about varying workflows without complexity |
+
+## Technical Research
+
+### OWASP Analysis
+
+Not applicable — this PR is doc fixes + one test. No user input, no auth, no API, no data processing. Zero security risk surface.
+
+### Blast-Radius Search
+
+Version tags (v1.5, v1.6, v1.7) also appear in:
+- docs/ENHANCED_ONBOARDING.md (6 occurrences) — out of scope (forge-z1ft epic)
+- docs/AGENT_INSTALL_PROMPT.md (1 occurrence) — out of scope (forge-z1ft epic)
+- docs/research/dependency-chain.md (2 occurrences) — research docs, not user-facing
+
+Only README.md lines 166, 180, 194 are in scope for this PR.
+
+"30+" claim appears only in README.md line 181 — single fix point.
+
+### Verified Findings
+
+| Item | README Claim | Actual Code | File |
+|------|-------------|-------------|------|
+| Version | v1.5.0, v1.6.0, v1.7.0 | 0.0.3 | package.json:3 |
+| Tool count | "30+ curated tools" | 15 tool entries | lib/plugin-catalog.js |
+| CLI-first | "Prefers CLI over MCPs" | Skips MCPs unless mcpJustified=true | lib/plugin-recommender.js:117-124 |
+| OWASP | "built-in" | Manual checklist in /plan Phase 2 | .claude/commands/plan.md:206 |
+| Plugin docs | lib/agents/README.md | Should be docs/TOOLCHAIN.md | README.md:192 |
+| Profiles | "7-stage" universal | 6 profiles, 3-8 stages | lib/workflow-profiles.js |
+| Paid alts | "Every paid tool shows free alternatives" | parallel-deep-research missing alternatives | lib/plugin-catalog.js:78 |
+| CHANGELOG | /check in v1.4.0 section | Should be /validate | CHANGELOG.md:381 |
+
+### TDD Test Scenarios
+
+1. **Happy path**: All `tier: 'paid'` entries in plugin-catalog have a non-empty `alternatives` array
+2. **Failure path**: Test fails when a paid entry has no alternatives (validates enforcement)
+3. **Edge case**: Each alternative has required `tool` and `tier` fields

--- a/docs/plans/2026-03-22-docs-accuracy-tasks.md
+++ b/docs/plans/2026-03-22-docs-accuracy-tasks.md
@@ -1,0 +1,147 @@
+# Task List: docs-accuracy
+
+**Epic**: forge-e3qj
+**Design**: docs/plans/2026-03-22-docs-accuracy-design.md
+**Branch**: feat/docs-accuracy
+**Worktree**: .worktrees/docs-accuracy
+
+## Parallel Waves
+
+```
+Wave 1 (parallel): Tasks 1-6 (all independent README edits)
+Wave 2 (sequential after Wave 1): Task 7 (CHANGELOG — independent but logically after README)
+Wave 3 (sequential after Wave 1): Task 8 (test + code fix — independent)
+```
+
+## Dependency Graph
+
+```
+Task 1 ──┐
+Task 2 ──┤
+Task 3 ──┤
+Task 4 ──┼──▶ Wave 1 complete ──▶ Task 7 (CHANGELOG)
+Task 5 ──┤                   └──▶ Task 8 (test + catalog fix)
+Task 6 ──┘
+```
+
+---
+
+## Task 1: Remove version tags and reframe feature headers (forge-zl6y)
+
+**File(s)**: README.md (lines 166, 180, 194)
+**What to implement**: Remove "(v1.5.0)", "(v1.7.0)", "(v1.6.0)" from feature section headers. Reframe each header to lead with developer value, not version number. Examples:
+- "Built-in TDD Enforcement (v1.5.0)" → "Built-in TDD Enforcement"
+- "Smart Tool Recommendations (v1.7.0)" → "Smart Tool Recommendations"
+- "Enhanced Onboarding (v1.6.0)" → "Enhanced Onboarding"
+Also remove the "New" emoji from line 194 since there's no version context for it.
+
+**TDD steps**:
+1. This is a doc-only change — no test needed
+2. Verify: grep for "v1\.[567]" in README returns no matches after edit
+
+**Expected output**: No version tags in README feature headers
+
+---
+
+## Task 2: Soften OWASP claim (forge-64x0)
+
+**File(s)**: README.md (line 48)
+**What to implement**: Change "OWASP Top 10 analysis built-in" to "OWASP Top 10 analysis in every /plan". This is accurate — OWASP is a manual checklist in /plan Phase 2, documented in design docs, not an automated gate.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: grep for "OWASP.*built-in" in README returns no matches
+
+**Expected output**: README accurately describes OWASP as part of /plan workflow
+
+---
+
+## Task 3: Reframe tool catalog around categories (forge-g491)
+
+**File(s)**: README.md (line 181)
+**What to implement**: Replace "Intelligent plugin catalog with 30+ curated tools:" with framing around category breadth. The catalog has 15 tools across 7 categories (research, dev, validate, ship, review, premerge, plan). Suggested wording: "Curated plugin catalog across 7 workflow stages:" — emphasizes breadth and integration with the 7-stage workflow rather than raw count.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: grep for "30+" in README returns no matches
+
+**Expected output**: README frames catalog value around workflow coverage, not tool count
+
+---
+
+## Task 4: Replace "CLI-first" with portability-first wording (forge-qk9d)
+
+**File(s)**: README.md (line 184)
+**What to implement**: Replace "CLI-first: Prefers CLI tools over MCPs for portability" with "Portability-first: MCPs included only when they add clear value over CLI alternatives". This matches the actual mcpJustified filtering logic in plugin-recommender.js:117-124.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: grep for "CLI-first" in README returns no matches
+
+**Expected output**: README accurately describes MCP filtering strategy
+
+---
+
+## Task 5: Fix Plugin docs link (forge-sl2f)
+
+**File(s)**: README.md (line 192)
+**What to implement**: Change `[Plugin docs](lib/agents/README.md)` to `[Plugin docs](docs/TOOLCHAIN.md)`. Users clicking "Plugin docs" want setup/usage info, not agent architecture source code.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: grep for "lib/agents/README.md" in README returns no matches
+
+**Expected output**: Plugin docs link points to user-facing toolchain guide
+
+---
+
+## Task 6: Fix profile stage counts in README (forge-6fm1)
+
+**File(s)**: README.md (lines 213-218)
+**What to implement**: The workflow profiles section currently lists specific profiles with stage counts. The actual code (lib/workflow-profiles.js) has 6 profiles ranging from 3 to 8 stages:
+- critical: 8, standard: 7, refactor: 5, simple: 4, hotfix: 3, docs: 3
+
+Update the profiles list in README to match actual code. The profile names and stage counts in the README (feature=7, fix=5, refactor=5, chore=3) don't match the code names (critical=8, standard=7, simple=4, hotfix=3, docs=3, refactor=5). Fix to use actual profile names and counts.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: README profile names match lib/workflow-profiles.js exactly
+
+**Expected output**: README profiles match code reality
+
+---
+
+## Task 7: Add CHANGELOG rename note (forge-4oxc)
+
+**File(s)**: CHANGELOG.md (top of file)
+**What to implement**: Add a note at the top of CHANGELOG (after the title/header) clarifying:
+"Note: `/check` was renamed to `/validate` and `/merge` was renamed to `/premerge` in v0.0.3. Historical entries below may use the old names."
+
+Do NOT rewrite historical entries — this preserves the record while preventing confusion.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: note exists at top of CHANGELOG
+
+**Expected output**: CHANGELOG has clarifying note about stage renames
+
+---
+
+## Task 8: Add paid-alternatives enforcement test + fix catalog (forge-b1ai)
+
+**File(s)**:
+- test/lib/plugin-catalog.test.js (new test)
+- lib/plugin-catalog.js (fix parallel-deep-research entry)
+
+**What to implement**:
+1. Add test that iterates all CATALOG entries, finds those with `tier: 'paid'`, and asserts each has a non-empty `alternatives` array where each alternative has `tool` and `tier` fields.
+2. Add `alternatives` array to `parallel-deep-research` entry (line 78) with at least one free alternative (e.g., WebSearch as the free alternative, since it's already referenced in other code as the fallback).
+
+**TDD steps**:
+1. Write test: `test/lib/plugin-catalog.test.js` — assert all paid entries have alternatives with tool+tier
+2. Run test: confirm it FAILS (parallel-deep-research has no alternatives)
+3. Implement: add `alternatives: [{ tool: 'WebSearch', tier: 'free', note: 'Built-in web search — no API key needed' }]` to parallel-deep-research
+4. Run test: confirm it PASSES
+5. Commit: `test: add paid-alternatives enforcement for plugin catalog` then `fix: add free alternative to parallel-deep-research`
+
+**Expected output**: Test passes, all paid catalog entries have free alternatives defined

--- a/docs/plans/2026-03-22-docs-accuracy-tasks.md
+++ b/docs/plans/2026-03-22-docs-accuracy-tasks.md
@@ -128,24 +128,17 @@ Do NOT rewrite historical entries — this preserves the record while preventing
 
 ---
 
-## Task 8: Add paid-alternatives enforcement test + fix catalog (forge-b1ai)
+## Task 8: Verify paid-alternatives enforcement test (forge-b1ai)
 
 **File(s)**:
-- test/lib/plugin-catalog.test.js (new test)
-- lib/plugin-catalog.js (fix parallel-deep-research entry)
+- test/plugin-catalog.test.js (existing test at line 148)
 
 **What to implement**:
-1. Add test that iterates all CATALOG entries, finds those with `tier: 'paid'`, and asserts each has a non-empty `alternatives` array where each alternative has `tool` and `tier` fields.
-2. Add `alternatives` array to `parallel-deep-research` entry (line 78) with at least one free alternative (e.g., WebSearch as the free alternative, since it's already referenced in other code as the fallback).
+No action needed. The enforcement test already exists at `test/plugin-catalog.test.js:148` ("every paid tool has >= 1 free alternative") and passes (25/25 tests, 0 failures). All paid catalog entries already have alternatives defined.
 
-**TDD steps**:
-1. Write test: `test/lib/plugin-catalog.test.js` — assert all paid entries have alternatives with tool+tier
-2. Run test: confirm it FAILS (parallel-deep-research has no alternatives)
-3. Implement: add `alternatives: [{ tool: 'WebSearch', tier: 'free', note: 'Built-in web search — no API key needed' }]` to parallel-deep-research
-4. Run test: confirm it PASSES
-5. Commit: `test: add paid-alternatives enforcement for plugin catalog` then `fix: add free alternative to parallel-deep-research`
+**Status**: Already satisfied — verified during /dev
 
-**Expected output**: Test passes, all paid catalog entries have free alternatives defined
+**Expected output**: Existing test passes, all paid catalog entries have free alternatives defined
 
 ---
 

--- a/docs/plans/2026-03-22-docs-accuracy-tasks.md
+++ b/docs/plans/2026-03-22-docs-accuracy-tasks.md
@@ -9,8 +9,7 @@
 
 ```
 Wave 1 (parallel): Tasks 1-6 (all independent README edits)
-Wave 2 (sequential after Wave 1): Task 7 (CHANGELOG — independent but logically after README)
-Wave 3 (sequential after Wave 1): Task 8 (test + code fix — independent)
+Wave 2 (parallel): Tasks 7-11 (CHANGELOG, test, QUICKSTART, ROADMAP, GREPTILE — all independent)
 ```
 
 ## Dependency Graph
@@ -20,8 +19,10 @@ Task 1 ──┐
 Task 2 ──┤
 Task 3 ──┤
 Task 4 ──┼──▶ Wave 1 complete ──▶ Task 7 (CHANGELOG)
-Task 5 ──┤                   └──▶ Task 8 (test + catalog fix)
-Task 6 ──┘
+Task 5 ──┤                   ├──▶ Task 8 (test + catalog fix)
+Task 6 ──┘                   ├──▶ Task 9 (QUICKSTART /research fix)
+                              ├──▶ Task 10 (ROADMAP stale dates)
+                              └──▶ Task 11 (GREPTILE hardcoded PR)
 ```
 
 ---
@@ -145,3 +146,42 @@ Do NOT rewrite historical entries — this preserves the record while preventing
 5. Commit: `test: add paid-alternatives enforcement for plugin catalog` then `fix: add free alternative to parallel-deep-research`
 
 **Expected output**: Test passes, all paid catalog entries have free alternatives defined
+
+---
+
+## Task 9: Fix QUICKSTART.md /research stage reference
+
+**File(s)**: QUICKSTART.md (lines 95-113)
+**What to implement**: QUICKSTART references `/research` as a separate stage/command, but research is Phase 2 of `/plan` — not its own command. Fix the section to show research as part of `/plan` output, not a separate step. Ensure the walkthrough matches the actual 7-stage workflow (/plan -> /dev -> /validate -> /ship -> /review -> /premerge -> /verify).
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: grep for "/research" in QUICKSTART.md returns no matches as a stage name
+
+**Expected output**: QUICKSTART walkthrough matches actual workflow stages
+
+---
+
+## Task 10: Update ROADMAP.md stale status info
+
+**File(s)**: docs/ROADMAP.md
+**What to implement**: ROADMAP has stale status information — Feb 2026 plans and PR merge dates that are inconsistent with current date (March 2026). Update status of completed items, remove outdated timeline references, and ensure the roadmap reflects current project state.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: no obviously stale dates or incorrect PR statuses remain
+
+**Expected output**: ROADMAP reflects current project state accurately
+
+---
+
+## Task 11: Fix GREPTILE_SETUP.md hardcoded PR reference
+
+**File(s)**: docs/GREPTILE_SETUP.md (line 375)
+**What to implement**: Replace hardcoded "Your PR #13" reference with a generic example or a note to use your own PR number. Hardcoded PR references become stale as the repo evolves.
+
+**TDD steps**:
+1. Doc-only change — no test needed
+2. Verify: no hardcoded PR numbers remain as "examples" in the guide
+
+**Expected output**: GREPTILE_SETUP uses generic/dynamic PR references


### PR DESCRIPTION
## Problem
README and user-facing docs contained multiple factual inaccuracies — fake version tags (v1.5-v1.7 when package.json is 0.0.3), overclaimed features ("OWASP built-in", "30+ tools", "CLI-first"), wrong links, wrong profile names, and stale stage references. Users reading these docs hit dead ends or form wrong expectations on first contact.

## Root Cause
Features were documented aspirationally during development but never updated to match the actual shipped code. Version tags were marketing-style labels rather than real semver releases. QUICKSTART had a `/research` stage that doesn't exist as a separate command.

## Fix
Corrected all 8 identified inaccuracies under epic forge-e3qj, plus 3 additional doc fixes found during audit:

**README.md:**
- Removed version tags (v1.5.0, v1.6.0, v1.7.0) from feature headers
- Softened OWASP claim: "built-in" → "in every /plan"
- Reframed tool catalog around 7 workflow stages, not raw count
- Replaced "CLI-first" with "Portability-first" matching actual MCP filtering logic
- Fixed Plugin docs link: `lib/agents/README.md` → `docs/TOOLCHAIN.md`
- Fixed workflow profile names and stage counts to match code (3-8 stages across 6 profiles)

**QUICKSTART.md:**
- Merged `/research` into `/plan` (Phase 2) — it's not a separate stage
- Renumbered all stages to match actual 7-stage workflow
- Fixed `docs/research/` path to `docs/plans/`

**CHANGELOG.md:**
- Added rename note at top: `/check` → `/validate`, `/merge` → `/premerge`

**ROADMAP.md:**
- Updated status: PRs 0-6 merged, PR7-8 planned (was "blocked")
- Fixed stale timeline description

**GREPTILE_SETUP.md:**
- Replaced hardcoded PR #13 reference with generic link

## Value
- First-time users see accurate claims that match what they'll actually experience
- No more trust erosion from version tags that don't exist in package.json
- Workflow profiles, stage names, and tool catalog match the real code
- Documentation serves its purpose: README introduces, QUICKSTART guides, CHANGELOG records

## Beads
Closes: forge-e3qj, forge-zl6y, forge-64x0, forge-g491, forge-qk9d, forge-sl2f, forge-6fm1, forge-4oxc

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 109/109 related tests passing (plugin-catalog, stage-naming, workflow-profiles)
- Full suite: 1907 tests, pre-existing failures unchanged
- Paid-alternatives enforcement test already exists and passes

### Security Review
- OWASP Top 10: Not applicable — documentation-only changes, no code risk surface
- No user input, no auth, no API, no data processing changes

### Design Doc
See: docs/plans/2026-03-22-docs-accuracy-design.md

### Decisions Log
See: docs/plans/2026-03-22-docs-accuracy-decisions.md (0 decision gates fired)

### Key Decisions
1. Remove version tags entirely rather than using correct 0.0.3 — avoids maintenance burden
2. Soften OWASP to "in every /plan" — honest about manual nature while preserving value message
3. Reframe catalog around categories, not count — stays accurate as catalog grows/shrinks
4. "Portability-first" over "CLI-first" — matches actual mcpJustified filtering logic
5. CHANGELOG note at top, not history rewrite — preserves historical record

### Documentation Updated
- README.md (6 fixes)
- QUICKSTART.md (stage renumber + /research merge)
- CHANGELOG.md (rename note)
- docs/ROADMAP.md (stale status)
- docs/GREPTILE_SETUP.md (hardcoded PR)

### Validation
- [x] Type check passing (no TS in project)
- [x] Lint passing (0 errors, 0 warnings)
- [x] All related tests passing (109/109)
- [x] Security review completed (N/A — doc-only)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Documentation-only changes with no code modifications — safe to merge.
- All changes are doc corrections with zero code risk surface. Every inaccuracy identified in the epic has a corresponding fix that is traceable to the actual codebase (verified against package.json, lib/workflow-profiles.js, lib/plugin-recommender.js, lib/plugin-catalog.js). Prior review concerns about the decisions log, design doc contradictions, and the "research" stage naming have all been addressed. The 109 related tests continue to pass and no new regressions are possible from doc edits.
- No files require special attention.
</details>

<sub>Last reviewed commit: ["fix: correct stale f..."](https://github.com/harshanandak/forge/commit/5ebbd0d3914d9618a626cbf5abe91ede5fbc5689)</sub>

<!-- /greptile_comment -->