### PR TITLE
fix: harden T3 worktree workflow guardrails

### DIFF
--- a/.claude/commands/premerge.md
+++ b/.claude/commands/premerge.md
@@ -94,7 +94,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -153,7 +153,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -298,10 +298,13 @@ git push
 ### Step 9: Verify ALL Checks Pass
 
 ```bash
-# Wait for checks to complete
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -184,9 +184,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-Next: /review <pr-number> (after automated checks complete)
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -208,5 +209,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.claude/rules/greptile-review-process.md
+++ b/.claude/rules/greptile-review-process.md
@@ -131,7 +131,7 @@ bash .claude/scripts/greptile-resolve.sh stats <pr-number>
 
 **Should show**: "✓ All Greptile threads resolved!"
 
-### Step 4: Push Changes & Wait for Re-review
+### Step 4: Push Changes & Poll Briefly for Re-review
 
 ```bash
 git push
@@ -188,7 +188,7 @@ $ git push
 - **Reply to EACH comment thread** using the script (not as separate PR comment)
 - **Mark EACH thread as resolved** after fixing using the script
 - **Track progress** (X of Y fixed) in your notes
-- **Wait for Greptile re-review** after pushing fixes
+- **Poll for Greptile re-review for at most 60 seconds** after pushing fixes, then stop and hand off if it is still pending
 - **Use comment ID for replies**, thread ID for resolving
 - **Commit fixes BEFORE replying** so you can reference commit SHA
 
@@ -251,7 +251,7 @@ The `/review` command should now include these steps:
    - Fix each issue
    - Reply and resolve systematically
 3. Verify all threads resolved before declaring review complete
-4. Push changes and wait for Greptile re-review
+4. Push changes and poll briefly for Greptile re-review
 
 ---
 
@@ -271,7 +271,7 @@ The `/review` command should now include these steps:
 
 ### Greptile score not updating after fixes
 **Cause**: Must push commits to trigger re-analysis
-**Solution**: `git push` and wait 2-3 minutes for Greptile re-scan
+**Solution**: `git push`, check once immediately, and poll for up to 60 seconds. If Greptile is still pending after that, stop and wait for the user to resume later.
 
 ---
 

--- a/.cline/workflows/premerge.md
+++ b/.cline/workflows/premerge.md
@@ -91,7 +91,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -150,7 +150,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.cline/workflows/review.md
+++ b/.cline/workflows/review.md
@@ -295,10 +295,13 @@ git push
 ### Step 9: Verify ALL Checks Pass
 
 ```bash
-# Wait for checks to complete
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate

--- a/.cline/workflows/ship.md
+++ b/.cline/workflows/ship.md
@@ -181,9 +181,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-Next: /review <pr-number> (after automated checks complete)
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -205,5 +206,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.codex/skills/premerge/SKILL.md
+++ b/.codex/skills/premerge/SKILL.md
@@ -94,7 +94,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for at most 60 seconds. If checks are still pending after that, stop and tell the user to return with `/premerge <pr-number>` once the PR checks finish. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -153,7 +153,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.codex/skills/premerge/SKILL.md
+++ b/.codex/skills/premerge/SKILL.md
@@ -94,7 +94,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for at most 60 seconds. If checks are still pending after that, stop and tell the user to return with `/premerge <pr-number>` once the PR checks finish. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -297,13 +297,14 @@ git push
 
 ### Step 9: Verify ALL Checks Pass
 
-Poll PR checks for at most 60 seconds total after pushing fixes. If checks are still pending after that cap, stop and tell the user to return with `/review <pr-number>` once the PR checks finish. Do not idle in long polling loops.
-
 ```bash
-# Check current status immediately, then poll briefly if needed
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate
@@ -365,7 +366,7 @@ Next: /premerge <pr-number>
 Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
-3. gh pr checks <pr-number> shows all checks passing, or you stopped after the 60-second poll cap and handed off cleanly
+3. gh pr checks <pr-number> shows all checks passing
 4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
 5. Stage transition: Run the following → exit 0 confirmed:
    bash scripts/beads-context.sh stage-transition <id> review premerge \
@@ -443,7 +444,7 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Reply inline to Greptile**: Respond to each comment directly
 - **Post summary response**: Address Greptile's overall assessment
 - **Use sonarcloud skill**: Don't just check the web UI
-- **Verify all checks with a 60-second cap**: If checks stay pending longer, stop and wait for the user to resume later
+- **Verify all checks**: Ensure everything is green before /premerge
 - **Update Beads**: Keep issue status current
 - **Research if needed**: Use WebSearch for unclear suggestions
 - **Document fixes**: Clear commit messages for all fixes

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -297,8 +297,10 @@ git push
 
 ### Step 9: Verify ALL Checks Pass
 
+Poll PR checks for at most 60 seconds total after pushing fixes. If checks are still pending after that cap, stop and tell the user to return with `/review <pr-number>` once the PR checks finish. Do not idle in long polling loops.
+
 ```bash
-# Wait for checks to complete
+# Check current status immediately, then poll briefly if needed
 gh pr checks <pr-number>
 
 # Ensure all status checks are green:
@@ -363,7 +365,7 @@ Next: /premerge <pr-number>
 Do NOT declare /review complete until:
 1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
 2. ALL human reviewer comments are either resolved or have a reply with explanation
-3. gh pr checks <pr-number> shows all checks passing
+3. gh pr checks <pr-number> shows all checks passing, or you stopped after the 60-second poll cap and handed off cleanly
 4. Context check: Run `bash scripts/beads-context.sh validate <id>` and address any warnings
 5. Stage transition: Run the following → exit 0 confirmed:
    bash scripts/beads-context.sh stage-transition <id> review premerge \
@@ -441,7 +443,7 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Reply inline to Greptile**: Respond to each comment directly
 - **Post summary response**: Address Greptile's overall assessment
 - **Use sonarcloud skill**: Don't just check the web UI
-- **Verify all checks**: Ensure everything is green before /premerge
+- **Verify all checks with a 60-second cap**: If checks stay pending longer, stop and wait for the user to resume later
 - **Update Beads**: Keep issue status current
 - **Research if needed**: Use WebSearch for unclear suggestions
 - **Document fixes**: Clear commit messages for all fixes

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -184,9 +184,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created. Poll automated checks for up to 60 seconds.
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-If checks are still pending after 60 seconds, stop and tell the user to return with `/review <pr-number>` after GitHub Actions, Greptile, and SonarCloud finish.
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -208,5 +209,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait cap is 60 seconds**: Poll once or briefly after PR creation, then stop and hand off if checks are still pending
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -184,9 +184,9 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created. Poll automated checks for up to 60 seconds.
 
-Next: /review <pr-number> (after automated checks complete)
+If checks are still pending after 60 seconds, stop and tell the user to return with `/review <pr-number>` after GitHub Actions, Greptile, and SonarCloud finish.
 ```
 
 ## Integration with Workflow
@@ -208,5 +208,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Wait cap is 60 seconds**: Poll once or briefly after PR creation, then stop and hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.cursor/commands/premerge.md
+++ b/.cursor/commands/premerge.md
@@ -91,7 +91,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -150,7 +150,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -295,10 +295,13 @@ git push
 ### Step 9: Verify ALL Checks Pass
 
 ```bash
-# Wait for checks to complete
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -181,9 +181,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-Next: /review <pr-number> (after automated checks complete)
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -205,5 +206,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-28T17:20:53.983Z",
+  "generatedAt": "2026-04-09T10:36:00.700Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.github/prompts/premerge.prompt.md
+++ b/.github/prompts/premerge.prompt.md
@@ -96,7 +96,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -155,7 +155,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -300,10 +300,13 @@ git push
 ### Step 9: Verify ALL Checks Pass
 
 ```bash
-# Wait for checks to complete
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate

--- a/.github/prompts/ship.prompt.md
+++ b/.github/prompts/ship.prompt.md
@@ -186,9 +186,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-Next: /review <pr-number> (after automated checks complete)
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -210,5 +211,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test Suite
+    if: github.event_name != 'pull_request' || github.event.action != 'synchronize'
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -81,8 +86,118 @@ jobs:
           echo "✓ Edge case tests completed" >> $GITHUB_STEP_SUMMARY
           echo "✓ Automation tests completed" >> $GITHUB_STEP_SUMMARY
 
+  followup-tests:
+    name: Targeted PR Tests
+    if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.5
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Setup test fixtures
+        run: bash test-env/automation/setup-fixtures.sh --force
+
+      - name: Resolve affected test targets
+        id: affected
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.sha }}"
+          mapfile -t changed_files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          declare -A seen=()
+          test_targets=()
+          run_edge_cases=false
+
+          add_target() {
+            local target="$1"
+            if [[ -n "$target" && -f "$target" && -z "${seen[$target]:-}" ]]; then
+              seen["$target"]=1
+              test_targets+=("$target")
+            fi
+          }
+
+          for file in "${changed_files[@]}"; do
+            case "$file" in
+              test-env/*|test/e2e/*)
+                run_edge_cases=true
+                ;;
+              test/*.test.js|test/**/*.test.js)
+                add_target "$file"
+                ;;
+              lib/*.js|lib/**/*.js)
+                candidate="test/${file#lib/}"
+                add_target "${candidate%.js}.test.js"
+                ;;
+              scripts/*.js|scripts/**/*.js)
+                relative="${file#scripts/}"
+                add_target "test/scripts/${relative%.js}.test.js"
+                add_target "test/${relative%.js}.test.js"
+                ;;
+              .github/workflows/*)
+                workflow_name="$(basename "${file%.*}")"
+                add_target "test/workflows/${workflow_name}.test.js"
+                add_target "test/ci-workflow.test.js"
+                ;;
+              package.json|bun.lockb|pnpm-lock.yaml|yarn.lock|package-lock.json|packages/*)
+                echo "mode=full" >> "$GITHUB_OUTPUT"
+                echo "run_edge_cases=true" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          done
+
+          if [[ "${#test_targets[@]}" -gt 0 ]]; then
+            {
+              echo "mode=targeted"
+              echo "targets<<EOF"
+              printf '%s\n' "${test_targets[@]}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "run_edge_cases=${run_edge_cases}" >> "$GITHUB_OUTPUT"
+
+      - name: Run targeted unit tests
+        if: steps.affected.outputs.mode == 'targeted'
+        shell: bash
+        run: |
+          mapfile -t test_targets <<'EOF'
+          ${{ steps.affected.outputs.targets }}
+          EOF
+          bun test "${test_targets[@]}"
+
+      - name: Run single-platform unit suite fallback
+        if: steps.affected.outputs.mode == 'full'
+        run: bun test test/
+
+      - name: Run affected edge-case tests
+        if: steps.affected.outputs.run_edge_cases == 'true'
+        run: node --test test-env/**/*.test.js || true
+
   coverage:
     name: Code Coverage
+    if: github.event_name != 'pull_request' || github.event.action != 'synchronize'
     runs-on: ubuntu-latest
 
     steps:
@@ -131,6 +246,7 @@ jobs:
 
   e2e:
     name: E2E Tests
+    if: github.event_name != 'pull_request' || github.event.action != 'synchronize'
     runs-on: ubuntu-latest
 
     steps:
@@ -211,6 +327,7 @@ jobs:
 
   dashboard:
     name: Test Dashboard
+    if: github.event_name != 'pull_request' || github.event.action != 'synchronize'
     runs-on: ubuntu-latest
     needs: [test, coverage]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,10 +149,12 @@ jobs:
                 add_target "$file"
                 ;;
               lib/*.js|lib/**/*.js)
+                run_test_env=true
                 candidate="test/${file#lib/}"
                 add_target "${candidate%.js}.test.js"
                 ;;
               scripts/*.js|scripts/**/*.js)
+                run_test_env=true
                 relative="${file#scripts/}"
                 add_target "test/scripts/${relative%.js}.test.js"
                 add_target "test/${relative%.js}.test.js"
@@ -170,6 +172,7 @@ jobs:
                 ;;
               *)
                 unmapped_files=true
+                run_test_env=true
                 ;;
             esac
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,9 @@ jobs:
 
           declare -A seen=()
           test_targets=()
-          run_edge_cases=false
+          run_test_env=false
+          run_e2e=false
+          unmapped_files=false
 
           add_target() {
             local target="$1"
@@ -137,8 +139,11 @@ jobs:
 
           for file in "${changed_files[@]}"; do
             case "$file" in
-              test-env/*|test/e2e/*)
-                run_edge_cases=true
+              test-env/*)
+                run_test_env=true
+                ;;
+              test/e2e/*)
+                run_e2e=true
                 ;;
               test/*.test.js|test/**/*.test.js)
                 add_target "$file"
@@ -159,13 +164,19 @@ jobs:
                 ;;
               package.json|bun.lockb|pnpm-lock.yaml|yarn.lock|package-lock.json|packages/*)
                 echo "mode=full" >> "$GITHUB_OUTPUT"
-                echo "run_edge_cases=true" >> "$GITHUB_OUTPUT"
+                echo "run_test_env=true" >> "$GITHUB_OUTPUT"
+                echo "run_e2e=true" >> "$GITHUB_OUTPUT"
                 exit 0
+                ;;
+              *)
+                unmapped_files=true
                 ;;
             esac
           done
 
-          if [[ "${#test_targets[@]}" -gt 0 ]]; then
+          if [[ "$unmapped_files" == "true" ]]; then
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          elif [[ "${#test_targets[@]}" -gt 0 ]]; then
             {
               echo "mode=targeted"
               echo "targets<<EOF"
@@ -176,7 +187,8 @@ jobs:
             echo "mode=full" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "run_edge_cases=${run_edge_cases}" >> "$GITHUB_OUTPUT"
+          echo "run_test_env=${run_test_env}" >> "$GITHUB_OUTPUT"
+          echo "run_e2e=${run_e2e}" >> "$GITHUB_OUTPUT"
 
       - name: Run targeted unit tests
         if: steps.affected.outputs.mode == 'targeted'
@@ -191,8 +203,12 @@ jobs:
         if: steps.affected.outputs.mode == 'full'
         run: bun test test/
 
+      - name: Run affected e2e tests
+        if: steps.affected.outputs.run_e2e == 'true'
+        run: bun test test/e2e/
+
       - name: Run affected edge-case tests
-        if: steps.affected.outputs.run_edge_cases == 'true'
+        if: steps.affected.outputs.run_test_env == 'true'
         run: node --test test-env/**/*.test.js || true
 
   coverage:

--- a/.kilocode/workflows/premerge.md
+++ b/.kilocode/workflows/premerge.md
@@ -95,7 +95,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -154,7 +154,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.kilocode/workflows/review.md
+++ b/.kilocode/workflows/review.md
@@ -299,10 +299,13 @@ git push
 ### Step 9: Verify ALL Checks Pass
 
 ```bash
-# Wait for checks to complete
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate

--- a/.kilocode/workflows/ship.md
+++ b/.kilocode/workflows/ship.md
@@ -185,9 +185,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-Next: /review <pr-number> (after automated checks complete)
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -209,5 +210,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.opencode/commands/premerge.md
+++ b/.opencode/commands/premerge.md
@@ -94,7 +94,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -153,7 +153,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -298,10 +298,13 @@ git push
 ### Step 9: Verify ALL Checks Pass
 
 ```bash
-# Wait for checks to complete
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -184,9 +184,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-Next: /review <pr-number> (after automated checks complete)
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -208,5 +209,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/.roo/commands/premerge.md
+++ b/.roo/commands/premerge.md
@@ -95,7 +95,7 @@ git commit -m "docs: update documentation for <feature-name>
 git push
 ```
 
-⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Wait for checks to pass. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
+⚠️  **After pushing**: CI will re-trigger (Greptile, SonarCloud, etc.). Poll for up to 60 seconds. If checks are still pending after that, stop and ask the user to return to `/premerge <pr-number>` later. If new Greptile comments appear on the doc changes, run `/review <pr-number>` again.
 
 ### Step 4: Sync Beads
 
@@ -154,7 +154,7 @@ Do NOT suggest merging.
   - README.md: Features list updated
   - CLAUDE.md: USER section updated with new pattern
   - Committed: docs: update documentation for auth-refresh
-✓ CI re-triggered after doc push — all checks still passing
+✓ CI re-triggered after doc push — checks passed within the 60 second poll window
 ✓ Beads synced
 
 ✅ PR #89 is ready to merge

--- a/.roo/commands/review.md
+++ b/.roo/commands/review.md
@@ -299,10 +299,13 @@ git push
 ### Step 9: Verify ALL Checks Pass
 
 ```bash
-# Wait for checks to complete
+# Check status immediately, then poll for at most 60 seconds
 gh pr checks <pr-number>
 
