### PR TITLE
fix(validate): speed up conflict scans and align Forge guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ forge close <id>      # Complete work
 
 ### Rules
 
-- Use `forge` for routine issue tracking and sync workflows — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/plans/YYYY-MM-DD-<slug>-tasks.md` — these are approved artifacts consumed by `/dev`, but Beads remains the source of truth for issue state under the Forge layer. Use `bd` directly only for operations Forge does not wrap yet, such as `bd init`, `bd comments`, `bd dep`, and `bd dolt *`. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/BEADS_GITHUB_SYNC.md`).
+- Use `forge` as the routine command surface for bd-backed issue tracking and sync workflows — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/plans/YYYY-MM-DD-<slug>-tasks.md` — these are approved artifacts consumed by `/dev`, but Beads (`bd`) remains the source of truth for issue state and IDs. Use `bd` directly only for operations Forge does not wrap yet, such as `bd init`, `bd comments`, `bd dep`, and `bd dolt *`. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/BEADS_GITHUB_SYNC.md`).
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,15 +232,15 @@ This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full 
 ### Quick Reference
 
 ```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --claim  # Claim work
-bd close <id>         # Complete work
+forge ready           # Find available work
+forge show <id>       # View issue details
+forge claim <id>      # Claim work
+forge close <id>      # Complete work
 ```
 
 ### Rules
 
-- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/plans/YYYY-MM-DD-<slug>-tasks.md` — these are approved artifacts consumed by `/dev`, but `bd` remains the source of truth for issue state. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/BEADS_GITHUB_SYNC.md`).
+- Use `forge` for routine issue tracking and sync workflows — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/plans/YYYY-MM-DD-<slug>-tasks.md` — these are approved artifacts consumed by `/dev`, but Beads remains the source of truth for issue state under the Forge layer. Use `bd` directly only for operations Forge does not wrap yet, such as `bd init`, `bd comments`, `bd dep`, and `bd dolt *`. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/BEADS_GITHUB_SYNC.md`).
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 
@@ -255,10 +255,10 @@ bd close <id>         # Complete work
 3. **Update issue status** - Close finished work, update in-progress items
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
-   git pull --rebase
-   bd dolt push   # requires Dolt-backed Beads — run 'bd init' if missing
-   git push
-   git status  # MUST show "up to date with origin"
+    git pull --rebase
+    forge sync     # wraps the supported Beads sync flow when Beads is configured
+    git push
+    git status  # MUST show "up to date with origin"
    ```
 5. **Clean up** - Clear stashes, prune remote branches
 6. **Verify** - All changes committed AND pushed

--- a/README.md
+++ b/README.md
@@ -413,6 +413,9 @@ forge sync                 # Sync Beads state
 For advanced Beads operations that Forge does not wrap yet, use `bd` directly for
 `bd comments`, `bd dep`, and `bd dolt`.
 
+Forge is the preferred command surface for routine workflows, but Beads (`bd`)
+remains the underlying source of truth for issue state and IDs.
+
 ---
 
 ## License

--- a/README.md
+++ b/README.md
@@ -402,13 +402,16 @@ gh auth login
 /premerge <pr>             # Complete docs, hand off PR
 /verify                    # Post-merge health check
 
-# Beads commands (optional)
-bd init                    # Initialize tracking
-bd ready                   # Find ready work
-bd create "title"          # Create issue
-bd update <id> --status X  # Update status
-bd sync                    # Sync with git
+# Issue commands (via Forge)
+bd init                    # Initialize Beads tracking
+forge ready                # Find ready work
+forge create "title"       # Create issue
+forge update <id> --status X  # Update status
+forge sync                 # Sync Beads state
 ```
