### PR TITLE
chore: bump to v0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-workflow",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "7-stage TDD workflow for ALL AI coding agents (Claude, Cursor, Cline, OpenCode, Copilot, Kilo Code, Roo Code, Codex)",
   "bin": {
     "forge": "bin/forge.js",


### PR DESCRIPTION
## Summary
- Version bump to v0.0.8

## Changes in this release
- Forge issue command surface (create/update/claim/close/show/list/ready)
- Global flag passthrough for issue commands (-p, --type, --help all reach bd)
- Eval worktree cleanup for Windows (self-healing stale directory removal)
- Tighter sync error classification (auth/network errors no longer masked)

## Test plan
- [x] Only package.json version changed
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — only the version field in package.json changed, no functional code modifications.

The entire diff is a single-field change to the version string in package.json. There are no logic, security, or correctness concerns with a version bump of this nature.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump to v0.0.8"](https://github.com/harshanandak/forge/commit/dd22058d890801fbc1648071c6ebaab42594d4ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27411813)</sub>

<!-- /greptile_comment -->