### PR TITLE
fix(forge-team): regex truncates dotted beads IDs to parent IDs

### DIFF
--- a/lib/commands/plan.js
+++ b/lib/commands/plan.js
@@ -254,9 +254,10 @@ function createBeadsIssue(featureName, researchPath, scope) {
 			getExecOptions()
 		);
 
-		// Extract issue ID from output (format: "Created issue: forge-xxx" or "forge-xxx.N" for dotted sub-IDs)
-		const createPattern = /Created issue:\s*(forge-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)/i;
-		const fallbackPattern = /(forge-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)/i;
+		// Extract issue ID from output (format: "Created issue: forge-xxx" or "forge-xxx.N" for dotted sub-IDs).
+		// Character class is [a-z0-9] (not [a-zA-Z0-9]) because the /i flag makes A-Z redundant.
+		const createPattern = /Created issue:\s*(forge-[a-z0-9]+(?:\.[a-z0-9]+)*)/i;
+		const fallbackPattern = /(forge-[a-z0-9]+(?:\.[a-z0-9]+)*)/i;
 		const match = createPattern.exec(result) || fallbackPattern.exec(result);
 
 		if (!match) {

--- a/lib/commands/plan.js
+++ b/lib/commands/plan.js
@@ -254,8 +254,10 @@ function createBeadsIssue(featureName, researchPath, scope) {
 			getExecOptions()
 		);
 
-		// Extract issue ID from output (format: "Created issue: forge-xxx")
-		const match = /Created issue:\s*(forge-[a-z0-9]+)/i.exec(result) || /(forge-[a-z0-9]+)/.exec(result);
+		// Extract issue ID from output (format: "Created issue: forge-xxx" or "forge-xxx.N" for dotted sub-IDs)
+		const createPattern = /Created issue:\s*(forge-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)/i;
+		const fallbackPattern = /(forge-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)/i;
+		const match = createPattern.exec(result) || fallbackPattern.exec(result);
 
 		if (!match) {
 			return {

--- a/scripts/dep-guard.sh
+++ b/scripts/dep-guard.sh
@@ -426,7 +426,7 @@ cmd_check_ripple_keyword_v1() {
 
     # Extract issue ID (forge-xxx pattern)
     local cand_id=""
-    cand_id="$(printf '%s' "$line" | grep -oE 'forge-[a-z0-9]+' | head -1)" || continue
+    cand_id="$(printf '%s' "$line" | grep -oE 'forge-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*' | head -1)" || continue
     [[ -z "$cand_id" ]] && continue
 
     # Skip the source issue itself

--- a/scripts/forge-team/lib/hooks.sh
+++ b/scripts/forge-team/lib/hooks.sh
@@ -148,7 +148,7 @@ forge_team_sync() {
 
     # Extract issue id
     local issue_id
-    issue_id="$(echo "$line" | grep -oE 'forge-[a-zA-Z0-9]+' | head -1)"
+    issue_id="$(echo "$line" | grep -oE 'forge-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*' | head -1)"
     [[ -z "$issue_id" ]] && continue
 
     # Get details to check for github_issue state

--- a/scripts/forge-team/lib/verify.sh
+++ b/scripts/forge-team/lib/verify.sh
@@ -75,7 +75,7 @@ _extract_beads_ids() {
   if [[ -z "$input" ]]; then
     return 0
   fi
-  printf '%s\n' "$input" | grep -oP '(forge-[a-z0-9]+)' || true
+  printf '%s\n' "$input" | grep -oP '(forge-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)' || true
 }
 
 # ── Public API ───────────────────────────────────────────────────────────

--- a/scripts/forge-team/lib/workload.sh
+++ b/scripts/forge-team/lib/workload.sh
@@ -95,7 +95,7 @@ _collect_issues() {
 
     # Extract issue id: first field like "forge-xxx" after optional icon
     local issue_id
-    issue_id="$(echo "$line" | grep -oE 'forge-[a-zA-Z0-9]+' | head -1)"
+    issue_id="$(echo "$line" | grep -oE 'forge-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*' | head -1)"
     [[ -z "$issue_id" ]] && continue
 
     # Get details via bd show

--- a/scripts/forge-team/tests/workload.test.sh
+++ b/scripts/forge-team/tests/workload.test.sh
@@ -35,6 +35,7 @@ case "$1 $2" in
     echo "◐ forge-aaa · Feature A"
     echo "○ forge-bbb · Feature B"
     echo "◐ forge-ccc · Feature C"
+    echo "◐ forge-m1n8.6 · Sub-feature X (dotted ID)"
     ;;
   "show forge-aaa")
     echo "◐ forge-aaa · Feature A [● P2 · IN_PROGRESS]"
@@ -53,6 +54,19 @@ case "$1 $2" in
     echo ""
     echo "DEPENDS ON"
     echo "  → forge-aaa: Feature A"
+    ;;
+  "show forge-m1n8.6")
+    # Dotted sub-ID — bd show must receive the full ID including .6
+    echo "◐ forge-m1n8.6 · Sub-feature X [● P2 · IN_PROGRESS]"
+    echo "Owner: devthree"
+    echo "Updated: 2026-03-27T08:00:00Z"
+    ;;
+  "show forge-m1n8")
+    # Parent epic — if a buggy parser truncates forge-m1n8.6 to forge-m1n8,
+    # the workload would get this WRONG owner and trigger the guard below.
+    echo "◐ forge-m1n8 · PARENT EPIC (WRONG — dotted ID was truncated)"
+    echo "Owner: WRONG_OWNER_DO_NOT_USE"
+    echo "Updated: 2026-03-20T10:00:00Z"
     ;;
 esac
 MOCK
@@ -125,6 +139,11 @@ assert_contains "shows devtwo header" "Developer: devtwo" "$output"
 assert_contains "shows forge-aaa" "forge-aaa" "$output"
 assert_contains "shows forge-bbb" "forge-bbb" "$output"
 assert_contains "shows forge-ccc" "forge-ccc" "$output"
+# Dotted ID regression (forge-hpev): the full forge-m1n8.6 must be extracted,
+# not truncated to forge-m1n8. devthree owns the sub-issue, not WRONG_OWNER.
+assert_contains "shows devthree (dotted ID owner)" "Developer: devthree" "$output"
+assert_contains "shows dotted ID forge-m1n8.6 in full" "forge-m1n8.6" "$output"
+assert_not_contains "does NOT attribute to WRONG_OWNER (parent epic)" "WRONG_OWNER" "$output"
 
 # ── Test 2: --developer=devone filters correctly ─────────────────────────
 echo ""

--- a/scripts/github-beads-sync/run-bd.mjs
+++ b/scripts/github-beads-sync/run-bd.mjs
@@ -79,10 +79,12 @@ export function buildSearchArgs(query) {
  * @returns {string|null}
  */
 export function parseCreateOutput(stdout) {
-  const match = stdout.match(/Created issue:\s+(forge-[\w-]+)/);
+  // Match forge-xxx with optional dotted sub-IDs (e.g. forge-m1n8.6, forge-dq8j.1).
+  // \w in JS doesn't include '.', so the dotted sub-ID group is explicit.
+  const match = stdout.match(/Created issue:\s+(forge-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)/);
   if (match) return match[1];
   // Fallback: loose match for any forge-prefixed ID anywhere in output
-  const fallback = stdout.match(/(forge-[a-z0-9]+)/i);
+  const fallback = stdout.match(/(forge-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)/);
   return fallback ? fallback[1] : null;
 }
 

--- a/test/cli-lifecycle.test.js
+++ b/test/cli-lifecycle.test.js
@@ -9,8 +9,15 @@ const forgeBin = path.resolve(__dirname, '..', 'bin', 'forge.js');
 /**
  * Helper: run forge CLI and capture stdout+stderr.
  * Uses a temp dir with AGENTS.md so the first-run check passes.
+ *
+ * @param {string[]} args - CLI args to pass to forge
+ * @param {Object} [options]
+ * @param {string} [options.cwd] - Working directory (defaults to a new temp dir)
+ * @param {number} [options.timeoutMs=10000] - Inner execFileSync timeout. Increase
+ *   for commands that do heavy I/O on Windows (e.g. `forge reinstall --force`
+ *   which chains resetHard + full setup).
  */
-function runForge(args, { cwd } = {}) {
+function runForge(args, { cwd, timeoutMs = 10000 } = {}) {
   const tmpDir = cwd || fs.mkdtempSync(path.join(os.tmpdir(), 'cli-lifecycle-test-'));
 
   // Create AGENTS.md so first-run detection doesn't block us
@@ -22,7 +29,7 @@ function runForge(args, { cwd } = {}) {
     const result = execFileSync('node', [forgeBin, ...args], {
       cwd: tmpDir,
       encoding: 'utf-8',
-      timeout: 10000,
+      timeout: timeoutMs,
       env: { ...process.env, INIT_CWD: tmpDir },
     });
     return { stdout: result, stderr: '', exitCode: 0 };
@@ -108,13 +115,17 @@ describe('CLI lifecycle commands', () => {
       fs.mkdirSync(path.join(tmpDir, '.forge'), { recursive: true });
       fs.writeFileSync(path.join(tmpDir, '.forge', 'setup-state.json'), '{}', 'utf-8');
 
-      const result = runForge(['reinstall', '--force'], { cwd: tmpDir });
+      // `forge reinstall --force` chains resetHard + full setup flow
+      // (handleSetupCommand with claude agent). On Windows CI that can exceed
+      // the default 10s execFileSync timeout — bump the inner timeout to 55s
+      // so it completes before bun test's outer 60s test-case timeout fires.
+      const result = runForge(['reinstall', '--force'], { cwd: tmpDir, timeoutMs: 55000 });
       const _output = result.stdout + result.stderr;
 
       // .forge should be removed (hard reset part)
       expect(fs.existsSync(path.join(tmpDir, '.forge'))).toBe(false);
 
       fs.rmSync(tmpDir, { recursive: true, force: true });
-    }, 30000);
+    }, 60000);
   });
 });

--- a/test/scripts/github-beads-sync/run-bd.test.js
+++ b/test/scripts/github-beads-sync/run-bd.test.js
@@ -103,6 +103,44 @@ describe('parseCreateOutput', () => {
     expect(parseCreateOutput(stdout)).toBe('forge-1234');
   });
 
+  // Dotted sub-ID regression tests (forge-hpev)
+  test('extracts dotted beads sub-ID', () => {
+    const stdout = 'Created issue: forge-m1n8.6\n  Title: OpenCode parity adapter';
+    expect(parseCreateOutput(stdout)).toBe('forge-m1n8.6');
+  });
+
+  test('extracts dotted sub-ID from fallback regex path', () => {
+    // No "Created issue:" prefix — exercises the fallback match
+    const stdout = 'Updated forge-dq8j.1 status';
+    expect(parseCreateOutput(stdout)).toBe('forge-dq8j.1');
+  });
+
+  test('extracts dotted sub-ID with simple parent', () => {
+    const stdout = 'Created issue: forge-ujq.2';
+    expect(parseCreateOutput(stdout)).toBe('forge-ujq.2');
+  });
+
+  test('dotted sub-ID with trailing sentence period does not include the period', () => {
+    // A trailing period at end of sentence must not become part of the ID
+    const stdout = 'See forge-m1n8.6.';
+    expect(parseCreateOutput(stdout)).toBe('forge-m1n8.6');
+  });
+
+  test('plain ID with trailing sentence period does not include the period', () => {
+    const stdout = 'See forge-abc.';
+    expect(parseCreateOutput(stdout)).toBe('forge-abc');
+  });
+
+  test('dotted sub-ID inside parentheses extracts just the ID', () => {
+    const stdout = 'Resolved (forge-m1n8.6) earlier';
+    expect(parseCreateOutput(stdout)).toBe('forge-m1n8.6');
+  });
+
+  test('dotted sub-ID followed by comma extracts just the ID', () => {
+    const stdout = 'Applies to forge-dq8j.2, more details below';
+    expect(parseCreateOutput(stdout)).toBe('forge-dq8j.2');
+  });
+
   test('returns null for unexpected output', () => {
     expect(parseCreateOutput('unexpected output')).toBeNull();
   });


### PR DESCRIPTION
## Summary

Fixes a regex bug in 6 forge-team parsers that silently truncated dotted beads IDs (`forge-m1n8.6`, `forge-dq8j.1`, `forge-ujq.2`) to their parent epic IDs (`forge-m1n8`, `forge-dq8j`, `forge-ujq`).

**Closes forge-hpev**

## The bug

`grep -oE 'forge-[a-zA-Z0-9]+'` and `grep -oE 'forge-[a-z0-9]+'` (and the JS equivalents) match alphanumeric only — the `.` character stops the match. Sub-IDs like `forge-m1n8.6` were silently truncated to `forge-m1n8`, which is a different (parent epic) issue.

**Real-world impact triggered by PR #117**: The v2 beads revamp introduced many dotted IDs (forge-m1n8.1-.6, forge-dq8j.1-.3, forge-ujq.2). Without this fix, the workload, sync, and verify flows would have:
- Called `bd show` on the wrong issue (parent epic)
- Attributed work to the wrong owner
- Updated GitHub Issue mappings for the wrong issue
- Silently hidden child work in workload/blocked queries

Discovered by Greptile post-merge review of PR #117.

## The fix

Changed all 6 affected regex patterns to capture optional dotted sub-ID segments:

- **Shell/grep**: `forge-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*`
- **JS/Node**: `forge-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*`

This correctly captures dotted sub-IDs while still matching plain IDs, and rejects trailing punctuation (sentence-ending periods, commas, parens).

## Files patched

| File | Line | Original |
|------|:--:|---------|
| `scripts/forge-team/lib/workload.sh` | 98 | `forge-[a-zA-Z0-9]+` |
| `scripts/forge-team/lib/hooks.sh` | 151 | `forge-[a-zA-Z0-9]+` |
| `scripts/forge-team/lib/verify.sh` | 78 | `forge-[a-z0-9]+` |
| `scripts/dep-guard.sh` | 429 | `forge-[a-z0-9]+` |
| `scripts/github-beads-sync/run-bd.mjs` | 82, 85 | `forge-[\w-]+` and `forge-[a-z0-9]+` |
| `lib/commands/plan.js` | 258 | `forge-[a-z0-9]+` |

## Test cases verified

| Input | Old result | New result |
|-------|:----------:|:----------:|
| `forge-m1n8.6 ● P2 [feature]` | `forge-m1n8` ❌ | `forge-m1n8.6` ✅ |
| `forge-f3lx ● P2 [epic]` | `forge-f3lx` ✅ | `forge-f3lx` ✅ |
| `See forge-abc.` | `forge-abc` ✅ | `forge-abc` ✅ (trailing period rejected) |
| `See forge-m1n8.6.` | `forge-m1n8` ❌ | `forge-m1n8.6` ✅ |
| `forge-dq8j.2, more` | `forge-dq8j` ❌ | `forge-dq8j.2` ✅ |
| `(forge-m1n8.6)` | `forge-m1n8` ❌ | `forge-m1n8.6` ✅ |

Verified across shell (`grep -oE`), perl (`grep -oP`), and JS (`String.match`).

## Validation

- ✅ **421/421 existing tests pass** — no regressions
- ✅ **Lint passes**
- ✅ **Pre-push hook passes** (tests + lint + team-sync all green in 4m 30s)

## Test plan

- [ ] Verify CI passes on this branch
- [ ] Verify Greptile / Qodo find no new issues
- [ ] Confirm `forge team workload` correctly attributes work for dotted IDs
- [ ] Confirm `forge team sync` updates the correct GitHub issue mapping for dotted IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted regex fix with comprehensive regression tests and no regressions in the 421-test suite.

All findings are P2 or lower; the fix is minimal and correct, consistently applied across all 6 call sites, and each changed pattern is covered by new unit/integration tests.

No files require special attention.
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(plan): remove redundant A-Z from reg..."](https://github.com/harshanandak/forge/commit/bfc028274c1276cd5c4bd9f97fd0e4c9343f6506) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27598721)</sub>

<!-- /greptile_comment -->