-# Ensure all status checks are green:
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
 # ✓ GitHub Actions workflows
 # ✓ Greptile review (no unresolved critical comments)
 # ✓ SonarCloud quality gate

--- a/.roo/commands/ship.md
+++ b/.roo/commands/ship.md
@@ -185,9 +185,10 @@ bash scripts/forge-team/index.sh verify 2>&1 || true
   - Beads linked: forge-xyz
   - Implementation details in collapsible section
 
-⏸️  PR created, awaiting automated checks (Greptile, SonarCloud, GitHub Actions)
+⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
+   Poll for up to 60 seconds. If checks are still pending, stop here.
 
-Next: /review <pr-number> (after automated checks complete)
+Next: /review <pr-number> (when automated checks complete or new feedback appears)
 ```
 
 ## Integration with Workflow
@@ -209,5 +210,5 @@ Stage 7: /verify     → Post-merge CI check on main
 - **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
 - **Include "Closes beads-xxx"**: Required for auto-close in /verify
 - **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
-- **Wait for checks**: Let GitHub Actions, Greptile, SonarCloud run
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
 - **NO auto-merge**: Always wait for /review phase

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -219,6 +219,51 @@ function parseDoltRemoteNames(remoteListOutput) {
     .filter(Boolean);
 }
 
+function readBeadsSyncRemoteConfig(projectDir = projectRoot) {
+  const jsonConfigPath = path.join(projectDir, '.beads', 'config.json');
+  if (fs.existsSync(jsonConfigPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(jsonConfigPath, 'utf8'));
+      if (typeof parsed.sync_remote === 'string' && parsed.sync_remote.trim()) {
+        return parsed.sync_remote.trim();
+      }
+    } catch (_error) {
+      // Ignore malformed config and fall back to other sources.
+    }
+  }
+
+  const yamlConfigPath = path.join(projectDir, '.beads', 'config.yaml');
+  if (fs.existsSync(yamlConfigPath)) {
+    const match = fs.readFileSync(yamlConfigPath, 'utf8').match(/^\s*sync-remote:\s*["']?([^"'#\r\n]+)["']?/m);
+    if (match && match[1] && match[1].trim()) {
+      return match[1].trim();
+    }
+  }
+
+  return '';
+}
+
+function resolveExpectedBeadsRemote(options = {}) {
+  const projectDir = options.projectDir || projectRoot;
+  const env = options.env || process.env;
+  const configuredRemote = readBeadsSyncRemoteConfig(projectDir);
+  if (configuredRemote) {
+    return configuredRemote;
+  }
+
+  if (typeof env.BD_SYNC_REMOTE === 'string' && env.BD_SYNC_REMOTE.trim()) {
+    return env.BD_SYNC_REMOTE.trim();
+  }
+
+  const gitRemoteProbe = options.gitRemoteProbe
+    || ((remoteName) => safeExec(`git -C "${projectDir}" remote get-url ${remoteName}`));
+  if (gitRemoteProbe('upstream')) {
+    return 'upstream';
+  }
+
+  return 'origin';
+}
+
 function hasBeadsDoltRemote(commandRunner, remoteName = 'origin') {
   const output = commandRunner('bd dolt remote list');
   if (!output) {
@@ -233,7 +278,11 @@ function checkPrerequisites(options = {}) {
   const requireGithubCli = options.requireGithubCli !== false;
   const requireBeadsCli = options.requireBeadsCli === true;
   const requireJq = options.requireJq === true;
-  const expectedBeadsRemote = options.expectedBeadsRemote || 'origin';
+  const expectedBeadsRemote = options.expectedBeadsRemote || resolveExpectedBeadsRemote({
+    env: options.env,
+    gitRemoteProbe: options.gitRemoteProbe,
+    projectDir: options.projectDir,
+  });
   const commandRunner = options.commandRunner || safeExec;
   const errors = [];
   const warnings = [];

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -234,10 +234,38 @@ function readBeadsSyncRemoteConfig(projectDir = projectRoot) {
 
   const yamlConfigPath = path.join(projectDir, '.beads', 'config.yaml');
   if (fs.existsSync(yamlConfigPath)) {
-    const match = fs.readFileSync(yamlConfigPath, 'utf8').match(/^\s*sync-remote:\s*["']?([^"'#\r\n]+)["']?/m);
-    if (match && match[1] && match[1].trim()) {
-      return match[1].trim();
+    const configuredRemote = parseBeadsYamlSyncRemote(fs.readFileSync(yamlConfigPath, 'utf8'));
+    if (configuredRemote) {
+      return configuredRemote;
     }
+  }
+
+  return '';
+}
+
+function parseBeadsYamlSyncRemote(content) {
+  for (const rawLine of String(content || '').split(/\r?\n/)) {
+    const trimmedLine = rawLine.trimStart();
+    if (!trimmedLine.startsWith('sync-remote:')) {
+      continue;
+    }
+
+    const rawValue = trimmedLine.slice('sync-remote:'.length).trim();
+    if (!rawValue) {
+      return '';
+    }
+
+    const quote = rawValue[0];
+    if ((quote === '"' || quote === '\'') && rawValue.length > 1) {
+      const closingQuoteIndex = rawValue.indexOf(quote, 1);
+      if (closingQuoteIndex > 1) {
+        return rawValue.slice(1, closingQuoteIndex).trim();
+      }
+    }
+
+    const commentIndex = rawValue.indexOf('#');
+    const unquotedValue = commentIndex === -1 ? rawValue : rawValue.slice(0, commentIndex);
+    return unquotedValue.trim();
   }
 
   return '';

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -205,11 +205,35 @@ function validateAgents(agentList) {
   return valid;
 }
 
+function parseDoltRemoteNames(remoteListOutput) {
+  const output = String(remoteListOutput || '').trim();
+  if (!output || /^No remotes configured\.?$/i.test(output)) {
+    return [];
+  }
+
+  return output
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => line.split(/\s+/)[0])
+    .filter(Boolean);
+}
+
+function hasBeadsDoltRemote(commandRunner, remoteName = 'origin') {
+  const output = commandRunner('bd dolt remote list');
+  if (!output) {
+    return null;
+  }
+
+  return parseDoltRemoteNames(output).includes(remoteName);
+}
+
 // Prerequisite check function
 function checkPrerequisites(options = {}) {
   const requireGithubCli = options.requireGithubCli !== false;
   const requireBeadsCli = options.requireBeadsCli === true;
   const requireJq = options.requireJq === true;
+  const expectedBeadsRemote = options.expectedBeadsRemote || 'origin';
   const commandRunner = options.commandRunner || safeExec;
   const errors = [];
   const warnings = [];
@@ -248,6 +272,15 @@ function checkPrerequisites(options = {}) {
   const bdVersion = commandRunner('bd --version');
   if (bdVersion) {
     console.log(`  ✓ ${bdVersion.split('\n')[0]}`);
+    if (requireBeadsCli) {
+      const hasRemote = hasBeadsDoltRemote(commandRunner, expectedBeadsRemote);
+      if (hasRemote === false) {
+        warnings.push(
+          `Beads Dolt remote '${expectedBeadsRemote}' is not configured. ` +
+          `Sync will remain local until you run: bd dolt remote add ${expectedBeadsRemote} <url>`
+        );
+      }
+    }
   } else if (requireBeadsCli) {
     errors.push('bd (Beads CLI) - Install from https://github.com/steveyegge/beads');
   }

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -279,6 +279,11 @@ function checkPrerequisites(options = {}) {
           `Beads Dolt remote '${expectedBeadsRemote}' is not configured. ` +
           `Sync will remain local until you run: bd dolt remote add ${expectedBeadsRemote} <url>`
         );
+      } else if (hasRemote === null) {
+        warnings.push(
+          `Unable to inspect Beads Dolt remotes. ` +
+          `Sync may remain local until '${expectedBeadsRemote}' is configured and bd dolt remote list succeeds.`
+        );
       }
     }
   } else if (requireBeadsCli) {

--- a/lib/commands/ship.js
+++ b/lib/commands/ship.js
@@ -33,12 +33,22 @@ function getGitExecOptions(cwd = process.cwd()) {
 	return { ...getExecOptions(), cwd };
 }
 
-function remoteHasTrackingBase(exec = execFileSync, cwd = process.cwd(), remoteName) {
+function resolveRemoteHeadTarget(exec = execFileSync, cwd = process.cwd(), remoteName) {
 	try {
-		exec('git', ['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], getGitExecOptions(cwd));
-		return true;
+		const symbolicRef = exec('git', ['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], getGitExecOptions(cwd)).trim();
+		if (!symbolicRef) {
+			return null;
+		}
+		exec('git', ['rev-parse', '--verify', symbolicRef], getGitExecOptions(cwd));
+		return symbolicRef;
 	} catch (_error) {
-		// Fall through to explicit branch probes.
+		return null;
+	}
+}
+
+function remoteHasTrackingBase(exec = execFileSync, cwd = process.cwd(), remoteName) {
+	if (resolveRemoteHeadTarget(exec, cwd, remoteName)) {
+		return true;
 	}
 
 	for (const candidate of ['main', 'master']) {
@@ -69,14 +79,12 @@ function resolveBaseRemote(exec = execFileSync, cwd = process.cwd()) {
 }
 
 function resolveBaseBranch(exec = execFileSync, cwd = process.cwd(), remoteName = resolveBaseRemote(exec, cwd)) {
-	try {
-		const symbolicRef = exec('git', ['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], getGitExecOptions(cwd)).trim();
+	const symbolicRef = resolveRemoteHeadTarget(exec, cwd, remoteName);
+	if (symbolicRef) {
 		const match = new RegExp(`^refs/remotes/${remoteName}/(.+)$`).exec(symbolicRef);
 		if (match && match[1]) {
 			return match[1];
 		}
-	} catch (_error) {
-		// Fall through to explicit branch probes.
 	}
 
 	for (const candidate of ['main', 'master']) {

--- a/lib/commands/ship.js
+++ b/lib/commands/ship.js
@@ -33,11 +33,33 @@ function getGitExecOptions(cwd = process.cwd()) {
 	return { ...getExecOptions(), cwd };
 }
 
+function remoteHasTrackingBase(exec = execFileSync, cwd = process.cwd(), remoteName) {
+	try {
+		exec('git', ['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], getGitExecOptions(cwd));
+		return true;
+	} catch (_error) {
+		// Fall through to explicit branch probes.
+	}
+
+	for (const candidate of ['main', 'master']) {
+		try {
+			exec('git', ['rev-parse', '--verify', `refs/remotes/${remoteName}/${candidate}`], getGitExecOptions(cwd));
+			return true;
+		} catch (_error) {
+			// Probe next candidate.
+		}
+	}
+
+	return false;
+}
+
 function resolveBaseRemote(exec = execFileSync, cwd = process.cwd()) {
 	for (const candidate of ['upstream', 'origin']) {
 		try {
 			exec('git', ['remote', 'get-url', candidate], getGitExecOptions(cwd));
-			return candidate;
+			if (remoteHasTrackingBase(exec, cwd, candidate)) {
+				return candidate;
+			}
 		} catch (_error) {
 			// Probe next candidate.
 		}

--- a/lib/commands/ship.js
+++ b/lib/commands/ship.js
@@ -33,13 +33,17 @@ function getGitExecOptions(cwd = process.cwd()) {
 	return { ...getExecOptions(), cwd };
 }
 
+function getQuietGitExecOptions(cwd = process.cwd()) {
+	return { ...getGitExecOptions(cwd), stdio: 'pipe' };
+}
+
 function resolveRemoteHeadTarget(exec = execFileSync, cwd = process.cwd(), remoteName) {
 	try {
-		const symbolicRef = exec('git', ['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], getGitExecOptions(cwd)).trim();
+		const symbolicRef = exec('git', ['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], getQuietGitExecOptions(cwd)).trim();
 		if (!symbolicRef) {
 			return null;
 		}
-		exec('git', ['rev-parse', '--verify', symbolicRef], getGitExecOptions(cwd));
+		exec('git', ['rev-parse', '--verify', symbolicRef], getQuietGitExecOptions(cwd));
 		return symbolicRef;
 	} catch (_error) {
 		return null;
@@ -53,7 +57,7 @@ function remoteHasTrackingBase(exec = execFileSync, cwd = process.cwd(), remoteN
 
 	for (const candidate of ['main', 'master']) {
 		try {
-			exec('git', ['rev-parse', '--verify', `refs/remotes/${remoteName}/${candidate}`], getGitExecOptions(cwd));
+			exec('git', ['rev-parse', '--verify', `refs/remotes/${remoteName}/${candidate}`], getQuietGitExecOptions(cwd));
 			return true;
 		} catch (_error) {
 			// Probe next candidate.
@@ -66,7 +70,7 @@ function remoteHasTrackingBase(exec = execFileSync, cwd = process.cwd(), remoteN
 function resolveBaseRemote(exec = execFileSync, cwd = process.cwd()) {
 	for (const candidate of ['upstream', 'origin']) {
 		try {
-			exec('git', ['remote', 'get-url', candidate], getGitExecOptions(cwd));
+			exec('git', ['remote', 'get-url', candidate], getQuietGitExecOptions(cwd));
 			if (remoteHasTrackingBase(exec, cwd, candidate)) {
 				return candidate;
 			}
@@ -89,7 +93,7 @@ function resolveBaseBranch(exec = execFileSync, cwd = process.cwd(), remoteName 
 
 	for (const candidate of ['main', 'master']) {
 		try {
-			exec('git', ['rev-parse', '--verify', `refs/remotes/${remoteName}/${candidate}`], getGitExecOptions(cwd));
+			exec('git', ['rev-parse', '--verify', `refs/remotes/${remoteName}/${candidate}`], getQuietGitExecOptions(cwd));
 			return candidate;
 		} catch (_error) {
 			// Probe next candidate.
@@ -97,6 +101,14 @@ function resolveBaseBranch(exec = execFileSync, cwd = process.cwd(), remoteName 
 	}
 
 	return 'master';
+}
+
+function refreshBaseReference(exec = execFileSync, cwd = process.cwd(), remoteName, baseBranch) {
+	exec(
+		'git',
+		['fetch', '--quiet', '--no-tags', remoteName, `refs/heads/${baseBranch}:refs/remotes/${remoteName}/${baseBranch}`],
+		getQuietGitExecOptions(cwd),
+	);
 }
 
 function getBranchReadiness(options = {}) {
@@ -114,6 +126,18 @@ function getBranchReadiness(options = {}) {
 			baseRemote,
 			baseBranch,
 			error: 'Current HEAD is detached. Check out a feature branch before running /ship.',
+		};
+	}
+
+	try {
+		refreshBaseReference(exec, cwd, baseRemote, baseBranch);
+	} catch (error) {
+		return {
+			ready: false,
+			branchName,
+			baseRemote,
+			baseBranch,
+			error: `Unable to refresh ${baseRef} before comparing branch readiness. Verify that remote '${baseRemote}' and branch '${baseBranch}' can be fetched. Git said: ${error.message}`,
 		};
 	}
 

--- a/lib/commands/ship.js
+++ b/lib/commands/ship.js
@@ -33,10 +33,23 @@ function getGitExecOptions(cwd = process.cwd()) {
 	return { ...getExecOptions(), cwd };
 }
 
-function resolveBaseBranch(exec = execFileSync, cwd = process.cwd()) {
+function resolveBaseRemote(exec = execFileSync, cwd = process.cwd()) {
+	for (const candidate of ['upstream', 'origin']) {
+		try {
+			exec('git', ['remote', 'get-url', candidate], getGitExecOptions(cwd));
+			return candidate;
+		} catch (_error) {
+			// Probe next candidate.
+		}
+	}
+
+	return 'origin';
+}
+
+function resolveBaseBranch(exec = execFileSync, cwd = process.cwd(), remoteName = resolveBaseRemote(exec, cwd)) {
 	try {
-		const symbolicRef = exec('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], getGitExecOptions(cwd)).trim();
-		const match = /^refs\/remotes\/origin\/(.+)$/.exec(symbolicRef);
+		const symbolicRef = exec('git', ['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], getGitExecOptions(cwd)).trim();
+		const match = new RegExp(`^refs/remotes/${remoteName}/(.+)$`).exec(symbolicRef);
 		if (match && match[1]) {
 			return match[1];
 		}
@@ -46,7 +59,7 @@ function resolveBaseBranch(exec = execFileSync, cwd = process.cwd()) {
 
 	for (const candidate of ['main', 'master']) {
 		try {
-			exec('git', ['rev-parse', '--verify', `refs/remotes/origin/${candidate}`], getGitExecOptions(cwd));
+			exec('git', ['rev-parse', '--verify', `refs/remotes/${remoteName}/${candidate}`], getGitExecOptions(cwd));
 			return candidate;
 		} catch (_error) {
 			// Probe next candidate.
@@ -59,28 +72,62 @@ function resolveBaseBranch(exec = execFileSync, cwd = process.cwd()) {
 function getBranchReadiness(options = {}) {
 	const exec = options.exec || execFileSync;
 	const cwd = options.cwd || process.cwd();
-	const baseBranch = options.baseBranch || resolveBaseBranch(exec, cwd);
-	const baseRef = `origin/${baseBranch}`;
+	const baseRemote = options.baseRemote || resolveBaseRemote(exec, cwd);
+	const baseBranch = options.baseBranch || resolveBaseBranch(exec, cwd, baseRemote);
+	const baseRef = `${baseRemote}/${baseBranch}`;
 	const branchName = exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], getGitExecOptions(cwd)).trim();
 
 	if (!branchName || branchName === 'HEAD') {
 		return {
 			ready: false,
 			branchName: branchName || 'HEAD',
+			baseRemote,
 			baseBranch,
 			error: 'Current HEAD is detached. Check out a feature branch before running /ship.',
 		};
 	}
 
-	const counts = exec('git', ['rev-list', '--left-right', '--count', `${baseRef}...HEAD`], getGitExecOptions(cwd)).trim();
+	let counts;
+	try {
+		counts = exec('git', ['rev-list', '--left-right', '--count', `${baseRef}...HEAD`], getGitExecOptions(cwd)).trim();
+	} catch (error) {
+		return {
+			ready: false,
+			branchName,
+			baseRemote,
+			baseBranch,
+			error: `Unable to compare the current branch against ${baseRef}. Verify that remote '${baseRemote}' and branch '${baseBranch}' exist. Git said: ${error.message}`,
+		};
+	}
+
 	const [behindRaw = '0', aheadRaw = '0'] = counts.split(/\s+/);
 	const behind = Number.parseInt(behindRaw, 10) || 0;
 	const ahead = Number.parseInt(aheadRaw, 10) || 0;
 
-	if (ahead === 0) {
+	let hasDiff = false;
+	try {
+		exec('git', ['diff', '--quiet', `${baseRef}...HEAD`, '--'], getGitExecOptions(cwd));
+	} catch (error) {
+		if (error.status === 1) {
+			hasDiff = true;
+		} else {
+			return {
+				ready: false,
+				branchName,
+				baseRemote,
+				baseBranch,
+				ahead,
+				behind,
+				error: `Unable to inspect the tree diff against ${baseRef}. Git said: ${error.message}`,
+			};
+		}
+	}
+
+	if (!hasDiff) {
 		return {
 			ready: false,
 			branchName,
+			baseRemote,
 			baseBranch,
 			ahead,
 			behind,
@@ -93,6 +140,7 @@ function getBranchReadiness(options = {}) {
 	return {
 		ready: true,
 		branchName,
+		baseRemote,
 		baseBranch,
 		ahead,
 		behind,
@@ -473,5 +521,6 @@ module.exports = {
 	createPR,
 	executeShip,
 	getBranchReadiness,
+	resolveBaseRemote,
 	resolveBaseBranch,
 };

--- a/lib/commands/ship.js
+++ b/lib/commands/ship.js
@@ -29,6 +29,76 @@ function isCommandNotFound(error) {
 	return error.message.includes('ENOENT') || error.message.includes('not found');
 }
 
+function getGitExecOptions(cwd = process.cwd()) {
+	return { ...getExecOptions(), cwd };
+}
+
+function resolveBaseBranch(exec = execFileSync, cwd = process.cwd()) {
+	try {
+		const symbolicRef = exec('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], getGitExecOptions(cwd)).trim();
+		const match = /^refs\/remotes\/origin\/(.+)$/.exec(symbolicRef);
+		if (match && match[1]) {
+			return match[1];
+		}
+	} catch (_error) {
+		// Fall through to explicit branch probes.
+	}
+
+	for (const candidate of ['main', 'master']) {
+		try {
+			exec('git', ['rev-parse', '--verify', `refs/remotes/origin/${candidate}`], getGitExecOptions(cwd));
+			return candidate;
+		} catch (_error) {
+			// Probe next candidate.
+		}
+	}
+
+	return 'master';
+}
+
+function getBranchReadiness(options = {}) {
+	const exec = options.exec || execFileSync;
+	const cwd = options.cwd || process.cwd();
+	const baseBranch = options.baseBranch || resolveBaseBranch(exec, cwd);
+	const baseRef = `origin/${baseBranch}`;
+	const branchName = exec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], getGitExecOptions(cwd)).trim();
+
+	if (!branchName || branchName === 'HEAD') {
+		return {
+			ready: false,
+			branchName: branchName || 'HEAD',
+			baseBranch,
+			error: 'Current HEAD is detached. Check out a feature branch before running /ship.',
+		};
+	}
+
+	const counts = exec('git', ['rev-list', '--left-right', '--count', `${baseRef}...HEAD`], getGitExecOptions(cwd)).trim();
+	const [behindRaw = '0', aheadRaw = '0'] = counts.split(/\s+/);
+	const behind = Number.parseInt(behindRaw, 10) || 0;
+	const ahead = Number.parseInt(aheadRaw, 10) || 0;
+
+	if (ahead === 0) {
+		return {
+			ready: false,
+			branchName,
+			baseBranch,
+			ahead,
+			behind,
+			error:
+				`Current branch ${branchName} has no diff against ${baseRef}. ` +
+				'It is not PR-ready because all changes are already upstream or the branch collapsed onto the base during rebase.',
+		};
+	}
+
+	return {
+		ready: true,
+		branchName,
+		baseBranch,
+		ahead,
+		behind,
+	};
+}
+
 /**
  * Validate feature slug format
  * Ensures slug matches expected pattern and doesn't contain path traversal
@@ -256,11 +326,11 @@ function validatePRTitle(title) {
 }
 
 async function createPR(options) { // NOSONAR S3776
-	const { title, body, dryRun = false } = options;
+	const { title, body, dryRun = false, exec = execFileSync, cwd = process.cwd() } = options;
 	const titleValidation = validatePRTitle(title);
 	if (!titleValidation.valid) return { success: false, error: titleValidation.error };
 	try {
-		execFileSync('gh', ['--version'], getGhCheckOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
+		exec('gh', ['--version'], { ...getGhCheckOptions(), cwd });  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
 	} catch (error) {
 		if (isCommandNotFound(error)) {
 			return { success: false, error: 'GitHub CLI (gh) not found. Install from: https://cli.github.com/' };
@@ -272,22 +342,30 @@ async function createPR(options) { // NOSONAR S3776
 		return { success: false, error: `GitHub CLI check failed: ${error.message}` };
 	}
 	try {
-		execFileSync('git', ['rev-parse', '--git-dir'], getExecOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
+		exec('git', ['rev-parse', '--git-dir'], getGitExecOptions(cwd));  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
 	} catch (error_) { // NOSONAR S2486 - intentional: not-a-git-repo is the expected failure signal
 		void error_;
 		return { success: false, error: 'Not in a git repository. Initialize with: git init' };
 	}
 	try {
-		execFileSync('git', ['remote', 'get-url', 'origin'], getExecOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
+		exec('git', ['remote', 'get-url', 'origin'], getGitExecOptions(cwd));  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
 	} catch (error_) { // NOSONAR S2486 - intentional: no-remote is the expected failure signal
 		void error_;
 		return { success: false, error: 'No git remote configured. Add with: git remote add origin <url>' };
+	}
+	try {
+		const readiness = getBranchReadiness({ exec, cwd });
+		if (!readiness.ready) {
+			return { success: false, error: readiness.error };
+		}
+	} catch (error) {
+		return { success: false, error: `Failed to verify branch readiness: ${error.message}` };
 	}
 	if (dryRun) {
 		return { success: true, message: '[DRY RUN] Would create PR with title: ' + title, prUrl: 'https://github.com/owner/repo/pull/1' };
 	}
 	try {
-		const result = execFileSync('gh', ['pr', 'create', '--title', title, '--body', body], getExecOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
+		const result = exec('gh', ['pr', 'create', '--title', title, '--body', body], getGitExecOptions(cwd));  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
 		const urlMatch = /https:\/\/github\.com\/[^\s]+/.exec(result);
 		const prUrl = urlMatch ? urlMatch[0] : null;
 		const numberMatch = /\/pull\/(\d+)/.exec(result);
@@ -394,4 +472,6 @@ module.exports = {
 	validatePRTitle,
 	createPR,
 	executeShip,
+	getBranchReadiness,
+	resolveBaseBranch,
 };

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -60,20 +60,7 @@ function checkBeadsConnectivity(execFileSync) {
 	}
 }
 
-/**
- * Get changed files relative to main branch, mapped to test file paths.
- *
- * Falls back to `git diff --name-only HEAD` if merge-base fails.
- *
- * @param {string} projectRoot - Project root for test file existence checks
- * @param {Function} execFileSync - Injected execFileSync
- * @param {Object} [fs] - Injected fs module
- * @returns {string[]} Array of test file paths (e.g. ['test/foo.test.js'])
- */
-function getAffectedTestFiles(projectRoot, execFileSync, fs = defaultFs) {
-	let diffRef;
-
-	// Detect default branch, then try merge-base
+function resolveBaseBranch(execFileSync) {
 	let baseBranch = 'main';
 	try {
 		baseBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'origin/HEAD'], {
@@ -89,17 +76,39 @@ function getAffectedTestFiles(projectRoot, execFileSync, fs = defaultFs) {
 			} catch (_e2) { /* intentional: branch doesn't exist, try next name */ } // NOSONAR S2486
 		}
 	}
+	return baseBranch;
+}
 
+function resolveDiffRef(execFileSync, options = {}) {
+	if (options.sinceUpstream) {
+		try {
+			const upstreamRef = execFileSync('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], {
+				encoding: 'utf8',
+				stdio: 'pipe',
+				timeout: 3000,
+			}).trim();
+			if (upstreamRef) {
+				return `${upstreamRef}...HEAD`;
+			}
+		} catch (_e) { // NOSONAR S2486
+			/* intentional: branch may not track a remote yet, fall back to base branch */
+		}
+	}
+
+	const baseBranch = resolveBaseBranch(execFileSync);
 	try {
 		const mergeBase = execFileSync('git', ['merge-base', 'HEAD', baseBranch], {
 			encoding: 'utf8',
 			timeout: 5000,
 		}).trim();
-		diffRef = `${mergeBase}...HEAD`;
+		return `${mergeBase}...HEAD`;
 	} catch (_e) { /* intentional: merge-base failed, fallback to diff against HEAD */ // NOSONAR S2486
-		diffRef = 'HEAD';
+		return 'HEAD';
 	}
+}
 
+function getChangedFiles(execFileSync, options = {}) {
+	const diffRef = resolveDiffRef(execFileSync, options);
 	let output;
 	try {
 		output = execFileSync('git', ['diff', '--name-only', diffRef], {
@@ -112,9 +121,22 @@ function getAffectedTestFiles(projectRoot, execFileSync, fs = defaultFs) {
 	}
 
 	if (!output) return [];
+	return output.split('\n').filter(Boolean);
+}
 
-	const changedFiles = output.split('\n').filter(Boolean);
-
+/**
+ * Get changed files relative to main branch, mapped to test file paths.
+ *
+ * Falls back to `git diff --name-only HEAD` if merge-base fails.
+ *
+ * @param {string} projectRoot - Project root for test file existence checks
+ * @param {Function} execFileSync - Injected execFileSync
+ * @param {Object} [fs] - Injected fs module
+ * @param {Object} [options] - Diff selection options
+ * @returns {string[]} Array of test file paths (e.g. ['test/foo.test.js'])
+ */
+function getAffectedTestFiles(projectRoot, execFileSync, fs = defaultFs, options = {}) {
+	const changedFiles = getChangedFiles(execFileSync, options);
 	const testFiles = new Set();
 	for (const file of changedFiles) {
 		for (const candidate of getTestCandidatesForChangedFile(file)) {
@@ -155,10 +177,18 @@ function getTestCandidatesForChangedFile(file) {
 		];
 	}
 
+	if (file.startsWith('.claude/commands/') && file.endsWith('.md')) {
+		return [
+			'test/command-sync-check.test.js',
+			'test/structural/command-sync.test.js',
+		];
+	}
+
 	return [];
 }
 
 module.exports = {
+	getChangedFiles,
 	getAffectedTestFiles,
 	getTestCandidatesForChangedFile,
 	name: 'test',
@@ -214,7 +244,9 @@ module.exports = {
 
 		// 5. --affected flag: find changed test files
 		if (flags['--affected'] || flags.affected) {
-			const affectedTests = getAffectedTestFiles(projectRoot, execFileSync, fs);
+			const affectedTests = getAffectedTestFiles(projectRoot, execFileSync, fs, {
+				sinceUpstream: flags.sinceUpstream || flags['--since-upstream'],
+			});
 			if (affectedTests.length > 0) {
 				testArgs = ['run', 'test', ...affectedTests];
 			}

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -65,11 +65,12 @@ function checkBeadsConnectivity(execFileSync) {
  *
  * Falls back to `git diff --name-only HEAD` if merge-base fails.
  *
- * @param {string} _projectRoot - Project root (unused, git uses cwd)
+ * @param {string} projectRoot - Project root for test file existence checks
  * @param {Function} execFileSync - Injected execFileSync
+ * @param {Object} [fs] - Injected fs module
  * @returns {string[]} Array of test file paths (e.g. ['test/foo.test.js'])
  */
-function getAffectedTestFiles(_projectRoot, execFileSync) {
+function getAffectedTestFiles(projectRoot, execFileSync, fs = defaultFs) {
 	let diffRef;
 
 	// Detect default branch, then try merge-base
@@ -114,20 +115,52 @@ function getAffectedTestFiles(_projectRoot, execFileSync) {
 
 	const changedFiles = output.split('\n').filter(Boolean);
 
-	// Map lib/*.js files to test/*.test.js
-	const testFiles = [];
+	const testFiles = new Set();
 	for (const file of changedFiles) {
-		if (file.startsWith('lib/') && file.endsWith('.js')) {
-			const relative = file.slice('lib/'.length);
-			const testFile = `test/${relative.replace(/\.js$/, '.test.js')}`;
-			testFiles.push(testFile);
+		for (const candidate of getTestCandidatesForChangedFile(file)) {
+			if (fs.existsSync(path.join(projectRoot, candidate))) {
+				testFiles.add(candidate);
+			}
 		}
 	}
 
-	return testFiles;
+	return Array.from(testFiles).sort();
+}
+
+function getTestCandidatesForChangedFile(file) {
+	if (!file) return [];
+
+	if (file.startsWith('test/') && file.endsWith('.test.js')) {
+		return [file];
+	}
+
+	if (file.startsWith('lib/') && file.endsWith('.js')) {
+		const relative = file.slice('lib/'.length);
+		return [`test/${relative.replace(/\.js$/, '.test.js')}`];
+	}
+
+	if (file.startsWith('scripts/') && file.endsWith('.js')) {
+		const relative = file.slice('scripts/'.length).replace(/\.js$/, '.test.js');
+		return [
+			`test/scripts/${relative}`,
+			`test/${relative}`,
+		];
+	}
+
+	if (file.startsWith('.github/workflows/')) {
+		const workflowName = path.basename(file, path.extname(file));
+		return [
+			`test/workflows/${workflowName}.test.js`,
+			'test/ci-workflow.test.js',
+		];
+	}
+
+	return [];
 }
 
 module.exports = {
+	getAffectedTestFiles,
+	getTestCandidatesForChangedFile,
 	name: 'test',
 	description: 'Run tests with smart defaults (timeout, Beads skip, affected-only)',
 	usage: 'forge test [--affected]',
@@ -181,7 +214,7 @@ module.exports = {
 
 		// 5. --affected flag: find changed test files
 		if (flags['--affected'] || flags.affected) {
-			const affectedTests = getAffectedTestFiles(projectRoot, execFileSync);
+			const affectedTests = getAffectedTestFiles(projectRoot, execFileSync, fs);
 			if (affectedTests.length > 0) {
 				testArgs = ['run', 'test', ...affectedTests];
 			}

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -124,7 +124,7 @@ function getAffectedTestFiles(projectRoot, execFileSync, fs = defaultFs) {
 		}
 	}
 
-	return Array.from(testFiles).sort();
+	return Array.from(testFiles).sort((left, right) => left.localeCompare(right));
 }
 
 function getTestCandidatesForChangedFile(file) {

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -29,6 +29,12 @@ const CONFLICT_MARKER_IGNORE_DIRS = new Set([
 	'dist',
 	'node_modules',
 ]);
+const CONFLICT_MARKER_ALLOWED_DOT_DIRS = new Set([
+	'.claude',
+	'.codex',
+	'.cursor',
+	'.github',
+]);
 const CONFLICT_START_PATTERN = /^<<<<<<<(?: .*)?$/;
 const CONFLICT_DIVIDER_PATTERN = /^=======$/;
 const CONFLICT_END_PATTERN = /^>>>>>>>.*$/;
@@ -76,6 +82,9 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 	function walk(currentDir) {
 		for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
 			if (entry.isDirectory()) {
+				if (entry.name.startsWith('.') && !CONFLICT_MARKER_ALLOWED_DOT_DIRS.has(entry.name)) {
+					continue;
+				}
 				if (CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)) {
 					continue;
 				}

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -14,11 +14,22 @@ const path = require('node:path');
 
 // Constants
 const CHECK_TYPES = {
+	CONFLICT_MARKERS: 'conflictMarkers',
 	TYPE_CHECK: 'typeCheck',
 	LINT: 'lint',
 	SECURITY: 'security',
 	TESTS: 'tests',
 };
+
+const CONFLICT_MARKER_PATTERN = /^(<<<<<<<|=======|>>>>>>>)( .*)?$/m;
+const CONFLICT_MARKER_IGNORE_DIRS = new Set([
+	'.beads',
+	'.git',
+	'.next',
+	'coverage',
+	'dist',
+	'node_modules',
+]);
 
 function getExecOptions() {
 	return { encoding: 'utf8', cwd: process.cwd(), timeout: 120000 };
@@ -55,6 +66,58 @@ function getCheckStatus(check) {
 	if (!check) return null;
 	if (check.skipped) return 'SKIPPED';
 	return check.success ? 'PASS' : 'FAIL';
+}
+
+function scanForConflictMarkers(rootDir = process.cwd()) {
+	const filesWithMarkers = [];
+
+	function walk(currentDir) {
+		for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+			if (entry.name.startsWith('.') && !['.claude', '.codex', '.cursor', '.github'].includes(entry.name)) {
+				if (CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)) {
+					continue;
+				}
+			}
+
+			if (entry.isDirectory()) {
+				if (CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)) {
+					continue;
+				}
+				walk(path.join(currentDir, entry.name));
+				continue;
+			}
+
+			if (!entry.isFile()) {
+				continue;
+			}
+
+			const absolutePath = path.join(currentDir, entry.name);
+			let content;
+			try {
+				content = fs.readFileSync(absolutePath, 'utf8');
+			} catch (_error) {
+				continue;
+			}
+
+			if (!CONFLICT_MARKER_PATTERN.test(content)) {
+				continue;
+			}
+
+			const relativePath = path.relative(rootDir, absolutePath) || entry.name;
+			const lineNumber = content.slice(0, content.search(CONFLICT_MARKER_PATTERN)).split(/\r?\n/).length;
+			filesWithMarkers.push({ path: relativePath, line: lineNumber });
+		}
+	}
+
+	walk(rootDir);
+
+	return {
+		success: filesWithMarkers.length === 0,
+		files: filesWithMarkers,
+		message: filesWithMarkers.length === 0
+			? 'No conflict markers found'
+			: `Conflict markers found in ${filesWithMarkers.length} file(s)`,
+	};
 }
 
 /**
@@ -450,12 +513,28 @@ async function runAllTests() {
  * console.log(result.summary);
  */
 async function executeValidate(options = {}) { // NOSONAR S3776
-	const { skip = [], continueOnError = true } = options || {};
+	const { skip = [], continueOnError = true, rootDir = process.cwd() } = options || {};
 
 	const checks = {};
 	const failedChecks = [];
 	const errors = [];
 	const startTime = Date.now();
+
+	// 0. Conflict markers
+	if (!skip.includes(CHECK_TYPES.CONFLICT_MARKERS)) {
+		try {
+			checks.conflictMarkers = scanForConflictMarkers(rootDir);
+			if (!checks.conflictMarkers.success) {
+				failedChecks.push(CHECK_TYPES.CONFLICT_MARKERS);
+				if (!continueOnError) {
+					return buildResult(checks, failedChecks, errors, startTime);
+				}
+			}
+		} catch (error) {
+			errors.push(`Conflict marker scan error: ${error.message}`);
+			checks.conflictMarkers = { success: false, message: error.message };
+		}
+	}
 
 	// 1. Type checking
 	if (!skip.includes(CHECK_TYPES.TYPE_CHECK)) {
@@ -535,6 +614,7 @@ function buildResult(checks, failedChecks, errors, startTime) {
 	// Build summary using getCheckStatus helper
 	const checkResults = [];
 	const checkLabels = {
+		conflictMarkers: 'Conflict Markers',
 		typeCheck: 'Type',
 		lint: 'Lint',
 		security: 'Security',
@@ -610,6 +690,7 @@ module.exports = {
 	runLint,
 	runSecurityScan,
 	runAllTests,
+	scanForConflictMarkers,
 	executeValidate,
 	executeDebugMode,
 };

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -21,7 +21,6 @@ const CHECK_TYPES = {
 	TESTS: 'tests',
 };
 
-const CONFLICT_MARKER_PATTERN = /^(<<<<<<<|=======|>>>>>>>)( .*)?$/m;
 const CONFLICT_MARKER_IGNORE_DIRS = new Set([
 	'.beads',
 	'.git',
@@ -30,6 +29,9 @@ const CONFLICT_MARKER_IGNORE_DIRS = new Set([
 	'dist',
 	'node_modules',
 ]);
+const CONFLICT_START_PATTERN = /^<<<<<<<(?: .*)?$/;
+const CONFLICT_DIVIDER_PATTERN = /^=======$/;
+const CONFLICT_END_PATTERN = /^>>>>>>>.*$/;
 
 function getExecOptions() {
 	return { encoding: 'utf8', cwd: process.cwd(), timeout: 120000 };
@@ -73,12 +75,6 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 
 	function walk(currentDir) {
 		for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
-			if (entry.name.startsWith('.') && !['.claude', '.codex', '.cursor', '.github'].includes(entry.name)) {
-				if (CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)) {
-					continue;
-				}
-			}
-
 			if (entry.isDirectory()) {
 				if (CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)) {
 					continue;
@@ -99,13 +95,13 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 				continue;
 			}
 
-			if (!CONFLICT_MARKER_PATTERN.test(content)) {
+			const startLine = findConflictMarkerStartLine(content);
+			if (startLine === null) {
 				continue;
 			}
 
 			const relativePath = path.relative(rootDir, absolutePath) || entry.name;
-			const lineNumber = content.slice(0, content.search(CONFLICT_MARKER_PATTERN)).split(/\r?\n/).length;
-			filesWithMarkers.push({ path: relativePath, line: lineNumber });
+			filesWithMarkers.push({ path: relativePath, line: startLine });
 		}
 	}
 
@@ -118,6 +114,38 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 			? 'No conflict markers found'
 			: `Conflict markers found in ${filesWithMarkers.length} file(s)`,
 	};
+}
+
+function findConflictMarkerStartLine(content) {
+	const lines = String(content || '').split(/\r?\n/);
+	let activeStartLine = null;
+	let sawDivider = false;
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index];
+		if (activeStartLine === null) {
+			if (CONFLICT_START_PATTERN.test(line)) {
+				activeStartLine = index + 1;
+				sawDivider = false;
+			}
+			continue;
+		}
+
+		if (!sawDivider) {
+			if (CONFLICT_DIVIDER_PATTERN.test(line)) {
+				sawDivider = true;
+			} else if (CONFLICT_START_PATTERN.test(line)) {
+				activeStartLine = index + 1;
+			}
+			continue;
+		}
+
+		if (CONFLICT_END_PATTERN.test(line)) {
+			return activeStartLine;
+		}
+	}
+
+	return null;
 }
 
 /**

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -88,13 +88,11 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 
 	function walk(currentDir) {
 		for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+			if (shouldSkipConflictScanEntry(entry)) {
+				continue;
+			}
+
 			if (entry.isDirectory()) {
-				if (entry.name.startsWith('.') && !CONFLICT_MARKER_ALLOWED_DOT_DIRS.has(entry.name)) {
-					continue;
-				}
-				if (CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)) {
-					continue;
-				}
 				walk(path.join(currentDir, entry.name));
 				continue;
 			}
@@ -104,14 +102,7 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 			}
 
 			const absolutePath = path.join(currentDir, entry.name);
-			let content;
-			try {
-				content = fs.readFileSync(absolutePath, 'utf8');
-			} catch (_error) {
-				continue;
-			}
-
-			const startLine = findConflictMarkerStartLine(content);
+			const startLine = findConflictMarkerStartLine(readConflictScanFile(absolutePath));
 			if (startLine === null) {
 				continue;
 			}
@@ -138,6 +129,21 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 	};
 }
 
+function shouldSkipConflictScanEntry(entry) {
+	return entry.isDirectory() && (
+		(entry.name.startsWith('.') && !CONFLICT_MARKER_ALLOWED_DOT_DIRS.has(entry.name))
+		|| CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)
+	);
+}
+
+function readConflictScanFile(absolutePath) {
+	try {
+		return fs.readFileSync(absolutePath, 'utf8');
+	} catch (_error) {
+		return null;
+	}
+}
+
 function findConflictMarkerStartLine(content) {
 	const lines = String(content || '').split(/\r?\n/);
 	let activeStartLine = null;
@@ -145,10 +151,13 @@ function findConflictMarkerStartLine(content) {
 
 	for (let index = 0; index < lines.length; index += 1) {
 		const line = lines[index];
+		const lineNumber = index + 1;
 		if (activeStartLine === null) {
 			if (CONFLICT_START_PATTERN.test(line)) {
-				activeStartLine = index + 1;
+				activeStartLine = lineNumber;
 				sawDivider = false;
+			} else if (CONFLICT_END_PATTERN.test(line)) {
+				return lineNumber;
 			}
 			continue;
 		}

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -31,9 +31,16 @@ const CONFLICT_MARKER_IGNORE_DIRS = new Set([
 ]);
 const CONFLICT_MARKER_ALLOWED_DOT_DIRS = new Set([
 	'.claude',
+	'.cline',
 	'.codex',
 	'.cursor',
+	'.forge',
 	'.github',
+	'.husky',
+	'.kilocode',
+	'.opencode',
+	'.roo',
+	'.sonarlint',
 ]);
 const CONFLICT_START_PATTERN = /^<<<<<<<(?: .*)?$/;
 const CONFLICT_DIVIDER_PATTERN = /^=======$/;
@@ -154,7 +161,7 @@ function findConflictMarkerStartLine(content) {
 		}
 	}
 
-	return null;
+	return activeStartLine;
 }
 
 /**

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -122,6 +122,12 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 	}
 
 	walk(rootDir);
+	filesWithMarkers.sort((left, right) => {
+		if (left.path === right.path) {
+			return left.line - right.line;
+		}
+		return left.path.localeCompare(right.path);
+	});
 
 	return {
 		success: filesWithMarkers.length === 0,

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -293,7 +293,7 @@ _has_dolt_remote() {
     return 1
   fi
 
-  printf '%s\n' "$remote_list" | awk 'NF { print $1 }' | grep -qx "$remote_name"
+  printf '%s\n' "$remote_list" | awk 'NF { print $1 }' | grep -Fqx -- "$remote_name"
 }
 
 # Environment overrides (for testing):

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -274,6 +274,7 @@ _run_sync() {
 _has_dolt_remote() {
   local remote_name="${1:-origin}"
   local remote_list=""
+  local raw_output=""
   local bd_cmd="${BD_CMD:-bd}"
   local remote_status=0
 
@@ -281,11 +282,12 @@ _has_dolt_remote() {
     return 2
   fi
 
-  remote_list="$("$bd_cmd" dolt remote list 2>/dev/null | tr -d '\r')"
+  raw_output="$("$bd_cmd" dolt remote list 2>/dev/null)"
   remote_status=$?
   if [[ "$remote_status" -ne 0 ]]; then
     return 2
   fi
+  remote_list="$(printf '%s' "$raw_output" | tr -d '\r')"
 
   if [[ -z "$remote_list" ]]; then
     return 1

--- a/scripts/sync-utils.sh
+++ b/scripts/sync-utils.sh
@@ -271,7 +271,8 @@ _run_sync() {
   fi
 }
 
-_has_dolt_origin_remote() {
+_has_dolt_remote() {
+  local remote_name="${1:-origin}"
   local remote_list=""
   local bd_cmd="${BD_CMD:-bd}"
   local remote_status=0
@@ -290,7 +291,7 @@ _has_dolt_origin_remote() {
     return 1
   fi
 
-  printf '%s\n' "$remote_list" | awk 'NF { print $1 }' | grep -qx 'origin'
+  printf '%s\n' "$remote_list" | awk 'NF { print $1 }' | grep -qx "$remote_name"
 }
 
 # Environment overrides (for testing):
@@ -299,18 +300,20 @@ _has_dolt_origin_remote() {
 auto_sync() {
   local repo_dir="${1:-.}"
   local last_sync_file="$repo_dir/.beads/.last-sync"
+  local sync_remote
+  sync_remote="$(get_sync_remote "$repo_dir")"
 
   # Ensure .beads directory exists
   mkdir -p "$repo_dir/.beads"
 
-  if _has_dolt_origin_remote; then
+  if _has_dolt_remote "$sync_remote"; then
     :
   else
     local remote_status=$?
     if [[ "$remote_status" -eq 2 ]]; then
       echo "Warning: sync skipped, unable to inspect Beads Dolt remotes (is 'bd' installed and configured?)." >&2
     else
-      echo "Warning: sync skipped, Beads Dolt remote 'origin' is not configured (run 'bd dolt remote add origin <url>')." >&2
+      echo "Warning: sync skipped, Beads Dolt remote '$sync_remote' is not configured (run 'bd dolt remote add $sync_remote <url>')." >&2
     fi
     return 0
   fi

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,17 +1,29 @@
 #!/usr/bin/env node
 /**
- * Cross-platform test runner for lefthook pre-push hook.
- * Replaces bash-only: bun/pnpm/yarn/npm test detection with if/elif.
- * Works on Windows CMD, PowerShell, macOS, Linux.
+ * Cross-platform test runner for the lefthook pre-push hook.
+ *
+ * Runs only the tests affected by the changes being pushed when possible.
+ * Falls back to the full suite only for package-level changes.
  */
 
-const { spawnSync } = require('node:child_process');
+const { execFileSync: defaultExecFileSync, spawnSync: defaultSpawnSync } = require('node:child_process');
 const fs = require('node:fs');
 
-// On Windows, package manager CLIs are .cmd files — shell: true resolves them
+const {
+  getAffectedTestFiles,
+  getChangedFiles,
+} = require('../lib/commands/test');
+
+const PACKAGE_LEVEL_PATHS = new Set([
+  'package.json',
+  'bun.lockb',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'package-lock.json',
+]);
+
 const isWindows = process.platform === 'win32';
 
-// Detect package manager from lock files (same priority as forge.js)
 function detectPackageManager() {
   if (fs.existsSync('bun.lockb') || fs.existsSync('bun.lock')) return 'bun';
   if (fs.existsSync('pnpm-lock.yaml')) return 'pnpm';
@@ -19,43 +31,123 @@ function detectPackageManager() {
   return 'npm';
 }
 
-const pkgManager = detectPackageManager();
-console.log(`🧪 Running test suite (${pkgManager} test)...`);
+function stripGitHookEnv(sourceEnv = process.env) {
+  const env = { ...sourceEnv };
+  for (const key of Object.keys(env)) {
+    if (key === 'GIT_DIR' || key === 'GIT_WORK_TREE' || key === 'GIT_INDEX_FILE'
+      || key === 'GIT_OBJECT_DIRECTORY' || key === 'GIT_ALTERNATE_OBJECT_DIRECTORIES'
+      || key === 'GIT_QUARANTINE_PATH') {
+      delete env[key];
+    }
+  }
+  return env;
+}
 
-// Strip git hook environment variables so child processes (especially tests
-// that create temp git repos) never accidentally operate on the real worktree.
-// During pre-push hooks, git sets GIT_DIR pointing to the repo — any test that
-// runs `git init` / `git commit` in a temp dir inherits this and silently
-// commits into the worktree instead, creating rogue "initial commit" that
-// deletes the entire codebase.
-const env = { ...process.env };
-for (const key of Object.keys(env)) {
-  if (key === 'GIT_DIR' || key === 'GIT_WORK_TREE' || key === 'GIT_INDEX_FILE'
-    || key === 'GIT_OBJECT_DIRECTORY' || key === 'GIT_ALTERNATE_OBJECT_DIRECTORIES'
-    || key === 'GIT_QUARANTINE_PATH') {
-    delete env[key];
+function classifyPushTests(projectRoot, execFileSync = defaultExecFileSync) {
+  const changedFiles = getChangedFiles(execFileSync, { sinceUpstream: true });
+  const testTargets = getAffectedTestFiles(projectRoot, execFileSync, fs, { sinceUpstream: true });
+
+  let runFullSuite = false;
+  let runTestEnv = false;
+  let runE2E = false;
+
+  for (const file of changedFiles) {
+    if (PACKAGE_LEVEL_PATHS.has(file) || file.startsWith('packages/')) {
+      runFullSuite = true;
+      runTestEnv = true;
+      runE2E = true;
+      break;
+    }
+
+    if (file.startsWith('test-env/')) {
+      runTestEnv = true;
+      continue;
+    }
+
+    if (file.startsWith('test/e2e/')) {
+      runE2E = true;
+      continue;
+    }
+
+    if ((file.startsWith('lib/') || file.startsWith('scripts/')) && file.endsWith('.js')) {
+      runTestEnv = true;
+    }
+  }
+
+  return {
+    changedFiles,
+    runE2E,
+    runFullSuite,
+    runTestEnv,
+    testTargets,
+  };
+}
+
+function runCommand(command, args, options = {}, spawnSync = defaultSpawnSync) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    shell: isWindows,
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result.status ?? 1;
+}
+
+function runPrePushTests(projectRoot = process.cwd(), deps = {}) {
+  const spawnSync = deps.spawnSync || defaultSpawnSync;
+  const execFileSync = deps.execFileSync || defaultExecFileSync;
+  const pkgManager = deps.pkgManager || detectPackageManager();
+  const env = deps.env || stripGitHookEnv(process.env);
+  const plan = classifyPushTests(projectRoot, execFileSync);
+
+  console.log(`Running pre-push tests (${pkgManager})...`);
+
+  try {
+    if (plan.runFullSuite) {
+      console.log('  Mode: full suite (package-level changes detected)');
+      const status = runCommand(pkgManager, ['run', 'test'], { env }, spawnSync);
+      if (status !== 0) return status;
+    } else if (plan.testTargets.length > 0) {
+      console.log(`  Mode: targeted (${plan.testTargets.length} test file${plan.testTargets.length === 1 ? '' : 's'})`);
+      const status = runCommand(pkgManager, ['run', 'test', ...plan.testTargets], { env }, spawnSync);
+      if (status !== 0) return status;
+    } else {
+      console.log('  Mode: no mapped unit tests for pushed files');
+    }
+
+    if (plan.runE2E) {
+      console.log('  Extra: running affected e2e tests');
+      const status = runCommand('bun', ['test', 'test/e2e/'], { env }, spawnSync);
+      if (status !== 0) return status;
+    }
+
+    if (plan.runTestEnv) {
+      console.log('  Extra: running affected edge-case tests');
+      const status = runCommand('node', ['--test', 'test-env/**/*.test.js'], { env }, spawnSync);
+      if (status !== 0) return status;
+    }
+
+    console.log('Relevant tests passed');
+    return 0;
+  } catch (error) {
+    console.error('');
+    console.error(`Failed to run tests: ${error.message}`);
+    console.error('');
+    return 1;
   }
 }
 
-// Use 'run test' to invoke the package.json script (which may include --timeout flags)
-// 'bun test' is a built-in that ignores package.json scripts
-const result = spawnSync(pkgManager, ['run', 'test'], { stdio: 'inherit', shell: isWindows, env });
-
-if (result.error) {
-  console.error('');
-  console.error(`❌ Failed to run ${pkgManager} test: ${result.error.message}`);
-  console.error(`   Is '${pkgManager}' installed and on PATH?`);
-  console.error('');
-  process.exit(1);
+if (require.main === module) {
+  process.exit(runPrePushTests());
 }
 
-if (result.status !== 0) {
-  console.error('');
-  console.error('❌ Tests failed. Fix them before pushing.');
-  console.error('');
-  console.error('Fix the failing checks. Do not bypass hooks.');
-  console.error('');
-  process.exit(1);
-}
-
-console.log('✅ All tests passed');
+module.exports = {
+  classifyPushTests,
+  detectPackageManager,
+  runPrePushTests,
+  stripGitHookEnv,
+};

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -51,6 +51,7 @@ function classifyPushTests(projectRoot, execFileSync = defaultExecFileSync) {
   let runTestEnv = false;
   let runE2E = false;
   let hasUnmappedFiles = false;
+  const hasUnknownChangedFiles = changedFiles.length === 0 && testTargets.length === 0;
 
   for (const file of changedFiles) {
     if (PACKAGE_LEVEL_PATHS.has(file) || file.startsWith('packages/')) {
@@ -85,8 +86,9 @@ function classifyPushTests(projectRoot, execFileSync = defaultExecFileSync) {
   return {
     changedFiles,
     hasUnmappedFiles,
+    hasUnknownChangedFiles,
     runE2E,
-    runFullSuite: runFullSuite || hasUnmappedFiles,
+    runFullSuite: runFullSuite || hasUnmappedFiles || hasUnknownChangedFiles,
     runTestEnv,
     testTargets,
   };
@@ -119,7 +121,9 @@ function runPrePushTests(projectRoot = process.cwd(), deps = {}) {
     if (plan.runFullSuite) {
       const reason = plan.hasUnmappedFiles
         ? 'unmapped pushed files require full unit coverage'
-        : 'package-level changes detected';
+        : plan.hasUnknownChangedFiles
+          ? 'changed files could not be resolved safely'
+          : 'package-level changes detected';
       console.log(`  Mode: full suite (${reason})`);
       const status = runCommand(pkgManager, ['run', 'test'], { env }, spawnSync);
       if (status !== 0) return status;

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -50,6 +50,7 @@ function classifyPushTests(projectRoot, execFileSync = defaultExecFileSync) {
   let runFullSuite = false;
   let runTestEnv = false;
   let runE2E = false;
+  let hasUnmappedFiles = false;
 
   for (const file of changedFiles) {
     if (PACKAGE_LEVEL_PATHS.has(file) || file.startsWith('packages/')) {
@@ -71,13 +72,21 @@ function classifyPushTests(projectRoot, execFileSync = defaultExecFileSync) {
 
     if ((file.startsWith('lib/') || file.startsWith('scripts/')) && file.endsWith('.js')) {
       runTestEnv = true;
+      continue;
     }
+
+    if (file.startsWith('test/') || file.startsWith('.github/workflows/') || file.startsWith('.claude/commands/')) {
+      continue;
+    }
+
+    hasUnmappedFiles = true;
   }
 
   return {
     changedFiles,
+    hasUnmappedFiles,
     runE2E,
-    runFullSuite,
+    runFullSuite: runFullSuite || hasUnmappedFiles,
     runTestEnv,
     testTargets,
   };
@@ -108,15 +117,16 @@ function runPrePushTests(projectRoot = process.cwd(), deps = {}) {
 
   try {
     if (plan.runFullSuite) {
-      console.log('  Mode: full suite (package-level changes detected)');
+      const reason = plan.hasUnmappedFiles
+        ? 'unmapped pushed files require full unit coverage'
+        : 'package-level changes detected';
+      console.log(`  Mode: full suite (${reason})`);
       const status = runCommand(pkgManager, ['run', 'test'], { env }, spawnSync);
       if (status !== 0) return status;
     } else if (plan.testTargets.length > 0) {
       console.log(`  Mode: targeted (${plan.testTargets.length} test file${plan.testTargets.length === 1 ? '' : 's'})`);
       const status = runCommand(pkgManager, ['run', 'test', ...plan.testTargets], { env }, spawnSync);
       if (status !== 0) return status;
-    } else {
-      console.log('  Mode: no mapped unit tests for pushed files');
     }
 
     if (plan.runE2E) {

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -127,7 +127,7 @@ function runPrePushTests(projectRoot = process.cwd(), deps = {}) {
 
     if (plan.runTestEnv) {
       console.log('  Extra: running affected edge-case tests');
-      const status = runCommand('node', ['--test', 'test-env/**/*.test.js'], { env }, spawnSync);
+      const status = runCommand('bun', ['test', 'test-env/'], { env }, spawnSync);
       if (status !== 0) return status;
     }
 

--- a/test/ci-workflow.test.js
+++ b/test/ci-workflow.test.js
@@ -133,6 +133,27 @@ describe('CI Workflow Configuration', () => {
       expect(stepNames.includes('Resolve affected test targets')).toBeTruthy();
       expect(stepNames.includes('Run targeted unit tests')).toBeTruthy();
       expect(stepNames.includes('Run single-platform unit suite fallback')).toBeTruthy();
+      expect(stepNames.includes('Run affected e2e tests')).toBeTruthy();
+      expect(stepNames.includes('Run affected edge-case tests')).toBeTruthy();
+    });
+
+    test('followup-tests falls back to full mode for unmapped changed files', () => {
+      const followup = workflow.jobs['followup-tests'];
+      const resolveStep = followup.steps.find((step) => step.name === 'Resolve affected test targets');
+      expect(resolveStep).toBeTruthy();
+      expect(resolveStep.run.includes('unmapped_files=false')).toBeTruthy();
+      expect(resolveStep.run.includes('unmapped_files=true')).toBeTruthy();
+      expect(resolveStep.run.includes('if [[ "$unmapped_files" == "true" ]]')).toBeTruthy();
+    });
+
+    test('followup-tests tracks e2e and test-env changes separately', () => {
+      const followup = workflow.jobs['followup-tests'];
+      const resolveStep = followup.steps.find((step) => step.name === 'Resolve affected test targets');
+      expect(resolveStep).toBeTruthy();
+      expect(resolveStep.run.includes('run_test_env=false')).toBeTruthy();
+      expect(resolveStep.run.includes('run_e2e=false')).toBeTruthy();
+      expect(resolveStep.run.includes('test-env/*')).toBeTruthy();
+      expect(resolveStep.run.includes('test/e2e/*')).toBeTruthy();
     });
 
     test('full matrix, coverage, e2e, and dashboard skip synchronize events', () => {

--- a/test/ci-workflow.test.js
+++ b/test/ci-workflow.test.js
@@ -156,6 +156,15 @@ describe('CI Workflow Configuration', () => {
       expect(resolveStep.run.includes('test/e2e/*')).toBeTruthy();
     });
 
+    test('followup-tests runs edge-case checks for library and script changes', () => {
+      const followup = workflow.jobs['followup-tests'];
+      const resolveStep = followup.steps.find((step) => step.name === 'Resolve affected test targets');
+      expect(resolveStep).toBeTruthy();
+      expect(resolveStep.run.includes('lib/*.js|lib/**/*.js')).toBeTruthy();
+      expect(resolveStep.run.includes('scripts/*.js|scripts/**/*.js')).toBeTruthy();
+      expect(resolveStep.run.includes('run_test_env=true')).toBeTruthy();
+    });
+
     test('full matrix, coverage, e2e, and dashboard skip synchronize events', () => {
       expect(workflow.jobs.test.if).toBe(synchronizeSkipCondition);
       expect(workflow.jobs.coverage.if).toBe(synchronizeSkipCondition);

--- a/test/ci-workflow.test.js
+++ b/test/ci-workflow.test.js
@@ -7,6 +7,7 @@ describe('CI Workflow Configuration', () => {
   const workflowPath = path.join(__dirname, '..', '.github', 'workflows', 'test.yml');
   const workflowContent = fs.readFileSync(workflowPath, 'utf-8');
   const workflow = yaml.parse(workflowContent);
+  const synchronizeSkipCondition = "github.event_name != 'pull_request' || github.event.action != 'synchronize'";
 
   describe('Coverage Job', () => {
     test('should have a separate coverage job', () => {
@@ -105,6 +106,40 @@ describe('CI Workflow Configuration', () => {
       expect(!test.needs).toBeTruthy();
       expect(!coverage.needs).toBeTruthy();
       expect(!e2e.needs).toBeTruthy();
+    });
+  });
+
+  describe('Follow-up PR Pushes', () => {
+    test('workflow cancels older in-progress runs for the same PR or ref', () => {
+      expect(workflow.concurrency).toBeTruthy();
+      expect(workflow.concurrency.group).toContain('github.event.pull_request.number || github.ref');
+      expect(workflow.concurrency['cancel-in-progress']).toBe(true);
+    });
+
+    test('followup-tests job exists for synchronize events', () => {
+      expect(workflow.jobs['followup-tests']).toBeTruthy();
+      expect(workflow.jobs['followup-tests'].if).toBe("github.event_name == 'pull_request' && github.event.action == 'synchronize'");
+    });
+
+    test('followup-tests job runs on a single ubuntu runner', () => {
+      const followup = workflow.jobs['followup-tests'];
+      expect(followup['runs-on']).toBe('ubuntu-latest');
+      expect(!followup.strategy).toBeTruthy();
+    });
+
+    test('followup-tests resolves affected targets before running tests', () => {
+      const followup = workflow.jobs['followup-tests'];
+      const stepNames = followup.steps.map(s => s.name);
+      expect(stepNames.includes('Resolve affected test targets')).toBeTruthy();
+      expect(stepNames.includes('Run targeted unit tests')).toBeTruthy();
+      expect(stepNames.includes('Run single-platform unit suite fallback')).toBeTruthy();
+    });
+
+    test('full matrix, coverage, e2e, and dashboard skip synchronize events', () => {
+      expect(workflow.jobs.test.if).toBe(synchronizeSkipCondition);
+      expect(workflow.jobs.coverage.if).toBe(synchronizeSkipCondition);
+      expect(workflow.jobs.e2e.if).toBe(synchronizeSkipCondition);
+      expect(workflow.jobs.dashboard.if).toBe(synchronizeSkipCondition);
     });
   });
 

--- a/test/commands/ship.test.js
+++ b/test/commands/ship.test.js
@@ -6,6 +6,8 @@ const {
 	generatePRBody,
 	createPR,
 	executeShip,
+	getBranchReadiness,
+	resolveBaseBranch,
 } = require('../../lib/commands/ship.js');
 
 describe('Ship Command - PR Creation', () => {
@@ -195,6 +197,37 @@ No test scenarios section.`;
 	});
 
 	describe('Create PR via gh CLI', () => {
+		test('should detect the default base branch from origin/HEAD', () => {
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				expect(args).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+				return 'refs/remotes/origin/main\n';
+			};
+
+			expect(resolveBaseBranch(exec, process.cwd())).toBe('main');
+		});
+
+		test('should report when the current branch has no diff against the base branch', () => {
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				if (args[0] === 'symbolic-ref') {
+					return 'refs/remotes/origin/master\n';
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
+					return 'feat/setup-hardening-codex-parity\n';
+				}
+				if (args[0] === 'rev-list') {
+					return '0\t0\n';
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			const result = getBranchReadiness({ exec, cwd: process.cwd() });
+			expect(result.ready).toBe(false);
+			expect(result.error).toContain('has no diff against origin/master');
+			expect(result.error).toContain('not PR-ready');
+		});
+
 		test.skip('should create PR with generated body', async () => {
 			const prBody = '## Summary\n\nTest PR body';
 			const result = await createPR({
@@ -229,6 +262,40 @@ No test scenarios section.`;
 
 			// Should fail validation
 			expect(result.success === false || result.error).toBeTruthy();
+		});
+
+		test('should refuse to create a PR when the branch has no diff against base', async () => {
+			const exec = (command, args) => {
+				if (command === 'gh' && args[0] === '--version') {
+					return 'gh version 2.81.0\n';
+				}
+				if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--git-dir') {
+					return '.git\n';
+				}
+				if (command === 'git' && args[0] === 'remote' && args[1] === 'get-url') {
+					return 'https://github.com/owner/repo.git\n';
+				}
+				if (command === 'git' && args[0] === 'symbolic-ref') {
+					return 'refs/remotes/origin/master\n';
+				}
+				if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
+					return 'feat/setup-hardening-codex-parity\n';
+				}
+				if (command === 'git' && args[0] === 'rev-list') {
+					return '0\t0\n';
+				}
+				throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+			};
+
+			const result = await createPR({
+				title: 'feat: test feature branch readiness',
+				body: 'Test body',
+				dryRun: true,
+				exec,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('has no diff against origin/master');
 		});
 	});
 

--- a/test/commands/ship.test.js
+++ b/test/commands/ship.test.js
@@ -7,6 +7,7 @@ const {
 	createPR,
 	executeShip,
 	getBranchReadiness,
+	resolveBaseRemote,
 	resolveBaseBranch,
 } = require('../../lib/commands/ship.js');
 
@@ -197,6 +198,21 @@ No test scenarios section.`;
 	});
 
 	describe('Create PR via gh CLI', () => {
+		test('should prefer upstream as the base remote when present', () => {
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'upstream') {
+					return 'https://github.com/base/repo.git\n';
+				}
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+					return 'https://github.com/fork/repo.git\n';
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			expect(resolveBaseRemote(exec, process.cwd())).toBe('upstream');
+		});
+
 		test('should detect the default base branch from origin/HEAD', () => {
 			const exec = (command, args) => {
 				expect(command).toBe('git');
@@ -204,27 +220,37 @@ No test scenarios section.`;
 				return 'refs/remotes/origin/main\n';
 			};
 
-			expect(resolveBaseBranch(exec, process.cwd())).toBe('main');
+			expect(resolveBaseBranch(exec, process.cwd(), 'origin')).toBe('main');
 		});
 
-		test('should report when the current branch has no diff against the base branch', () => {
+		test('should report when the current branch has no tree diff against the base branch', () => {
 			const exec = (command, args) => {
 				expect(command).toBe('git');
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'upstream') {
+					return 'https://github.com/base/repo.git\n';
+				}
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+					return 'https://github.com/fork/repo.git\n';
+				}
 				if (args[0] === 'symbolic-ref') {
-					return 'refs/remotes/origin/master\n';
+					return 'refs/remotes/upstream/master\n';
 				}
 				if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
 					return 'feat/setup-hardening-codex-parity\n';
 				}
 				if (args[0] === 'rev-list') {
-					return '0\t0\n';
+					return '0\t2\n';
+				}
+				if (args[0] === 'diff') {
+					return '';
 				}
 				throw new Error(`Unexpected git command: ${args.join(' ')}`);
 			};
 
 			const result = getBranchReadiness({ exec, cwd: process.cwd() });
 			expect(result.ready).toBe(false);
-			expect(result.error).toContain('has no diff against origin/master');
+			expect(result.baseRemote).toBe('upstream');
+			expect(result.error).toContain('has no diff against upstream/master');
 			expect(result.error).toContain('not PR-ready');
 		});
 
@@ -269,6 +295,9 @@ No test scenarios section.`;
 				if (command === 'gh' && args[0] === '--version') {
 					return 'gh version 2.81.0\n';
 				}
+				if (command === 'git' && args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'upstream') {
+					return 'https://github.com/base/repo.git\n';
+				}
 				if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--git-dir') {
 					return '.git\n';
 				}
@@ -276,13 +305,16 @@ No test scenarios section.`;
 					return 'https://github.com/owner/repo.git\n';
 				}
 				if (command === 'git' && args[0] === 'symbolic-ref') {
-					return 'refs/remotes/origin/master\n';
+					return 'refs/remotes/upstream/master\n';
 				}
 				if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
 					return 'feat/setup-hardening-codex-parity\n';
 				}
 				if (command === 'git' && args[0] === 'rev-list') {
-					return '0\t0\n';
+					return '0\t2\n';
+				}
+				if (command === 'git' && args[0] === 'diff') {
+					return '';
 				}
 				throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
 			};
@@ -295,7 +327,7 @@ No test scenarios section.`;
 			});
 
 			expect(result.success).toBe(false);
-			expect(result.error).toContain('has no diff against origin/master');
+			expect(result.error).toContain('has no diff against upstream/master');
 		});
 	});
 

--- a/test/commands/ship.test.js
+++ b/test/commands/ship.test.js
@@ -210,6 +210,9 @@ No test scenarios section.`;
 				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/upstream/HEAD') {
 					return 'refs/remotes/upstream/main\n';
 				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/main') {
+					return 'refs/remotes/upstream/main\n';
+				}
 				throw new Error(`Unexpected git command: ${args.join(' ')}`);
 			};
 
@@ -243,14 +246,72 @@ No test scenarios section.`;
 			expect(resolveBaseRemote(exec, process.cwd())).toBe('origin');
 		});
 
