### PR TITLE
feat: enforce descriptive context convention across workflow

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -275,7 +275,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -466,10 +466,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.claude/commands/premerge.md
+++ b/.claude/commands/premerge.md
@@ -123,6 +123,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -364,7 +364,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -120,9 +120,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -228,7 +228,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/.cline/workflows/dev.md
+++ b/.cline/workflows/dev.md
@@ -272,7 +272,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.cline/workflows/plan.md
+++ b/.cline/workflows/plan.md
@@ -463,10 +463,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.cline/workflows/premerge.md
+++ b/.cline/workflows/premerge.md
@@ -120,6 +120,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.cline/workflows/review.md
+++ b/.cline/workflows/review.md
@@ -361,7 +361,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.cline/workflows/ship.md
+++ b/.cline/workflows/ship.md
@@ -117,9 +117,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.cline/workflows/validate.md
+++ b/.cline/workflows/validate.md
@@ -225,7 +225,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -275,7 +275,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -466,10 +466,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.codex/skills/premerge/SKILL.md
+++ b/.codex/skills/premerge/SKILL.md
@@ -123,6 +123,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -364,7 +364,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -120,9 +120,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.codex/skills/validate/SKILL.md
+++ b/.codex/skills/validate/SKILL.md
@@ -228,7 +228,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/.cursor/commands/dev.md
+++ b/.cursor/commands/dev.md
@@ -272,7 +272,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -463,10 +463,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.cursor/commands/premerge.md
+++ b/.cursor/commands/premerge.md
@@ -120,6 +120,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -361,7 +361,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -117,9 +117,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.cursor/commands/validate.md
+++ b/.cursor/commands/validate.md
@@ -225,7 +225,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-25T13:31:01.433Z",
+  "generatedAt": "2026-03-26T12:08:10.215Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.github/prompts/dev.prompt.md
+++ b/.github/prompts/dev.prompt.md
@@ -277,7 +277,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -468,10 +468,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.github/prompts/premerge.prompt.md
+++ b/.github/prompts/premerge.prompt.md
@@ -125,6 +125,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -366,7 +366,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.github/prompts/ship.prompt.md
+++ b/.github/prompts/ship.prompt.md
@@ -122,9 +122,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.github/prompts/validate.prompt.md
+++ b/.github/prompts/validate.prompt.md
@@ -230,7 +230,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,5 @@ test-env/fixtures/*
 .beads/*.db
 .beads-credential-key
 
-# Note: .beads/*.db is scoped above — avoid global *.db which hides legitimate database files
+# Beads / Dolt files (added by bd init)
+*.db

--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,3 @@ test-env/fixtures/*
 .dolt/
 .beads/*.db
 .beads-credential-key
-.dolt/*.db

--- a/.kilocode/workflows/dev.md
+++ b/.kilocode/workflows/dev.md
@@ -276,7 +276,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.kilocode/workflows/plan.md
+++ b/.kilocode/workflows/plan.md
@@ -467,10 +467,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.kilocode/workflows/premerge.md
+++ b/.kilocode/workflows/premerge.md
@@ -124,6 +124,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.kilocode/workflows/review.md
+++ b/.kilocode/workflows/review.md
@@ -365,7 +365,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.kilocode/workflows/ship.md
+++ b/.kilocode/workflows/ship.md
@@ -121,9 +121,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.kilocode/workflows/validate.md
+++ b/.kilocode/workflows/validate.md
@@ -229,7 +229,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/.opencode/commands/dev.md
+++ b/.opencode/commands/dev.md
@@ -275,7 +275,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -466,10 +466,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.opencode/commands/premerge.md
+++ b/.opencode/commands/premerge.md
@@ -123,6 +123,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -364,7 +364,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -120,9 +120,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.opencode/commands/validate.md
+++ b/.opencode/commands/validate.md
@@ -228,7 +228,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/.roo/commands/dev.md
+++ b/.roo/commands/dev.md
@@ -276,7 +276,12 @@ Do NOT declare /dev complete until:
 ### Beads update
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> dev validate
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "<N tasks done, M decision gates fired>" \
+  --decisions "<key spec gaps and how they were resolved>" \
+  --artifacts "<changed source files and test files>" \
+  --next "<validation priorities — lint issues, type concerns>"
 ```
 
 ---

--- a/.roo/commands/plan.md
+++ b/.roo/commands/plan.md
@@ -467,10 +467,15 @@ Do NOT proceed to /dev until ALL are confirmed:
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, record the stage transition on the Beads issue:
+After all HARD-GATE items pass, validate context and record the stage transition:
 
 ```bash
-bash scripts/beads-context.sh stage-transition <id> plan dev
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> plan dev \
+  --summary "<design approach chosen, task count>" \
+  --decisions "<key trade-offs resolved during Q&A>" \
+  --artifacts "docs/plans/YYYY-MM-DD-<slug>-design.md docs/plans/YYYY-MM-DD-<slug>-tasks.md" \
+  --next "<first dev task focus area>"
 ```
 
 ---

--- a/.roo/commands/premerge.md
+++ b/.roo/commands/premerge.md
@@ -124,6 +124,16 @@ Output:
 After you merge, run /verify to confirm everything landed correctly.
 ```
 
+### Step 6: Validate Context and Record Stage Transition
+
+```bash
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> premerge verify \
+  --summary "<docs updated, CI green, PR ready>" \
+  --artifacts "<updated doc files, PR URL>" \
+  --next "<merge instructions for user>"
+```
+
 ```
 <HARD-GATE: /premerge exit>
 Do NOT run gh pr merge.

--- a/.roo/commands/review.md
+++ b/.roo/commands/review.md
@@ -365,7 +365,13 @@ Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
 3. gh pr checks <pr-number> shows all checks passing
-4. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> review premerge` → exit 0 confirmed
+4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> review premerge \
+     --summary "<all feedback addressed summary>" \
+     --decisions "<comment resolutions — valid fixes and justified rejections>" \
+     --artifacts "<fixed files, commit SHAs>" \
+     --next "<doc update needs for premerge>"
 </HARD-GATE>
 ```
 

--- a/.roo/commands/ship.md
+++ b/.roo/commands/ship.md
@@ -121,9 +121,14 @@ Rules for the PR body:
 - **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
 - **Include "Closes beads-xxx"** in the Beads section (required for auto-close in /verify)
 
-### Step 6: Record Stage Transition
+### Step 6: Validate Context and Record Stage Transition
 ```bash
-bash scripts/beads-context.sh stage-transition <id> ship review
+bash scripts/beads-context.sh validate <id>
+bash scripts/beads-context.sh stage-transition <id> ship review \
+  --summary "<PR created, checks pending>" \
+  --decisions "<template sections filled, beads linked>" \
+  --artifacts "<PR URL, branch name>" \
+  --next "<review focus areas>"
 ```
 
 ## Example Output

--- a/.roo/commands/validate.md
+++ b/.roo/commands/validate.md
@@ -229,7 +229,13 @@ until ALL FOUR show fresh output in this session:
 "Should pass", "was passing earlier", and "I'm confident" are not evidence.
 Run the commands. Show the output. THEN declare done.
 
-5. Stage transition: Run `bash scripts/beads-context.sh stage-transition <id> validate ship` → exit 0 confirmed
+5. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition: Run the following → exit 0 confirmed:
+   bash scripts/beads-context.sh stage-transition <id> validate ship \
+     --summary "<all checks pass/fail summary>" \
+     --decisions "<any failures diagnosed and fixed>" \
+     --artifacts "<scripts and commands run>" \
+     --next "<ship readiness notes>"
 </HARD-GATE>
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,9 +256,9 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push   # requires Dolt-backed Beads — run 'bd init' if missing
    git push
    git status  # MUST show "up to date with origin"
+   bd dolt push   # requires Dolt-backed Beads — run 'bd init' if missing
    ```
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,56 @@ Task 2: Validation logic
 
 **Load these files when you need detailed instructions for a specific stage.**
 
+## Descriptive Context Convention
+
+Every stage transition should carry structured context so the next stage (or a new session) can resume without re-reading the full design doc. This convention is **advisory** — warnings are informational, not blocking.
+
+### Required Fields at Each Stage Exit
+
+| Stage Exit | Summary | Decisions | Artifacts | Next |
+|------------|---------|-----------|-----------|------|
+| /plan      | Design approach chosen | Key trade-offs resolved | Design doc, task list paths | First dev task focus |
+| /dev       | Tasks completed, gate count | Spec gaps encountered | Changed files, test files | Validation priorities |
+| /validate  | All checks pass/fail summary | Failures diagnosed | Scripts/commands run | Ship readiness |
+| /ship      | PR created, checks pending | Template sections filled | PR URL, branch name | Review focus areas |
+| /review    | All feedback addressed | Comment resolutions | Fixed files, commit SHAs | Doc update needs |
+| /premerge  | Docs updated, CI green | N/A | Updated doc files | Merge instructions |
+
+### Validation Command
+
+Run at each stage exit to check for missing context:
+
+```bash
+bash scripts/beads-context.sh validate <beads-issue-id>
+```
+
+This checks: (1) issue has a description, (2) at least one stage transition exists, (3) most recent transition has a summary, (4) design metadata is set if past the plan stage. Always exits 0 (advisory).
+
+### Field Definitions
+
+- **Summary**: 1-2 sentence recap of what was accomplished in this stage. Example: `--summary "All 5 tasks done, 1 decision gate fired"`
+- **Decisions**: Key choices made during this stage that affect downstream work. Example: `--decisions "Used streaming parser over DOM for memory efficiency"`
+- **Artifacts**: File paths or URLs produced by this stage. Example: `--artifacts "lib/parser.js test/parser.test.js docs/plans/2026-03-26-parser-design.md"`
+- **Next**: Guidance for the next stage on what to focus on. Example: `--next "Run lint first — streaming approach may trigger no-await rule"`
+
+### Usage in Stage Transitions
+
+```bash
+# Basic (backward compatible)
+bash scripts/beads-context.sh stage-transition <id> dev validate
+
+# With context fields (recommended)
+bash scripts/beads-context.sh stage-transition <id> dev validate \
+  --summary "All 5 tasks done, 0 gates fired" \
+  --decisions "Used approach A per design doc" \
+  --artifacts "lib/foo.js test/foo.test.js" \
+  --next "Run type check and lint"
+```
+
+### Enforcement Level
+
+This convention is **advisory only**. The `validate` subcommand prints warnings but always exits 0. It does not block any stage transition. The goal is to build good habits, not to create friction.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,9 +190,7 @@ bd close <id>         # Complete work
 
 ### Rules
 
-- Use `bd` for ALL ad-hoc task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
-  - Exception: `/plan` Phase 3 generates task lists at `docs/plans/YYYY-MM-DD-<slug>-tasks.md` — these are approved artifacts consumed by `/dev`, but `bd` remains the source of truth for issue state
-  - GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/BEADS_GITHUB_SYNC.md`)
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 
@@ -208,12 +206,9 @@ bd close <id>         # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
+   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
-   ```
-   If using Dolt-backed Beads (the default for this project), also run:
-   ```bash
-   bd dolt push      # Sync Beads Dolt database to remote
    ```
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ Run at each stage exit to check for missing context:
 bash scripts/beads-context.sh validate <beads-issue-id>
 ```
 
-This checks: (1) issue has a description, (2) at least one stage transition exists, (3) most recent transition has a summary, (4) design metadata is set if past the plan stage. Always exits 0 (advisory).
+This checks: (1) issue has a description, (2) at least one stage transition exists, (3) most recent transition has a summary, (4) design metadata is set if past the plan stage. Exits 0 when context checks run (even if warnings are found); exits 1 only if the issue cannot be retrieved.
 
 ### Field Definitions
 
@@ -240,7 +240,7 @@ bd close <id>         # Complete work
 
 ### Rules
 
-- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/plans/YYYY-MM-DD-<slug>-tasks.md` — these are approved artifacts consumed by `/dev`, but `bd` remains the source of truth for issue state.
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/plans/YYYY-MM-DD-<slug>-tasks.md` — these are approved artifacts consumed by `/dev`, but `bd` remains the source of truth for issue state. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/BEADS_GITHUB_SYNC.md`).
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 

--- a/docs/plans/2026-03-26-context-convention-design.md
+++ b/docs/plans/2026-03-26-context-convention-design.md
@@ -1,0 +1,90 @@
+# Context Convention — Design Doc
+
+**Feature**: context-convention
+**Date**: 2026-03-26
+**Status**: planning
+**Issue**: forge-8scl
+
+---
+
+## Purpose
+
+AI agents create beads issues and stage transitions with minimal context. The current `stage-transition` output is a single line: "Stage: X complete -> ready for Y". When a different session, agent, or post-compaction revisit occurs, this sparse record makes it hard to understand what happened and why.
+
+This feature enforces structured context at every workflow stage boundary so that any agent can pick up where another left off with full understanding of decisions made, artifacts produced, and priorities for the next stage.
+
+## Success Criteria
+
+1. Stage transitions include summary, decisions, artifact links, and next-stage priorities
+2. `beads-context.sh validate <id>` checks required fields and warns on missing ones
+3. Command files reference the convention so agents know to follow it
+4. AGENTS.md documents the convention as a project standard
+
+## Out of Scope
+
+- Hard git hook enforcement (no exit-1 blocking)
+- Automated context generation (agents write the context manually)
+- Retroactive context for existing issues (only new transitions)
+
+## Approach Selected
+
+**Medium enforcement (Option B)**: Richer stage-transition templates in `beads-context.sh` plus a `beads-context.sh validate` subcommand that warns (soft block) when required fields are missing. Agents see warnings and self-correct. No hard git hooks.
+
+Why this over alternatives:
+- **Option A (docs-only)**: Too weak -- agents ignore conventions without tooling feedback
+- **Option B (medium -- selected)**: Balanced -- templates guide agents, validation warns on gaps, no workflow breakage
+- **Option C (hard enforcement)**: Too aggressive -- exit-1 hooks would block legitimate hotfix workflows
+
+## Constraints
+
+- Must not break existing workflow. Validation is advisory (exit 0 with warnings, not exit 1).
+- Must work for all 7 stages.
+- New flags to `stage-transition` are all optional -- existing calls continue to work unchanged.
+- Shell script must remain cross-platform (Git Bash on Windows, macOS, Linux).
+
+## Edge Cases
+
+1. **Docs-only changes**: `security_notes` field not required -- no security surface.
+2. **Hotfix stages**: May skip non-critical fields (summary is still required, but decisions/artifacts are optional).
+3. **Agent ignores warnings**: Acceptable. Convention is self-correcting over time as agents learn from validation output. No hard block.
+4. **No stage transitions yet**: `validate` warns "no transitions recorded" rather than erroring.
+5. **Multiple transitions for same stage**: Valid (e.g., re-running /validate). Validate checks the most recent transition only.
+
+## Ambiguity Policy
+
+Use 7-dimension rubric scoring per /dev decision gate. >= 80% confidence: proceed and document. < 80%: stop and ask user. Applies project-wide.
+
+---
+
+## Technical Research
+
+### OWASP Top 10 Analysis
+
+This feature is a convention/documentation change with a shell script validator. No user input processing, no network calls, no authentication, no data storage. Risk surface: zero.
+
+| Category | Applies? | Notes |
+|----------|----------|-------|
+| A01: Broken Access Control | N/A | No access control involved |
+| A02: Cryptographic Failures | N/A | No cryptography involved |
+| A03: Injection | N/A | Script uses existing `sanitize()` function; new flags follow same pattern |
+| A04: Insecure Design | N/A | Advisory-only validation, no security decisions |
+| A05: Security Misconfiguration | N/A | No configuration surfaces |
+| A06: Vulnerable Components | N/A | No new dependencies |
+| A07: Auth Failures | N/A | No authentication involved |
+| A08: Data Integrity Failures | N/A | No data integrity concerns |
+| A09: Logging Failures | N/A | Beads comments are the audit log; this improves them |
+| A10: SSRF | N/A | No network requests |
+
+### TDD Test Scenarios
+
+1. **Happy path: rich stage transition** -- Call `stage-transition` with `--summary`, `--decisions`, `--artifacts`, `--next` flags. Assert the comment includes all four sections as structured lines below the header.
+
+2. **Happy path: validate on well-documented issue** -- Issue has description, at least one stage transition with summary, and design metadata set. `validate` returns exit 0 with "All context fields present" message.
+
+3. **Error: validate on sparse issue** -- Issue exists but has no summary in latest transition and no design metadata. `validate` returns exit 0 but prints warnings listing the missing fields.
+
+4. **Error: validate on nonexistent issue** -- `validate` with a bogus ID returns non-zero exit and prints "Issue not found" error.
+
+5. **Edge: docs-only transition** -- `stage-transition` called without `--security_notes`. No warning emitted for missing security notes (not required for docs changes).
+
+6. **Edge: validate before any transitions** -- Issue exists but has no stage-transition comments. `validate` warns "no transitions recorded" and exits 0.

--- a/docs/plans/2026-03-26-context-convention-tasks.md
+++ b/docs/plans/2026-03-26-context-convention-tasks.md
@@ -1,0 +1,85 @@
+# Context Convention — Task List
+
+**Feature**: context-convention
+**Date**: 2026-03-26
+**Issue**: forge-8scl
+**Design doc**: docs/plans/2026-03-26-context-convention-design.md
+
+---
+
+## Wave 1: Template Enhancement (no dependencies)
+
+### Task 1: Extend stage-transition comment format
+
+**File(s)**: `scripts/beads-context.sh`
+
+**What**: Modify the `cmd_stage_transition` function to accept and include optional flags: `--summary` (what was accomplished), `--decisions` (key choices made), `--artifacts` (file paths, PR URLs, commit SHAs), `--next` (priorities for next stage). All optional but logged when provided. Current format `"Stage: X complete -> ready for Y"` becomes the header; new fields append as structured lines below it. Existing calls without flags continue to work unchanged.
+
+**TDD**:
+1. Write test: `test/beads-context-transition.test.js` -- assert stage-transition with all four flags produces a structured comment containing `Summary:`, `Decisions:`, `Artifacts:`, `Next:` sections below the header line
+2. Run test: expect fail (flags not parsed yet)
+3. Implement: Extend `cmd_stage_transition` in `beads-context.sh` to parse `--summary`, `--decisions`, `--artifacts`, `--next` flags after the three positional args, build multi-line comment, pass to `bd_comment`
+4. Run test: expect pass
+5. Commit: `feat: extend stage-transition with structured context fields`
+
+---
+
+### Task 2: Add validate subcommand
+
+**File(s)**: `scripts/beads-context.sh`
+
+**What**: Add `beads-context.sh validate <id>` subcommand that checks: (1) issue has a description (via `bd show`), (2) at least one stage transition comment exists (grep beads comments for "Stage:" pattern), (3) most recent transition has a summary field, (4) design metadata is set (if issue is past plan stage, i.e., has a "plan complete" transition). Output: list of warnings. Exit 0 always (advisory). Print "All context fields present" when everything checks out, or "Missing: <field1>, <field2>" with details for each gap.
+
+**TDD**:
+1. Write test: `test/beads-context-validate.test.js` -- assert validate on well-documented issue exits 0 with no warnings; assert validate on sparse issue exits 0 with warning lines listing missing fields; assert validate on nonexistent ID exits non-zero; assert validate before any transitions warns "no transitions recorded"
+2. Run test: expect fail (validate subcommand doesn't exist)
+3. Implement: Add `cmd_validate` function and `validate)` case to the dispatcher in `beads-context.sh`
+4. Run test: expect pass
+5. Commit: `feat: add beads-context validate subcommand`
+
+---
+
+## Wave 2: Convention Documentation (depends on Wave 1)
+
+### Task 3: Add convention section to AGENTS.md
+
+**File(s)**: `AGENTS.md`
+
+**What**: Add a `## Descriptive Context Convention` section documenting: (1) purpose -- why structured context matters for cross-session continuity, (2) required fields at each stage exit (`--summary` always required, others stage-dependent), (3) the validation command (`bash scripts/beads-context.sh validate <id>`), (4) field definitions with examples of good vs sparse transitions, (5) enforcement level (advisory warnings, not hard blocks). Place after the existing "Documentation Index" section and before the Beads Integration section.
+
+**TDD**:
+1. Write test: `test/agents-md-convention.test.js` -- assert AGENTS.md contains "Descriptive Context Convention" heading, contains "beads-context.sh validate" reference, contains field definition subsections (Summary, Decisions, Artifacts, Next)
+2. Run test: expect fail (section doesn't exist)
+3. Implement: Add the section to AGENTS.md
+4. Run test: expect pass
+5. Commit: `docs: add descriptive context convention to AGENTS.md`
+
+---
+
+### Task 4: Update command files to reference convention
+
+**File(s)**: `.claude/commands/plan.md`, `.claude/commands/dev.md`, `.claude/commands/validate.md`, `.claude/commands/ship.md`, `.claude/commands/review.md`, `.claude/commands/premerge.md`
+
+**What**: At each stage's exit HARD-GATE section, add instruction: "Run `bash scripts/beads-context.sh validate <id>` and address any warnings before proceeding." Also update existing `stage-transition` call examples to include `--summary` and `--decisions` flags showing the expected pattern. Do not modify `/status` or `/verify` (utility stages without transitions).
+
+**TDD**:
+1. Write test: `test/commands-convention-ref.test.js` -- assert each of the 6 command files contains `beads-context.sh validate` reference and at least one `--summary` flag in a stage-transition example
+2. Run test: expect fail (references not added yet)
+3. Implement: Edit each command file to add validate call and update stage-transition examples
+4. Run test: expect pass
+5. Commit: `docs: reference context convention in all workflow commands`
+
+---
+
+### Task 5: Sync commands to agent directories
+
+**File(s)**: (run sync script)
+
+**What**: After editing `.claude/commands/*.md` in Task 4, run `node scripts/sync-commands.js` to propagate changes to all 7 agent directories. Verify with `--check` flag.
+
+**TDD**:
+1. Write test: `test/command-sync-check.test.js` -- assert `node scripts/sync-commands.js --check` exits 0 (no drift between source and agent copies)
+2. Run test: expect fail (commands just changed in Task 4, not yet synced)
+3. Implement: Run `node scripts/sync-commands.js`
+4. Run test: expect pass
+5. Commit: `chore: sync commands to agent directories`

--- a/scripts/beads-context.sh
+++ b/scripts/beads-context.sh
@@ -255,19 +255,19 @@ cmd_stage_transition() {
     case "$1" in
       --summary)
         shift
-        flag_summary="$(sanitize "$1")"
+        flag_summary="$(sanitize "${1:-}")"
         ;;
       --decisions)
         shift
-        flag_decisions="$(sanitize "$1")"
+        flag_decisions="$(sanitize "${1:-}")"
         ;;
       --artifacts)
         shift
-        flag_artifacts="$(sanitize "$1")"
+        flag_artifacts="$(sanitize "${1:-}")"
         ;;
       --next)
         shift
-        flag_next="$(sanitize "$1")"
+        flag_next="$(sanitize "${1:-}")"
         ;;
       *)
         # Ignore unknown flags for forward compatibility

--- a/scripts/beads-context.sh
+++ b/scripts/beads-context.sh
@@ -7,7 +7,8 @@
 #   set-acceptance   <issue-id> "<criteria-text>"
 #   update-progress  <issue-id> <task-num> <total> "<title>" <commit-sha> <test-count> <gate-count>
 #   parse-progress   <issue-id>
-#   stage-transition <issue-id> <completed-stage> <next-stage>
+#   stage-transition <issue-id> <completed-stage> <next-stage> [--summary "..."] [--decisions "..."] [--artifacts "..."] [--next "..."]
+#   validate         <issue-id>
 #
 # Cross-platform: works on Windows (Git Bash), macOS, and Linux.
 # OWASP A03: All variables properly quoted to prevent shell injection.
@@ -25,7 +26,8 @@ Subcommands:
   set-acceptance   <issue-id> "<criteria-text>"
   update-progress  <issue-id> <task-num> <total> "<title>" <commit-sha> <test-count> <gate-count>
   parse-progress   <issue-id>
-  stage-transition <issue-id> <completed-stage> <next-stage>
+  stage-transition <issue-id> <completed-stage> <next-stage> [--summary "..."] [--decisions "..."] [--artifacts "..."] [--next "..."]
+  validate         <issue-id>
 EOF
   exit 1
 }
@@ -250,7 +252,7 @@ cmd_parse_progress() {
 
 cmd_stage_transition() {
   if [[ $# -lt 3 ]]; then
-    echo "Usage: beads-context.sh stage-transition <issue-id> <completed-stage> <next-stage>" >&2
+    echo "Usage: beads-context.sh stage-transition <issue-id> <completed-stage> <next-stage> [--summary \"...\"] [--decisions \"...\"] [--artifacts \"...\"] [--next \"...\"]" >&2
     exit 1
   fi
 
@@ -259,8 +261,55 @@ cmd_stage_transition() {
   completed="$(sanitize "$2")"
   local next
   next="$(sanitize "$3")"
+  shift 3
 
+  # Parse optional flags
+  local flag_summary="" flag_decisions="" flag_artifacts="" flag_next=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --summary)
+        shift
+        flag_summary="$(sanitize "$1")"
+        ;;
+      --decisions)
+        shift
+        flag_decisions="$(sanitize "$1")"
+        ;;
+      --artifacts)
+        shift
+        flag_artifacts="$(sanitize "$1")"
+        ;;
+      --next)
+        shift
+        flag_next="$(sanitize "$1")"
+        ;;
+      *)
+        # Ignore unknown flags for forward compatibility
+        ;;
+    esac
+    shift
+  done
+
+  # Build comment: header line always present
   local comment="Stage: ${completed} complete → ready for ${next}"
+
+  # Append structured fields only if provided
+  if [[ -n "$flag_summary" ]]; then
+    comment="${comment}
+Summary: ${flag_summary}"
+  fi
+  if [[ -n "$flag_decisions" ]]; then
+    comment="${comment}
+Decisions: ${flag_decisions}"
+  fi
+  if [[ -n "$flag_artifacts" ]]; then
+    comment="${comment}
+Artifacts: ${flag_artifacts}"
+  fi
+  if [[ -n "$flag_next" ]]; then
+    comment="${comment}
+Next: ${flag_next}"
+  fi
 
   if ! bd_comment "$issue_id" "$comment" > /dev/null; then
     die "Failed to record stage transition on issue ${issue_id}"

--- a/scripts/beads-context.sh
+++ b/scripts/beads-context.sh
@@ -318,6 +318,102 @@ Next: ${flag_next}"
   echo "Stage transition recorded on ${issue_id}: ${completed} → ${next}"
 }
 
+cmd_validate() {
+  if [[ $# -lt 1 ]]; then
+    echo "Usage: beads-context.sh validate <issue-id>" >&2
+    exit 1
+  fi
+
+  local issue_id="$1"
+  local warnings=0
+
+  # Get issue JSON
+  local json
+  json="$(bd show "$issue_id" --json 2>&1)" || {
+    echo "Error: Failed to retrieve issue ${issue_id}" >&2
+    exit 1
+  }
+
+  # Check for bd error patterns
+  if printf '%s' "$json" | grep -Eqi '^Error|Error resolving|Error fetching'; then
+    echo "Error: Issue not found: ${issue_id}" >&2
+    exit 1
+  fi
+
+  if [[ -z "$json" || "$json" == "[]" || "$json" == "null" ]]; then
+    echo "Error: Issue not found: ${issue_id}" >&2
+    exit 1
+  fi
+
+  # Extract fields — prefer jq, fall back to grep/sed
+  local description="" design=""
+  if command -v jq &>/dev/null; then
+    description="$(printf '%s' "$json" | jq -r 'if type == "array" then .[0].description else .description end // empty' 2>/dev/null || true)"
+    design="$(printf '%s' "$json" | jq -r 'if type == "array" then .[0].design else .design end // empty' 2>/dev/null || true)"
+  else
+    description="$(printf '%s' "$json" | grep -o '"description": *"[^"]*"' | head -1 | sed 's/^"description": *"//;s/"$//' || true)"
+    design="$(printf '%s' "$json" | grep -o '"design": *"[^"]*"' | head -1 | sed 's/^"design": *"//;s/"$//' || true)"
+  fi
+
+  # Check 1: Issue has description
+  if [[ -z "$description" ]]; then
+    echo "Warning: Issue ${issue_id} has no description"
+    warnings=$((warnings + 1))
+  fi
+
+  # Get comments to check for stage transitions
+  local comments
+  comments="$(bd comments list "$issue_id" 2>/dev/null || true)"
+
+  # Check 2: At least one stage transition exists
+  local has_transition=false
+  if echo "$comments" | grep -q 'Stage:.*complete'; then
+    has_transition=true
+  fi
+
+  if [[ "$has_transition" == "false" ]]; then
+    echo "Warning: No stage transition found on issue ${issue_id}"
+    warnings=$((warnings + 1))
+  fi
+
+  # Check 3: Most recent transition has summary
+  if [[ "$has_transition" == "true" ]]; then
+    local has_summary=false
+    if echo "$comments" | grep -q 'Summary:'; then
+      has_summary=true
+    fi
+    if [[ "$has_summary" == "false" ]]; then
+      echo "Warning: Most recent stage transition has no summary on issue ${issue_id}"
+      warnings=$((warnings + 1))
+    fi
+  fi
+
+  # Check 4: Design metadata is set if past plan stage
+  # "Past plan" means there's a transition FROM plan or any later stage
+  local past_plan=false
+  if echo "$comments" | grep -q 'Stage: plan complete'; then
+    past_plan=true
+  fi
+  if echo "$comments" | grep -Eq 'Stage: (dev|validate|ship|review|premerge) complete'; then
+    past_plan=true
+  fi
+
+  if [[ "$past_plan" == "true" && -z "$design" ]]; then
+    echo "Warning: Design metadata not set on issue ${issue_id} (past plan stage)"
+    warnings=$((warnings + 1))
+  fi
+
+  # Summary
+  if [[ $warnings -eq 0 ]]; then
+    echo "All context fields present on issue ${issue_id}"
+  else
+    echo "${warnings} warning(s) found on issue ${issue_id}"
+  fi
+
+  # Always exit 0 — advisory only
+  exit 0
+}
+
 # ── Main dispatcher ──────────────────────────────────────────────────────
 
 if [[ $# -lt 1 ]]; then
@@ -333,6 +429,7 @@ case "$subcommand" in
   update-progress)  cmd_update_progress "$@" ;;
   parse-progress)   cmd_parse_progress "$@" ;;
   stage-transition) cmd_stage_transition "$@" ;;
+  validate)         cmd_validate "$@" ;;
   *)
     echo "Error: Unknown subcommand '${subcommand}'" >&2
     usage

--- a/test/agents-md-convention.test.js
+++ b/test/agents-md-convention.test.js
@@ -1,0 +1,39 @@
+const { describe, test, expect } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+
+const AGENTS_MD = path.resolve(__dirname, '..', 'AGENTS.md');
+
+describe('AGENTS.md Descriptive Context Convention section', () => {
+  let content;
+
+  // Read the file once for all tests
+  content = fs.readFileSync(AGENTS_MD, 'utf8');
+
+  test('contains Descriptive Context Convention heading', () => {
+    expect(content).toContain('## Descriptive Context Convention');
+  });
+
+  test('references beads-context.sh validate command', () => {
+    expect(content).toContain('beads-context.sh validate');
+  });
+
+  test('contains Summary field definition', () => {
+    expect(content).toContain('Summary');
+  });
+
+  test('contains Decisions field definition', () => {
+    expect(content).toContain('Decisions');
+  });
+
+  test('contains Artifacts field definition', () => {
+    expect(content).toContain('Artifacts');
+  });
+
+  test('contains Next field definition', () => {
+    // Match "Next" as a field definition, not just any occurrence
+    // Look for it in context of the convention section
+    const conventionSection = content.split('## Descriptive Context Convention')[1] || '';
+    expect(conventionSection).toContain('Next');
+  });
+});

--- a/test/beads-context-transition.test.js
+++ b/test/beads-context-transition.test.js
@@ -1,0 +1,128 @@
+const { describe, test, expect } = require('bun:test');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'beads-context.sh');
+
+/**
+ * Helper: run beads-context.sh stage-transition with given args.
+ * Uses a bd shim that captures the comment text passed to `bd comments add`.
+ * This avoids needing a real Beads installation for unit tests.
+ *
+ * Note: execSync is safe here — all arguments are test-controlled string literals,
+ * not user input. Shell invocation is required to run the bash script under test.
+ */
+function runTransition(args, _env = {}) {
+  const tmpDir = os.tmpdir();
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const captureFile = path.join(tmpDir, `beads-ctx-test-${suffix}.txt`);
+
+  // Create a bd shim that captures the comment text
+  const shimDir = path.join(tmpDir, `bd-shim-${suffix}`);
+  fs.mkdirSync(shimDir, { recursive: true });
+  const shimPath = path.join(shimDir, 'bd');
+  fs.writeFileSync(shimPath, `#!/usr/bin/env bash
+# Shim: capture the comment argument
+if [ "$1" = "comments" ] && [ "$2" = "add" ]; then
+  printf '%s' "$4" > "${captureFile}"
+  echo "Comment added"
+  exit 0
+fi
+if [ "$1" = "update" ]; then
+  echo "Updated"
+  exit 0
+fi
+echo "bd shim: unknown command $*"
+exit 0
+`, { mode: 0o755 });
+
+  try {
+    execSync(`chmod +x "${shimPath}"`, { stdio: 'ignore' });
+  } catch (_e) {
+    // chmod may fail on Windows — mode was set above
+  }
+
+  const fullEnv = {
+    ...process.env,
+    PATH: `${shimDir}${path.delimiter}${process.env.PATH}`,
+    CAPTURE_FILE: captureFile,
+  };
+
+  try {
+    const output = execSync(`bash "${SCRIPT}" stage-transition ${args}`, {
+      env: fullEnv,
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+
+    let comment = '';
+    try {
+      comment = fs.readFileSync(captureFile, 'utf8');
+    } catch (_e) {
+      // File may not exist if bd wasn't called
+    }
+
+    // Cleanup
+    try { fs.unlinkSync(captureFile); } catch (_e) { /* ignore */ }
+    try { fs.unlinkSync(shimPath); } catch (_e) { /* ignore */ }
+    try { fs.rmdirSync(shimDir); } catch (_e) { /* ignore */ }
+
+    return { output, comment };
+  } catch (err) {
+    let comment = '';
+    try {
+      comment = fs.readFileSync(captureFile, 'utf8');
+    } catch (_e) { /* ignore */ }
+    try { fs.unlinkSync(captureFile); } catch (_e) { /* ignore */ }
+    try { fs.unlinkSync(shimPath); } catch (_e) { /* ignore */ }
+    try { fs.rmdirSync(shimDir); } catch (_e) { /* ignore */ }
+
+    return { output: err.stdout || '', stderr: err.stderr || '', comment, exitCode: err.status };
+  }
+}
+
+describe('beads-context.sh stage-transition', () => {
+  test('backward compat: without flags produces simple transition comment', () => {
+    const result = runTransition('test-issue-001 plan dev');
+    expect(result.comment).toContain('Stage: plan complete');
+    expect(result.comment).toContain('ready for dev');
+    // Should NOT contain structured fields when no flags given
+    expect(result.comment).not.toContain('Summary:');
+    expect(result.comment).not.toContain('Decisions:');
+    expect(result.comment).not.toContain('Artifacts:');
+    expect(result.comment).not.toContain('Next:');
+  });
+
+  test('with all four flags produces structured comment', () => {
+    const result = runTransition(
+      'test-issue-002 dev validate --summary "All 5 tasks done" --decisions "Used approach A" --artifacts "lib/foo.js test/foo.test.js" --next "Run type check and lint"'
+    );
+    expect(result.comment).toContain('Stage: dev complete');
+    expect(result.comment).toContain('ready for validate');
+    expect(result.comment).toContain('Summary: All 5 tasks done');
+    expect(result.comment).toContain('Decisions: Used approach A');
+    expect(result.comment).toContain('Artifacts: lib/foo.js test/foo.test.js');
+    expect(result.comment).toContain('Next: Run type check and lint');
+  });
+
+  test('with partial flags only includes provided fields', () => {
+    const result = runTransition(
+      'test-issue-003 validate ship --summary "All checks pass" --artifacts "scripts/validate.sh"'
+    );
+    expect(result.comment).toContain('Stage: validate complete');
+    expect(result.comment).toContain('Summary: All checks pass');
+    expect(result.comment).toContain('Artifacts: scripts/validate.sh');
+    // Not provided, should be absent
+    expect(result.comment).not.toContain('Decisions:');
+    expect(result.comment).not.toContain('Next:');
+  });
+
+  test('output message still reports transition', () => {
+    const result = runTransition('test-issue-004 ship review --summary "PR created"');
+    expect(result.output).toContain('Stage transition recorded on test-issue-004');
+    expect(result.output).toContain('ship');
+    expect(result.output).toContain('review');
+  });
+});

--- a/test/beads-context-validate.test.js
+++ b/test/beads-context-validate.test.js
@@ -1,0 +1,151 @@
+const { describe, test, expect } = require('bun:test');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const SCRIPT = path.resolve(__dirname, '..', 'scripts', 'beads-context.sh');
+
+/**
+ * Helper: run beads-context.sh validate with a bd shim.
+ *
+ * Note: execSync is safe here — all arguments are test-controlled literals,
+ * not user input. Shell invocation required to run bash script under test.
+ */
+function runValidate(issueId, shimBehavior = {}) {
+  const tmpDir = os.tmpdir();
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  const shimDir = path.join(tmpDir, `bd-shim-validate-${suffix}`);
+  fs.mkdirSync(shimDir, { recursive: true });
+  const shimPath = path.join(shimDir, 'bd');
+
+  const showJson = shimBehavior.showJson ?? JSON.stringify({
+    id: issueId,
+    title: 'Test issue',
+    description: 'description' in shimBehavior ? shimBehavior.description : 'A test feature',
+    design: 'design' in shimBehavior ? shimBehavior.design : '5 tasks | docs/plans/test-tasks.md',
+    notes: shimBehavior.notes ?? '',
+    status: 'in_progress',
+  });
+
+  const commentsOutput = shimBehavior.comments || '';
+  const showExitCode = shimBehavior.showExitCode || 0;
+
+  // Write comments to a temp file so the shim can cat it (avoids escaping issues)
+  const commentsFile = path.join(shimDir, 'comments.txt');
+  // Expand \n to real newlines before writing
+  fs.writeFileSync(commentsFile, commentsOutput.replace(/\\n/g, '\n'));
+
+  const jsonFile = path.join(shimDir, 'show.json');
+  fs.writeFileSync(jsonFile, showJson);
+
+  const shimContent = [
+    '#!/usr/bin/env bash',
+    'if [ "$1" = "show" ] && [ "$3" = "--json" ]; then',
+    `  if [ "${showExitCode}" -ne 0 ]; then`,
+    '    echo "Error resolving issue: $2" >&2',
+    `    exit ${showExitCode}`,
+    '  fi',
+    `  cat "${jsonFile.replace(/\\/g, '/')}"`,
+    '  exit 0',
+    'fi',
+    'if [ "$1" = "comments" ] && [ "$2" = "list" ]; then',
+    `  cat "${commentsFile.replace(/\\/g, '/')}"`,
+    '  exit 0',
+    'fi',
+    'echo "bd shim: $*"',
+    'exit 0',
+  ].join('\n');
+
+  fs.writeFileSync(shimPath, shimContent, { mode: 0o755 });
+
+  try {
+    execSync(`chmod +x "${shimPath}"`, { stdio: 'ignore' });
+  } catch (_e) { /* ignore */ }
+
+  const fullEnv = {
+    ...process.env,
+    PATH: `${shimDir}${path.delimiter}${process.env.PATH}`,
+  };
+
+  try {
+    const output = execSync(`bash "${SCRIPT}" validate ${issueId}`, {
+      env: fullEnv,
+      encoding: 'utf8',
+      timeout: 10000,
+    });
+
+    try { fs.rmSync(shimDir, { recursive: true, force: true }); } catch (_e) { /* ignore */ }
+
+    return { output, exitCode: 0 };
+  } catch (err) {
+    try { fs.rmSync(shimDir, { recursive: true, force: true }); } catch (_e) { /* ignore */ }
+
+    return {
+      output: (err.stdout || '') + (err.stderr || ''),
+      exitCode: err.status,
+    };
+  }
+}
+
+describe('beads-context.sh validate', () => {
+  test('nonexistent issue exits non-zero or prints error', () => {
+    const result = runValidate('nonexistent-999', {
+      showExitCode: 1,
+      showJson: '',
+    });
+    const hasError = result.exitCode !== 0 || result.output.toLowerCase().includes('error');
+    expect(hasError).toBe(true);
+  });
+
+  test('warns when description is missing', () => {
+    const result = runValidate('test-issue-010', {
+      description: '',
+      comments: 'Stage: plan complete → ready for dev\nSummary: Design done',
+      design: '3 tasks | docs/plans/test.md',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output.toLowerCase()).toContain('description');
+  });
+
+  test('warns when no stage transition exists', () => {
+    const result = runValidate('test-issue-011', {
+      description: 'A real description',
+      comments: '',
+      design: '3 tasks | docs/plans/test.md',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output.toLowerCase()).toContain('stage transition');
+  });
+
+  test('warns when most recent transition has no summary', () => {
+    const result = runValidate('test-issue-012', {
+      description: 'A real description',
+      comments: 'Stage: plan complete → ready for dev',
+      design: '3 tasks | docs/plans/test.md',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output.toLowerCase()).toContain('summary');
+  });
+
+  test('warns when design metadata is missing for post-plan stage', () => {
+    const result = runValidate('test-issue-013', {
+      description: 'A real description',
+      comments: 'Stage: dev complete → ready for validate\nSummary: All tasks done',
+      design: '',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output.toLowerCase()).toContain('design');
+  });
+
+  test('outputs success when all fields are present', () => {
+    const result = runValidate('test-issue-014', {
+      description: 'A real description',
+      comments: 'Stage: dev complete → ready for validate\nSummary: All 5 tasks done',
+      design: '5 tasks | docs/plans/test-tasks.md',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('All context fields present');
+  });
+});

--- a/test/command-sync-check.test.js
+++ b/test/command-sync-check.test.js
@@ -1,0 +1,26 @@
+const { describe, test, expect } = require('bun:test');
+const { execSync } = require('child_process');
+const path = require('path');
+
+/**
+ * Verify command files are synced to all agent directories.
+ *
+ * Note: execSync runs a fixed script path with --check flag.
+ * No user input — safe from injection.
+ */
+describe('Command sync check', () => {
+  test('sync-commands.js --check exits 0 (all commands synced)', () => {
+    const scriptPath = path.resolve(__dirname, '..', 'scripts', 'sync-commands.js');
+    let exitCode = 0;
+    try {
+      execSync(`node "${scriptPath}" --check`, {
+        cwd: path.resolve(__dirname, '..'),
+        encoding: 'utf8',
+        timeout: 30000,
+      });
+    } catch (err) {
+      exitCode = err.status;
+    }
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/commands-convention-ref.test.js
+++ b/test/commands-convention-ref.test.js
@@ -1,0 +1,30 @@
+const { describe, test, expect } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+
+const COMMANDS_DIR = path.resolve(__dirname, '..', '.claude', 'commands');
+
+const COMMAND_FILES = [
+  'plan.md',
+  'dev.md',
+  'validate.md',
+  'ship.md',
+  'review.md',
+  'premerge.md',
+];
+
+describe('Command files reference context convention', () => {
+  for (const file of COMMAND_FILES) {
+    const filePath = path.join(COMMANDS_DIR, file);
+
+    test(`${file} contains beads-context.sh validate reference`, () => {
+      const content = fs.readFileSync(filePath, 'utf8');
+      expect(content).toContain('beads-context.sh validate');
+    });
+
+    test(`${file} contains --summary flag in a stage-transition example`, () => {
+      const content = fs.readFileSync(filePath, 'utf8');
+      expect(content).toContain('--summary');
+    });
+  }
+});


### PR DESCRIPTION
## Problem
AI agents create beads issues and stage transitions with minimal context — just "Stage: X complete → ready for Y". When revisiting in a different session or after compaction, there's no way to understand what happened and why.

## Root Cause
Stage-transition comments are purely state tracking. No structured fields for summary, decisions, artifacts, or next-stage priorities. No validation to catch missing context.

## Fix
- Extend `beads-context.sh stage-transition` with `--summary`, `--decisions`, `--artifacts`, `--next` flags (backward compatible)
- Add `beads-context.sh validate <id>` subcommand — warns on missing context fields (advisory, exit 0)
- Document convention in AGENTS.md with field definitions and examples
- Reference validate command in all 6 workflow command HARD-GATEs
- Sync commands to all agent directories

## Value
Cross-session continuity improves dramatically. Any agent or human can understand what happened at each stage without re-reading entire conversation history.

## Beads
Closes forge-8scl

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 29 passing
- Scenarios covered: structured transitions with all flags, backward compat without flags, validate on complete/sparse/nonexistent issues, AGENTS.md convention section, command file references, sync check

### Security Review
- OWASP Top 10: All N/A — shell script + documentation changes only. No user input processing, no network, no auth.
- Automated scan: No new vulnerabilities

### Design Doc
See: docs/plans/2026-03-26-context-convention-design.md

### Key Decisions
1. Medium enforcement (warn, not block) — agents self-correct on warnings without wasting cycles on hard blocks
2. All flags optional — backward compatible, existing calls unchanged
3. Advisory validation (exit 0 always) — no false positive blocking
4. Convention documented in AGENTS.md as project standard

### Documentation Updated
- AGENTS.md (new Descriptive Context Convention section)
- .claude/commands/{plan,dev,validate,ship,review,premerge}.md (validate references)
- All 7 agent directories synced

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previously flagged issues have been addressed and no new critical issues were found.

All P0/P1 concerns from prior review cycles are resolved: the set -u unbound-variable crash is fixed with ${1:-}, Check 3 now correctly isolates the last transition block, the /plan task-list exception is restored in AGENTS.md, and .gitignore uses scoped patterns. The flag-parsing loop, validate checks, tests, and cross-directory sync all look correct. No new logic, security, or data-integrity issues were identified.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/beads-context.sh | Adds --summary/--decisions/--artifacts/--next flags to stage-transition (backward compatible) and a new advisory validate subcommand with 4 context checks; flag parsing correctly uses ${1:-} and awk isolates the last transition block. |
| AGENTS.md | Adds Descriptive Context Convention section with field definitions, usage examples, and enforcement level; restores /plan task-list exception and GitHub issues note in the bd tracking rule. |
| .gitignore | Removes redundant .dolt/*.db entry since .dolt/ already covers the full directory. |
| test/beads-context-validate.test.js | New test file covering nonexistent issue, missing description, missing transition, missing summary, missing design metadata, and all-fields-present scenarios. |
| test/beads-context-transition.test.js | New test file verifying backward compat (no flags), all four flags, partial flags, and output message correctness via a bd shim. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/plans/2026-03-26-context-convention-decisions.md`, line 1 ([link](https://github.com/harshanandak/forge/blob/00e4029c80b1ef24f59eaf27ab76e4ecfbc19dfe/docs/plans/2026-03-26-context-convention-decisions.md#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Empty decisions file shipped**

   `docs/plans/2026-03-26-context-convention-decisions.md` is a 0-byte file. The PR description links to a design doc and mentions a decisions doc, and the task list explicitly lists four key decisions that were made. This looks like the file was created as a placeholder but never filled in. Consider either populating it with the four key decisions from the PR description, or removing the file if it was unintentional.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/plans/2026-03-26-context-convention-decisions.md
   Line: 1

   Comment:
   **Empty decisions file shipped**

   `docs/plans/2026-03-26-context-convention-decisions.md` is a 0-byte file. The PR description links to a design doc and mentions a decisions doc, and the task list explicitly lists four key decisions that were made. This looks like the file was created as a placeholder but never filled in. Consider either populating it with the four key decisions from the PR description, or removing the file if it was unintentional.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/harshanandak/forge/commit/a042721efa8bb271576025649d29c995f941eb0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26438221)</sub>

<!-- /greptile_comment -->