### PR TITLE
feat: add zero-arg forge status dashboard

### DIFF
--- a/docs/plans/2026-04-10-forge-status-personal-focus-decisions.md
+++ b/docs/plans/2026-04-10-forge-status-personal-focus-decisions.md
@@ -1,0 +1,2 @@
+# Forge Status Personal Focus - Decisions Log
+

--- a/docs/plans/2026-04-10-forge-status-personal-focus-design.md
+++ b/docs/plans/2026-04-10-forge-status-personal-focus-design.md
@@ -1,0 +1,209 @@
+## Feature
+
+- **Slug**: `forge-status-personal-focus`
+- **Issue**: `forge-sxg2`
+- **Date**: `2026-04-10`
+- **Status**: `Phase 2 complete / awaiting approval`
+
+## Purpose
+
+`forge status` currently succeeds only when the caller supplies authoritative workflow context through `--workflow-state` or `--issue-id`. The command does not yet provide the zero-argument "what should I work on right now?" view requested for Forge v2.
+
+This track adds a zero-arg personal status dashboard that works from local repo state first. The command should show branch/worktree context, active Beads work assigned to the current developer, ready work, recent completions, and the current workflow stage when an active `/plan -> /verify` cycle can be resolved unambiguously.
+
+## Verified Baseline
+
+1. The current command parses `--issue-id`, `--workflow-state`, `--bd-comments`, and `--project-root`, then tries to resolve workflow state from those inputs rather than auto-discovering current work (`lib/commands/status.js:341-360`).
+2. When no authoritative workflow state is found, the command returns a low-confidence placeholder that explicitly asks for `--workflow-state` or `--issue-id` (`lib/commands/status.js:399-409`).
+3. The current formatter is stage-centric and emits either authoritative stage output or heuristic fallback output; it does not render branch/worktree context, personal issue groups, or recent completions (`lib/commands/status.js:440-515`).
+4. The workflow-state loader already supports `.forge-state.json` plus Beads comment-backed state, but only when a project root or issue id is supplied (`lib/workflow/state-manager.js:22-79`).
+5. The repo already has reusable worktree detection that distinguishes the main checkout from linked worktrees and returns the current branch (`lib/detect-worktree.js:6-47`).
+6. The WS1 strategy doc describes a broader personal dashboard vision for `forge status`, including ready/blocked/PR groupings and multi-dimensional ranking, but that vision is larger than the zero-arg local slice requested here (`docs/plans/2026-04-06-forge-v2-unified-strategy.md:109-159`).
+7. Targeted status baselines currently pass:
+   - `bun test --timeout 15000 test/status-command.test.js test/commands/status-smart.test.js` -> `13 pass / 0 fail`
+   - `bun test --timeout 15000 test/commands/status.test.js` -> `22 pass / 0 fail`
+
+## Success Criteria
+
+1. Running `forge status` with no flags succeeds from the repo root or a linked worktree.
+2. Zero-arg output includes current branch and worktree context, including whether the checkout is the main worktree or a linked worktree.
+3. Zero-arg output includes active Beads issues assigned to the current developer and filtered to `in_progress`.
+4. Zero-arg output includes ready Beads issues that are open and not blocked by unresolved dependencies.
+5. Zero-arg output includes recent completions from local Beads state.
+6. If an active workflow cycle can be identified, zero-arg output shows the current authoritative workflow stage and next command.
+7. If workflow-stage discovery is ambiguous or unavailable, the command still returns the other sections and explains that no active workflow cycle was detected.
+8. Existing explicit `--workflow-state` and `--issue-id` behavior remains backward compatible.
+
+## Out of Scope
+
+1. GitHub PR sections such as "Your PRs" and "PRs awaiting your reply".
+2. The external issue classifier described in WS1 for non-Forge metadata.
+3. Role-aware ranking via `.forge/config.yaml`.
+4. Shared Dolt-backed state or cross-repo/team aggregation.
+5. Replacing the existing authoritative workflow-state model with a new stage system.
+
+## Approach Selected
+
+### Selected approach
+
+Add a small JS status-context layer ahead of the existing status command:
+
+1. Keep `lib/commands/status.js` as the command entry point and preserve explicit-flag behavior.
+2. Add zero-arg context discovery helpers that gather:
+   - git branch, dirty/clean state, and linked-worktree details
+   - Beads issue snapshots from local `.beads/issues.jsonl`
+   - current developer identity from local git config
+   - current workflow state from `.forge-state.json` first, then a discovered current issue if one can be resolved safely
+3. Render a new human-readable dashboard for the zero-arg path while preserving the existing stage-oriented output for explicit authoritative calls.
+
+### Why this approach
+
+1. It solves the user-requested gap without dragging in GitHub API, PR state, or role-configuration work.
+2. It reuses verified repo primitives that already exist: authoritative workflow-state parsing and worktree detection.
+3. It avoids coupling the CLI to the older shell-based `smart-status.sh` output format, while still leaving room to borrow future ranking logic if needed.
+4. It keeps the explicit authoritative path intact for tests and downstream callers.
+
+### Rejected alternatives
+
+#### 1. Shell out to `scripts/smart-status.sh` and print its output
+
+Rejected because the feature request targets `forge status` in `lib/commands/status.js`, and the shell script covers a broader, different surface with session/team features that are not needed for this slice.
+
+#### 2. Implement the full WS1 smart dashboard in one track
+
+Rejected because the explicit request is narrower: zero-arg local context plus Beads-backed personal work focus. Pulling in PR integrations, external classification, and config-driven role scoring would expand the scope well past the requested feature.
+
+#### 3. Infer workflow stage heuristically again when no authoritative state exists
+
+Rejected because the current command intentionally prefers authoritative stage data. This slice should add discovery, not reintroduce guesswork as the primary source of truth.
+
+## Data Model and Resolution Order
+
+### Branch/worktree context
+
+Collect:
+
+1. current branch
+2. main-vs-linked worktree status
+3. linked worktree path and main worktree path when applicable
+4. dirty/clean working tree summary
+
+Implementation note: reuse `detectWorktree()` and add a lightweight git-status helper rather than embedding shell parsing in the command.
+
+### Current developer identity
+
+Resolve from:
+
+1. `git config user.email`
+2. `git config user.name`
+
+Assignment matching should prefer `issue.owner === user.email` and fall back to `created_by === user.name` only when `owner` is absent.
+
+### Beads issue snapshot
+
+Read local `.beads/issues.jsonl` and apply last-write-wins grouping by issue id. The snapshot layer should expose:
+
+1. `activeAssigned`: `status === "in_progress"` and assigned to current developer
+2. `ready`: `status === "open"` and `dependency_count === 0`
+3. `recentCompleted`: `status === "closed"` sorted by `updated_at` descending, capped for display
+
+### Current workflow cycle discovery
+
+Resolution order:
+
+1. Explicit `--workflow-state`
+2. Explicit `--issue-id`
+3. `.forge-state.json` in the current checkout
+4. Auto-discovered current issue from branch/worktree context when unambiguous
+
+Auto-discovered current issue rules:
+
+1. Match non-main feature/worktree slug against issue design metadata when the design/task path embeds the same slug.
+2. If no slug match exists, allow exactly one owned `in_progress` issue as the current issue.
+3. If multiple candidates remain, treat workflow-stage detection as ambiguous and omit the workflow section rather than guessing.
+
+## Output Design
+
+Default zero-arg output should use five sections in this order:
+
+1. `Context`
+2. `Active Issues`
+3. `Ready`
+4. `Recent Completions`
+5. `Workflow`
+
+Display rules:
+
+1. Empty sections should print a concise "none" message rather than disappearing silently.
+2. Ready and recent-completion lists should cap at a small default count and mention overflow when more items exist.
+3. The workflow section should say either:
+   - authoritative stage + next command, or
+   - no active workflow cycle detected
+4. If explicit authoritative flags are used, preserve the current stage-centric output contract instead of forcing the new dashboard.
+
+## Constraints
+
+1. Zero-arg must work entirely from local git and Beads state.
+2. The command must remain useful on `master` and in linked worktrees.
+3. Stage reporting must stay authoritative-only.
+4. The implementation must not require GitHub access or new credentials.
+5. Existing status exports used by tests must remain available.
+
+## Edge Cases
+
+1. **No `.beads/issues.jsonl` present**
+   - Return context plus a clear message that no Beads issue data is available.
+2. **Multiple owned `in_progress` issues on `master`**
+   - Show all active issues, but mark workflow stage as ambiguous unless `.forge-state.json` exists.
+3. **Feature branch with no design metadata on issues**
+   - Fall back to the "exactly one owned in-progress issue" rule only.
+4. **Malformed issue rows or duplicate JSONL entries**
+   - Ignore invalid rows and apply last-write-wins per id.
+5. **Missing git identity**
+   - Show context and non-personal ready/completed sections, but explain that assigned-work filtering is unavailable.
+6. **Current repo has `.forge-state.json` but no Beads issue match**
+   - Use the file-backed workflow state anyway; the workflow section is about current checkout state, not issue discovery alone.
+
+## Ambiguity Policy
+
+Use the repo's existing `/dev` rubric threshold:
+
+1. If confidence is `>= 80%`, proceed conservatively and document the decision.
+2. If confidence is `< 80%`, stop and ask.
+
+For this feature, the high-impact ambiguities are:
+
+1. changing the authoritative workflow-state contract
+2. guessing a current issue when multiple active candidates exist
+3. adding GitHub/PR integration to this slice
+
+## Technical Research
+
+### Current command contract
+
+The current command has already moved away from filesystem heuristics as the primary path. It reads authoritative workflow state from explicit input or state-manager helpers, then formats that state into a stage summary. The gap is not stage parsing; the gap is zero-arg discovery and broader personal-work presentation.
+
+Relevant code:
+
+1. `lib/commands/status.js:341-409`
+2. `lib/commands/status.js:440-515`
+3. `test/status-command.test.js:20-155`
+
+### Existing repo helpers worth reusing
+
+1. `lib/detect-worktree.js:13-47` already returns `inWorktree`, `branch`, and `mainWorktree`.
+2. `lib/workflow/state-manager.js:57-79` already resolves workflow state from file first, then Beads.
+3. `scripts/smart-status.sh:275-376` proves the repo already values worktree/session-aware status and local issue ranking, but its shell-centric surface is broader than the requested CLI slice.
+4. `scripts/sync-utils.sh:35-80` documents current git-based identity conventions that align with local-developer filtering.
+
+### Scope decision versus WS1 strategy
+
+The WS1 strategy doc describes a much larger "smart personal status" command with PR integrations, label/body-based classification, JSON mode, and role-specific scoring (`docs/plans/2026-04-06-forge-v2-unified-strategy.md:109-159`). This design deliberately narrows the first implementation slice to the concrete requirements in the current issue request:
+
+1. branch/worktree context
+2. assigned active work
+3. ready work
+4. recent completions
+5. current workflow stage when active
+
+That narrower scope is the safest standalone implementation with no dependency on other tracks.