+		test('should fall back to origin when upstream HEAD points to a missing ref', () => {
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'upstream') {
+					return 'https://github.com/base/repo.git\n';
+				}
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+					return 'https://github.com/fork/repo.git\n';
+				}
+				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/upstream/HEAD') {
+					return 'refs/remotes/upstream/trunk\n';
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/trunk') {
+					throw new Error('missing upstream trunk');
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/main') {
+					throw new Error('missing upstream main');
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/master') {
+					throw new Error('missing upstream master');
+				}
+				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/origin/HEAD') {
+					return 'refs/remotes/origin/main\n';
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/origin/main') {
+					return 'refs/remotes/origin/main\n';
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			expect(resolveBaseRemote(exec, process.cwd())).toBe('origin');
+		});
+
 		test('should detect the default base branch from origin/HEAD', () => {
 			const exec = (command, args) => {
 				expect(command).toBe('git');
-				expect(args).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
-				return 'refs/remotes/origin/main\n';
+				if (args[0] === 'symbolic-ref') {
+					expect(args).toEqual(['symbolic-ref', 'refs/remotes/origin/HEAD']);
+					return 'refs/remotes/origin/main\n';
+				}
+				if (args[0] === 'rev-parse') {
+					expect(args).toEqual(['rev-parse', '--verify', 'refs/remotes/origin/main']);
+					return 'refs/remotes/origin/main\n';
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
 			};
 
 			expect(resolveBaseBranch(exec, process.cwd(), 'origin')).toBe('main');
+		});
+
+		test('should ignore a stale remote HEAD target and fall back to main', () => {
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/upstream/HEAD') {
+					return 'refs/remotes/upstream/trunk\n';
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/trunk') {
+					throw new Error('missing upstream trunk');
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/main') {
+					return 'refs/remotes/upstream/main\n';
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			expect(resolveBaseBranch(exec, process.cwd(), 'upstream')).toBe('main');
 		});
 
 		test('should report when the current branch has no tree diff against the base branch', () => {
@@ -263,6 +324,9 @@ No test scenarios section.`;
 					return 'https://github.com/fork/repo.git\n';
 				}
 				if (args[0] === 'symbolic-ref') {
+					return 'refs/remotes/upstream/master\n';
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/master') {
 					return 'refs/remotes/upstream/master\n';
 				}
 				if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
@@ -335,6 +399,9 @@ No test scenarios section.`;
 					return 'https://github.com/owner/repo.git\n';
 				}
 				if (command === 'git' && args[0] === 'symbolic-ref') {
+					return 'refs/remotes/upstream/master\n';
+				}
+				if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/upstream/master') {
 					return 'refs/remotes/upstream/master\n';
 				}
 				if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {

--- a/test/commands/ship.test.js
+++ b/test/commands/ship.test.js
@@ -207,10 +207,40 @@ No test scenarios section.`;
 				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
 					return 'https://github.com/fork/repo.git\n';
 				}
+				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/upstream/HEAD') {
+					return 'refs/remotes/upstream/main\n';
+				}
 				throw new Error(`Unexpected git command: ${args.join(' ')}`);
 			};
 
 			expect(resolveBaseRemote(exec, process.cwd())).toBe('upstream');
+		});
+
+		test('should fall back to origin when upstream has no fetched tracking refs', () => {
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'upstream') {
+					return 'https://github.com/base/repo.git\n';
+				}
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+					return 'https://github.com/fork/repo.git\n';
+				}
+				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/upstream/HEAD') {
+					throw new Error('missing upstream HEAD');
+				}
+				if (args[0] === 'rev-parse' && args[2] === 'refs/remotes/upstream/main') {
+					throw new Error('missing upstream main');
+				}
+				if (args[0] === 'rev-parse' && args[2] === 'refs/remotes/upstream/master') {
+					throw new Error('missing upstream master');
+				}
+				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/origin/HEAD') {
+					return 'refs/remotes/origin/main\n';
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			expect(resolveBaseRemote(exec, process.cwd())).toBe('origin');
 		});
 
 		test('should detect the default base branch from origin/HEAD', () => {

--- a/test/commands/ship.test.js
+++ b/test/commands/ship.test.js
@@ -254,7 +254,7 @@ No test scenarios section.`;
 			expect(result.error).toContain('not PR-ready');
 		});
 
