### PR TITLE
fix: eval-runner orphaned branch cleanup

### DIFF
--- a/scripts/lib/eval-runner.js
+++ b/scripts/lib/eval-runner.js
@@ -11,6 +11,34 @@
 const path = require('path');
 const { execSync } = require('node:child_process');
 
+// ── active worktree tracking (cleanup on crash) ─────────────────────
+// Tracks active eval worktrees so we can clean up on process exit/crash.
+// Prevents orphaned eval-* branches when interrupted.
+// Note: execSync is safe here — all paths are internally generated, never user input.
+const activeEvalWorktrees = new Map(); // path -> branch
+
+function cleanupActiveWorktrees() {
+  if (activeEvalWorktrees.size === 0) return;
+  let repoRoot;
+  try { repoRoot = getRepoRoot(); } catch (_err) { return; }
+  for (const [wtPath, branch] of activeEvalWorktrees) {
+    try {
+      execSync(`git worktree remove --force "${wtPath}"`, { cwd: repoRoot, stdio: 'pipe' });
+    } catch (_err) { /* already removed */ }
+    if (branch && branch.startsWith('eval-')) {
+      try {
+        execSync(`git branch -D "${branch}"`, { cwd: repoRoot, stdio: 'pipe' });
+      } catch (_err) { /* already deleted */ }
+    }
+  }
+  try { execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' }); } catch (_err) { /* ignore */ }
+  activeEvalWorktrees.clear();
+}
+
+process.on('exit', cleanupActiveWorktrees);
+process.on('SIGINT', () => { cleanupActiveWorktrees(); process.exit(130); });
+process.on('SIGTERM', () => { cleanupActiveWorktrees(); process.exit(143); });
+
 // ── helpers ──────────────────────────────────────────────────────────
 
 /**
@@ -56,6 +84,7 @@ async function createEvalWorktree() {
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
+  activeEvalWorktrees.set(wtPath, branch);
   return { path: wtPath, branch };
 }
 
@@ -97,6 +126,8 @@ async function destroyEvalWorktree(worktreePath) {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+
+  activeEvalWorktrees.delete(worktreePath);
 
   // Delete the temporary branch (force in case it's not fully merged)
   if (branch && branch.startsWith('eval-')) {

--- a/scripts/lib/eval-runner.js
+++ b/scripts/lib/eval-runner.js
@@ -36,8 +36,16 @@ function cleanupActiveWorktrees() {
 }
 
 process.on('exit', cleanupActiveWorktrees);
-process.on('SIGINT', () => { cleanupActiveWorktrees(); process.exit(130); });
-process.on('SIGTERM', () => { cleanupActiveWorktrees(); process.exit(143); });
+process.on('SIGINT', () => {
+  const hadWork = activeEvalWorktrees.size > 0;
+  cleanupActiveWorktrees();
+  if (hadWork) process.exit(130);
+});
+process.on('SIGTERM', () => {
+  const hadWork = activeEvalWorktrees.size > 0;
+  cleanupActiveWorktrees();
+  if (hadWork) process.exit(143);
+});
 
 // ── helpers ──────────────────────────────────────────────────────────
 

--- a/test/eval/eval-runner.test.js
+++ b/test/eval/eval-runner.test.js
@@ -19,13 +19,27 @@ const createdWorktrees = [];
 afterAll(() => {
   // Cleanup any worktrees that tests didn't destroy
   for (const wt of createdWorktrees) {
+    // Extract branch name from worktree path for cleanup
+    const branchName = path.basename(wt);
     try {
+      // execSync is safe here — paths are generated internally, not from user input
       execSync(`git worktree remove --force "${wt}"`, {
         cwd: WORKTREE_ROOT,
         stdio: 'pipe',
       });
     } catch (_err) {
       // already removed — ignore
+    }
+    // Delete the eval branch (worktree removal doesn't clean up branches)
+    if (branchName.startsWith('eval-')) {
+      try {
+        execSync(`git branch -D "${branchName}"`, {
+          cwd: WORKTREE_ROOT,
+          stdio: 'pipe',
+        });
+      } catch (_err) {
+        // already deleted — ignore
+      }
     }
   }
   // Prune stale worktree references


### PR DESCRIPTION
## Problem
The eval-runner created `eval-{timestamp}-{pid}` branches for isolated worktree testing, but never cleaned them up — resulting in **372 orphaned local branches** and 10+ stale worktree directories.

## Root Cause
1. `eval-runner.test.js` `afterAll()` removed worktrees but **never deleted the branches** (`git branch -D`)
2. If a process crashed or was interrupted mid-eval, there was **no safety net** — branches and worktrees were permanently orphaned

## Fix
1. **eval-runner.js**: Added `activeEvalWorktrees` Map that tracks all created worktrees. Registered `process.on('exit'/'SIGINT'/'SIGTERM')` handlers that clean up branches + worktrees on crash/interrupt
2. **eval-runner.test.js**: `afterAll()` now explicitly deletes `eval-*` branches after removing worktrees

## Value
- No more branch accumulation from eval runs
- Crash-safe: process exit always cleans up
- 13/13 eval-runner tests passing, 0 orphan branches after test run

## Verification
```
$ bun test test/eval/eval-runner.test.js
13 pass, 0 fail

$ git branch --list 'eval-*' | wc -l
0
```

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge — the fix is correct and directly solves the documented root cause with no regressions in the 13 passing tests.
- The core tracking logic (`activeEvalWorktrees` Map, add/delete lifecycle, exit/signal handlers) is implemented correctly, and the test cleanup gap is properly closed. The prior review concern about unconditional `process.exit()` has been addressed. The one remaining minor nuance — that when no worktrees are active, SIGINT/SIGTERM are swallowed rather than re-emitted — was explicitly suggested by the prior reviewer and is an acceptable trade-off for a standalone eval script. No new bugs introduced.
- No files require special attention.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: gate process.exit in signal handler..."](https://github.com/harshanandak/forge/commit/e6d1dc8462f5909d651f6cbbedca2f94e875c611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26294969)</sub>

<!-- /greptile_comment -->