--- a/docs/plans/2026-04-10-forge-status-personal-focus-tasks.md
+++ b/docs/plans/2026-04-10-forge-status-personal-focus-tasks.md
@@ -1,0 +1,98 @@
+# Forge Status Personal Focus - Task List
+
+**Issue**: `forge-sxg2`
+**Branch**: `feat/forge-status-personal-focus`
+**Design doc**: `docs/plans/2026-04-10-forge-status-personal-focus-design.md`
+**Baseline**:
+- `13 pass / 0 fail` on `bun test --timeout 15000 test/status-command.test.js test/commands/status-smart.test.js`
+- `22 pass / 0 fail` on `bun test --timeout 15000 test/commands/status.test.js`
+
+YAGNI check:
+- Every task below maps directly to the zero-arg output requirements in the user request.
+- PR integration, external issue classification, role config, and cross-repo sync are intentionally excluded from this task list.
+
+---
+
+## Wave 1: Discovery and data collection
+
+## Task 1: Add zero-arg context discovery for branch and worktree state
+Beads: `TBD`
+File(s): `lib/commands/status.js`, `lib/detect-worktree.js`, `test/status-command.test.js`
+OWNS: lib/commands/status.js, lib/detect-worktree.js, test/status-command.test.js
+What to implement: Add a zero-arg entry path that gathers current branch, worktree type, main-worktree reference, and working-tree cleanliness. Preserve existing explicit `--workflow-state` and `--issue-id` behavior.
+TDD steps:
+  1. Write test: extend `test/status-command.test.js` to assert `handler([], {}, projectRoot)` returns context details instead of the current "Provide --workflow-state or --issue-id" placeholder.
+  2. Run test: confirm it fails against the current zero-arg behavior.
+  3. Implement: add context-discovery helpers and reuse `detectWorktree()` where possible.
+  4. Run test: confirm it passes.
+  5. Commit: `feat: add zero-arg status context discovery`
+Expected output: `forge status` can always describe the current checkout before any issue/workflow lookup.
+
+## Task 2: Build a local Beads snapshot reader for active, ready, and completed work
+Beads: `TBD`
+File(s): `lib/status/beads-snapshot.js`, `test/status-command.test.js`
+OWNS: lib/status/beads-snapshot.js, test/status-command.test.js
+What to implement: Read `.beads/issues.jsonl` with last-write-wins grouping and expose filtered groups for active assigned issues, ready issues, and recent completions. Resolve current developer identity from local git config.
+TDD steps:
+  1. Write test: add fixture-driven coverage in `test/status-command.test.js` for active-assigned filtering, ready filtering (`dependency_count === 0`), recent completion ordering, and malformed-row tolerance.
+  2. Run test: confirm it fails because no Beads snapshot helper exists yet.
+  3. Implement: add `lib/status/beads-snapshot.js` and wire it into the command.
+  4. Run test: confirm it passes.
+  5. Commit: `feat: add local beads snapshot reader for status`
+Expected output: The command can build the three personal-work sections from local Beads state without calling GitHub or requiring extra flags.
+
+---
+
+## Wave 2: Workflow-cycle discovery and rendering
+
+## Task 3: Auto-discover the current workflow cycle without reintroducing heuristics
+Beads: `TBD`
+File(s): `lib/commands/status.js`, `lib/workflow/state-manager.js`, `test/status-command.test.js`, `test/commands/status.test.js`
+OWNS: lib/commands/status.js, lib/workflow/state-manager.js, test/status-command.test.js, test/commands/status.test.js
+What to implement: Add workflow-cycle auto-discovery using this priority order: explicit flags, `.forge-state.json`, branch-to-issue slug match through design metadata, then single owned `in_progress` issue fallback. If multiple candidates remain, omit the workflow section instead of guessing.
+TDD steps:
+  1. Write test: extend `test/status-command.test.js` for `.forge-state.json` precedence, branch-slug issue matching, single-active-issue fallback, and ambiguous multi-issue fallback.
+  2. Run test: confirm it fails because zero-arg workflow discovery does not exist.
+  3. Implement: add discovery helpers while preserving existing authoritative state parsing and exports.
+  4. Run test: confirm it passes.
+  5. Commit: `feat: auto-discover current workflow cycle for zero-arg status`
+Expected output: The workflow section appears only when authoritative state can be resolved safely.
+
+## Task 4: Add the zero-arg presenter for context, active, ready, completions, and workflow
+Beads: `TBD`
+File(s): `lib/status/presenter.js`, `lib/commands/status.js`, `test/status-command.test.js`
+OWNS: lib/status/presenter.js, lib/commands/status.js, test/status-command.test.js
+What to implement: Render the new five-section dashboard for the zero-arg path. Keep explicit authoritative calls on the existing stage-centric formatter to avoid breaking current contract expectations.
+TDD steps:
+  1. Write test: assert formatted zero-arg output contains the five sections in order, prints sensible empty-state messages, and preserves the explicit authoritative output shape.
+  2. Run test: confirm it fails because no dashboard presenter exists.
+  3. Implement: add `lib/status/presenter.js` and route zero-arg calls through it.
+  4. Run test: confirm it passes.
+  5. Commit: `feat: add zero-arg personal status presenter`
+Expected output: `forge status` answers "what should I work on right now?" in one local dashboard view.
+
+---
+
+## Wave 3: Regression coverage and command-surface cleanup
+
+## Task 5: Lock down command compatibility and docs-facing behavior
+Beads: `TBD`
+File(s): `test/status-command.test.js`, `test/commands/status.test.js`, `test/commands/status-smart.test.js`, `lib/commands/status.js`
+OWNS: test/status-command.test.js, test/commands/status.test.js, test/commands/status-smart.test.js, lib/commands/status.js
+What to implement: Add regression coverage for legacy explicit flags, ambiguous workflow detection, missing Beads data, and linked-worktree output. Ensure the new zero-arg behavior does not regress the existing authoritative state contract or the smart-status command-doc integration tests.
+TDD steps:
+  1. Write test: extend the three status test files for the new edge cases and compatibility guarantees.
+  2. Run test: confirm at least one new case fails before implementation is finalized.
+  3. Implement: make the minimum command changes required to satisfy the new regression suite.
+  4. Run test: confirm the targeted status suites pass.
+  5. Commit: `test: cover zero-arg status compatibility and edge cases`
+Expected output: The zero-arg redesign is protected by focused status-specific regression coverage.
+
+---
+
+## Review notes for /dev
+
+1. Do not pull GitHub PR data into this slice unless the user explicitly expands scope.
+2. Preserve `parseStatusInputs`, `resolveWorkflowState`, and explicit-authoritative formatting for current callers and tests.
+3. Prefer a small `lib/status/` helper surface over adding more unrelated responsibilities to `lib/commands/status.js`.
+4. Treat ambiguous current-issue detection as a display limitation, not a reason to guess.

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -3,11 +3,15 @@
  * Detects workflow stage (1-9) with confidence scoring
  */
 
+const { execFileSync } = require('node:child_process');
 const {
 	readWorkflowState,
 	getAllowedTransitionsForWorkflowState,
 } = require('../workflow/state');
 const { STAGE_IDS } = require('../workflow/stages');
+const { detectWorktree } = require('../detect-worktree');
+const { readBeadsSnapshot } = require('../status/beads-snapshot');
+const { formatZeroArgStatus } = require('../status/presenter');
 const {
 	loadState,
 	extractWorkflowStateFromComments,
@@ -346,6 +350,94 @@ function parseStatusInputs(args = [], flags = {}) {
 	};
 }
 
