### PR TITLE
chore: bump to v0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-workflow",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "7-stage TDD workflow for ALL AI coding agents (Claude, Cursor, Cline, OpenCode, Copilot, Kilo Code, Roo Code, Codex)",
   "bin": {
     "forge": "bin/forge.js",


### PR DESCRIPTION
## Summary
- Version bump to v0.0.8 for npm publish

After merge, tag `v0.0.8` will be pushed to trigger the npm release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a single-field version bump with no logic or behavior changes.

Only the version field changed; no code, dependencies, or configuration logic was modified. A score of 5 is appropriate as all remaining findings (none) are P2 or lower.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump to v0.0.8"](https://github.com/harshanandak/forge/commit/9e76c95ba5598c8f4b4d8b7a5a7000c5a00e429c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27412025)</sub>

<!-- /greptile_comment -->