### PR TITLE
fix: bump v0.0.6, fix npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.2.5

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.2.5
       - run: bun install
-      - run: bun test
+      - run: bun test test/  # Exclude test-env/ (uses node:test, incompatible with Bun)
 
   publish-npm:
     needs: build
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.2.5
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: bun install
       # Verify package contents before publishing (no build needed - pure JS package)

--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -160,6 +160,13 @@ async function handler(_args, flags, projectRoot, opts = {}) {
     }
   }
 
+  // Prune stale worktree refs to prevent bare repo state
+  if (!dryRun && cleaned > 0) {
+    try {
+      runFile('git', ['worktree', 'prune'], { stdio: 'pipe' });
+    } catch (_e) { /* intentional: prune is best-effort cleanup */ } // NOSONAR S2486
+  }
+
   return { success: true, cleaned, active, dryRun };
 }
 

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -179,6 +179,17 @@ async function handleCreate(slug, flags, projectRoot, opts) {
   const branchName = flags['--branch'] || flags.branch || `feat/${slug}`;
   const worktreesDir = path.resolve(projectRoot, '.worktrees');
 
+  // Guard: Detect bare repo state — worktrees created from bare repos produce broken branches
+  try {
+    const gitDir = runFile('git', ['-C', projectRoot, 'rev-parse', '--git-dir'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const workTree = runFile('git', ['-C', projectRoot, 'rev-parse', '--show-toplevel'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    if (!workTree) {
+      return { success: false, error: 'Main repo is in bare state (no working tree). Clone fresh instead: git clone <url> /tmp/forge-<slug>' };
+    }
+  } catch (_e) { // NOSONAR S2486
+    /* intentional: if rev-parse fails, likely bare — warn and continue */
+  }
+
   // Security: Validate slug doesn't contain path traversal (OWASP A01/A03)
   if (slug.includes('..') || slug.includes('/') || slug.includes('\\')) {
     return { success: false, error: String.raw`Invalid slug: must not contain "..", "/", or "\"` };

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -180,14 +180,12 @@ async function handleCreate(slug, flags, projectRoot, opts) {
   const worktreesDir = path.resolve(projectRoot, '.worktrees');
 
   // Guard: Detect bare repo state — worktrees created from bare repos produce broken branches
+  // git rev-parse --show-toplevel throws in a bare repo (no working tree)
   try {
-    const gitDir = runFile('git', ['-C', projectRoot, 'rev-parse', '--git-dir'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-    const workTree = runFile('git', ['-C', projectRoot, 'rev-parse', '--show-toplevel'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-    if (!workTree) {
-      return { success: false, error: 'Main repo is in bare state (no working tree). Clone fresh instead: git clone <url> /tmp/forge-<slug>' };
-    }
+    runFile('git', ['-C', projectRoot, 'rev-parse', '--show-toplevel'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
   } catch (_e) { // NOSONAR S2486
-    /* intentional: if rev-parse fails, likely bare — warn and continue */
+    /* intentional: show-toplevel fails in bare repos */
+    return { success: false, error: 'Main repo is in bare state (no working tree). Clone fresh instead: git clone <url> /tmp/forge-<slug>' };
   }
 
   // Security: Validate slug doesn't contain path traversal (OWASP A01/A03)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-workflow",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "7-stage TDD workflow for ALL AI coding agents (Claude, Cursor, Cline, OpenCode, Copilot, Kilo Code, Roo Code, Codex)",
   "bin": {
     "forge": "bin/forge.js",


### PR DESCRIPTION
Bump package.json 0.0.5 to 0.0.6. Fix npm-publish.yml: pin Bun 1.2.5 (was latest), scope tests to test/ only (test-env/ uses node:test incompatible with Bun), Node 22 (was 20).

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — all changes are well-scoped fixes with no new logic risks introduced.

The bare-repo guard in worktree.js is now correctly implemented via try/catch (directly addressing the previous review thread). The workflow changes are standard maintenance (pinning Bun, upgrading Node, scoping tests). The post-clean prune in clean.js is consistent with existing git call patterns in that file and is appropriately gated behind a best-effort try/catch. No P0 or P1 issues found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/npm-publish.yml | Pins Bun to 1.2.5, bumps Node to 22 in both jobs, adds setup-node to build job, and narrows test scope to test/ to avoid node:test incompatibility. |
| lib/commands/worktree.js | Adds bare-repo guard using try/catch around git rev-parse --show-toplevel — correctly handles the case where the command throws in a bare repo. |
| lib/commands/clean.js | Adds a best-effort git worktree prune call after successful worktree removals to clean up stale refs. |
| package.json | Version bump from 0.0.5 to 0.0.6. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: remove unused var, pin Node 22 in b..."](https://github.com/harshanandak/forge/commit/e6c47f15006938d68d03e55da5b2fb05ac7f5243) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26706592)</sub>

<!-- /greptile_comment -->