+function runGitCommand(projectRoot, args) {
+	if (!projectRoot) {
+		return '';
+	}
+
+	try {
+		return execFileSync('git', args, {
+			encoding: 'utf8',
+			cwd: projectRoot,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		}).trim();
+	} catch (_error) {
+		return '';
+	}
+}
+
+function detectRepoContext(projectRoot = process.cwd()) {
+	const worktree = detectWorktree(projectRoot);
+	const branch = worktree.branch || runGitCommand(projectRoot, ['branch', '--show-current']) || 'unknown';
+	const statusOutput = runGitCommand(projectRoot, ['status', '--short']);
+	const changedEntries = statusOutput ? statusOutput.split(/\r?\n/).filter(Boolean) : [];
+	const clean = changedEntries.length === 0;
+	const summary = clean ? 'clean' : `${changedEntries.length} uncommitted change${changedEntries.length === 1 ? '' : 's'}`;
+
+	return {
+		branch,
+		inWorktree: worktree.inWorktree === true,
+		worktreePath: worktree.currentWorktree || projectRoot,
+		mainWorktree: worktree.mainWorktree || projectRoot,
+		workingTree: {
+			clean,
+			summary,
+		},
+	};
+}
+
+function readIssueDetails(issueId) {
+	if (!issueId) {
+		return null;
+	}
+
+	try {
+		const raw = execFileSync('bd', ['show', issueId, '--json'], {
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		}).trim();
+		if (!raw) {
+			return null;
+		}
+
+		const parsed = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed[0] || null : parsed;
+	} catch (_error) {
+		return null;
+	}
+}
+
+function discoverCurrentIssue(snapshot, context) {
+	const activeAssigned = snapshot.activeAssigned || [];
+	if (activeAssigned.length === 0) {
+		return null;
+	}
+
+	const branchInfo = analyzeBranch(context.branch || 'master');
+	if (branchInfo.featureSlug) {
+		const slugMatches = activeAssigned.filter(issue => {
+			const hydratedIssue = issue.design ? issue : { ...issue, ...readIssueDetails(issue.id) };
+			return typeof hydratedIssue.design === 'string' && hydratedIssue.design.includes(branchInfo.featureSlug);
+		});
+
+		if (slugMatches.length === 1) {
+			const match = slugMatches[0];
+			return match.design ? match : { ...match, ...readIssueDetails(match.id) };
+		}
+
+		if (slugMatches.length > 1) {
+			return null;
+		}
+	}
+
+	if (activeAssigned.length === 1) {
+		const [issue] = activeAssigned;
+		return issue.comments || issue.design ? issue : { ...issue, ...readIssueDetails(issue.id) };
+	}
+
+	return null;
+}
+
 function resolveWorkflowState(inputs) {
 	try {
 		if (inputs.workflowState) {
@@ -354,6 +446,7 @@ function resolveWorkflowState(inputs) {
 
 		const { state } = loadState(inputs.projectRoot, {
 			issueId: inputs.issueId,
+			issue: inputs.issue,
 			comments: inputs.bdComments,
 		});
 
@@ -498,10 +591,48 @@ module.exports = {
 	description: 'Intelligent stage detection with confidence scoring',
 	handler: async (args, flags, projectRoot) => {
 		const inputs = parseStatusInputs(args, flags);
+		const isZeroArgStatus = !inputs.issueId && !inputs.workflowState && !inputs.bdComments;
 		if (!inputs.projectRoot && projectRoot) {
 			inputs.projectRoot = projectRoot;
 		}
+
+		if (isZeroArgStatus) {
+			const context = detectRepoContext(inputs.projectRoot || process.cwd());
+			const snapshot = readBeadsSnapshot(inputs.projectRoot || process.cwd());
+			const discoveredIssue = discoverCurrentIssue(snapshot, context);
+			if (discoveredIssue) {
+				inputs.issueId = discoveredIssue.id;
+				inputs.issue = discoveredIssue;
+			}
+		}
+
 		const { workflowState, fallbackReason } = resolveWorkflowState(inputs);
+
+		if (isZeroArgStatus) {
+			const context = detectRepoContext(inputs.projectRoot || process.cwd());
+			const snapshot = readBeadsSnapshot(inputs.projectRoot || process.cwd());
+			if (workflowState) {
+				const result = buildAuthoritativeStatus(workflowState);
+				return {
+					success: true,
+					context,
+					snapshot,
+					issueId: inputs.issueId,
+					output: formatZeroArgStatus({ context, snapshot, workflowResult: result }),
+					...result,
+				};
+			}
+
+			return {
+				success: true,
+				context,
+				snapshot,
+				issueId: inputs.issueId,
+				missingWorkflowState: true,
+				output: formatZeroArgStatus({ context, snapshot }),
+				...(fallbackReason ? { fallbackReason } : {}),
+			};
+		}
 
 		if (workflowState) {
 			const result = buildAuthoritativeStatus(workflowState);
@@ -521,6 +652,8 @@ module.exports = {
 	parseStatusInputs,
 	readWorkflowStateFromBeads,
 	detectStage,
+	detectRepoContext,
+	discoverCurrentIssue,
 	analyzeBranch,
 	analyzeFiles,
 	analyzePR,

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -3,7 +3,6 @@
  * Detects workflow stage (1-9) with confidence scoring
  */
 
-const { execFileSync } = require('node:child_process');
 const {
 	readWorkflowState,
 	getAllowedTransitionsForWorkflowState,
@@ -17,6 +16,7 @@ const {
 	extractWorkflowStateFromComments,
 	readWorkflowStateFromBeads,
 } = require('../workflow/state-manager');
+const { secureExecFileSync } = require('../shell-utils.js');
 
 const WORKFLOW_STAGES = {
 	1: { name: 'Fresh Start', nextCommand: 'research' },
@@ -356,7 +356,7 @@ function runGitCommand(projectRoot, args) {
 	}
 
 	try {
-		return execFileSync('git', args, {
+		return secureExecFileSync('git', args, {
 			encoding: 'utf8',
 			cwd: projectRoot,
 			stdio: ['pipe', 'pipe', 'pipe'],
@@ -386,14 +386,15 @@ function detectRepoContext(projectRoot = process.cwd()) {
 	};
 }
 
-function readIssueDetails(issueId) {
+function readIssueDetails(issueId, projectRoot = process.cwd()) {
 	if (!issueId) {
 		return null;
 	}
 
 	try {
-		const raw = execFileSync('bd', ['show', issueId, '--json'], {
+		const raw = secureExecFileSync('bd', ['show', issueId, '--json'], {
 			encoding: 'utf8',
+			cwd: projectRoot,
 			stdio: ['pipe', 'pipe', 'pipe'],
 		}).trim();
 		if (!raw) {
@@ -407,22 +408,66 @@ function readIssueDetails(issueId) {
 	}
 }
 
-function discoverCurrentIssue(snapshot, context) {
+function extractDesignSlugs(design) {
+	if (typeof design !== 'string' || design.trim() === '') {
+		return [];
+	}
+
+	const slugs = new Set();
+	const pattern = /docs[\\/]+plans[\\/]+\d{4}-\d{2}-\d{2}-([a-z0-9-]+?)-(?:design|tasks|decisions)\.md/g;
+	let match = pattern.exec(design);
+	while (match) {
+		slugs.add(match[1]);
+		match = pattern.exec(design);
+	}
+
+	return [...slugs];
+}
+
+function designMatchesFeatureSlug(issue, featureSlug) {
+	if (!issue || !featureSlug) {
+		return false;
+	}
+
+	return extractDesignSlugs(issue.design).includes(featureSlug);
+}
+
+function discoverCurrentIssue(snapshot, context, projectRoot = process.cwd()) {
 	const activeAssigned = snapshot.activeAssigned || [];
 	if (activeAssigned.length === 0) {
 		return null;
 	}
 
 	const branchInfo = analyzeBranch(context.branch || 'master');
+	const hydratedIssues = new Map();
+
+	function hydrateIssue(issue) {
+		if (!issue || !issue.id) {
+			return issue;
+		}
+
+		if (hydratedIssues.has(issue.id)) {
+			return hydratedIssues.get(issue.id);
+		}
+
+		const details = issue.design && issue.comments ? issue : readIssueDetails(issue.id, projectRoot);
+		const hydratedIssue = details ? { ...issue, ...details } : issue;
+		hydratedIssues.set(issue.id, hydratedIssue);
+		return hydratedIssue;
+	}
+
 	if (branchInfo.featureSlug) {
-		const slugMatches = activeAssigned.filter(issue => {
-			const hydratedIssue = issue.design ? issue : { ...issue, ...readIssueDetails(issue.id) };
-			return typeof hydratedIssue.design === 'string' && hydratedIssue.design.includes(branchInfo.featureSlug);
-		});
+		const slugMatches = [];
+
+		for (const issue of activeAssigned) {
+			const candidate = issue.design ? issue : hydrateIssue(issue);
+			if (designMatchesFeatureSlug(candidate, branchInfo.featureSlug)) {
+				slugMatches.push(candidate);
+			}
+		}
 
 		if (slugMatches.length === 1) {
-			const match = slugMatches[0];
-			return match.design ? match : { ...match, ...readIssueDetails(match.id) };
+			return hydrateIssue(slugMatches[0]);
 		}
 
 		if (slugMatches.length > 1) {
@@ -431,8 +476,7 @@ function discoverCurrentIssue(snapshot, context) {
 	}
 
 	if (activeAssigned.length === 1) {
-		const [issue] = activeAssigned;
-		return issue.comments || issue.design ? issue : { ...issue, ...readIssueDetails(issue.id) };
+		return hydrateIssue(activeAssigned[0]);
 	}
 
 	return null;
@@ -595,11 +639,14 @@ module.exports = {
 		if (!inputs.projectRoot && projectRoot) {
 			inputs.projectRoot = projectRoot;
 		}
+		const effectiveProjectRoot = inputs.projectRoot || process.cwd();
+		let context = null;
+		let snapshot = null;
 
 		if (isZeroArgStatus) {
-			const context = detectRepoContext(inputs.projectRoot || process.cwd());
-			const snapshot = readBeadsSnapshot(inputs.projectRoot || process.cwd());
-			const discoveredIssue = discoverCurrentIssue(snapshot, context);
+			context = detectRepoContext(effectiveProjectRoot);
+			snapshot = readBeadsSnapshot(effectiveProjectRoot);
+			const discoveredIssue = discoverCurrentIssue(snapshot, context, effectiveProjectRoot);
 			if (discoveredIssue) {
 				inputs.issueId = discoveredIssue.id;
 				inputs.issue = discoveredIssue;
@@ -609,8 +656,6 @@ module.exports = {
 		const { workflowState, fallbackReason } = resolveWorkflowState(inputs);
 
 		if (isZeroArgStatus) {
-			const context = detectRepoContext(inputs.projectRoot || process.cwd());
-			const snapshot = readBeadsSnapshot(inputs.projectRoot || process.cwd());
 			if (workflowState) {
 				const result = buildAuthoritativeStatus(workflowState);
 				return {
@@ -661,4 +706,5 @@ module.exports = {
 	analyzeBeads,
 	calculateConfidence,
 	formatStatus,
+	extractDesignSlugs,
 };

--- a/lib/detect-worktree.js
+++ b/lib/detect-worktree.js
@@ -8,7 +8,7 @@ const path = require('path');
  * Uses git rev-parse --git-dir vs --git-common-dir — they differ in worktrees.
  *
  * @param {string} [cwd=process.cwd()] - Directory to check
- * @returns {{ inWorktree: boolean, branch?: string, mainWorktree?: string }}
+ * @returns {{ inWorktree: boolean, branch?: string, mainWorktree?: string, currentWorktree?: string }}
  */
 function detectWorktree(cwd = process.cwd()) {
   try {
@@ -24,20 +24,19 @@ function detectWorktree(cwd = process.cwd()) {
     const absGitDir = path.resolve(cwd, gitDir);
     const absCommonDir = path.resolve(cwd, gitCommonDir);
 
+    const branch = execFileSync('git', ['branch', '--show-current'], {
+      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    const mainWorktree = path.resolve(absCommonDir, '..');
+    const currentWorktree = path.resolve(cwd);
+
     // In a worktree, git-dir is like .git/worktrees/<name>
     // while git-common-dir is the main .git directory
     if (absGitDir !== absCommonDir) {
-      const branch = execFileSync('git', ['branch', '--show-current'], {
-        encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe']
-      }).trim();
-
-      // Main worktree is one level above the common .git dir
-      const mainWorktree = path.resolve(absCommonDir, '..');
-
-      return { inWorktree: true, branch, mainWorktree };
+      return { inWorktree: true, branch, mainWorktree, currentWorktree };
     }
 
-    return { inWorktree: false };
+    return { inWorktree: false, branch, mainWorktree, currentWorktree };
   } catch (_err) {
     // Not in a git repo or git not available
     return { inWorktree: false };

--- a/lib/status/beads-snapshot.js
+++ b/lib/status/beads-snapshot.js
@@ -23,6 +23,10 @@ function getDeveloperIdentity(projectRoot) {
 	};
 }
 
+function normalizeEmail(value) {
+	return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
 function readIssues(projectRoot) {
 	const issuesPath = path.join(projectRoot, '.beads', 'issues.jsonl');
 	if (!fs.existsSync(issuesPath)) {
@@ -56,15 +60,25 @@ function isAssignedToDeveloper(issue, developer) {
 	}
 
 	if (issue.owner) {
-		return developer.email !== '' && issue.owner === developer.email;
+		const developerEmail = normalizeEmail(developer.email);
+		return developerEmail !== '' && normalizeEmail(issue.owner) === developerEmail;
 	}
 
 	return developer.name !== '' && issue.created_by === developer.name;
 }
 
+function parseTimestampOrZero(value) {
+	if (!value) {
+		return 0;
+	}
+
+	const parsed = Date.parse(value);
+	return Number.isNaN(parsed) ? 0 : parsed;
+}
+
 function sortByUpdatedAtDesc(left, right) {
-	const leftTime = left.updated_at ? Date.parse(left.updated_at) : 0;
-	const rightTime = right.updated_at ? Date.parse(right.updated_at) : 0;
+	const leftTime = parseTimestampOrZero(left.updated_at);
+	const rightTime = parseTimestampOrZero(right.updated_at);
 	return rightTime - leftTime;
 }
 

--- a/lib/status/beads-snapshot.js
+++ b/lib/status/beads-snapshot.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { secureExecFileSync } = require('../shell-utils.js');
 
 function getGitConfig(projectRoot, key) {
 	try {
-		return execFileSync('git', ['config', key], {
+		return secureExecFileSync('git', ['config', key], {
 			encoding: 'utf8',
 			cwd: projectRoot,
 			stdio: ['pipe', 'pipe', 'pipe'],
@@ -63,8 +63,8 @@ function isAssignedToDeveloper(issue, developer) {
 }
 
 function sortByUpdatedAtDesc(left, right) {
-	const leftTime = Date.parse(left.updated_at || 0);
-	const rightTime = Date.parse(right.updated_at || 0);
+	const leftTime = left.updated_at ? Date.parse(left.updated_at) : 0;
+	const rightTime = right.updated_at ? Date.parse(right.updated_at) : 0;
 	return rightTime - leftTime;
 }
 

--- a/lib/status/beads-snapshot.js
+++ b/lib/status/beads-snapshot.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function getGitConfig(projectRoot, key) {
+	try {
+		return execFileSync('git', ['config', key], {
+			encoding: 'utf8',
+			cwd: projectRoot,
+			stdio: ['pipe', 'pipe', 'pipe'],
+		}).trim();
+	} catch (_error) {
+		return '';
+	}
+}
+
+function getDeveloperIdentity(projectRoot) {
+	return {
+		email: getGitConfig(projectRoot, 'user.email'),
+		name: getGitConfig(projectRoot, 'user.name'),
+	};
+}
+
+function readIssues(projectRoot) {
+	const issuesPath = path.join(projectRoot, '.beads', 'issues.jsonl');
+	if (!fs.existsSync(issuesPath)) {
+		return [];
+	}
+
+	const raw = fs.readFileSync(issuesPath, 'utf8');
+	const latestById = new Map();
+
+	for (const line of raw.split(/\r?\n/)) {
+		if (!line.trim()) {
+			continue;
+		}
+
+		try {
+			const issue = JSON.parse(line);
+			if (issue && issue.id) {
+				latestById.set(issue.id, issue);
+			}
+		} catch (_error) {
+			// Ignore malformed rows so one bad append does not break status.
+		}
+	}
+
+	return Array.from(latestById.values());
+}
+
+function isAssignedToDeveloper(issue, developer) {
+	if (!issue || !developer) {
+		return false;
+	}
+
+	if (issue.owner) {
+		return developer.email !== '' && issue.owner === developer.email;
+	}
+
+	return developer.name !== '' && issue.created_by === developer.name;
+}
+
+function sortByUpdatedAtDesc(left, right) {
+	const leftTime = Date.parse(left.updated_at || 0);
+	const rightTime = Date.parse(right.updated_at || 0);
+	return rightTime - leftTime;
+}
+
+function readBeadsSnapshot(projectRoot) {
+	const developer = getDeveloperIdentity(projectRoot);
+	const issues = readIssues(projectRoot);
+
+	return {
+		developer,
+		issues,
+		activeAssigned: issues.filter(issue => issue.status === 'in_progress' && isAssignedToDeveloper(issue, developer)),
+		ready: issues.filter(issue => issue.status === 'open' && Number(issue.dependency_count || 0) === 0),
+		recentCompleted: issues.filter(issue => issue.status === 'closed').sort(sortByUpdatedAtDesc),
+	};
+}
+
+module.exports = {
+	getDeveloperIdentity,
+	isAssignedToDeveloper,
+	readBeadsSnapshot,
+};

--- a/lib/status/presenter.js
+++ b/lib/status/presenter.js
@@ -1,13 +1,23 @@
 'use strict';
 
-function buildSection(title, items) {
+const DEFAULT_SECTION_LIMIT = 5;
+
+function buildSection(title, items, options = {}) {
 	const lines = ['', title];
 	if (!items || items.length === 0) {
 		lines.push('  none', '');
 		return lines;
 	}
 
-	lines.push(...items.map(item => `  ${item}`), '');
+	const limit = options.limit ?? null;
+	const visibleItems = limit ? items.slice(0, limit) : items;
+	lines.push(...visibleItems.map(item => `  ${item}`));
+
+	if (limit && items.length > limit) {
+		lines.push(`  ...and ${items.length - limit} more`);
+	}
+
+	lines.push('');
 	return lines;
 }
 
@@ -44,8 +54,8 @@ function formatZeroArgStatus({ context, snapshot, workflowResult = null }) {
 	return [
 		...buildSection('Context', contextLines),
 		...buildSection('Active Issues', (snapshot.activeAssigned || []).map(issue => formatIssue(issue, { includeStatus: true }))),
-		...buildSection('Ready', (snapshot.ready || []).map(issue => formatIssue(issue))),
-		...buildSection('Recent Completions', (snapshot.recentCompleted || []).map(issue => formatIssue(issue))),
+		...buildSection('Ready', (snapshot.ready || []).map(issue => formatIssue(issue)), { limit: DEFAULT_SECTION_LIMIT }),
+		...buildSection('Recent Completions', (snapshot.recentCompleted || []).map(issue => formatIssue(issue)), { limit: DEFAULT_SECTION_LIMIT }),
 		...buildSection('Workflow', formatWorkflow(workflowResult)),
 	].join('\n');
 }

--- a/lib/status/presenter.js
+++ b/lib/status/presenter.js
@@ -1,0 +1,55 @@
+'use strict';
+
+function buildSection(title, items) {
+	const lines = ['', title];
+	if (!items || items.length === 0) {
+		lines.push('  none', '');
+		return lines;
+	}
+
+	lines.push(...items.map(item => `  ${item}`), '');
+	return lines;
+}
+
+function formatIssue(issue, options = {}) {
+	const status = options.includeStatus && issue.status ? ` [${issue.status}]` : '';
+	return `${issue.id} ${issue.title || '(untitled)'}${status}`;
+}
+
+function formatWorkflow(workflowResult) {
+	if (!workflowResult) {
+		return ['No active workflow state detected.'];
+	}
+
+	return [
+		`${workflowResult.stageName} (${workflowResult.stageId})`,
+		`Run now: /${workflowResult.runCommand}`,
+		workflowResult.nextCommand ? `Next after this: /${workflowResult.nextCommand}` : 'Next after this: none',
+	];
+}
+
+function formatZeroArgStatus({ context, snapshot, workflowResult = null }) {
+	const contextLines = [
+		`Branch: ${context.branch}`,
+		`Worktree: ${context.inWorktree ? 'linked' : 'main'}`,
+		`Path: ${context.worktreePath}`,
+	];
+
+	if (context.inWorktree && context.mainWorktree) {
+		contextLines.push(`Main worktree: ${context.mainWorktree}`);
+	}
+
+	contextLines.push(`Working tree: ${context.workingTree.summary}`);
+
+	return [
+		...buildSection('Context', contextLines),
+		...buildSection('Active Issues', (snapshot.activeAssigned || []).map(issue => formatIssue(issue, { includeStatus: true }))),
+		...buildSection('Ready', (snapshot.ready || []).map(issue => formatIssue(issue))),
+		...buildSection('Recent Completions', (snapshot.recentCompleted || []).map(issue => formatIssue(issue))),
+		...buildSection('Workflow', formatWorkflow(workflowResult)),
+	].join('\n');
+}
+
+module.exports = {
+	formatZeroArgStatus,
+};

--- a/lib/workflow/state-manager.js
+++ b/lib/workflow/state-manager.js
@@ -9,14 +9,60 @@ const { getWorkflowPath, WORKFLOW_CLASSIFICATIONS, normalizeStageId } = require(
 
 const WORKFLOW_STATE_FILENAME = '.forge-state.json';
 
+function parseRelaxedWorkflowStatePayload(payload = '') {
+  const currentStage = String(payload).match(/currentStage:([a-z]+)/)?.[1];
+  if (!currentStage) {
+    return null;
+  }
+
+  const completedStages = (String(payload).match(/completedStages:\[([^\]]*)\]/)?.[1] || '')
+    .split(',')
+    .map(stage => stage.trim())
+    .filter(Boolean);
+  const skippedStages = (String(payload).match(/skippedStages:\[([^\]]*)\]/)?.[1] || '')
+    .split(',')
+    .map(stage => stage.trim())
+    .filter(Boolean);
+  const classification = String(payload).match(/classification:([a-z]+)/)?.[1] || 'standard';
+  const reason = String(payload).match(/reason:([^,}\]]+)/)?.[1]?.trim() || 'legacy-comment';
+
+  return readWorkflowState(JSON.stringify({
+    currentStage,
+    completedStages,
+    skippedStages,
+    workflowDecisions: {
+      classification,
+      reason,
+      userOverride: false,
+      overrides: [],
+    },
+    parallelTracks: [],
+  }));
+}
+
 function extractWorkflowStateFromComments(comments = '') {
-  const matches = String(comments).match(/^WorkflowState:\s*(\{.*\})$/gm);
+  const matches = String(comments).match(/^WorkflowState:\s*(.+)$/gm);
   if (!matches || matches.length === 0) {
     return null;
   }
 
-  const latest = matches.at(-1).replace(/^WorkflowState:\s*/, '');
-  return readWorkflowState(latest);
+  for (const match of [...matches].reverse()) {
+    const payload = match.replace(/^WorkflowState:\s*/, '');
+    try {
+      return readWorkflowState(payload);
+    } catch (_strictError) {
+      try {
+        const relaxedState = parseRelaxedWorkflowStatePayload(payload);
+        if (relaxedState) {
+          return relaxedState;
+        }
+      } catch (_relaxedError) {
+        // Continue to any earlier payloads.
+      }
+    }
+  }
+
+  return null;
 }
 
 function extractWorkflowStateFromIssue(issue = {}) {

--- a/lib/workflow/state-manager.js
+++ b/lib/workflow/state-manager.js
@@ -103,22 +103,28 @@ function readBeadsIssue(issueId, options = {}) {
     return null;
   }
 
-  const raw = secureExecFileSync('bd', ['show', issueId, '--json'], {
-    encoding: 'utf8',
-    cwd: options.projectRoot,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }).trim();
+  try {
+    const { projectRoot, ...execOptions } = options;
+    const raw = secureExecFileSync('bd', ['show', issueId, '--json'], {
+      encoding: 'utf8',
+      cwd: projectRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...execOptions,
+    }).trim();
 
-  if (!raw) {
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed[0] || null;
+    }
+
+    return parsed;
+  } catch (_error) {
     return null;
   }
-
-  const parsed = JSON.parse(raw);
-  if (Array.isArray(parsed)) {
-    return parsed[0] || null;
-  }
-
-  return parsed;
 }
 
 function readWorkflowStateFromBeads(issueId, options = {}) {

--- a/lib/workflow/state-manager.js
+++ b/lib/workflow/state-manager.js
@@ -41,7 +41,9 @@ function parseRelaxedWorkflowStatePayload(payload = '') {
 }
 
 function extractWorkflowStateFromComments(comments = '') {
-  const matches = String(comments).match(/^WorkflowState:\s*(.+)$/gm);
+  const matches = String(comments)
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('WorkflowState:'));
   if (!matches || matches.length === 0) {
     return null;
   }
@@ -96,13 +98,14 @@ function extractWorkflowStateFromIssue(issue = {}) {
   return extractWorkflowStateFromComments(mergedComments);
 }
 
-function readBeadsIssue(issueId) {
+function readBeadsIssue(issueId, options = {}) {
   if (!issueId) {
     return null;
   }
 
   const raw = secureExecFileSync('bd', ['show', issueId, '--json'], {
     encoding: 'utf8',
+    cwd: options.projectRoot,
     stdio: ['pipe', 'pipe', 'pipe'],
   }).trim();
 
@@ -133,7 +136,7 @@ function readWorkflowStateFromBeads(issueId, options = {}) {
   let comments = options.comments;
   if (!comments) {
     try {
-      const issue = readBeadsIssue(issueId);
+      const issue = readBeadsIssue(issueId, { projectRoot: options.projectRoot });
       const state = extractWorkflowStateFromIssue(issue);
       if (state) {
         return state;
@@ -145,6 +148,7 @@ function readWorkflowStateFromBeads(issueId, options = {}) {
 
   comments = comments || secureExecFileSync('bd', ['comments', 'list', issueId], {
     encoding: 'utf8',
+    cwd: options.projectRoot,
     stdio: ['pipe', 'pipe', 'pipe'],
   }).trim();
 
@@ -155,7 +159,7 @@ function readWorkflowStateFromBeads(issueId, options = {}) {
   return extractWorkflowStateFromComments(comments);
 }
 
-function loadStateFromBeads(options) {
+function loadStateFromBeads(options, projectRoot) {
   if (options.comments) {
     const state = extractWorkflowStateFromComments(options.comments);
     if (state) {
@@ -171,7 +175,11 @@ function loadStateFromBeads(options) {
   }
 
   if (options.issueId) {
-    const state = readWorkflowStateFromBeads(options.issueId, { comments: options.comments, issue: options.issue });
+    const state = readWorkflowStateFromBeads(options.issueId, {
+      comments: options.comments,
+      issue: options.issue,
+      projectRoot,
+    });
     if (state) {
       return { state, source: 'beads' };
     }
@@ -182,7 +190,7 @@ function loadStateFromBeads(options) {
 
 function loadState(projectRoot, options = {}) {
   if (!projectRoot) {
-    const beadsResult = loadStateFromBeads(options);
+    const beadsResult = loadStateFromBeads(options, null);
     return beadsResult || { state: null, source: null };
   }
 
@@ -196,7 +204,7 @@ function loadState(projectRoot, options = {}) {
     }
   }
 
-  const beadsResult = loadStateFromBeads(options);
+  const beadsResult = loadStateFromBeads(options, projectRoot);
   if (beadsResult) {
     return beadsResult;
   }

--- a/lib/workflow/state-manager.js
+++ b/lib/workflow/state-manager.js
@@ -19,12 +19,85 @@ function extractWorkflowStateFromComments(comments = '') {
   return readWorkflowState(latest);
 }
 
+function extractWorkflowStateFromIssue(issue = {}) {
+  if (!issue || typeof issue !== 'object') {
+    return null;
+  }
+
+  if (typeof issue.comments === 'string') {
+    return extractWorkflowStateFromComments(issue.comments);
+  }
+
+  if (!Array.isArray(issue.comments) || issue.comments.length === 0) {
+    return null;
+  }
+
+  const mergedComments = issue.comments
+    .map(comment => {
+      if (typeof comment === 'string') {
+        return comment;
+      }
+
+      return comment && typeof comment === 'object' ? comment.text || '' : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+
+  if (!mergedComments) {
+    return null;
+  }
+
+  return extractWorkflowStateFromComments(mergedComments);
+}
+
+function readBeadsIssue(issueId) {
+  if (!issueId) {
+    return null;
+  }
+
+  const raw = secureExecFileSync('bd', ['show', issueId, '--json'], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = JSON.parse(raw);
+  if (Array.isArray(parsed)) {
+    return parsed[0] || null;
+  }
+
+  return parsed;
+}
+
 function readWorkflowStateFromBeads(issueId, options = {}) {
   if (!issueId) {
     return null;
   }
 
-  const comments = options.comments || secureExecFileSync('bd', ['comments', 'list', issueId], {
+  if (options.issue) {
+    const state = extractWorkflowStateFromIssue(options.issue);
+    if (state) {
+      return state;
+    }
+  }
+
+  let comments = options.comments;
+  if (!comments) {
+    try {
+      const issue = readBeadsIssue(issueId);
+      const state = extractWorkflowStateFromIssue(issue);
+      if (state) {
+        return state;
+      }
+    } catch (_error) {
+      // Fall through to comments-list fallback.
+    }
+  }
+
+  comments = comments || secureExecFileSync('bd', ['comments', 'list', issueId], {
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
   }).trim();
@@ -44,8 +117,15 @@ function loadStateFromBeads(options) {
     }
   }
 
+  if (options.issue) {
+    const state = extractWorkflowStateFromIssue(options.issue);
+    if (state) {
+      return { state, source: 'beads' };
+    }
+  }
+
   if (options.issueId) {
-    const state = readWorkflowStateFromBeads(options.issueId, { comments: options.comments });
+    const state = readWorkflowStateFromBeads(options.issueId, { comments: options.comments, issue: options.issue });
     if (state) {
       return { state, source: 'beads' };
     }
@@ -185,8 +265,10 @@ function transitionStage(projectRoot, toStage, options = {}) {
 module.exports = {
   WORKFLOW_STATE_FILENAME,
   extractWorkflowStateFromComments,
+  extractWorkflowStateFromIssue,
   initializeState,
   loadState,
+  readBeadsIssue,
   readWorkflowStateFromBeads,
   saveState,
   transitionStage,

--- a/test/commands/status-smart.test.js
+++ b/test/commands/status-smart.test.js
@@ -37,4 +37,9 @@ describe("/status command — smart-status integration", () => {
       expect(agentContent).toContain("smart-status.sh");
     }
   });
+
+  it("does not instruct users to pass --workflow-state or --issue-id for status discovery", () => {
+    expect(content).not.toContain("--workflow-state");
+    expect(content).not.toContain("--issue-id");
+  });
 });

--- a/test/commands/status.test.js
+++ b/test/commands/status.test.js
@@ -9,9 +9,25 @@ const {
 	analyzePR,
 	analyzeChecks,
 	analyzeBeads,
+	detectRepoContext,
 	formatStatus,
 	resolveWorkflowState,
 } = require('../../lib/commands/status.js');
+
+function createTempRepo(options = {}) {
+	const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-status-context-'));
+	fs.writeFileSync(path.join(repoRoot, 'README.md'), '# temp repo\n', 'utf8');
+	require('child_process').execFileSync('git', ['init'], { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'] });
+	require('child_process').execFileSync('git', ['config', 'user.email', 'harshanandak@users.noreply.github.com'], { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'] });
+	require('child_process').execFileSync('git', ['config', 'user.name', 'Harsha Nanda'], { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'] });
+	if (options.branch) {
+		require('child_process').execFileSync('git', ['checkout', '-b', options.branch], { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'] });
+	}
+	if (options.dirty) {
+		fs.writeFileSync(path.join(repoRoot, 'dirty.txt'), 'dirty\n', 'utf8');
+	}
+	return repoRoot;
+}
 
 describe('Status Command - Stage Detection', () => {
 	describe('detectStage', () => {
@@ -238,6 +254,15 @@ describe('Status Command - Stage Detection', () => {
 			const factors = analyzeBeads({ status: 'in_progress', type: 'feature' });
 			expect(factors.hasActiveIssue).toBe(true);
 			expect(factors.issueStatus).toBe('in_progress');
+		});
+
+		test('detectRepoContext returns branch and working tree summary for zero-arg status', () => {
+			const repoRoot = createTempRepo({ branch: 'feat/context-check', dirty: true });
+			const context = detectRepoContext(repoRoot);
+			expect(context.branch).toBe('feat/context-check');
+			expect(typeof context.inWorktree).toBe('boolean');
+			expect(context.workingTree.clean).toBe(false);
+			expect(context.workingTree.summary).toMatch(/uncommitted change/);
 		});
 	});
 

--- a/test/status-command.test.js
+++ b/test/status-command.test.js
@@ -1,5 +1,10 @@
 const { describe, test, expect } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
+const { readBeadsSnapshot } = require('../lib/status/beads-snapshot.js');
 const statusCommand = require('../lib/commands/status.js');
 
 function createWorkflowState(currentStage = 'dev') {
@@ -17,7 +22,54 @@ function createWorkflowState(currentStage = 'dev') {
   };
 }
 
+function createTempBeadsRepo(entries, options = {}) {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-status-beads-'));
+  const beadsDir = path.join(repoRoot, '.beads');
+  fs.mkdirSync(beadsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(beadsDir, 'issues.jsonl'),
+    `${entries.map(entry => JSON.stringify(entry)).join('\n')}\n`,
+    'utf8'
+  );
+
+  execFileSync('git', ['init'], { cwd: repoRoot, stdio: ['pipe', 'pipe', 'pipe'] });
+  execFileSync('git', ['config', 'user.email', options.email || 'harshanandak@users.noreply.github.com'], {
+    cwd: repoRoot,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  execFileSync('git', ['config', 'user.name', options.name || 'Harsha Nanda'], {
+    cwd: repoRoot,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (options.branch) {
+    execFileSync('git', ['checkout', '-b', options.branch], {
+      cwd: repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }
+  if (options.workflowState) {
+    fs.writeFileSync(
+      path.join(repoRoot, '.forge-state.json'),
+      JSON.stringify(options.workflowState, null, 2),
+      'utf8'
+    );
+  }
+
+  return repoRoot;
+}
+
 describe('status command authoritative workflow state', () => {
+  test('handler reports repo context for zero-arg status calls', async () => {
+    const projectRoot = path.resolve(__dirname, '..');
+
+    const result = await statusCommand.handler([], {}, projectRoot);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Context');
+    expect(result.output).toContain('Branch:');
+    expect(result.output).not.toContain('Provide --workflow-state or --issue-id');
+  });
+
   test('handler prefers explicit workflow state over heuristic context', async () => {
     const workflowState = JSON.stringify(createWorkflowState('validate'));
 
@@ -118,7 +170,8 @@ describe('status command authoritative workflow state', () => {
   test('handler does not fall back to heuristic stage detection when state is missing', async () => {
     const result = await statusCommand.handler([], {}, process.cwd());
     expect(result.missingWorkflowState).toBe(true);
-    expect(result.output).toContain('No authoritative workflow state available');
+    expect(result.output).toContain('Context');
+    expect(result.output).toContain('No active workflow state detected.');
   });
 
   test('handler falls back gracefully when --workflow-state is malformed JSON', async () => {
@@ -152,5 +205,234 @@ describe('status command authoritative workflow state', () => {
       process.env.PATH = originalPATH;
       process.env.Path = originalPath;
     }
+  });
+});
+
+describe('status command beads snapshot helpers', () => {
+  test('readBeadsSnapshot filters active assigned issues for the current developer', () => {
+    const repoRoot = createTempBeadsRepo([
+      { id: 'forge-a', title: 'Mine active', status: 'in_progress', owner: 'harshanandak@users.noreply.github.com', updated_at: '2026-04-10T08:00:00Z' },
+      { id: 'forge-b', title: 'Other active', status: 'in_progress', owner: 'other@example.com', updated_at: '2026-04-10T07:00:00Z' },
+      { id: 'forge-c', title: 'Mine open', status: 'open', owner: 'harshanandak@users.noreply.github.com', updated_at: '2026-04-10T06:00:00Z' },
+    ]);
+
+    const snapshot = readBeadsSnapshot(repoRoot);
+
+    expect(snapshot.developer.email).toBe('harshanandak@users.noreply.github.com');
+    expect(snapshot.activeAssigned.map(issue => issue.id)).toEqual(['forge-a']);
+  });
+
+  test('readBeadsSnapshot filters ready issues to open work with no unresolved dependencies', () => {
+    const repoRoot = createTempBeadsRepo([
+      { id: 'forge-ready', title: 'Ready', status: 'open', dependency_count: 0, updated_at: '2026-04-10T08:00:00Z' },
+      { id: 'forge-blocked', title: 'Blocked', status: 'open', dependency_count: 2, updated_at: '2026-04-10T07:00:00Z' },
+      { id: 'forge-active', title: 'Active', status: 'in_progress', dependency_count: 0, updated_at: '2026-04-10T06:00:00Z' },
+    ]);
+
+    const snapshot = readBeadsSnapshot(repoRoot);
+
+    expect(snapshot.ready.map(issue => issue.id)).toEqual(['forge-ready']);
+  });
+
+  test('readBeadsSnapshot sorts recent completions by updated_at descending', () => {
+    const repoRoot = createTempBeadsRepo([
+      { id: 'forge-old', title: 'Older completion', status: 'closed', updated_at: '2026-04-07T08:00:00Z' },
+      { id: 'forge-new', title: 'Newer completion', status: 'closed', updated_at: '2026-04-10T08:00:00Z' },
+      { id: 'forge-open', title: 'Still open', status: 'open', updated_at: '2026-04-09T08:00:00Z' },
+    ]);
+
+    const snapshot = readBeadsSnapshot(repoRoot);
+
+    expect(snapshot.recentCompleted.map(issue => issue.id)).toEqual(['forge-new', 'forge-old']);
+  });
+
+  test('readBeadsSnapshot ignores malformed JSONL rows and keeps the latest issue record', () => {
+    const repoRoot = createTempBeadsRepo([]);
+    fs.writeFileSync(
+      path.join(repoRoot, '.beads', 'issues.jsonl'),
+      [
+        '{"id":"forge-a","title":"Old","status":"open","updated_at":"2026-04-09T08:00:00Z"}',
+        'not-json',
+        '{"id":"forge-a","title":"New","status":"in_progress","owner":"harshanandak@users.noreply.github.com","updated_at":"2026-04-10T08:00:00Z"}',
+      ].join('\n'),
+      'utf8'
+    );
+
+    const snapshot = readBeadsSnapshot(repoRoot);
+
+    expect(snapshot.issues.map(issue => issue.title)).toEqual(['New']);
+    expect(snapshot.activeAssigned.map(issue => issue.id)).toEqual(['forge-a']);
+  });
+});
+
+describe('status command workflow discovery', () => {
+  test('zero-arg status prefers .forge-state.json over discovered issue context', async () => {
+    const repoRoot = createTempBeadsRepo([
+      {
+        id: 'forge-a',
+        title: 'Discovered issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        design: '5 tasks | docs/plans/2026-04-10-other-feature-tasks.md',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('dev'))}` }],
+        updated_at: '2026-04-10T08:00:00Z',
+      },
+    ], {
+      workflowState: createWorkflowState('validate'),
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    expect(result.stageId).toBe('validate');
+    expect(result.output).toContain('Validation (validate)');
+  });
+
+  test('zero-arg status discovers workflow from a slug-matched active issue', async () => {
+    const repoRoot = createTempBeadsRepo([
+      {
+        id: 'forge-match',
+        title: 'Matched issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        design: '5 tasks | docs/plans/2026-04-10-forge-status-personal-focus-tasks.md',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('dev'))}` }],
+        updated_at: '2026-04-10T08:00:00Z',
+      },
+      {
+        id: 'forge-other',
+        title: 'Other issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        design: '5 tasks | docs/plans/2026-04-10-unrelated-feature-tasks.md',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('ship'))}` }],
+        updated_at: '2026-04-10T07:00:00Z',
+      },
+    ], {
+      branch: 'feat/forge-status-personal-focus',
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    expect(result.stageId).toBe('dev');
+    expect(result.output).toContain('Development (dev)');
+  });
+
+  test('zero-arg status falls back to the single active assigned issue when no slug match exists', async () => {
+    const repoRoot = createTempBeadsRepo([
+      {
+        id: 'forge-only',
+        title: 'Only active issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('ship'))}` }],
+        updated_at: '2026-04-10T08:00:00Z',
+      },
+    ], {
+      branch: 'feat/no-design-match',
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    expect(result.stageId).toBe('ship');
+    expect(result.output).toContain('Shipping (ship)');
+  });
+
+  test('zero-arg status leaves workflow unresolved when multiple active issues are ambiguous', async () => {
+    const repoRoot = createTempBeadsRepo([
+      {
+        id: 'forge-a',
+        title: 'First active issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('dev'))}` }],
+        updated_at: '2026-04-10T08:00:00Z',
+      },
+      {
+        id: 'forge-b',
+        title: 'Second active issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('validate'))}` }],
+        updated_at: '2026-04-10T07:00:00Z',
+      },
+    ], {
+      branch: 'feat/ambiguous-work',
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    expect(result.missingWorkflowState).toBe(true);
+    expect(result.output).toContain('No active workflow state detected.');
+    expect(result.stageId).toBeUndefined();
+  });
+});
+
+describe('status command zero-arg presentation', () => {
+  test('zero-arg status renders all personal status sections in order', async () => {
+    const repoRoot = createTempBeadsRepo([
+      {
+        id: 'forge-active',
+        title: 'Active issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        design: '5 tasks | docs/plans/2026-04-10-forge-status-personal-focus-tasks.md',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('validate'))}` }],
+        updated_at: '2026-04-10T08:00:00Z',
+      },
+      {
+        id: 'forge-ready',
+        title: 'Ready issue',
+        status: 'open',
+        dependency_count: 0,
+        updated_at: '2026-04-09T08:00:00Z',
+      },
+      {
+        id: 'forge-done',
+        title: 'Completed issue',
+        status: 'closed',
+        updated_at: '2026-04-10T09:00:00Z',
+      },
+    ], {
+      branch: 'feat/forge-status-personal-focus',
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    const sections = ['Context', 'Active Issues', 'Ready', 'Recent Completions', 'Workflow'];
+    for (const section of sections) {
+      expect(result.output).toContain(section);
+    }
+
+    expect(result.output.indexOf('Context')).toBeLessThan(result.output.indexOf('Active Issues'));
+    expect(result.output.indexOf('Active Issues')).toBeLessThan(result.output.indexOf('Ready'));
+    expect(result.output.indexOf('Ready')).toBeLessThan(result.output.indexOf('Recent Completions'));
+    expect(result.output.indexOf('Recent Completions')).toBeLessThan(result.output.indexOf('Workflow'));
+    expect(result.output).toContain('forge-active');
+    expect(result.output).toContain('forge-ready');
+    expect(result.output).toContain('forge-done');
+    expect(result.output).toContain('Validation (validate)');
+  });
+
+  test('zero-arg status prints explicit empty-state messages for issue sections', async () => {
+    const repoRoot = createTempBeadsRepo([], {
+      branch: 'feat/empty-status',
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    expect(result.output).toContain('Active Issues');
+    expect(result.output).toContain('Ready');
+    expect(result.output).toContain('Recent Completions');
+    expect(result.output).toContain('none');
+  });
+
+  test('explicit workflow-state output preserves the authoritative stage-only format', async () => {
+    const workflowState = JSON.stringify(createWorkflowState('validate'));
+
+    const result = await statusCommand.handler(['--workflow-state', workflowState], {}, process.cwd());
+
+    expect(result.output).toContain('Current Stage: validate - Validation');
+    expect(result.output).not.toContain('Context');
+    expect(result.output).not.toContain('Active Issues');
   });
 });

--- a/test/status-command.test.js
+++ b/test/status-command.test.js
@@ -256,6 +256,17 @@ describe('status command beads snapshot helpers', () => {
     expect(snapshot.recentCompleted.map(issue => issue.id)).toEqual(['forge-new', 'forge-old']);
   });
 
+  test('readBeadsSnapshot treats missing completion timestamps as the oldest entries', () => {
+    const repoRoot = createTempBeadsRepo([
+      { id: 'forge-undated', title: 'Undated completion', status: 'closed' },
+      { id: 'forge-dated', title: 'Dated completion', status: 'closed', updated_at: '2026-04-10T08:00:00Z' },
+    ]);
+
+    const snapshot = readBeadsSnapshot(repoRoot);
+
+    expect(snapshot.recentCompleted.map(issue => issue.id)).toEqual(['forge-dated', 'forge-undated']);
+  });
+
   test('readBeadsSnapshot ignores malformed JSONL rows and keeps the latest issue record', () => {
     const repoRoot = createTempBeadsRepo([]);
     fs.writeFileSync(
@@ -325,6 +336,37 @@ describe('status command workflow discovery', () => {
 
     expect(result.stageId).toBe('dev');
     expect(result.output).toContain('Development (dev)');
+  });
+
+  test('zero-arg status matches branch slug against exact design-path slugs only', async () => {
+    const repoRoot = createTempBeadsRepo([
+      {
+        id: 'forge-plan',
+        title: 'Exact slug match',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        design: '5 tasks | docs/plans/2026-04-10-plan-tasks.md',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('dev'))}` }],
+        updated_at: '2026-04-10T08:00:00Z',
+      },
+      {
+        id: 'forge-planning',
+        title: 'Substring-only match',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        design: '5 tasks | docs/plans/2026-04-10-task-planning-tasks.md',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('validate'))}` }],
+        updated_at: '2026-04-10T07:00:00Z',
+      },
+    ], {
+      branch: 'feat/plan',
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    expect(result.stageId).toBe('dev');
+    expect(result.output).toContain('Development (dev)');
+    expect(result.output).not.toContain('Validation (validate)');
   });
 
   test('zero-arg status falls back to the single active assigned issue when no slug match exists', async () => {
@@ -434,6 +476,46 @@ describe('status command zero-arg presentation', () => {
     expect(result.output).toContain('Ready');
     expect(result.output).toContain('Recent Completions');
     expect(result.output).toContain('none');
+  });
+
+  test('zero-arg status caps ready and completion sections for readability', async () => {
+    const readyIssues = Array.from({ length: 6 }, (_value, index) => ({
+      id: `forge-ready-${index + 1}`,
+      title: `Ready ${index + 1}`,
+      status: 'open',
+      dependency_count: 0,
+      updated_at: `2026-04-0${Math.min(index + 1, 9)}T08:00:00Z`,
+    }));
+    const completedIssues = Array.from({ length: 6 }, (_value, index) => ({
+      id: `forge-done-${index + 1}`,
+      title: `Done ${index + 1}`,
+      status: 'closed',
+      updated_at: `2026-04-1${Math.min(index, 9)}T08:00:00Z`,
+    }));
+    const repoRoot = createTempBeadsRepo([
+      {
+        id: 'forge-active',
+        title: 'Active issue',
+        status: 'in_progress',
+        owner: 'harshanandak@users.noreply.github.com',
+        design: '5 tasks | docs/plans/2026-04-10-forge-status-personal-focus-tasks.md',
+        comments: [{ text: `WorkflowState: ${JSON.stringify(createWorkflowState('dev'))}` }],
+        updated_at: '2026-04-10T08:00:00Z',
+      },
+      ...readyIssues,
+      ...completedIssues,
+    ], {
+      branch: 'feat/forge-status-personal-focus',
+    });
+
+    const result = await statusCommand.handler([], {}, repoRoot);
+
+    expect(result.output).toContain('...and 1 more');
+    expect(result.output).toContain('forge-ready-5');
+    expect(result.output).not.toContain('forge-ready-6 Ready 6');
+    expect(result.output).toContain('forge-done-6');
+    expect(result.output).toContain('forge-done-2');
+    expect(result.output).not.toContain('forge-done-1 Done 1');
   });
 
   test('explicit workflow-state output preserves the authoritative stage-only format', async () => {

--- a/test/status-command.test.js
+++ b/test/status-command.test.js
@@ -232,6 +232,18 @@ describe('status command beads snapshot helpers', () => {
     expect(snapshot.activeAssigned.map(issue => issue.id)).toEqual(['forge-a']);
   });
 
+  test('readBeadsSnapshot matches owner email case-insensitively for active assignment', () => {
+    const repoRoot = createTempBeadsRepo([
+      { id: 'forge-a', title: 'Mine active', status: 'in_progress', owner: 'HarshaNandak@Users.Noreply.GitHub.com' },
+    ], {
+      email: 'harshanandak@users.noreply.github.com',
+    });
+
+    const snapshot = readBeadsSnapshot(repoRoot);
+
+    expect(snapshot.activeAssigned.map(issue => issue.id)).toEqual(['forge-a']);
+  });
+
   test('readBeadsSnapshot filters ready issues to open work with no unresolved dependencies', () => {
     const repoRoot = createTempBeadsRepo([
       { id: 'forge-ready', title: 'Ready', status: 'open', dependency_count: 0, updated_at: '2026-04-10T08:00:00Z' },
@@ -265,6 +277,17 @@ describe('status command beads snapshot helpers', () => {
     const snapshot = readBeadsSnapshot(repoRoot);
 
     expect(snapshot.recentCompleted.map(issue => issue.id)).toEqual(['forge-dated', 'forge-undated']);
+  });
+
+  test('readBeadsSnapshot treats invalid completion timestamps as the oldest entries', () => {
+    const repoRoot = createTempBeadsRepo([
+      { id: 'forge-invalid', title: 'Invalid completion', status: 'closed', updated_at: 'not-a-date' },
+      { id: 'forge-dated', title: 'Dated completion', status: 'closed', updated_at: '2026-04-10T08:00:00Z' },
+    ]);
+
+    const snapshot = readBeadsSnapshot(repoRoot);
+
+    expect(snapshot.recentCompleted.map(issue => issue.id)).toEqual(['forge-dated', 'forge-invalid']);
   });
 
   test('readBeadsSnapshot ignores malformed JSONL rows and keeps the latest issue record', () => {

--- a/test/status-command.test.js
+++ b/test/status-command.test.js
@@ -99,6 +99,16 @@ describe('status command authoritative workflow state', () => {
     expect(result.completedStages).toEqual(['plan', 'dev']);
   });
 
+  test('extractWorkflowStateFromComments tolerates relaxed WorkflowState comment payloads', () => {
+    const comments = 'WorkflowState: {currentStage:dev,completedStages:[plan],skippedStages:[],workflowDecisions:{classification:standard,reason:zero-arg';
+
+    const result = statusCommand.extractWorkflowStateFromComments(comments);
+
+    expect(result.currentStage).toBe('dev');
+    expect(result.completedStages).toEqual(['plan']);
+    expect(result.workflowDecisions.classification).toBe('standard');
+  });
+
   test('handler resolves authoritative state from Beads comments when issue id is provided', async () => {
     const comments =
       'Stage: plan complete → ready for dev\n' +

--- a/test/workflow/state-manager.test.js
+++ b/test/workflow/state-manager.test.js
@@ -9,6 +9,7 @@ const {
   WORKFLOW_STATE_FILENAME,
   extractWorkflowStateFromComments,
   loadState,
+  readBeadsIssue,
   readWorkflowStateFromBeads,
   saveState,
   initializeState,
@@ -472,6 +473,18 @@ describe('state-manager', () => {
       const result = readWorkflowStateFromBeads('forge-test', { comments });
       expect(result).not.toBeNull();
       expect(result.currentStage).toBe('validate');
+    });
+  });
+
+  describe('readBeadsIssue', () => {
+    test('returns null when bd show fails', () => {
+      const result = readBeadsIssue('forge-test', {
+        _execFileSync: () => {
+          throw new Error('bd failed');
+        },
+      });
+
+      expect(result).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Problem
`forge status` required either `--workflow-state` or `--issue-id`, which made it unusable as the zero-arg personal dashboard described in `forge-sxg2`.

## Root Cause
The current command only handled explicit authoritative workflow inputs and had no local discovery path for worktree context, assigned Beads work, ready work, recent completions, or current workflow stage selection.

## Fix
Add a zero-argument dashboard path that keeps the existing explicit flag behavior intact, gathers local git/worktree and Beads context, and renders a five-section personal status view. Keep workflow stage reporting authoritative by reusing file-backed state first and only auto-discovering a current issue when the local evidence is unambiguous.

## Value
Developers can run `forge status` with no flags and immediately see where they are working, what they own, what is ready next, what recently finished, and whether an active `/plan`?`/verify` cycle is in progress, without pulling in the larger WS1 GitHub/role-based scope.

## Beads
Closes forge-sxg2

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 50 targeted status tests passing
- Scenarios covered: zero-arg command output, worktree context detection, Beads snapshot grouping, ambiguous workflow discovery fallback, explicit flag backward compatibility

### Security Review
- OWASP Top 10: Low-risk CLI/status surface; no new auth, network, secret handling, or code execution paths were introduced. The feature reads local git and `.beads/issues.jsonl` state and preserves authoritative workflow-state precedence.
- Automated scan: `bun audit --audit-level critical` returned `No vulnerabilities found`

### Design Doc
`docs/plans/2026-04-10-forge-status-personal-focus-design.md`

### Key Decisions
- Ship only the zero-arg local dashboard slice and explicitly defer the broader WS1 PR/classifier/role-scoring work.
- Keep `lib/commands/status.js` as the entry point and preserve existing explicit `--workflow-state` / `--issue-id` behavior.
- Read local `.beads/issues.jsonl` with last-write-wins grouping to derive active assigned work, ready work, and recent completions.
- Resolve workflow state in strict order: explicit flags, `.forge-state.json`, slug-matched current issue, then single owned `in_progress` fallback.
- Omit workflow stage output when multiple active candidates remain instead of guessing.

### Documentation Updated
- `docs/plans/2026-04-10-forge-status-personal-focus-design.md`
- `docs/plans/2026-04-10-forge-status-personal-focus-tasks.md`
- `docs/plans/2026-04-10-forge-status-personal-focus-decisions.md`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [ ] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [ ] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [ ] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all prior P0/P1 concerns are resolved and the only remaining finding is a minor case-sensitivity inconsistency in a fallback code path.

All three issues from previous review rounds have been addressed. The single new finding (case-sensitive name comparison in the isAssignedToDeveloper fallback) is P2 and does not affect the primary email-based ownership path used in practice. Test coverage is comprehensive (50 targeted tests) and backward compatibility is intact.

lib/status/beads-snapshot.js — minor case-sensitivity inconsistency in the created_by fallback comparison at line 67.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/status/beads-snapshot.js
Line: 67

Comment:
**Case-sensitive name comparison in fallback path**

When `issue.owner` is absent, assignment falls back to `issue.created_by === developer.name`. Unlike the email path — which uses `normalizeEmail` to lower-case both sides before comparing — this comparison is case-sensitive. If the Beads `created_by` field was recorded with different capitalisation than the local git `user.name`, the developer will be silently excluded from their own active work in the dashboard.

```suggestion
	return developer.name !== '' && issue.created_by.trim().toLowerCase() === developer.name.trim().toLowerCase();
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: harden status snapshot helpers"](https://github.com/harshanandak/forge/commit/a6b66537dba10bff516f7e327953f27db5181def) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27975306)</sub>

<!-- /greptile_comment -->