-		test.skip('should create PR with generated body', async () => {
+		test.skip('forge-g11n: should create PR with generated body', async () => {
 			const prBody = '## Summary\n\nTest PR body';
 			const result = await createPR({
 				title: 'feat: test feature',

--- a/test/commands/ship.test.js
+++ b/test/commands/ship.test.js
@@ -219,6 +219,30 @@ No test scenarios section.`;
 			expect(resolveBaseRemote(exec, process.cwd())).toBe('upstream');
 		});
 
+		test('should use quiet git probe options during base remote resolution', () => {
+			const probeOptions = [];
+			const exec = (command, args, options) => {
+				expect(command).toBe('git');
+				probeOptions.push(options);
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'upstream') {
+					throw new Error('missing upstream');
+				}
+				if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+					return 'https://github.com/fork/repo.git\n';
+				}
+				if (args[0] === 'symbolic-ref' && args[1] === 'refs/remotes/origin/HEAD') {
+					throw new Error('missing origin HEAD');
+				}
+				if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/origin/main') {
+					return 'refs/remotes/origin/main\n';
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			expect(resolveBaseRemote(exec, process.cwd())).toBe('origin');
+			expect(probeOptions.every((options) => options && options.stdio === 'pipe')).toBe(true);
+		});
+
 		test('should fall back to origin when upstream has no fetched tracking refs', () => {
 			const exec = (command, args) => {
 				expect(command).toBe('git');
@@ -332,6 +356,9 @@ No test scenarios section.`;
 				if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
 					return 'feat/setup-hardening-codex-parity\n';
 				}
+				if (args[0] === 'fetch' && args[3] === 'upstream') {
+					return '';
+				}
 				if (args[0] === 'rev-list') {
 					return '0\t2\n';
 				}
@@ -346,6 +373,66 @@ No test scenarios section.`;
 			expect(result.baseRemote).toBe('upstream');
 			expect(result.error).toContain('has no diff against upstream/master');
 			expect(result.error).toContain('not PR-ready');
+		});
+
+		test('should refresh the selected base ref before readiness checks', () => {
+			const execCalls = [];
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				execCalls.push(args);
+				if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
+					return 'feat/ship-refresh\n';
+				}
+				if (args[0] === 'fetch' && args[3] === 'origin') {
+					return '';
+				}
+				if (args[0] === 'rev-list') {
+					return '0\t1\n';
+				}
+				if (args[0] === 'diff') {
+					const error = new Error('diff detected');
+					error.status = 1;
+					throw error;
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			const result = getBranchReadiness({
+				exec,
+				cwd: process.cwd(),
+				baseRemote: 'origin',
+				baseBranch: 'main',
+			});
+
+			expect(result.ready).toBe(true);
+			const fetchIndex = execCalls.findIndex((args) => args[0] === 'fetch');
+			const revListIndex = execCalls.findIndex((args) => args[0] === 'rev-list');
+			expect(fetchIndex).toBeGreaterThanOrEqual(0);
+			expect(revListIndex).toBeGreaterThan(fetchIndex);
+		});
+
+		test('should fail readiness when refreshing the base ref fails', () => {
+			const exec = (command, args) => {
+				expect(command).toBe('git');
+				if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
+					return 'feat/ship-refresh\n';
+				}
+				if (args[0] === 'fetch' && args[3] === 'origin') {
+					throw new Error('network unavailable');
+				}
+				throw new Error(`Unexpected git command: ${args.join(' ')}`);
+			};
+
+			const result = getBranchReadiness({
+				exec,
+				cwd: process.cwd(),
+				baseRemote: 'origin',
+				baseBranch: 'main',
+			});
+
+			expect(result.ready).toBe(false);
+			expect(result.error).toContain('Unable to refresh origin/main before comparing branch readiness');
+			expect(result.error).toContain('network unavailable');
 		});
 
 		test.skip('forge-g11n: should create PR with generated body', async () => {
@@ -406,6 +493,9 @@ No test scenarios section.`;
 				}
 				if (command === 'git' && args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
 					return 'feat/setup-hardening-codex-parity\n';
+				}
+				if (command === 'git' && args[0] === 'fetch' && args[3] === 'upstream') {
+					return '';
 				}
 				if (command === 'git' && args[0] === 'rev-list') {
 					return '0\t2\n';

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -28,11 +28,15 @@ try {
  * @param {string} [opts.packageJson] - JSON string for package.json readFileSync
  * @returns {Object} Stubbed fs
  */
-function makeFsStub({ lockfile = null, packageJson = '{}' } = {}) {
+function makeFsStub({ lockfile = null, packageJson = '{}', existingPaths = [] } = {}) {
+	const normalize = (value) => String(value).replace(/\\/g, '/');
+	const knownPaths = new Set(existingPaths.map(normalize));
 	return {
 		existsSync: (p) => {
-			if (lockfile && String(p).endsWith(lockfile)) return true;
-			if (String(p).endsWith('package.json') && packageJson) return true;
+			const normalized = normalize(p);
+			if (lockfile && normalized.endsWith(lockfile)) return true;
+			if (normalized.endsWith('package.json') && packageJson) return true;
+			if (knownPaths.has(normalized)) return true;
 			return false;
 		},
 		readFileSync: (p, _enc) => {
@@ -252,7 +256,12 @@ describe('forge test command', () => {
 		test('maps changed source files to test files', async () => {
 			const spawnSpy = makeSpawnSync();
 			await testCommand.handler([], { affected: true }, '/fake/root', {
-				fs: makeFsStub(),
+				fs: makeFsStub({
+					existingPaths: [
+						'/fake/root/test/foo.test.js',
+						'/fake/root/test/bar.test.js',
+					],
+				}),
 				execFileSync: makeExecFileSync({
 					mergeBaseOutput: 'abc123',
 					gitDiffOutput: 'lib/foo.js\nlib/bar.js\n',
@@ -322,7 +331,9 @@ describe('forge test command', () => {
 		test('skips non-lib files in affected mapping', async () => {
 			const spawnSpy = makeSpawnSync();
 			await testCommand.handler([], { affected: true }, '/fake/root', {
-				fs: makeFsStub(),
+				fs: makeFsStub({
+					existingPaths: ['/fake/root/test/foo.test.js'],
+				}),
 				execFileSync: makeExecFileSync({
 					gitDiffOutput: 'README.md\nlib/foo.js\ndocs/bar.md\n',
 				}),
@@ -347,6 +358,44 @@ describe('forge test command', () => {
 
 			// Falls back to 'run test' (no specific files)
 			expect(spawnSpy.calls[0].args).toEqual(['run', 'test']);
+		});
+
+		test('runs changed test files directly when they are edited', async () => {
+			const spawnSpy = makeSpawnSync();
+			await testCommand.handler([], { affected: true }, '/fake/root', {
+				fs: makeFsStub({
+					existingPaths: ['/fake/root/test/commands/ship.test.js'],
+				}),
+				execFileSync: makeExecFileSync({
+					gitDiffOutput: 'test/commands/ship.test.js\n',
+				}),
+				spawnSync: spawnSpy,
+			});
+
+			expect(spawnSpy.calls[0].args).toEqual(['run', 'test', 'test/commands/ship.test.js']);
+		});
+
+		test('maps workflow changes to workflow tests when they exist', async () => {
+			const spawnSpy = makeSpawnSync();
+			await testCommand.handler([], { affected: true }, '/fake/root', {
+				fs: makeFsStub({
+					existingPaths: [
+						'/fake/root/test/ci-workflow.test.js',
+						'/fake/root/test/workflows/size-check.test.js',
+					],
+				}),
+				execFileSync: makeExecFileSync({
+					gitDiffOutput: '.github/workflows/size-check.yml\n',
+				}),
+				spawnSync: spawnSpy,
+			});
+
+			expect(spawnSpy.calls[0].args).toEqual([
+				'run',
+				'test',
+				'test/ci-workflow.test.js',
+				'test/workflows/size-check.test.js',
+			]);
 		});
 	});
 });

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -328,6 +328,30 @@ describe('forge test command', () => {
 			expect(diffCall.args).not.toContain('abc123...HEAD');
 		});
 
+		test('uses upstream diff when requested for push-hook style runs', async () => {
+			const execCalls = [];
+			const execStub = (cmd, args, _opts) => {
+				execCalls.push({ cmd, args });
+				if (cmd === 'git' && args.includes('@{upstream}')) return 'origin/feature-branch';
+				if (cmd === 'git' && args[0] === 'diff') return 'lib/x.js\n';
+				return '';
+			};
+
+			await testCommand.handler([], { affected: true, sinceUpstream: true }, '/fake/root', {
+				fs: makeFsStub({
+					existingPaths: ['/fake/root/test/x.test.js'],
+				}),
+				execFileSync: execStub,
+				spawnSync: makeSpawnSync(),
+			});
+
+			const diffCall = execCalls.find(
+				(c) => c.cmd === 'git' && c.args[0] === 'diff',
+			);
+			expect(diffCall).toBeDefined();
+			expect(diffCall.args).toContain('origin/feature-branch...HEAD');
+		});
+
 		test('skips non-lib files in affected mapping', async () => {
 			const spawnSpy = makeSpawnSync();
 			await testCommand.handler([], { affected: true }, '/fake/root', {
@@ -395,6 +419,29 @@ describe('forge test command', () => {
 				'test',
 				'test/ci-workflow.test.js',
 				'test/workflows/size-check.test.js',
+			]);
+		});
+
+		test('maps canonical command edits to command sync tests', async () => {
+			const spawnSpy = makeSpawnSync();
+			await testCommand.handler([], { affected: true }, '/fake/root', {
+				fs: makeFsStub({
+					existingPaths: [
+						'/fake/root/test/command-sync-check.test.js',
+						'/fake/root/test/structural/command-sync.test.js',
+					],
+				}),
+				execFileSync: makeExecFileSync({
+					gitDiffOutput: '.claude/commands/review.md\n',
+				}),
+				spawnSync: spawnSpy,
+			});
+
+			expect(spawnSpy.calls[0].args).toEqual([
+				'run',
+				'test',
+				'test/command-sync-check.test.js',
+				'test/structural/command-sync.test.js',
 			]);
 		});
 	});

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -182,6 +182,28 @@ describe('Validate Command - Validation Orchestration', () => {
 			}
 		});
 
+		test('should flag orphaned closing conflict markers', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-orphaned-closing-'));
+			try {
+				fs.writeFileSync(
+					path.join(tmpDir, 'orphaned.md'),
+					'Normal content\n>>>>>>> feature-branch\nMore content\n',
+				);
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.checks.conflictMarkers.files).toEqual([
+					expect.objectContaining({ path: 'orphaned.md', line: 2 }),
+				]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
 		test('should run all checks in sequence', async () => {
 			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-sequence-'));
 			try {

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -106,6 +106,26 @@ describe('Validate Command - Validation Orchestration', () => {
 			}
 		});
 
+		test('should ignore standalone separator lines that are not full conflict blocks', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-separators-'));
+			try {
+				fs.writeFileSync(
+					path.join(tmpDir, 'notes.md'),
+					'Heading\n=======\nBody copy\n',
+				);
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.checks.conflictMarkers.files).toEqual([]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
 		test('should run all checks in sequence', async () => {
 			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-sequence-'));
 			try {

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -126,6 +126,34 @@ describe('Validate Command - Validation Orchestration', () => {
 			}
 		});
 
+		test('should skip hidden directories that are not explicitly allowlisted', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-dotdirs-'));
+			try {
+				fs.mkdirSync(path.join(tmpDir, '.hidden'), { recursive: true });
+				fs.mkdirSync(path.join(tmpDir, '.github'), { recursive: true });
+				fs.writeFileSync(
+					path.join(tmpDir, '.hidden', 'ignored.js'),
+					'<<<<<<< HEAD\nignore me\n=======\nignore me too\n>>>>>>> branch\n',
+				);
+				fs.writeFileSync(
+					path.join(tmpDir, '.github', 'workflow.yml'),
+					'<<<<<<< HEAD\nscan me\n=======\nscan me too\n>>>>>>> branch\n',
+				);
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.checks.conflictMarkers.files).toEqual([
+					expect.objectContaining({ path: path.join('.github', 'workflow.yml') }),
+				]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
 		test('should run all checks in sequence', async () => {
 			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-sequence-'));
 			try {

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -1,12 +1,18 @@
-const { describe, test, expect } = require('bun:test');
+const { describe, test, expect, setDefaultTimeout } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const {
 	runTypeCheck,
 	runLint,
 	runSecurityScan,
 	runAllTests,
+	scanForConflictMarkers,
 	executeValidate,
 	executeDebugMode,
 } = require('../../lib/commands/validate.js');
+
+setDefaultTimeout(15000);
 
 describe('Validate Command - Validation Orchestration', () => {
 	describe('Type checking', () => {
@@ -77,32 +83,71 @@ describe('Validate Command - Validation Orchestration', () => {
 	});
 
 	describe('Full validate orchestration', () => {
+		test('should fail fast when conflict markers are present', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-conflicts-'));
+			try {
+				fs.writeFileSync(
+					path.join(tmpDir, 'broken.js'),
+					'<<<<<<< HEAD\nconst a = 1;\n=======\nconst a = 2;\n>>>>>>> branch\n',
+				);
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.failedChecks).toContain('conflictMarkers');
+				expect(result.checks.conflictMarkers.files).toEqual([
+					expect.objectContaining({ path: 'broken.js' }),
+				]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
 		test('should run all checks in sequence', async () => {
-			// Skip heavy checks (lint/security/tests call real CLI tools)
-			// typeCheck gracefully skips if no tsconfig.json is present
-			const result = await executeValidate({ skip: ['lint', 'security', 'tests'] });
-			expect(typeof result.success).toBe('boolean');
-			expect(result.checks).toBeTruthy();
-			expect('typeCheck' in result.checks).toBeTruthy();
-			expect(typeof result.summary).toBe('string');
-			expect(typeof result.duration).toBe('number');
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-sequence-'));
+			try {
+				// Skip heavy checks (lint/security/tests call real CLI tools).
+				// Use an empty temp root so conflict-marker scanning stays deterministic and fast.
+				const result = await executeValidate({ rootDir: tmpDir, skip: ['lint', 'security', 'tests'] });
+				expect(typeof result.success).toBe('boolean');
+				expect(result.checks).toBeTruthy();
+				expect('conflictMarkers' in result.checks).toBeTruthy();
+				expect('typeCheck' in result.checks).toBeTruthy();
+				expect(typeof result.summary).toBe('string');
+				expect(typeof result.duration).toBe('number');
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
 		});
 
 		test('should return summary of all checks', async () => {
-			const result = await executeValidate({ skip: ['lint', 'security', 'tests'] });
-			expect(result.summary).toBeTruthy();
-			expect(typeof result.summary).toBe('string');
-			expect(result.summary.length > 0).toBeTruthy();
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-summary-'));
+			try {
+				const result = await executeValidate({ rootDir: tmpDir, skip: ['lint', 'security', 'tests'] });
+				expect(result.summary).toBeTruthy();
+				expect(typeof result.summary).toBe('string');
+				expect(result.summary.length > 0).toBeTruthy();
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
 		});
 
 		test('should fail if any critical check fails', async () => {
-			const result = await executeValidate({ skip: ['lint', 'security', 'tests'] });
-			if (!result.success) {
-				expect(Array.isArray(result.failedChecks)).toBeTruthy();
-				expect(result.failedChecks.length > 0).toBeTruthy();
-			} else {
-				expect(result.success).toBe(true);
-				expect(!result.failedChecks || result.failedChecks.length === 0).toBeTruthy();
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-critical-'));
+			try {
+				const result = await executeValidate({ rootDir: tmpDir, skip: ['lint', 'security', 'tests'] });
+				if (!result.success) {
+					expect(Array.isArray(result.failedChecks)).toBeTruthy();
+					expect(result.failedChecks.length > 0).toBeTruthy();
+				} else {
+					expect(result.success).toBe(true);
+					expect(!result.failedChecks || result.failedChecks.length === 0).toBeTruthy();
+				}
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
 			}
 		});
 
@@ -165,6 +210,10 @@ describe('Validate Command - Validation Orchestration', () => {
 		test('should export executeValidate function', () => {
 			const { executeValidate } = require('../../lib/commands/validate.js');
 			expect(typeof executeValidate).toBe('function');
+		});
+
+		test('should export scanForConflictMarkers function', () => {
+			expect(typeof scanForConflictMarkers).toBe('function');
 		});
 	});
 

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -126,14 +126,19 @@ describe('Validate Command - Validation Orchestration', () => {
 			}
 		});
 
-		test('should skip hidden directories that are not explicitly allowlisted', async () => {
+		test('should skip hidden directories that are not explicitly allowlisted while scanning tracked dotdirs', async () => {
 			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-dotdirs-'));
 			try {
 				fs.mkdirSync(path.join(tmpDir, '.hidden'), { recursive: true });
+				fs.mkdirSync(path.join(tmpDir, '.forge'), { recursive: true });
 				fs.mkdirSync(path.join(tmpDir, '.github'), { recursive: true });
 				fs.writeFileSync(
 					path.join(tmpDir, '.hidden', 'ignored.js'),
 					'<<<<<<< HEAD\nignore me\n=======\nignore me too\n>>>>>>> branch\n',
+				);
+				fs.writeFileSync(
+					path.join(tmpDir, '.forge', 'tracked.md'),
+					'<<<<<<< HEAD\ntracked dotdir\n=======\ntracked dotdir updated\n>>>>>>> branch\n',
 				);
 				fs.writeFileSync(
 					path.join(tmpDir, '.github', 'workflow.yml'),
@@ -147,7 +152,30 @@ describe('Validate Command - Validation Orchestration', () => {
 
 				expect(result.success).toBe(false);
 				expect(result.checks.conflictMarkers.files).toEqual([
+					expect.objectContaining({ path: path.join('.forge', 'tracked.md') }),
 					expect.objectContaining({ path: path.join('.github', 'workflow.yml') }),
+				]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		test('should flag unterminated conflict marker blocks', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-partial-conflicts-'));
+			try {
+				fs.writeFileSync(
+					path.join(tmpDir, 'partial.js'),
+					'<<<<<<< HEAD\nconst a = 1;\n=======\nconst a = 2;\n',
+				);
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.checks.conflictMarkers.files).toEqual([
+					expect.objectContaining({ path: 'partial.js', line: 1 }),
 				]);
 			} finally {
 				fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/scripts/test-runner.test.js
+++ b/test/scripts/test-runner.test.js
@@ -115,8 +115,8 @@ describe('scripts/test pre-push runner', () => {
     expect(status).toBe(0);
     expect(spawnSync.calls[0].command).toBe('bun');
     expect(spawnSync.calls[0].args).toEqual(['run', 'test', 'test/commands/ship.test.js']);
-    expect(spawnSync.calls[1].command).toBe('node');
-    expect(spawnSync.calls[1].args).toEqual(['--test', 'test-env/**/*.test.js']);
+    expect(spawnSync.calls[1].command).toBe('bun');
+    expect(spawnSync.calls[1].args).toEqual(['test', 'test-env/']);
   });
 
   test('runPrePushTests skips broad unit tests when only canonical command docs changed', () => {

--- a/test/scripts/test-runner.test.js
+++ b/test/scripts/test-runner.test.js
@@ -113,6 +113,17 @@ describe('scripts/test pre-push runner', () => {
     expect(plan.testTargets).toEqual([]);
   });
 
+  test('classifyPushTests falls back to full suite when changed files cannot be resolved', () => {
+    const plan = classifyPushTests(repoRoot, makeExecFileSync({
+      changedFiles: '',
+      useUpstream: false,
+    }));
+
+    expect(plan.hasUnknownChangedFiles).toBe(true);
+    expect(plan.runFullSuite).toBe(true);
+    expect(plan.testTargets).toEqual([]);
+  });
+
   test('runPrePushTests runs targeted tests instead of the full suite when possible', () => {
     const spawnSync = makeSpawnSync(0);
     const status = runPrePushTests(repoRoot, {
@@ -158,6 +169,24 @@ describe('scripts/test pre-push runner', () => {
       env: { PATH: process.env.PATH || '' },
       execFileSync: makeExecFileSync({
         changedFiles: 'scripts/sync-utils.sh\n',
+      }),
+      pkgManager: 'bun',
+      spawnSync,
+    });
+
+    expect(status).toBe(0);
+    expect(spawnSync.calls).toHaveLength(1);
+    expect(spawnSync.calls[0].command).toBe('bun');
+    expect(spawnSync.calls[0].args).toEqual(['run', 'test']);
+  });
+
+  test('runPrePushTests falls back to the full unit suite when diff-base resolution yields no changed files', () => {
+    const spawnSync = makeSpawnSync(0);
+    const status = runPrePushTests(repoRoot, {
+      env: { PATH: process.env.PATH || '' },
+      execFileSync: makeExecFileSync({
+        changedFiles: '',
+        useUpstream: false,
       }),
       pkgManager: 'bun',
       spawnSync,

--- a/test/scripts/test-runner.test.js
+++ b/test/scripts/test-runner.test.js
@@ -101,6 +101,18 @@ describe('scripts/test pre-push runner', () => {
     expect(plan.runE2E).toBe(true);
   });
 
+  test('classifyPushTests falls back to full suite for unmapped pushed files', () => {
+    const plan = classifyPushTests(repoRoot, makeExecFileSync({
+      changedFiles: 'scripts/sync-utils.sh\n',
+    }));
+
+    expect(plan.hasUnmappedFiles).toBe(true);
+    expect(plan.runFullSuite).toBe(true);
+    expect(plan.runTestEnv).toBe(false);
+    expect(plan.runE2E).toBe(false);
+    expect(plan.testTargets).toEqual([]);
+  });
+
   test('runPrePushTests runs targeted tests instead of the full suite when possible', () => {
     const spawnSync = makeSpawnSync(0);
     const status = runPrePushTests(repoRoot, {
@@ -138,5 +150,22 @@ describe('scripts/test pre-push runner', () => {
       'test/command-sync-check.test.js',
       'test/structural/command-sync.test.js',
     ]);
+  });
+
+  test('runPrePushTests falls back to the full unit suite for unmapped pushed files', () => {
+    const spawnSync = makeSpawnSync(0);
+    const status = runPrePushTests(repoRoot, {
+      env: { PATH: process.env.PATH || '' },
+      execFileSync: makeExecFileSync({
+        changedFiles: 'scripts/sync-utils.sh\n',
+      }),
+      pkgManager: 'bun',
+      spawnSync,
+    });
+
+    expect(status).toBe(0);
+    expect(spawnSync.calls).toHaveLength(1);
+    expect(spawnSync.calls[0].command).toBe('bun');
+    expect(spawnSync.calls[0].args).toEqual(['run', 'test']);
   });
 });

--- a/test/scripts/test-runner.test.js
+++ b/test/scripts/test-runner.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+const path = require('node:path');
+
+const {
+  classifyPushTests,
+  runPrePushTests,
+  stripGitHookEnv,
+} = require('../../scripts/test');
+
+const repoRoot = path.resolve(__dirname, '../..');
+
+function makeExecFileSync({
+  changedFiles = '',
+  upstream = 'origin/fix/t3-worktree-guardrails',
+  useUpstream = true,
+} = {}) {
+  return (cmd, args, _opts) => {
+    if (cmd !== 'git') {
+      throw new Error(`Unexpected command: ${cmd}`);
+    }
+
+    if (args[0] === 'rev-parse' && args.includes('@{upstream}')) {
+      if (!useUpstream) {
+        throw new Error('no upstream');
+      }
+      return upstream;
+    }
+
+    if (args[0] === 'diff') {
+      return changedFiles;
+    }
+
+    if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') {
+      return 'origin/master';
+    }
+
+    if (args[0] === 'merge-base') {
+      return 'abc123';
+    }
+
+    return '';
+  };
+}
+
+function makeSpawnSync(exitCode = 0) {
+  const calls = [];
+  const fn = (command, args, options) => {
+    calls.push({ args, command, options });
+    return { status: exitCode };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('scripts/test pre-push runner', () => {
+  test('stripGitHookEnv removes git hook environment variables', () => {
+    const env = stripGitHookEnv({
+      GIT_DIR: '.git',
+      GIT_WORK_TREE: '.',
+      GIT_INDEX_FILE: 'index',
+      PATH: '/bin',
+    });
+
+    expect(env.GIT_DIR).toBeUndefined();
+    expect(env.GIT_WORK_TREE).toBeUndefined();
+    expect(env.GIT_INDEX_FILE).toBeUndefined();
+    expect(env.PATH).toBe('/bin');
+  });
+
+  test('classifyPushTests selects targeted unit tests and edge-case suite for lib changes', () => {
+    const plan = classifyPushTests(repoRoot, makeExecFileSync({
+      changedFiles: 'lib/commands/ship.js\n',
+    }));
+
+    expect(plan.runFullSuite).toBe(false);
+    expect(plan.runTestEnv).toBe(true);
+    expect(plan.runE2E).toBe(false);
+    expect(plan.testTargets).toContain('test/commands/ship.test.js');
+  });
+
+  test('classifyPushTests maps canonical command edits to command sync checks', () => {
+    const plan = classifyPushTests(repoRoot, makeExecFileSync({
+      changedFiles: '.claude/commands/ship.md\n',
+    }));
+
+    expect(plan.testTargets).toEqual([
+      'test/command-sync-check.test.js',
+      'test/structural/command-sync.test.js',
+    ]);
+  });
+
+  test('classifyPushTests falls back to full suite for package-level changes', () => {
+    const plan = classifyPushTests(repoRoot, makeExecFileSync({
+      changedFiles: 'package.json\n',
+    }));
+
+    expect(plan.runFullSuite).toBe(true);
+    expect(plan.runTestEnv).toBe(true);
+    expect(plan.runE2E).toBe(true);
+  });
+
+  test('runPrePushTests runs targeted tests instead of the full suite when possible', () => {
+    const spawnSync = makeSpawnSync(0);
+    const status = runPrePushTests(repoRoot, {
+      env: { PATH: process.env.PATH || '' },
+      execFileSync: makeExecFileSync({
+        changedFiles: 'lib/commands/ship.js\n',
+      }),
+      pkgManager: 'bun',
+      spawnSync,
+    });
+
+    expect(status).toBe(0);
+    expect(spawnSync.calls[0].command).toBe('bun');
+    expect(spawnSync.calls[0].args).toEqual(['run', 'test', 'test/commands/ship.test.js']);
+    expect(spawnSync.calls[1].command).toBe('node');
+    expect(spawnSync.calls[1].args).toEqual(['--test', 'test-env/**/*.test.js']);
+  });
+
+  test('runPrePushTests skips broad unit tests when only canonical command docs changed', () => {
+    const spawnSync = makeSpawnSync(0);
+    const status = runPrePushTests(repoRoot, {
+      env: { PATH: process.env.PATH || '' },
+      execFileSync: makeExecFileSync({
+        changedFiles: '.claude/commands/review.md\n',
+      }),
+      pkgManager: 'bun',
+      spawnSync,
+    });
+
+    expect(status).toBe(0);
+    expect(spawnSync.calls).toHaveLength(1);
+    expect(spawnSync.calls[0].args).toEqual([
+      'run',
+      'test',
+      'test/command-sync-check.test.js',
+      'test/structural/command-sync.test.js',
+    ]);
+  });
+});

--- a/test/setup-runtime-flags.test.js
+++ b/test/setup-runtime-flags.test.js
@@ -331,4 +331,30 @@ describe('setup runtime flags', () => {
     expect(logLines.join('\n')).toContain('bd (Beads CLI) - Install from https://github.com/steveyegge/beads');
   });
 
+  serialTest('checkPrerequisites warns when the Beads Dolt origin remote is not configured', () => {
+    const result = setupCommand.checkPrerequisites({
+      requireBeadsCli: true,
+      requireGithubCli: false,
+      commandRunner: (command) => {
+        switch (command) {
+          case 'git --version':
+            return 'git version 2.42.0';
+          case 'bd --version':
+            return 'bd 0.49.1';
+          case 'bd dolt remote list':
+            return 'No remotes configured.';
+          case 'jq --version':
+            return 'jq-1.8.1';
+          default:
+            return '';
+        }
+      },
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain(
+      "Beads Dolt remote 'origin' is not configured. Sync will remain local until you run: bd dolt remote add origin <url>"
+    );
+  });
+
 });

--- a/test/setup-runtime-flags.test.js
+++ b/test/setup-runtime-flags.test.js
@@ -357,4 +357,28 @@ describe('setup runtime flags', () => {
     );
   });
 
+  serialTest('checkPrerequisites warns when Beads Dolt remotes cannot be inspected', () => {
+    const result = setupCommand.checkPrerequisites({
+      requireBeadsCli: true,
+      requireGithubCli: false,
+      commandRunner: (command) => {
+        switch (command) {
+          case 'git --version':
+            return 'git version 2.42.0';
+          case 'bd --version':
+            return 'bd 0.49.1';
+          case 'jq --version':
+            return 'jq-1.8.1';
+          default:
+            return '';
+        }
+      },
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain(
+      "Unable to inspect Beads Dolt remotes. Sync may remain local until 'origin' is configured and bd dolt remote list succeeds."
+    );
+  });
+
 });

--- a/test/setup-runtime-flags.test.js
+++ b/test/setup-runtime-flags.test.js
@@ -381,4 +381,65 @@ describe('setup runtime flags', () => {
     );
   });
 
+  serialTest('checkPrerequisites uses BD_SYNC_REMOTE when warning about missing Beads remotes', () => {
+    const result = setupCommand.checkPrerequisites({
+      env: { BD_SYNC_REMOTE: 'upstream' },
+      requireBeadsCli: true,
+      requireGithubCli: false,
+      commandRunner: (command) => {
+        switch (command) {
+          case 'git --version':
+            return 'git version 2.42.0';
+          case 'bd --version':
+            return 'bd 0.49.1';
+          case 'bd dolt remote list':
+            return 'origin https://example.com/repo';
+          case 'jq --version':
+            return 'jq-1.8.1';
+          default:
+            return '';
+        }
+      },
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain(
+      "Beads Dolt remote 'upstream' is not configured. Sync will remain local until you run: bd dolt remote add upstream <url>"
+    );
+  });
+
+  serialTest('checkPrerequisites uses .beads config sync remote before falling back to origin', () => {
+    const tmpDir = makeTempDir();
+    fs.mkdirSync(path.join(tmpDir, '.beads'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.beads', 'config.json'),
+      JSON.stringify({ sync_remote: 'upstream' }, null, 2)
+    );
+
+    const result = setupCommand.checkPrerequisites({
+      projectDir: tmpDir,
+      requireBeadsCli: true,
+      requireGithubCli: false,
+      commandRunner: (command) => {
+        switch (command) {
+          case 'git --version':
+            return 'git version 2.42.0';
+          case 'bd --version':
+            return 'bd 0.49.1';
+          case 'bd dolt remote list':
+            return 'origin https://example.com/repo';
+          case 'jq --version':
+            return 'jq-1.8.1';
+          default:
+            return '';
+        }
+      },
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain(
+      "Beads Dolt remote 'upstream' is not configured. Sync will remain local until you run: bd dolt remote add upstream <url>"
+    );
+  });
+
 });

--- a/test/setup-runtime-flags.test.js
+++ b/test/setup-runtime-flags.test.js
@@ -442,4 +442,38 @@ describe('setup runtime flags', () => {
     );
   });
 
+  serialTest('checkPrerequisites reads sync remote from .beads config.yaml without regex backtracking', () => {
+    const tmpDir = makeTempDir();
+    fs.mkdirSync(path.join(tmpDir, '.beads'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.beads', 'config.yaml'),
+      'database:\n  backend: dolt\nsync-remote: "upstream" # preferred remote\n'
+    );
+
+    const result = setupCommand.checkPrerequisites({
+      projectDir: tmpDir,
+      requireBeadsCli: true,
+      requireGithubCli: false,
+      commandRunner: (command) => {
+        switch (command) {
+          case 'git --version':
+            return 'git version 2.42.0';
+          case 'bd --version':
+            return 'bd 0.49.1';
+          case 'bd dolt remote list':
+            return 'origin https://example.com/repo';
+          case 'jq --version':
+            return 'jq-1.8.1';
+          default:
+            return '';
+        }
+      },
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain(
+      "Beads Dolt remote 'upstream' is not configured. Sync will remain local until you run: bd dolt remote add upstream <url>"
+    );
+  });
+
 });

--- a/test/sync-utils.test.js
+++ b/test/sync-utils.test.js
@@ -2,11 +2,13 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
-const { afterEach, describe, expect, test } = require('bun:test');
+const { afterEach, describe, expect, setDefaultTimeout, test } = require('bun:test');
 
 const tempDirs = [];
 const SCRIPT = path.join(__dirname, '..', 'scripts', 'sync-utils.sh');
 const GIT_BASH_PATH = 'C:\\Program Files\\Git\\bin\\bash.exe';
+
+setDefaultTimeout(15000);
 
 function resolveBashCommand() {
   if (process.env.BASH_CMD) {
@@ -134,6 +136,34 @@ exit 0
     const result = runSyncUtils('auto-sync', {
       BD_CMD: toBashPath(mockBd),
       BD_SYNC_REMOTE: 'upstream',
+      BD_SYNC_CMD: 'true',
+    }, repoDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(fs.existsSync(path.join(repoDir, '.beads', '.last-sync'))).toBe(true);
+  });
+
+  test('auto-sync matches configured remote names literally', () => {
+    const repoDir = makeTempDir();
+    fs.mkdirSync(path.join(repoDir, '.beads'), { recursive: true });
+
+    const mockBin = makeTempDir();
+    const mockBd = path.join(mockBin, 'bd');
+    writeExecutable(mockBd, `#!/usr/bin/env bash
+if [[ "$1 $2 $3" == "dolt remote list" ]]; then
+  echo "upstream.* file:///tmp/forge-beads"
+  exit 0
+fi
+if [[ "$1 $2" == "dolt pull" || "$1 $2" == "dolt push" ]]; then
+  exit 0
+fi
+exit 0
+`);
+
+    const result = runSyncUtils('auto-sync', {
+      BD_CMD: toBashPath(mockBd),
+      BD_SYNC_REMOTE: 'upstream.*',
       BD_SYNC_CMD: 'true',
     }, repoDir);
 

--- a/test/sync-utils.test.js
+++ b/test/sync-utils.test.js
@@ -92,6 +92,28 @@ exit 0
     expect(result.stderr).toContain("sync skipped, unable to inspect Beads Dolt remotes");
   });
 
+  test('auto-sync reports inspect failure when bd remote listing exits non-zero', () => {
+    const repoDir = makeTempDir();
+    fs.mkdirSync(path.join(repoDir, '.beads'), { recursive: true });
+
+    const mockBin = makeTempDir();
+    const mockBd = path.join(mockBin, 'bd');
+    writeExecutable(mockBd, `#!/usr/bin/env bash
+if [[ "$1 $2 $3" == "dolt remote list" ]]; then
+  exit 2
+fi
+exit 0
+`);
+
+    const result = runSyncUtils('auto-sync', {
+      BD_CMD: toBashPath(mockBd),
+    }, repoDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("sync skipped, unable to inspect Beads Dolt remotes");
+    expect(result.stderr).not.toContain("is not configured");
+  });
+
   test('auto-sync honors the configured sync remote name', () => {
     const repoDir = makeTempDir();
     fs.mkdirSync(path.join(repoDir, '.beads'), { recursive: true });

--- a/test/sync-utils.test.js
+++ b/test/sync-utils.test.js
@@ -91,4 +91,32 @@ exit 0
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("sync skipped, unable to inspect Beads Dolt remotes");
   });
+
+  test('auto-sync honors the configured sync remote name', () => {
+    const repoDir = makeTempDir();
+    fs.mkdirSync(path.join(repoDir, '.beads'), { recursive: true });
+
+    const mockBin = makeTempDir();
+    const mockBd = path.join(mockBin, 'bd');
+    writeExecutable(mockBd, `#!/usr/bin/env bash
+if [[ "$1 $2 $3" == "dolt remote list" ]]; then
+  echo "upstream file:///tmp/forge-beads"
+  exit 0
+fi
+if [[ "$1 $2" == "dolt pull" || "$1 $2" == "dolt push" ]]; then
+  exit 0
+fi
+exit 0
+`);
+
+    const result = runSyncUtils('auto-sync', {
+      BD_CMD: toBashPath(mockBd),
+      BD_SYNC_REMOTE: 'upstream',
+      BD_SYNC_CMD: 'true',
+    }, repoDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(fs.existsSync(path.join(repoDir, '.beads', '.last-sync'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Problem
T3 and other externally-created worktrees can fail in ways that are easy to miss: `/ship` can try to open a PR from a branch that collapsed onto the base during rebase, setup can leave Beads sync looking healthy while no Dolt remote is configured, unresolved conflict markers can survive into validation, and review-round pushes can still rerun broad local pre-push validation for small follow-up fixes.

## Root Cause
The workflow relied on implicit assumptions instead of explicit runtime checks. `/ship` did not verify that the current branch still had a real diff against the resolved base branch, setup only checked for the Beads CLI and not the configured Dolt remote, `sync-utils.sh` only looked for a literal `origin` remote, `/validate` did not scan for merge conflict markers before running the rest of the checks, and the local pre-push hook always delegated to the broad package test script instead of targeting only the files being pushed.

## Fix
Add explicit guardrails across ship, setup, validate, sync, and local push flows.

- `/ship` resolves the actual base branch and blocks PR creation for zero-diff branches.
- Setup warns when the expected Beads Dolt remote is missing or cannot be inspected.
- Sync honors the configured remote name instead of assuming `origin`.
- `/validate` fails fast when conflict markers remain in the worktree.
- Local pre-push validation now diffs against the tracked branch, runs only mapped tests plus relevant Bun-backed edge-case coverage, and reserves the full suite for package-level changes.

## Value
Future Forge users working from T3 or other external worktrees get clear failures instead of silent bad outcomes, and review-turn pushes stay fast instead of rerunning the full local suite for every small fix. This removes a class of broken PRs, makes Beads sync setup actionable, prevents conflict-marker artifacts from reaching later workflow stages, and keeps follow-up PR iteration efficient.

## Beads
Closes forge-g11n

<details>
<summary>Implementation Details</summary>

### Coverage
- Zero-diff branch rejection in `/ship`
- Resolved-base detection from remote tracking refs
- Beads Dolt remote warnings and configured-remote handling
- Conflict-marker detection in `/validate`
- Local pre-push targeting against the tracked branch
- Canonical command edits mapped to command-sync checks
- Bun-backed edge-case coverage only when relevant to the pushed diff

### Validation
- Focused command tests for affected-test resolution and upstream diff selection
- Focused pre-push runner tests for targeted/full-suite routing
- Local `git push` verified the narrowed pre-push path end-to-end

### Design Doc
None. This is follow-up workflow hardening from reproduced worktree failures and review-round push friction.
</details>

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all findings are P2 style/robustness suggestions that do not block correct behavior on standard configurations.

Both remaining comments are P2: a theoretical regex-escaping edge case for non-standard remote names (safe in the default origin/upstream path), and a minor package-manager consistency issue in edge-coverage branches. The core logic is correct and thoroughly tested.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Dynamic `new RegExp()` usage in `resolveBaseBranch` uses remote names derived from git's own trusted data, limiting exposure. Shell injection risk in `sync-utils.sh` is mitigated by `grep -Fqx` (fixed-string matching).
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/commands/ship.js
Line: 88

Comment:
**Unescaped remote name in dynamic regex**

`remoteName` is interpolated directly into `new RegExp(...)` without escaping. A git remote named with a dot (e.g. `heroku.staging`) would produce the pattern `^refs/remotes/heroku.staging/(.+)$`, where the `.` matches any character, allowing `refs/remotes/herokuXstaging/main` to pass. In practice `resolveBaseRemote` only ever returns `'origin'` or `'upstream'`, but since `resolveBaseBranch` is exported, callers with non-standard remote names can hit this.

```suggestion
		const escapedRemote = remoteName.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
		const match = new RegExp(`^refs/remotes/${escapedRemote}/(.+)$`).exec(symbolicRef);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/test.js
Line: 138-145

Comment:
**E2E and edge-case branches hardcode `bun` instead of `pkgManager`**

The full-suite and targeted-test branches both honour the detected `pkgManager`, but the `runE2E` and `runTestEnv` branches call `runCommand('bun', ...)` directly. In CI environments or contributor setups where Bun is not on PATH (e.g. only `npm` or `pnpm` is available), these branches will throw a spawn error and block the push even when all relevant tests would pass under the detected manager.

```suggestion
    if (plan.runE2E) {
      console.log('  Extra: running affected e2e tests');
      const status = runCommand(pkgManager, ['run', 'test', 'test/e2e/'], { env }, spawnSync);
      if (status !== 0) return status;
    }

    if (plan.runTestEnv) {
      console.log('  Extra: running affected edge-case tests');
      const status = runCommand(pkgManager, ['run', 'test', 'test-env/'], { env }, spawnSync);
      if (status !== 0) return status;
    }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (12): Last reviewed commit: ["fix: fail safe when pre-push diff resolu..."](https://github.com/harshanandak/forge/commit/be398c768720f05e73edb78dd6a8053eb869ead0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27828785)</sub>

<!-- /greptile_comment -->