+
+For advanced Beads operations that Forge does not wrap yet, use `bd` directly for
+`bd comments`, `bd dep`, and `bd dolt`.
 
 ---
 

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -2394,7 +2394,7 @@ function displaySetupSummary(selectedAgents) {
 
   // Beads status
   if (isBeadsInitialized()) {
-    console.log('  ✓ Beads initialized - Track work: bd ready');
+    console.log('  ✓ Beads initialized - Track work: forge ready');
   } else if (checkForBeads()) {
     console.log('  ! Beads available - Run: bd init');
   } else {
@@ -3347,7 +3347,7 @@ async function setupProjectTools(rl, question) {
   console.log('');
   console.log('• Beads - Git-backed issue tracking');
   console.log('  Persists tasks across sessions, tracks dependencies.');
-  console.log('  Command: bd ready, bd create, bd close');
+  console.log('  Command: forge ready, forge create, forge close');
   console.log('');
   console.log('• Skills - Universal SKILL.md management');
   console.log('  Manage AI agent skills across all agents.');

--- a/docs/BEADS_GITHUB_SYNC.md
+++ b/docs/BEADS_GITHUB_SYNC.md
@@ -3,9 +3,13 @@
 Automatic synchronization between GitHub Issues and Beads issue tracking.
 
 **GitHub Issues** = human/team/public interface.
-**Beads** = AI agent engine (`bd ready`, `bd close`).
+**Beads** = issue engine behind Forge (`forge ready`, `forge close`).
 
 Neither side needs to know about the other. Contributors file issues on GitHub; AI agents pick up work via Beads. Status changes propagate automatically.
+
+For human and agent workflows, prefer the Forge wrapper commands (`forge ready`,
+`forge create`, `forge close`, `forge sync`). The workflow automation shown below
+still calls `bd` directly as an internal implementation detail.
 
 ---
 
@@ -48,7 +52,7 @@ sequenceDiagram
     participant WF as GitHub Actions
     participant GH as GitHub Issues
 
-    AI->>BD: bd close forge-abc
+    AI->>BD: forge close forge-abc
     BD->>Repo: Update issues.jsonl
     AI->>Repo: git push
     Repo->>WF: push trigger (paths: .beads/**)

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -109,7 +109,7 @@ git commit -m "feat: add health check endpoint"
 /status
 
 # If Beads installed:
-bd create "SQL injection in search endpoint" \
+forge create "SQL injection in search endpoint" \
   --type bug \
   --priority 0 \
   --label "security,critical"
@@ -224,7 +224,7 @@ OWASP A03:2021 Injection"
 # ═══════════════════════════════════════════════════════════
 /status
 
-bd create "Extract auth logic to service" \
+forge create "Extract auth logic to service" \
   --type chore \
   --priority 2
 
@@ -337,35 +337,35 @@ Team of 3 developers:
 # PROJECT SETUP (Once per project)
 # ═══════════════════════════════════════════════════════════
 bd init --prefix SHOP
-bd sync  # Commit .beads/ to git
+forge sync  # Sync initial Beads state
 
 # ═══════════════════════════════════════════════════════════
 # ALICE: Payment Integration
 # ═══════════════════════════════════════════════════════════
 
 # Morning: Check what's available
-bd ready
+forge ready
 # Output:
 # SHOP-1: Payment integration (ready)
 # SHOP-3: Admin dashboard (ready)
 
 # Claim work
-bd update SHOP-1 --status in_progress
+forge claim SHOP-1
 /status
 /plan stripe-payment-integration
 /dev
 
 # Midday: Progress update
-bd comments SHOP-1 "Stripe SDK integrated, working on webhooks"
+bd comments add SHOP-1 "Stripe SDK integrated, working on webhooks"
 
 # Afternoon: Blocked on API keys
-bd update SHOP-1 --status blocked --comment "Need production Stripe API keys"
+forge update SHOP-1 --status blocked --comment "Need production Stripe API keys"
 
 # Create dependency
-bd create "Get Stripe API keys from DevOps" --type chore --priority 1
+forge create "Get Stripe API keys from DevOps" --type chore --priority 1
 bd dep add SHOP-1 SHOP-5  # SHOP-1 depends on SHOP-5
 
-bd sync  # Push to git
+forge sync  # Push Beads state
 
 # ═══════════════════════════════════════════════════════════
 # BOB: Email Notifications (Same Time)
@@ -373,24 +373,24 @@ bd sync  # Push to git
 
 # Morning: Pull latest, check work
 git pull
-bd sync  # Sync with Alice's updates
+forge sync  # Sync with Alice's updates
 
-bd ready
+forge ready
 # Output:
 # SHOP-3: Admin dashboard (ready)
 # SHOP-2: Email notifications (ready)
 
 # Claim different feature
-bd update SHOP-2 --status in_progress
+forge claim SHOP-2
 /plan email-notifications
 /dev
 
 # No conflicts with Alice (different files)
 
 # End of day: Complete
-bd close SHOP-2 --reason "Implemented with SendGrid"
+forge close SHOP-2 --reason "Implemented with SendGrid"
 /ship
-bd sync
+forge sync
 
 # ═══════════════════════════════════════════════════════════
 # CHARLIE: Admin Dashboard (Next Day)
@@ -398,17 +398,17 @@ bd sync
 
 # Morning: Check dependencies
 git pull
-bd sync
+forge sync
 
-bd show SHOP-3
+forge show SHOP-3
 # Output:
 # Status: ready
 # Depends on: (none)
 
-bd update SHOP-3 --status in_progress
+forge claim SHOP-3
 
 # Discovers overlap with Bob's work
-bd comments SHOP-3 "Need Bob's email service for user notifications"
+bd comments add SHOP-3 "Need Bob's email service for user notifications"
 bd dep add SHOP-3 SHOP-2  # SHOP-3 depends on SHOP-2
 
 # Bob's work already merged, so can proceed
@@ -428,7 +428,7 @@ bd blocked
 # SHOP-1: Payment integration (blocked by SHOP-5)
 
 # Find work with no blockers:
-bd ready
+forge ready
 
 # See full project status:
 bd stats
@@ -440,7 +440,7 @@ bd stats
 # Done: 4
 
 # Always sync at end of session:
-bd sync
+forge sync
 ```
 
 **Result**: Team can work in parallel, track dependencies, and avoid conflicts.
@@ -465,8 +465,8 @@ bd sync
 
 ### 4. Team Collaboration
 - Beads tracks dependencies
-- `bd ready` finds available work
-- `bd sync` at end of every session
+- `forge ready` finds available work
+- `forge sync` at end of every session
 - Comments keep teammates informed
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -291,8 +291,8 @@ All PRs tracked in Beads with proper dependencies:
 | PR8 | forge-dwm | Blocked | P3 | PR7 |
 | ~~Skills CLI~~ | ~~forge-mlm~~ | ~~Absorbed into PR5.5 + PR6 + PR8~~ | — | — |
 
-**View all issues**: `bd list`
-**View ready work**: `bd ready`
+**View all issues**: `forge list`
+**View ready work**: `forge ready`
 **View blocked issues**: `bd blocked`
 
 ### Git Workflow
@@ -348,7 +348,7 @@ Each PR is self-contained and can be rolled back independently:
 ## Resources
 
 - **Master Plan**: `docs/plans/*.md`
-- **Beads Issues**: `bd list` or `bd show <issue-id>`
+- **Beads Issues**: `forge list` or `forge show <issue-id>`
 - **Workflow Guide**: [AGENTS.md](../AGENTS.md)
 - **Architecture Docs**: Coming in PR0 - [ARCHITECTURE.md](./ARCHITECTURE.md)
 

--- a/docs/TOOLCHAIN.md
+++ b/docs/TOOLCHAIN.md
@@ -42,7 +42,7 @@ Complete reference for all tools integrated with the Forge workflow.
 - **Persists across sessions** - Issues survive context clearing, compaction, new chats
 - **Git-backed** - Version controlled, mergeable, team-shareable
 - **Dependency tracking** - Know what blocks what
-- **Ready detection** - `bd ready` finds unblocked work automatically
+- **Ready detection** - `forge ready` finds unblocked work automatically
 - **AI-optimized** - JSON output, semantic compaction, audit trails
 
 ### Installation
@@ -91,6 +91,11 @@ After `bd init`, creates `.beads/` directory:
 
 **Dual-database architecture**: JSONL for git versioning, SQLite for fast local queries. Background daemon keeps them in sync.
 
+For day-to-day issue workflows, prefer the Forge wrapper commands (`forge ready`,
+`forge create`, `forge update`, `forge close`, `forge sync`). Use `bd` directly
+for Beads capabilities Forge does not wrap yet, such as `bd init`, `bd comments`,
+`bd dep`, `bd blocked`, and `bd dolt *`.
+
 ### Complete Command Reference
 
 #### Initialization
@@ -106,36 +111,36 @@ bd init --prefix PROJ      # Custom issue prefix (PROJ-xxx)
 
 ```bash
 # Create issues
-bd create "Title"                           # Basic issue
-bd create "Title" --type feature            # With type (feature, bug, chore, etc.)
-bd create "Title" --priority 1              # With priority (0=critical, 4=backlog)
-bd create "Title" -p 0 -l "urgent,backend"  # P0 with labels
+forge create "Title"                           # Basic issue
+forge create "Title" --type feature            # With type (feature, bug, chore, etc.)
+forge create "Title" --priority 1              # With priority (0=critical, 4=backlog)
+forge create "Title" -p 0 -l "urgent,backend"  # P0 with labels
 
 # View issues
-bd show <id>                   # Detailed view with audit trail
-bd list                        # All issues
-bd list --status open          # Filter by status
-bd list --priority 1           # Filter by priority
-bd list --assignee bob         # Filter by assignee
-bd list --label bug            # Filter by label (AND logic)
-bd list --label-any bug,urgent # Filter by label (OR logic)
-bd list --type feature         # Filter by type
-bd list --title-contains "auth" # Search titles
-bd list --limit 10             # Limit results
+forge show <id>                   # Detailed view with audit trail
+forge list                        # All issues
+forge list --status open          # Filter by status
+forge list --priority 1           # Filter by priority
+forge list --assignee bob         # Filter by assignee
+forge list --label bug            # Filter by label (AND logic)
+forge list --label-any bug,urgent # Filter by label (OR logic)
+forge list --type feature         # Filter by type
+forge list --title-contains "auth" # Search titles
+forge list --limit 10             # Limit results
 
 # Update issues
-bd update <id> --status in_progress     # Change status
-bd update <id> --priority 2             # Change priority
-bd update <id> --assignee bob           # Assign
-bd update <id> --title "New title"      # Update title
-bd update <id> --description "..."      # Update description
-bd update <id> --notes "..."            # Add notes
-bd update <id> --label-add urgent       # Add label
+forge claim <id>                        # Claim work (sets in_progress)
+forge update <id> --priority 2          # Change priority
+forge update <id> --assignee bob        # Assign
+forge update <id> --title "New title"   # Update title
+forge update <id> --description "..."   # Update description
+forge update <id> --notes "..."         # Add notes
+forge update <id> --add-label urgent    # Add label
 
 # Complete issues
-bd close <id>                           # Close single issue
-bd close <id1> <id2> <id3>              # Close multiple (efficient)
-bd close <id> --reason "Completed auth" # Close with reason
+forge close <id>                           # Close single issue
+forge close <id1> <id2> <id3>              # Close multiple (efficient)
+forge close <id> --reason "Completed auth" # Close with reason
 bd delete <id>                          # Delete issue
 bd delete <id> --cascade                # Delete with dependents
 ```
@@ -144,8 +149,8 @@ bd delete <id> --cascade                # Delete with dependents
 
 ```bash
 # Find work
-bd ready                        # Issues with NO open blockers (start here!)
-bd ready --priority 1           # Filter ready work by priority
+forge ready                     # Issues with NO open blockers (start here!)
+forge ready --priority 1        # Filter ready work by priority
 bd blocked                      # Issues that ARE blocked
 
 # Dependencies
@@ -158,11 +163,11 @@ bd dep cycles                                  # Detect cycles
 
 # Comments
 bd comments <id>                # View comments
-bd comments <id> "Comment text" # Add comment
+bd comments add <id> "Comment text" # Add comment
 
 # Git sync
-bd sync                         # Export to JSONL, commit, push
-bd sync --status                # Check sync status
+forge sync                      # Pull + push Beads state through the Forge wrapper
+bd dolt status                  # Check Dolt sync/server status
 bd hooks install                # Install git hooks for auto-sync
 
 # Maintenance
@@ -203,18 +208,18 @@ bd admin compact --days 90      # Compact old closed issues
 
 ```bash
 # Start of session
-bd ready                    # What can I work on?
-bd show <id>                # Review the issue
-bd update <id> --status in_progress
+forge ready                 # What can I work on?
+forge show <id>             # Review the issue
+forge claim <id>
 
 # During work
-bd comments <id> "Progress update"
-bd update <id> --notes "Found edge case"
+bd comments add <id> "Progress update"
+forge update <id> --notes "Found edge case"
 
 # End of session
-bd close <id>               # If done, or:
-bd update <id> --status blocked --comment "Needs API response"
-bd sync                     # Always sync at end!
+forge close <id>            # If done, or:
+forge update <id> --status blocked --comment "Needs API response"
+forge sync                  # Always sync at end!
 ```
 
 ---
@@ -556,7 +561,10 @@ bun add -g @beads/bd
 irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 ```
 
-> **Why v0.49.x?** Earlier versions lack the `bd ready` dependency-aware query, `bd sync --status`, and the dual-database (JSONL + SQLite) architecture that Forge relies on.
+> **Why Forge + Beads?** Forge wraps the supported day-to-day issue workflow
+> (`forge ready`, `forge create`, `forge close`, `forge sync`) while Beads
+> remains the underlying store for initialization, dependencies, comments, and
+> Dolt-backed sync internals.
 
 ---
 
@@ -564,14 +572,14 @@ irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 
 | Stage | Tools Used |
 |-------|------------|
-| `/status` | `bd ready`, `bd list`, `git status` |
+| `/status` | `forge ready`, `forge list`, `git status` |
 | `/plan` (Phase 2) | Parallel AI, Context7, grep.app, codebase exploration |
-| `/plan` | `bd create`, `git checkout -b` |
-| `/dev` | Tests, code, `bd update`, `/tasks save` |
+| `/plan` | `forge create`, `git checkout -b` |
+| `/dev` | Tests, code, `forge update`, `/tasks save` |
 | `/validate` | Type check, lint, tests, SonarCloud |
-| `/ship` | `bd update --status done`, `gh pr create` |
+| `/ship` | `forge close`, `gh pr create` |
 | `/review` | `gh pr view`, Greptile, SonarCloud |
-| `/premerge` | `bd sync`, doc updates, hand off PR |
+| `/premerge` | `forge sync`, doc updates, hand off PR |
 | `/verify` | Documentation cross-check |
 
 ---
@@ -582,13 +590,13 @@ irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 
 ```bash
 bd init                     # Initialize
-bd ready                    # Find unblocked work
-bd create "Title"           # Create issue
-bd show <id>                # View details
-bd update <id> --status X   # Update status
+forge ready                 # Find unblocked work
+forge create "Title"        # Create issue
+forge show <id>             # View details
+forge update <id> --status X   # Update status
 bd dep add <a> <b>          # a depends on b
-bd close <id>               # Complete
-bd sync                     # Git sync
+forge close <id>            # Complete
+forge sync                  # Beads sync
 ```
 
 ### GitHub CLI
@@ -626,12 +634,12 @@ irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 
 **"database locked"**
 ```bash
-bd sync --force
+forge sync
 ```
 
 **Issues not showing after git pull**
 ```bash
-bd sync  # Re-imports from JSONL
+forge sync  # Re-syncs Beads state through the Forge wrapper
 ```
 
 ### GitHub CLI

--- a/docs/forge/TOOLCHAIN.md
+++ b/docs/forge/TOOLCHAIN.md
@@ -42,7 +42,7 @@ Complete reference for all tools integrated with the Forge workflow.
 - **Persists across sessions** - Issues survive context clearing, compaction, new chats
 - **Git-backed** - Version controlled, mergeable, team-shareable
 - **Dependency tracking** - Know what blocks what
-- **Ready detection** - `bd ready` finds unblocked work automatically
+- **Ready detection** - `forge ready` finds unblocked work automatically
 - **AI-optimized** - JSON output, semantic compaction, audit trails
 
 ### Installation
@@ -107,6 +107,11 @@ After `bd init`, creates `.beads/` directory:
 
 **Dual-database architecture**: JSONL for git versioning, SQLite for fast local queries. Background daemon keeps them in sync.
 
+For day-to-day issue workflows, prefer the Forge wrapper commands (`forge ready`,
+`forge create`, `forge update`, `forge close`, `forge sync`). Use `bd` directly
+for Beads capabilities Forge does not wrap yet, such as `bd init`, `bd comments`,
+`bd dep`, `bd blocked`, and `bd dolt *`.
+
 ### Complete Command Reference
 
 #### Initialization
@@ -122,36 +127,36 @@ bd init --prefix PROJ      # Custom issue prefix (PROJ-xxx)
 
 ```bash
 # Create issues
-bd create "Title"                           # Basic issue
-bd create "Title" --type feature            # With type (feature, bug, chore, etc.)
-bd create "Title" --priority 1              # With priority (0=critical, 4=backlog)
-bd create "Title" -p 0 -l "urgent,backend"  # P0 with labels
+forge create "Title"                           # Basic issue
+forge create "Title" --type feature            # With type (feature, bug, chore, etc.)
+forge create "Title" --priority 1              # With priority (0=critical, 4=backlog)
+forge create "Title" -p 0 -l "urgent,backend"  # P0 with labels
 
 # View issues
-bd show <id>                   # Detailed view with audit trail
-bd list                        # All issues
-bd list --status open          # Filter by status
-bd list --priority 1           # Filter by priority
-bd list --assignee bob         # Filter by assignee
-bd list --label bug            # Filter by label (AND logic)
-bd list --label-any bug,urgent # Filter by label (OR logic)
-bd list --type feature         # Filter by type
-bd list --title-contains "auth" # Search titles
-bd list --limit 10             # Limit results
+forge show <id>                   # Detailed view with audit trail
+forge list                        # All issues
+forge list --status open          # Filter by status
+forge list --priority 1           # Filter by priority
+forge list --assignee bob         # Filter by assignee
+forge list --label bug            # Filter by label (AND logic)
+forge list --label-any bug,urgent # Filter by label (OR logic)
+forge list --type feature         # Filter by type
+forge list --title-contains "auth" # Search titles
+forge list --limit 10             # Limit results
 
 # Update issues
-bd update <id> --status in_progress     # Change status
-bd update <id> --priority 2             # Change priority
-bd update <id> --assignee bob           # Assign
-bd update <id> --title "New title"      # Update title
-bd update <id> --description "..."      # Update description
-bd update <id> --notes "..."            # Add notes
-bd update <id> --label-add urgent       # Add label
+forge claim <id>                        # Claim work (sets in_progress)
+forge update <id> --priority 2          # Change priority
+forge update <id> --assignee bob        # Assign
+forge update <id> --title "New title"   # Update title
+forge update <id> --description "..."   # Update description
+forge update <id> --notes "..."         # Add notes
+forge update <id> --add-label urgent    # Add label
 
 # Complete issues
-bd close <id>                           # Close single issue
-bd close <id1> <id2> <id3>              # Close multiple (efficient)
-bd close <id> --reason "Completed auth" # Close with reason
+forge close <id>                           # Close single issue
+forge close <id1> <id2> <id3>              # Close multiple (efficient)
+forge close <id> --reason "Completed auth" # Close with reason
 bd delete <id>                          # Delete issue
 bd delete <id> --cascade                # Delete with dependents
 ```
@@ -160,8 +165,8 @@ bd delete <id> --cascade                # Delete with dependents
 
 ```bash
 # Find work
-bd ready                        # Issues with NO open blockers (start here!)
-bd ready --priority 1           # Filter ready work by priority
+forge ready                     # Issues with NO open blockers (start here!)
+forge ready --priority 1        # Filter ready work by priority
 bd blocked                      # Issues that ARE blocked
 
 # Dependencies
@@ -174,11 +179,11 @@ bd dep cycles                                  # Detect cycles
 
 # Comments
 bd comments <id>                # View comments
-bd comments <id> "Comment text" # Add comment
+bd comments add <id> "Comment text" # Add comment
 
 # Git sync
-bd sync                         # Export to JSONL, commit, push
-bd sync --status                # Check sync status
+forge sync                      # Pull + push Beads state through the Forge wrapper
+bd dolt status                  # Check Dolt sync/server status
 bd hooks install                # Install git hooks for auto-sync
 
 # Maintenance
@@ -219,18 +224,18 @@ bd admin compact --days 90      # Compact old closed issues
 
 ```bash
 # Start of session
-bd ready                    # What can I work on?
-bd show <id>                # Review the issue
-bd update <id> --status in_progress
+forge ready                 # What can I work on?
+forge show <id>             # Review the issue
+forge claim <id>
 
 # During work
-bd comments <id> "Progress update"
-bd update <id> --notes "Found edge case"
+bd comments add <id> "Progress update"
+forge update <id> --notes "Found edge case"
 
 # End of session
-bd close <id>               # If done, or:
-bd update <id> --status blocked --comment "Needs API response"
-bd sync                     # Always sync at end!
+forge close <id>            # If done, or:
+forge update <id> --status blocked --comment "Needs API response"
+forge sync                  # Always sync at end!
 ```
 
 ---
@@ -574,7 +579,10 @@ bun add -g @beads/bd
 # irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 -OutFile $env:TEMP\beads-install.ps1; & $env:TEMP\beads-install.ps1
 ```
 
-> **Why v0.49.x?** Earlier versions lack the `bd ready` dependency-aware query, `bd sync --status`, and the dual-database (JSONL + SQLite) architecture that Forge relies on.
+> **Why Forge + Beads?** Forge wraps the supported day-to-day issue workflow
+> (`forge ready`, `forge create`, `forge close`, `forge sync`) while Beads
+> remains the underlying store for initialization, dependencies, comments, and
+> Dolt-backed sync internals.
 
 ---
 
@@ -582,14 +590,14 @@ bun add -g @beads/bd
 
 | Stage | Tools Used |
 |-------|------------|
-| `/status` | `bd ready`, `bd list`, `git status` |
+| `/status` | `forge ready`, `forge list`, `git status` |
 | `/plan` (Phase 2) | Parallel AI, Context7, grep.app, codebase exploration |
-| `/plan` | `bd create`, `git checkout -b` |
-| `/dev` | Tests, code, `bd update`, `/tasks save` |
+| `/plan` | `forge create`, `git checkout -b` |
+| `/dev` | Tests, code, `forge update`, `/tasks save` |
 | `/validate` | Type check, lint, tests, SonarCloud |
-| `/ship` | `bd update --status done`, `gh pr create` |
+| `/ship` | `forge close`, `gh pr create` |
 | `/review` | `gh pr view`, Greptile, SonarCloud |
-| `/premerge` | `bd sync`, doc updates, hand off PR |
+| `/premerge` | `forge sync`, doc updates, hand off PR |
 | `/verify` | Documentation cross-check |
 
 ---
@@ -600,13 +608,13 @@ bun add -g @beads/bd
 
 ```bash
 bd init                     # Initialize
-bd ready                    # Find unblocked work
-bd create "Title"           # Create issue
-bd show <id>                # View details
-bd update <id> --status X   # Update status
+forge ready                 # Find unblocked work
+forge create "Title"        # Create issue
+forge show <id>             # View details
+forge update <id> --status X   # Update status
 bd dep add <a> <b>          # a depends on b
-bd close <id>               # Complete
-bd sync                     # Git sync
+forge close <id>            # Complete
+forge sync                  # Beads sync
 ```
 
 ### GitHub CLI
@@ -648,12 +656,12 @@ bun add -g @beads/bd
 
 **"database locked"**
 ```bash
-bd sync --force
+forge sync
 ```
 
 **Issues not showing after git pull**
 ```bash
-bd sync  # Re-imports from JSONL
+forge sync  # Re-syncs Beads state through the Forge wrapper
 ```
 
 ### GitHub CLI

--- a/lib/agents-config.js
+++ b/lib/agents-config.js
@@ -220,15 +220,18 @@ Configuration: \`.mcp.json\` or agent-specific config files
 
 ## Issue Tracking
 
-Use **Beads** for persistent tracking across sessions:
+Use **Forge's Beads wrapper** for persistent tracking across sessions:
 
 \`\`\`bash
-bd create "Feature name"              # Create issue
-bd update <id> --status in_progress   # Claim work
-bd update <id> --comment "Progress"   # Add notes
-bd close <id>                          # Complete
-bd sync                                # Sync with git
+forge create "Feature name"              # Create issue
+forge update <id> --status in_progress   # Claim work
+forge update <id> --notes "Progress"     # Add notes
+forge close <id>                         # Complete
+forge sync                               # Sync Beads state
 \`\`\`
+
+Use \`bd\` directly only for capabilities Forge does not wrap yet, such as
+\`bd init\`, \`bd comments\`, \`bd dep\`, and \`bd dolt\`.
 
 ## Git Workflow
 
@@ -480,15 +483,18 @@ Configure these MCP servers in \`.mcp.json\`:
 
 ## Issue Tracking with Beads
 
-Use **Beads** for persistent tracking across sessions:
+Use **Forge's Beads wrapper** for persistent tracking across sessions:
 
 \`\`\`bash
-bd create "Feature name"                  # Create issue
-bd update <id> --status in_progress       # Claim work
-bd update <id> --append-notes "Progress"  # Add notes
-bd close <id>                              # Complete
-bd sync                                    # Sync with git
+forge create "Feature name"                # Create issue
+forge update <id> --status in_progress     # Claim work
+forge update <id> --append-notes "Progress" # Add notes
+forge close <id>                           # Complete
+forge sync                                 # Sync Beads state
 \`\`\`
+
+Use \`bd\` directly only for capabilities Forge does not wrap yet, such as
+\`bd init\`, \`bd comments\`, \`bd dep\`, and \`bd dolt\`.
 
 ## Code Quality Standards
 

--- a/lib/agents-config.js
+++ b/lib/agents-config.js
@@ -224,8 +224,8 @@ Use **Forge's Beads wrapper** for persistent tracking across sessions:
 
 \`\`\`bash
 forge create "Feature name"              # Create issue
-forge update <id> --status in_progress   # Claim work
-forge update <id> --notes "Progress"     # Add notes
+forge claim <id>                         # Claim work
+forge update <id> --append-notes "Progress" # Add notes
 forge close <id>                         # Complete
 forge sync                               # Sync Beads state
 \`\`\`
@@ -487,7 +487,7 @@ Use **Forge's Beads wrapper** for persistent tracking across sessions:
 
 \`\`\`bash
 forge create "Feature name"                # Create issue
-forge update <id> --status in_progress     # Claim work
+forge claim <id>                           # Claim work
 forge update <id> --append-notes "Progress" # Add notes
 forge close <id>                           # Complete
 forge sync                                 # Sync Beads state

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -2477,7 +2477,7 @@ function displaySetupSummary(selectedAgents) {
 
   // Beads status
   if (isBeadsInitialized()) {
-    console.log('  ✓ Beads initialized - Track work: bd ready');
+    console.log('  ✓ Beads initialized - Track work: forge ready');
   } else if (checkForBeads()) {
     console.log('  ! Beads available - Run: bd init');
   } else {
@@ -3229,7 +3229,7 @@ async function setupProjectTools(rl, question) {
   console.log('');
   console.log('• Beads - Git-backed issue tracking');
   console.log('  Persists tasks across sessions, tracks dependencies.');
-  console.log('  Command: bd ready, bd create, bd close');
+  console.log('  Command: forge ready, forge create, forge close');
   console.log('');
   console.log('• Skills - Universal SKILL.md management');
   console.log('  Manage AI agent skills across all agents.');

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -63,6 +63,17 @@ function listConflictScanFiles(rootDir) {
 	}
 }
 
+function shouldSkipConflictScanPath(relativePath) {
+	const segments = String(relativePath || '')
+		.split(/[\\/]+/)
+		.filter(Boolean);
+	const directorySegments = segments.slice(0, -1);
+	return directorySegments.some(segment => (
+		(segment.startsWith('.') && !CONFLICT_MARKER_ALLOWED_DOT_DIRS.has(segment))
+		|| CONFLICT_MARKER_IGNORE_DIRS.has(segment)
+	));
+}
+
 function getExecOptions() {
 	return { encoding: 'utf8', cwd: process.cwd(), timeout: 120000 };
 }
@@ -104,12 +115,16 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 	const filesWithMarkers = [];
 
 	function inspectFile(absolutePath) {
+		const relativePath = path.relative(rootDir, absolutePath) || path.basename(absolutePath);
+		if (shouldSkipConflictScanPath(relativePath)) {
+			return;
+		}
+
 		const startLine = findConflictMarkerStartLine(readConflictScanFile(absolutePath));
 		if (startLine === null) {
 			return;
 		}
 
-		const relativePath = path.relative(rootDir, absolutePath) || path.basename(absolutePath);
 		filesWithMarkers.push({ path: relativePath, line: startLine });
 	}
 

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -46,6 +46,23 @@ const CONFLICT_START_PATTERN = /^<<<<<<<(?: .*)?$/;
 const CONFLICT_DIVIDER_PATTERN = /^=======$/;
 const CONFLICT_END_PATTERN = /^>>>>>>>.*$/;
 
+function listConflictScanFiles(rootDir) {
+	try {
+		const output = execFileSync(
+			'git',
+			['ls-files', '-z', '--cached', '--others', '--exclude-standard'],
+			{ encoding: 'utf8', cwd: rootDir, timeout: 120000 },
+		);
+		return output
+			.split('\0')
+			.map(file => file.trim())
+			.filter(Boolean)
+			.map(file => path.join(rootDir, file));
+	} catch (_error) {
+		return null;
+	}
+}
+
 function getExecOptions() {
 	return { encoding: 'utf8', cwd: process.cwd(), timeout: 120000 };
 }
@@ -86,6 +103,16 @@ function getCheckStatus(check) {
 function scanForConflictMarkers(rootDir = process.cwd()) {
 	const filesWithMarkers = [];
 
+	function inspectFile(absolutePath) {
+		const startLine = findConflictMarkerStartLine(readConflictScanFile(absolutePath));
+		if (startLine === null) {
+			return;
+		}
+
+		const relativePath = path.relative(rootDir, absolutePath) || path.basename(absolutePath);
+		filesWithMarkers.push({ path: relativePath, line: startLine });
+	}
+
 	function walk(currentDir) {
 		for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
 			if (shouldSkipConflictScanEntry(entry)) {
@@ -101,18 +128,18 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 				continue;
 			}
 
-			const absolutePath = path.join(currentDir, entry.name);
-			const startLine = findConflictMarkerStartLine(readConflictScanFile(absolutePath));
-			if (startLine === null) {
-				continue;
-			}
-
-			const relativePath = path.relative(rootDir, absolutePath) || entry.name;
-			filesWithMarkers.push({ path: relativePath, line: startLine });
+			inspectFile(path.join(currentDir, entry.name));
 		}
 	}
 
-	walk(rootDir);
+	const trackedFiles = listConflictScanFiles(rootDir);
+	if (trackedFiles) {
+		for (const absolutePath of trackedFiles) {
+			inspectFile(absolutePath);
+		}
+	} else {
+		walk(rootDir);
+	}
 	filesWithMarkers.sort((left, right) => {
 		if (left.path === right.path) {
 			return left.line - right.line;

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -55,8 +55,7 @@ function listConflictScanFiles(rootDir) {
 		);
 		return output
 			.split('\0')
-			.map(file => file.trim())
-			.filter(Boolean)
+			.filter(file => file.length > 0)
 			.map(file => path.join(rootDir, file));
 	} catch (_error) {
 		return null;
@@ -117,6 +116,14 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 	function inspectFile(absolutePath) {
 		const relativePath = path.relative(rootDir, absolutePath) || path.basename(absolutePath);
 		if (shouldSkipConflictScanPath(relativePath)) {
+			return;
+		}
+
+		try {
+			if (!fs.lstatSync(absolutePath).isFile()) {
+				return;
+			}
+		} catch (_error) {
 			return;
 		}
 

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -57,7 +57,10 @@ function listConflictScanFiles(rootDir) {
 			.split('\0')
 			.filter(file => file.length > 0)
 			.map(file => path.join(rootDir, file));
-	} catch (_error) {
+	} catch (error) {
+		if (!isGitListingUnavailableError(error)) {
+			throw error;
+		}
 		return null;
 	}
 }
@@ -80,6 +83,7 @@ function getExecOptions() {
 const ERROR_PATTERNS = {
 	COMMAND_NOT_FOUND: ['ENOENT', 'not found'],
 	NO_LOCK_FILE: ['requires an existing', 'package-lock'],
+	GIT_LISTING_UNAVAILABLE: ['not a git repository'],
 };
 
 /**
@@ -90,6 +94,14 @@ function isCommandNotFound(error) {
 	return ERROR_PATTERNS.COMMAND_NOT_FOUND.some(pattern =>
 		error.message.includes(pattern),
 	);
+}
+
+function isGitListingUnavailableError(error) {
+	if (!error || typeof error.message !== 'string') {
+		return false;
+	}
+	return isCommandNotFound(error)
+		|| ERROR_PATTERNS.GIT_LISTING_UNAVAILABLE.some(pattern => error.message.includes(pattern));
 }
 
 /**
@@ -123,7 +135,10 @@ function scanForConflictMarkers(rootDir = process.cwd()) {
 			if (!fs.lstatSync(absolutePath).isFile()) {
 				return;
 			}
-		} catch (_error) {
+		} catch (error) {
+			if (!canSkipConflictScanStatError(error)) {
+				throw error;
+			}
 			return;
 		}
 
@@ -183,6 +198,10 @@ function shouldSkipConflictScanEntry(entry) {
 		(entry.name.startsWith('.') && !CONFLICT_MARKER_ALLOWED_DOT_DIRS.has(entry.name))
 		|| CONFLICT_MARKER_IGNORE_DIRS.has(entry.name)
 	);
+}
+
+function canSkipConflictScanStatError(error) {
+	return Boolean(error && ['ENOENT', 'ENOTDIR', 'ELOOP'].includes(error.code));
 }
 
 function readConflictScanFile(absolutePath) {

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -161,10 +161,12 @@ describe('Validate Command - Validation Orchestration', () => {
 			}
 		});
 
-		test('should preserve skip rules when scanning Git-indexed files', async () => {
+		test('should skip ignored directories and non-allowlisted dotdirs when scanning Git-listed files', async () => {
 			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-git-fast-path-'));
 			try {
 				execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+				execFileSync('git', ['config', 'user.name', 'Forge Test'], { cwd: tmpDir, stdio: 'ignore' });
+				execFileSync('git', ['config', 'user.email', 'forge@example.com'], { cwd: tmpDir, stdio: 'ignore' });
 				fs.mkdirSync(path.join(tmpDir, '.beads'), { recursive: true });
 				fs.mkdirSync(path.join(tmpDir, '.hidden'), { recursive: true });
 				fs.mkdirSync(path.join(tmpDir, '.forge'), { recursive: true });
@@ -186,6 +188,7 @@ describe('Validate Command - Validation Orchestration', () => {
 					'<<<<<<< HEAD\ndist\n=======\ndist\n>>>>>>> branch\n',
 				);
 				execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'ignore' });
+				execFileSync('git', ['commit', '-m', 'seed tracked files'], { cwd: tmpDir, stdio: 'ignore' });
 
 				const result = await executeValidate({
 					rootDir: tmpDir,

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -1,4 +1,5 @@
 const { describe, test, expect, setDefaultTimeout } = require('bun:test');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -154,6 +155,46 @@ describe('Validate Command - Validation Orchestration', () => {
 				expect(result.checks.conflictMarkers.files).toEqual([
 					expect.objectContaining({ path: path.join('.forge', 'tracked.md') }),
 					expect.objectContaining({ path: path.join('.github', 'workflow.yml') }),
+				]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		test('should preserve skip rules when scanning Git-indexed files', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-git-fast-path-'));
+			try {
+				execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+				fs.mkdirSync(path.join(tmpDir, '.beads'), { recursive: true });
+				fs.mkdirSync(path.join(tmpDir, '.hidden'), { recursive: true });
+				fs.mkdirSync(path.join(tmpDir, '.forge'), { recursive: true });
+				fs.mkdirSync(path.join(tmpDir, 'dist'), { recursive: true });
+				fs.writeFileSync(
+					path.join(tmpDir, '.beads', 'metadata.json'),
+					'<<<<<<< HEAD\nbeads\n=======\nbeads\n>>>>>>> branch\n',
+				);
+				fs.writeFileSync(
+					path.join(tmpDir, '.hidden', 'ignored.js'),
+					'<<<<<<< HEAD\nhidden\n=======\nhidden\n>>>>>>> branch\n',
+				);
+				fs.writeFileSync(
+					path.join(tmpDir, '.forge', 'tracked.md'),
+					'<<<<<<< HEAD\ntracked dotdir\n=======\ntracked dotdir updated\n>>>>>>> branch\n',
+				);
+				fs.writeFileSync(
+					path.join(tmpDir, 'dist', 'bundle.js'),
+					'<<<<<<< HEAD\ndist\n=======\ndist\n>>>>>>> branch\n',
+				);
+				execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'ignore' });
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.checks.conflictMarkers.files).toEqual([
+					expect.objectContaining({ path: path.join('.forge', 'tracked.md') }),
 				]);
 			} finally {
 				fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -231,6 +231,7 @@ describe('Validate Command - Validation Orchestration', () => {
 
 		test('should skip tracked symlinks in Git-indexed scans', async () => {
 			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-symlink-paths-'));
+			const outsideTargetPath = path.join(os.tmpdir(), `forge-validate-symlink-target-${Date.now()}.txt`);
 			try {
 				execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
 				fs.writeFileSync(
@@ -238,13 +239,13 @@ describe('Validate Command - Validation Orchestration', () => {
 					'console.log("safe");\n',
 				);
 				fs.writeFileSync(
-					path.join(tmpDir, 'outside-target.txt'),
+					outsideTargetPath,
 					'<<<<<<< HEAD\noutside\n=======\noutside\n>>>>>>> branch\n',
 				);
 
 				try {
 					fs.symlinkSync(
-						path.join(tmpDir, 'outside-target.txt'),
+						outsideTargetPath,
 						path.join(tmpDir, 'linked.txt'),
 					);
 				} catch (error) {
@@ -265,6 +266,7 @@ describe('Validate Command - Validation Orchestration', () => {
 				expect(result.checks.conflictMarkers.files).toEqual([]);
 			} finally {
 				fs.rmSync(tmpDir, { recursive: true, force: true });
+				fs.rmSync(outsideTargetPath, { force: true });
 			}
 		});
 

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -201,6 +201,70 @@ describe('Validate Command - Validation Orchestration', () => {
 			}
 		});
 
+		test('should preserve leading whitespace in Git-indexed file paths', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-whitespace-paths-'));
+			try {
+				const spacedFile = ' leadingspace.js';
+				execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+				fs.writeFileSync(
+					path.join(tmpDir, spacedFile),
+					'<<<<<<< HEAD\nwhitespace path\n=======\nwhitespace path updated\n>>>>>>> branch\n',
+				);
+				execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'ignore' });
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.checks.conflictMarkers.files).toEqual([
+					expect.objectContaining({ path: spacedFile }),
+				]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		test('should skip tracked symlinks in Git-indexed scans', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-symlink-paths-'));
+			try {
+				execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+				fs.writeFileSync(
+					path.join(tmpDir, 'tracked.js'),
+					'console.log("safe");\n',
+				);
+				fs.writeFileSync(
+					path.join(tmpDir, 'outside-target.txt'),
+					'<<<<<<< HEAD\noutside\n=======\noutside\n>>>>>>> branch\n',
+				);
+
+				try {
+					fs.symlinkSync(
+						path.join(tmpDir, 'outside-target.txt'),
+						path.join(tmpDir, 'linked.txt'),
+					);
+				} catch (error) {
+					if (error && (error.code === 'EPERM' || error.code === 'EACCES' || error.code === 'UNKNOWN')) {
+						return;
+					}
+					throw error;
+				}
+
+				execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'ignore' });
+
+				const result = await executeValidate({
+					rootDir: tmpDir,
+					skip: ['typeCheck', 'lint', 'security', 'tests'],
+				});
+
+				expect(result.success).toBe(true);
+				expect(result.checks.conflictMarkers.files).toEqual([]);
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
 		test('should flag unterminated conflict marker blocks', async () => {
 			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-partial-conflicts-'));
 			try {


### PR DESCRIPTION
## Problem
Validation on large repos was slower than it needed to be because conflict marker checks walked the tree too broadly, and the public workflow guidance still pointed people at raw Beads commands after Forge had become the intended wrapper for routine issue tracking.

## Root Cause
The validate command scanned files recursively even when Git could provide a narrower file set, and the docs/setup messaging migration to Forge was only partial, leaving stale `bd ready` and `bd sync` guidance in active user-facing surfaces.

## Fix
This PR narrows conflict marker scans to Git-indexed files when available, keeps the existing fallback for non-Git contexts, and updates the active docs, setup messaging, and agent-facing guidance to use Forge issue and sync commands where Forge has wrapper support.

## Value
Validation gets faster on real repositories, and contributors and agents are less likely to follow stale issue-tracking instructions or hit missing Beads subcommands.

## Beads
Closes forge-rbkm

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: Type check passed, lint passed, security audit passed, and pre-push tests passed (264 passing tests across 18 files).
- Scenarios covered: validate conflict scan behavior on the branch, setup/runtime guidance, and the affected Forge command/test surfaces exercised by the pre-push gate.

### Security Review
- OWASP Top 10: No new auth, secrets, or trust-boundary changes. The code change narrows local file enumeration, and the doc/setup changes only update command guidance.
- Automated scan: `bun audit` reported no vulnerabilities.

### Design Doc
None - bugfix and workflow-doc alignment follow-up.

### Key Decisions
- Use Git-indexed file discovery for conflict scans when available to avoid unnecessary full-tree walks.
- Keep the filesystem fallback so validation still works outside normal Git-indexed paths.
- Treat Forge as the public issue-tracking layer for routine workflows, while explicitly reserving raw `bd` commands for init, comments, dependencies, and Dolt internals.
- Preserve the GitHub-to-Beads sync document's direct `bd` workflow calls as implementation detail, but clarify that human and agent workflows should use Forge.

### Documentation Updated
- AGENTS.md
- README.md
- docs/TOOLCHAIN.md
- docs/forge/TOOLCHAIN.md
- docs/EXAMPLES.md
- docs/ROADMAP.md
- docs/BEADS_GITHUB_SYNC.md

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 and non-blocking.

Both prior P1 issues are addressed, new functionality is well-tested with edge-case coverage, and the only remaining finding is a minor key-naming discrepancy in an infrequently-hit config read path.

lib/commands/setup.js — the sync_remote vs sync-remote key name in readBeadsSyncRemoteConfig is worth a quick cross-check against the Beads config schema.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The conflict-scanner change narrows local file enumeration and introduces no new trust boundaries. The Beads remote config reader accesses only `.beads/config.*` files and uses safe `JSON.parse` with error handling. No secrets, auth changes, or injection surfaces introduced.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/commands/setup.js
Line: 227-228

Comment:
**`sync_remote` / `sync-remote` key name mismatch**

The JSON reader looks up `parsed.sync_remote` (snake_case) while the YAML parser searches for `sync-remote:` (kebab-case). If Beads uses the same physical key name in both formats (the common case for a single-schema tool), one reader will always miss the configured value, causing `resolveExpectedBeadsRemote` to silently fall back to git-remote probing or `origin` and then possibly emit a spurious "remote not configured" warning even when the config is present.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(validate): harden git conflict scan ..."](https://github.com/harshanandak/forge/commit/e72eee81798c84f5761d33a0a948f8a5e73ebe24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27871393)</sub>

<!-- /greptile_comment -->