### PR TITLE
feat: add forge issues authority layer

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -2554,7 +2554,7 @@ function parseFlags() {
 
   // Issue passthrough commands delegate all flags to bd.
   // Skip global parsing so flags like --type, -p, --help reach the handler intact.
-  const issuePassthroughCommands = ['create', 'update', 'claim', 'close', 'show', 'list', 'ready', 'issue'];
+  const issuePassthroughCommands = ['create', 'update', 'claim', 'close', 'show', 'list', 'ready', 'issue', 'issues'];
   if (issuePassthroughCommands.includes(args[0])) {
     return flags;
   }

--- a/docs/plans/2026-04-13-forge-f3lx-issues-decisions.md
+++ b/docs/plans/2026-04-13-forge-f3lx-issues-decisions.md
@@ -1,0 +1,3 @@
+# Decisions Log
+
+No decisions recorded yet.

--- a/docs/plans/2026-04-13-forge-f3lx-issues-design.md
+++ b/docs/plans/2026-04-13-forge-f3lx-issues-design.md
@@ -1,0 +1,151 @@
+# Feature
+
+- Slug: `forge-f3lx-issues`
+- Date: `2026-04-13`
+- Status: `planned`
+- Issue: `forge-f3lx`
+- Branch: `feat/forge-f3lx-issues`
+- Worktree: `.worktrees/forge-f3lx-issues`
+
+## Purpose
+
+Introduce a new plural command surface, `forge issues`, that makes Forge the entrypoint for issue operations while keeping Beads behind a backend abstraction. This is the first v2 authority-layer seam: the CLI should stop acting like a direct `bd` passthrough at the command edge and instead route through a Forge-owned service that can later swap Beads for GitHub Issues, Linear, or Jira.
+
+This wave is intentionally narrow. It establishes the command shape and backend seam for `create`, `list`, `show`, `close`, and `update`, without taking on the broader sync, import, or GitHub reconciliation work that belongs to later children of `forge-f3lx`.
+
+## Success Criteria
+
+1. `lib/commands/issues.js` exists and auto-registers through [`lib/commands/_registry.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_registry.js:60) without any `bin/forge.js` changes.
+2. A new Forge-owned issue service module exists in a new file and exposes a pluggable backend contract for `create`, `list`, `show`, `close`, and `update`.
+3. The default backend for this wave delegates to the `bd` CLI, but the command module itself does not build `bd` argv directly.
+4. `forge issues list`, `forge issues create`, `forge issues show <id>`, and `forge issues close <id>` work through the new service surface, with `update` implemented in the backend contract even if it is not advertised as the headline UX path.
+5. The implementation leaves `lib/commands/worktree.js`, `lib/commands/setup.js`, and `lib/beads-health-check.js` untouched.
+6. Tests lock the backend contract, command help/dispatch behavior, and registry auto-discovery for the new plural command.
+
+## Out Of Scope
+
+- Replacing the existing singular [`lib/commands/issue.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/issue.js:1) or the legacy top-level aliases (`forge create`, `forge show`, `forge close`, `forge list`) in this wave.
+- Implementing GitHub Issues, Linear, or Jira backends.
+- Implementing sync queues, reconciliation rules, import flows, or shared-memory features from the broader `forge-f3lx` epic.
+- Modifying `lib/commands/worktree.js`, `lib/commands/setup.js`, or `lib/beads-health-check.js`.
+- Modifying internals of [`lib/beads-setup.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/beads-setup.js:348); only its exported API may be consumed.
+
+## Approach Selected
+
+Add a new plural command module plus a Forge-owned issue service:
+
+1. `lib/commands/issues.js`
+   - Thin CLI adapter.
+   - Parses the subcommand and arguments.
+   - Calls the Forge issue service.
+   - Formats Forge-level help and error output.
+2. `lib/forge-issues.js`
+   - Exposes the service entrypoint and backend factory.
+   - Owns the backend interface and command-to-operation mapping.
+   - Uses Beads as the default backend in this wave.
+3. Optional helper file(s) under a new issue-backend namespace if needed during implementation, but all new code stays in new files.
+
+Selected interface shape:
+
+```js
+class IssueBackend {
+  async create(args, context) {}
+  async list(args, context) {}
+  async show(args, context) {}
+  async close(args, context) {}
+  async update(args, context) {}
+}
+```
+
+Selected service shape:
+
+```js
+createIssueService({ backend, execFileSync, isBeadsInitialized })
+runIssueOperation(operation, rawArgs, projectRoot, deps)
+```
+
+Why this approach:
+
+- The current implementation in [`lib/commands/_issue.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_issue.js:1) shells out to `bd` directly from the command layer, which is fast to wire but is the wrong ownership boundary for v2.
+- The v2 strategy doc explicitly calls for `issueCore.create()` to sit behind both CLI and MCP entrypoints and for Forge to wrap Beads as a backend/cache rather than exposing `bd` as the real API.
+- A new plural command avoids collisions with the legacy singular command surface and satisfies the user constraint to keep this wave's code in new files.
+
+## Alternatives Considered
+
+### Option A: Extend `lib/commands/_issue.js`
+
+Rejected for this wave.
+
+- It would mix the new authority-layer seam into the legacy direct-wrapper code.
+- It increases conflict risk with adjacent tracks by turning a replacement into an in-place rewrite.
+- It makes it harder to keep the backend boundary explicit.
+
+### Option B: Add `lib/commands/issues.js` plus a new service module
+
+Selected.
+
+- Zero `bin/forge.js` work because the registry auto-discovers new command files.
+- Keeps the new architecture in new files only.
+- Lets `/dev` build the backend interface under test before any future migration of the old singular command surface.
+
+## Constraints
+
+- New implementation code for this wave must live in new files.
+- The command must rely on registry auto-discovery and not require manual CLI registration changes.
+- The design must be future-friendly for GitHub Issues, Linear, and Jira, but only Beads is implemented now.
+- If `lib/beads-setup.js` is used, only exported helpers such as `isBeadsInitialized()` may be consumed.
+- Error messages should be translated into Forge terms instead of exposing only raw `bd` failures, consistent with the v2 strategy document's error-handling requirement.
+- This plan stops before implementation. `/dev` work begins only after approval.
+
+## Edge Cases
+
+- `bd` binary missing: the Beads backend must translate `ENOENT` into a Forge-level installation/init message.
+- Beads not initialized in the repo: the service should fail clearly before attempting to execute issue operations.
+- Unknown subcommand or missing required ID: `forge issues` must return command-local usage guidance instead of raw backend errors.
+- Backend capability drift: future backends may not support every Beads-specific concept; the interface should be operation-based and conservative in this wave.
+- Legacy command coexistence: `forge issue` and `forge create/show/list/close` remain in place during this wave, so the new plural command must not rely on changing them.
+
+## Ambiguity Policy
+
+Use the repo's `/dev` decision-gate rubric.
+
+- If confidence is `>= 80%`, choose the conservative option, document it in the decisions log during implementation, and continue.
+- If confidence is `< 80%`, stop and ask before changing command semantics or backend contract shape.
+
+## Technical Research
+
+### Current Repo Findings
+
+- [`lib/commands/_registry.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_registry.js:60) auto-discovers `.js` files in `lib/commands/` and requires only `{ name, description, handler }`.
+- [`lib/commands/_issue.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_issue.js:1) already provides a legacy command surface for `forge issue`, `forge create`, `forge update`, `forge claim`, `forge close`, `forge show`, `forge list`, and `forge ready`.
+- Existing tests already cover the legacy surface in [`test/commands/issue.test.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/test/commands/issue.test.js:1) and [`test/commands/_issue.test.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/test/commands/_issue.test.js:1).
+- [`lib/beads-setup.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/beads-setup.js:348) exports `sanitizePrefix`, `writeBeadsConfig`, `writeBeadsGitignore`, `isBeadsInitialized`, `preSeedJsonl`, and `safeBeadsInit`.
+
+### V2 Strategy Findings
+
+- [`docs/plans/2026-04-06-forge-v2-unified-strategy.md`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/docs/plans/2026-04-06-forge-v2-unified-strategy.md:292) requires CLI/MCP parity through a shared issue core.
+- The same strategy doc defines a future-friendly `IssueBackend` shape with Beads, GitHub Issues, Linear, and Jira adapters ([line 940](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/docs/plans/2026-04-06-forge-v2-unified-strategy.md:940)).
+- The current wave only needs the Beads-backed default plus the abstraction seam; cloud-agent GitHub fallback belongs to later work.
+
+### Planning Preconditions
+
+- `git branch --show-current` returned `master` before worktree creation.
+- `bd worktree create .worktrees/forge-f3lx-issues --branch feat/forge-f3lx-issues` succeeded.
+- `scripts/forge-team/index.sh verify` reported `gh` is not authenticated. That is not a blocker for this local Beads-backed planning wave, but later GitHub-backed tracks will need `gh auth login`.
+- `scripts/pr-coordinator.sh merge-order` reported a dependency cycle. That is advisory input for coordination, not a reason to redesign this command boundary.
+
+## TDD Scenarios
+
+1. The issue service routes `create`, `list`, `show`, `close`, and `update` to the configured backend and rejects unsupported operations clearly.
+2. The default Beads backend builds the correct `bd` argv for each supported operation and translates missing-binary / missing-init failures into Forge-level errors.
+3. `forge issues --help` and `forge issues <bad-subcommand>` return stable help text without touching the backend.
+4. `forge issues create`, `forge issues list`, `forge issues show <id>`, and `forge issues close <id>` dispatch through the new service and are auto-discovered by the registry.
+5. The new plural command can ship without modifying the legacy singular command files.
+
+## Baseline
+
+- Issue: `forge-f3lx`
+- Worktree: `.worktrees/forge-f3lx-issues`
+- Branch: `feat/forge-f3lx-issues`
+- Planning blockers: none for local artifact creation
+- Implementation blockers to resolve later: GitHub CLI authentication for downstream GitHub-backed tracks

--- a/docs/plans/2026-04-13-forge-f3lx-issues-design.md
+++ b/docs/plans/2026-04-13-forge-f3lx-issues-design.md
@@ -15,7 +15,7 @@ This wave is intentionally narrow. It establishes the command shape and backend 
 
 ## Success Criteria
 
-1. `lib/commands/issues.js` exists and auto-registers through [`lib/commands/_registry.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_registry.js:60) without any `bin/forge.js` changes.
+1. `lib/commands/issues.js` exists and auto-registers through `lib/commands/_registry.js` without any `bin/forge.js` changes.
 2. A new Forge-owned issue service module exists in a new file and exposes a pluggable backend contract for `create`, `list`, `show`, `close`, and `update`.
 3. The default backend for this wave delegates to the `bd` CLI, but the command module itself does not build `bd` argv directly.
 4. `forge issues list`, `forge issues create`, `forge issues show <id>`, and `forge issues close <id>` work through the new service surface, with `update` implemented in the backend contract even if it is not advertised as the headline UX path.
@@ -24,11 +24,11 @@ This wave is intentionally narrow. It establishes the command shape and backend 
 
 ## Out Of Scope
 
-- Replacing the existing singular [`lib/commands/issue.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/issue.js:1) or the legacy top-level aliases (`forge create`, `forge show`, `forge close`, `forge list`) in this wave.
+- Replacing the existing singular `lib/commands/issue.js` or the legacy top-level aliases (`forge create`, `forge show`, `forge close`, `forge list`) in this wave.
 - Implementing GitHub Issues, Linear, or Jira backends.
 - Implementing sync queues, reconciliation rules, import flows, or shared-memory features from the broader `forge-f3lx` epic.
 - Modifying `lib/commands/worktree.js`, `lib/commands/setup.js`, or `lib/beads-health-check.js`.
-- Modifying internals of [`lib/beads-setup.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/beads-setup.js:348); only its exported API may be consumed.
+- Modifying internals of `lib/beads-setup.js`; only its exported API may be consumed.
 
 ## Approach Selected
 
@@ -66,7 +66,7 @@ runIssueOperation(operation, rawArgs, projectRoot, deps)
 
 Why this approach:
 
-- The current implementation in [`lib/commands/_issue.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_issue.js:1) shells out to `bd` directly from the command layer, which is fast to wire but is the wrong ownership boundary for v2.
+- The current implementation in `lib/commands/_issue.js` shells out to `bd` directly from the command layer, which is fast to wire but is the wrong ownership boundary for v2.
 - The v2 strategy doc explicitly calls for `issueCore.create()` to sit behind both CLI and MCP entrypoints and for Forge to wrap Beads as a backend/cache rather than exposing `bd` as the real API.
 - A new plural command avoids collisions with the legacy singular command surface and satisfies the user constraint to keep this wave's code in new files.
 
@@ -116,15 +116,15 @@ Use the repo's `/dev` decision-gate rubric.
 
 ### Current Repo Findings
 
-- [`lib/commands/_registry.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_registry.js:60) auto-discovers `.js` files in `lib/commands/` and requires only `{ name, description, handler }`.
-- [`lib/commands/_issue.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/commands/_issue.js:1) already provides a legacy command surface for `forge issue`, `forge create`, `forge update`, `forge claim`, `forge close`, `forge show`, `forge list`, and `forge ready`.
-- Existing tests already cover the legacy surface in [`test/commands/issue.test.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/test/commands/issue.test.js:1) and [`test/commands/_issue.test.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/test/commands/_issue.test.js:1).
-- [`lib/beads-setup.js`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/lib/beads-setup.js:348) exports `sanitizePrefix`, `writeBeadsConfig`, `writeBeadsGitignore`, `isBeadsInitialized`, `preSeedJsonl`, and `safeBeadsInit`.
+- `lib/commands/_registry.js` auto-discovers `.js` files in `lib/commands/` and requires only `{ name, description, handler }`.
+- `lib/commands/_issue.js` already provides a legacy command surface for `forge issue`, `forge create`, `forge update`, `forge claim`, `forge close`, `forge show`, `forge list`, and `forge ready`.
+- Existing tests already cover the legacy surface in `test/commands/issue.test.js` and `test/commands/_issue.test.js`.
+- `lib/beads-setup.js` exports `sanitizePrefix`, `writeBeadsConfig`, `writeBeadsGitignore`, `isBeadsInitialized`, `preSeedJsonl`, and `safeBeadsInit`.
 
 ### V2 Strategy Findings
 
-- [`docs/plans/2026-04-06-forge-v2-unified-strategy.md`](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/docs/plans/2026-04-06-forge-v2-unified-strategy.md:292) requires CLI/MCP parity through a shared issue core.
-- The same strategy doc defines a future-friendly `IssueBackend` shape with Beads, GitHub Issues, Linear, and Jira adapters ([line 940](C:/Users/harsha_befach/Downloads/forge/.worktrees/forge-f3lx-issues/docs/plans/2026-04-06-forge-v2-unified-strategy.md:940)).
+- `docs/plans/2026-04-06-forge-v2-unified-strategy.md` requires CLI/MCP parity through a shared issue core.
+- The same strategy doc defines a future-friendly `IssueBackend` shape with Beads, GitHub Issues, Linear, and Jira adapters (see `docs/plans/2026-04-06-forge-v2-unified-strategy.md`, around line 940).
 - The current wave only needs the Beads-backed default plus the abstraction seam; cloud-agent GitHub fallback belongs to later work.
 
 ### Planning Preconditions

--- a/docs/plans/2026-04-13-forge-f3lx-issues-tasks.md
+++ b/docs/plans/2026-04-13-forge-f3lx-issues-tasks.md
@@ -1,0 +1,58 @@
+# Task List
+
+Task 1: Lock The Forge Issue Backend Contract
+File(s): `test/forge-issues.test.js`
+OWNS: `test/forge-issues.test.js`
+What to implement: Define the service-level contract for `create`, `list`, `show`, `close`, and `update` before any production code exists. The tests should require a pluggable backend, stable operation routing, clear unknown-operation failures, and dependency injection for shell execution and initialization checks.
+TDD steps:
+  1. Write test: add coverage for `createIssueService()` and `runIssueOperation()` with a fake backend and injected dependencies.
+  2. Run test: confirm it fails because `lib/forge-issues.js` does not exist yet.
+  3. Implement: no production code in this task; tests only.
+  4. Run test: confirm the failures are for the missing service implementation, not test harness mistakes.
+  5. Commit: `test: add forge issues service contract coverage`
+Expected output: a stable failing test suite that defines the Forge-owned issue service boundary before the Beads wrapper is written.
+
+Task 2: Implement The Pluggable Forge Issue Service And Default Beads Backend
+File(s): `lib/forge-issues.js`, `test/forge-issues.test.js`
+OWNS: `lib/forge-issues.js`, `test/forge-issues.test.js`
+What to implement: Add the new Forge issue service with a default Beads-backed backend. The service should own operation dispatch, dependency injection, backend selection for this wave, and Forge-level error translation. The Beads path should use `bd` through injected execution helpers and may consume `isBeadsInitialized()` from `lib/beads-setup.js` through its public export only.
+TDD steps:
+  1. Write test: use `test/forge-issues.test.js` to require exact routing, init checks, and `ENOENT` translation behavior.
+  2. Run test: confirm it fails because the service implementation does not exist.
+  3. Implement: add `lib/forge-issues.js` with the backend contract, default backend factory, and Beads command mapping for `create`, `list`, `show`, `close`, and `update`.
+  4. Run test: confirm the new service contract tests pass.
+  5. Commit: `feat: add forge issues service and beads backend`
+Expected output: one Forge-owned module that turns issue operations into backend calls and makes Beads an implementation detail instead of the command surface.
+
+Task 3: Add The New `forge issues` Command Module
+File(s): `lib/commands/issues.js`, `test/commands/issues.test.js`
+OWNS: `lib/commands/issues.js`, `test/commands/issues.test.js`
+What to implement: Create the plural `forge issues` command as a thin wrapper over `lib/forge-issues.js`. It must parse subcommands, return stable help output, dispatch supported operations through the service, and avoid direct `bd` argv construction in the command module.
+TDD steps:
+  1. Write test: add `test/commands/issues.test.js` covering help output, invalid subcommands, and dispatch for `create`, `list`, `show`, and `close`.
+  2. Run test: confirm it fails because `lib/commands/issues.js` does not exist.
+  3. Implement: add `lib/commands/issues.js` using the standard command export shape required by the registry.
+  4. Run test: confirm the command tests pass.
+  5. Commit: `feat: add forge issues command`
+Expected output: `forge issues ...` becomes a first-class command surface without modifying `bin/forge.js`.
+
+Task 4: Prove Auto-Discovery And Coexistence With The Legacy Surface
+File(s): `test/forge-cli-registry.test.js`, `test/commands/issues.test.js`
+OWNS: `test/forge-cli-registry.test.js`, `test/commands/issues.test.js`
+What to implement: Extend registry and command coverage so the new plural command is auto-discovered and can coexist with the existing singular `issue` and top-level alias commands without replacing them in this wave.
+TDD steps:
+  1. Write test: require the registry to load `issues` from `lib/commands/` and verify that both `issue` and `issues` are present.
+  2. Run test: confirm it fails until the new module exists and exports the correct shape.
+  3. Implement: adjust tests only if Task 3 already satisfies the registry contract; otherwise refine the command module until discovery passes.
+  4. Run test: confirm registry coverage passes alongside the new command tests.
+  5. Commit: `test: cover forge issues auto-discovery`
+Expected output: proof that no `bin/forge.js` wiring is needed and that the new v2 command can land without destabilizing the existing issue entrypoints.
+
+## YAGNI Filter
+
+- Task 1 maps to success criteria 2 and 6.
+- Task 2 maps to success criteria 2, 3, and 5.
+- Task 3 maps to success criteria 1, 3, and 4.
+- Task 4 maps to success criteria 1 and 6.
+
+No task depends on sync queues, GitHub reconciliation, Linear/Jira adapters, or legacy command replacement.

--- a/lib/commands/issues.js
+++ b/lib/commands/issues.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { runIssueOperation } = require('../forge-issues');
+
+const SUPPORTED_SUBCOMMANDS = ['create', 'list', 'show', 'close', 'update'];
+
+function normalizeArgs(args = []) {
+  return args.filter(arg => arg !== '--');
+}
+
+function formatHelp() {
+  return [
+    'Usage: forge issues <subcommand> [...]',
+    '',
+    'Supported subcommands:',
+    '  create  Create an issue through Forge',
+    '  list    List issues through Forge',
+    '  show    Show a single issue through Forge',
+    '  close   Close an issue through Forge',
+    '  update  Update an issue through Forge',
+  ].join('\n');
+}
+
+module.exports = {
+  name: 'issues',
+  description: 'Manage issues through the Forge authority layer',
+  usage: 'forge issues <subcommand> [...]',
+  flags: {},
+  handler: async (args, _flags, projectRoot, opts = {}) => {
+    const [subcommand, ...rest] = normalizeArgs(args);
+
+    if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+      return {
+        success: true,
+        output: formatHelp(),
+      };
+    }
+
+    if (!SUPPORTED_SUBCOMMANDS.includes(subcommand)) {
+      return {
+        success: false,
+        error: `Unknown issue subcommand '${subcommand}'.\n\n${formatHelp()}`,
+      };
+    }
+
+    const runner = opts.runIssueOperation || runIssueOperation;
+    return runner(subcommand, rest, projectRoot, opts);
+  },
+};

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -86,7 +86,7 @@ function shouldCaptureOutput(operation, args, deps = {}) {
     return true;
   }
 
-  return operation === 'update';
+  return operation === 'update' || operation === 'show';
 }
 
 async function runBdCommand(operation, args, projectRoot, deps = {}) {

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -34,6 +34,15 @@ function hasBdSoftFailure(output) {
   return /(^|\n)Error(?: resolving| updating| fetching| adding)?\b/i.test(output);
 }
 
+function hasEmptyShowPayload(operation, output) {
+  if (operation !== 'show') {
+    return false;
+  }
+
+  const trimmedOutput = output.trim();
+  return trimmedOutput === '' || trimmedOutput === '[]' || trimmedOutput === 'null';
+}
+
 function isHelpInvocation(args = []) {
   return args.includes('--help') || args.includes('-h');
 }
@@ -97,8 +106,9 @@ async function runBdCommand(operation, args, projectRoot, deps = {}) {
       const normalizedChunk = normalizeExecOutput(chunk);
       if (captureOutput) {
         stdout += normalizedChunk;
+      } else {
+        stdoutTarget?.write?.(normalizedChunk);
       }
-      stdoutTarget?.write?.(normalizedChunk);
     });
     child.stderr?.on?.('data', chunk => {
       const normalizedChunk = normalizeExecOutput(chunk);
@@ -146,6 +156,13 @@ async function runBeadsOperation(operation, args, context, deps) {
       return {
         success: false,
         error: combinedOutput.trim() || 'Beads command failed',
+      };
+    }
+
+    if (hasEmptyShowPayload(operation, combinedOutput)) {
+      return {
+        success: false,
+        error: `Issue not found: ${args[0] || 'unknown issue'}`,
       };
     }
 
@@ -219,6 +236,7 @@ module.exports = {
   extractErrorMessage,
   getCommandErrorMessage,
   getSpawnOptions,
+  hasEmptyShowPayload,
   hasBdSoftFailure,
   isHelpInvocation,
   normalizeExecOutput,

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const { isBeadsInitialized } = require('./beads-setup');
+
+const OPERATION_TO_BD = {
+  create: 'create',
+  list: 'list',
+  show: 'show',
+  close: 'close',
+  update: 'update',
+};
+
+function getExecOptions(projectRoot) {
+  return {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  };
+}
+
+function extractErrorMessage(error) {
+  if (error?.code === 'ENOENT') {
+    return 'Beads (bd) command not found. Install or initialize Beads before using forge issues.';
+  }
+
+  return error?.message?.trim() || 'Beads command failed';
+}
+
+function buildBdArgs(operation, args) {
+  const bdCommand = OPERATION_TO_BD[operation];
+  if (!bdCommand) {
+    return null;
+  }
+
+  return [bdCommand, ...args];
+}
+
+async function runBeadsOperation(operation, args, context, deps) {
+  const checkInit = deps.isBeadsInitialized || isBeadsInitialized;
+  if (!checkInit(context.projectRoot)) {
+    return {
+      success: false,
+      error: 'Beads is not initialized in this project. Run forge setup before using forge issues.',
+    };
+  }
+
+  const exec = deps.execFileSync || execFileSync;
+
+  try {
+    exec('bd', buildBdArgs(operation, args), getExecOptions(context.projectRoot));
+    return { success: true, operation };
+  } catch (error) {
+    return {
+      success: false,
+      error: extractErrorMessage(error),
+    };
+  }
+}
+
+function createBeadsIssueBackend(deps = {}) {
+  return {
+    create: async (args, context) => runBeadsOperation('create', args, context, deps),
+    list: async (args, context) => runBeadsOperation('list', args, context, deps),
+    show: async (args, context) => runBeadsOperation('show', args, context, deps),
+    close: async (args, context) => runBeadsOperation('close', args, context, deps),
+    update: async (args, context) => runBeadsOperation('update', args, context, deps),
+  };
+}
+
+function createIssueService({ backend } = {}) {
+  const resolvedBackend = backend || createBeadsIssueBackend();
+
+  return {
+    async run(operation, args = [], context = {}) {
+      const method = resolvedBackend?.[operation];
+      if (typeof method !== 'function') {
+        return {
+          success: false,
+          error: `Unsupported issue operation: ${operation}`,
+        };
+      }
+
+      return method(args, context);
+    },
+  };
+}
+
+async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
+  const createService = deps.createService || (() => {
+    const backendDeps = {
+      execFileSync: deps.execFileSync,
+      isBeadsInitialized: deps.isBeadsInitialized,
+    };
+
+    return createIssueService({
+      backend: createBeadsIssueBackend(backendDeps),
+    });
+  });
+
+  const service = createService();
+  return service.run(operation, rawArgs, {
+    projectRoot,
+    deps,
+  });
+}
+
+module.exports = {
+  createIssueService,
+  createBeadsIssueBackend,
+  runIssueOperation,
+  buildBdArgs,
+  extractErrorMessage,
+};

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -31,6 +31,10 @@ function normalizeExecOutput(output) {
   return '';
 }
 
+function hasBdSoftFailure(output) {
+  return /(^|\n)Error(?: resolving| updating| fetching| adding)?\b/i.test(output);
+}
+
 function extractErrorMessage(error) {
   if (error?.code === 'ENOENT') {
     return 'Beads (bd) command not found. Install or initialize Beads before using forge issues.';
@@ -61,10 +65,19 @@ async function runBeadsOperation(operation, args, context, deps) {
 
   try {
     const output = exec('bd', buildBdArgs(operation, args), getExecOptions(context.projectRoot));
+    const normalizedOutput = normalizeExecOutput(output);
+
+    if (hasBdSoftFailure(normalizedOutput)) {
+      return {
+        success: false,
+        error: normalizedOutput.trim() || 'Beads command failed',
+      };
+    }
+
     return {
       success: true,
       operation,
-      output: normalizeExecOutput(output),
+      output: normalizedOutput,
     };
   } catch (error) {
     return {
@@ -127,5 +140,6 @@ module.exports = {
   runIssueOperation,
   buildBdArgs,
   extractErrorMessage,
+  hasBdSoftFailure,
   normalizeExecOutput,
 };

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { execFileSync } = require('node:child_process');
+const { spawn } = require('node:child_process');
 const { isBeadsInitialized } = require('./beads-setup');
 
 const OPERATION_TO_BD = {
@@ -11,11 +11,10 @@ const OPERATION_TO_BD = {
   update: 'update',
 };
 
-function getExecOptions(projectRoot) {
+function getSpawnOptions(projectRoot) {
   return {
     cwd: projectRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
-    encoding: 'utf8',
   };
 }
 
@@ -35,12 +34,29 @@ function hasBdSoftFailure(output) {
   return /(^|\n)Error(?: resolving| updating| fetching| adding)?\b/i.test(output);
 }
 
+function isHelpInvocation(args = []) {
+  return args.includes('--help') || args.includes('-h');
+}
+
 function extractErrorMessage(error) {
   if (error?.code === 'ENOENT') {
     return 'Beads (bd) command not found. Install or initialize Beads before using forge issues.';
   }
 
   return error?.message?.trim() || 'Beads command failed';
+}
+
+function getCommandErrorMessage(result) {
+  const output = [result?.stdout, result?.stderr].filter(Boolean).join('\n').trim();
+  if (output) {
+    return output;
+  }
+
+  if (typeof result?.code === 'number') {
+    return `Beads command failed with exit code ${result.code}`;
+  }
+
+  return 'Beads command failed';
 }
 
 function buildBdArgs(operation, args) {
@@ -52,32 +68,68 @@ function buildBdArgs(operation, args) {
   return [bdCommand, ...args];
 }
 
+async function runBdCommand(args, projectRoot, deps = {}) {
+  const spawnBd = deps.spawn || spawn;
+
+  return new Promise((resolve, reject) => {
+    const child = spawnBd('bd', args, getSpawnOptions(projectRoot));
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.setEncoding?.('utf8');
+    child.stderr?.setEncoding?.('utf8');
+    child.stdout?.on?.('data', chunk => {
+      stdout += normalizeExecOutput(chunk);
+    });
+    child.stderr?.on?.('data', chunk => {
+      stderr += normalizeExecOutput(chunk);
+    });
+
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({
+        code,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
 async function runBeadsOperation(operation, args, context, deps) {
   const checkInit = deps.isBeadsInitialized || isBeadsInitialized;
-  if (!checkInit(context.projectRoot)) {
+  if (!isHelpInvocation(args) && !checkInit(context.projectRoot)) {
     return {
       success: false,
       error: 'Beads is not initialized in this project. Run forge setup before using forge issues.',
     };
   }
-
-  const exec = deps.execFileSync || execFileSync;
+  const runCommand = deps.runBdCommand || ((bdArgs, projectRoot) => runBdCommand(bdArgs, projectRoot, deps));
 
   try {
-    const output = exec('bd', buildBdArgs(operation, args), getExecOptions(context.projectRoot));
-    const normalizedOutput = normalizeExecOutput(output);
+    const result = await runCommand(buildBdArgs(operation, args), context.projectRoot);
+    const stdout = normalizeExecOutput(result?.stdout);
+    const stderr = normalizeExecOutput(result?.stderr);
+    const combinedOutput = [stdout, stderr].filter(Boolean).join('\n');
 
-    if (hasBdSoftFailure(normalizedOutput)) {
+    if (result?.code !== 0) {
       return {
         success: false,
-        error: normalizedOutput.trim() || 'Beads command failed',
+        error: getCommandErrorMessage(result),
+      };
+    }
+
+    if (hasBdSoftFailure(combinedOutput)) {
+      return {
+        success: false,
+        error: combinedOutput.trim() || 'Beads command failed',
       };
     }
 
     return {
       success: true,
       operation,
-      output: normalizedOutput,
+      output: stdout,
     };
   } catch (error) {
     return {
@@ -118,8 +170,9 @@ function createIssueService({ backend } = {}) {
 async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
   const createService = deps.createService || (() => {
     const backendDeps = {
-      execFileSync: deps.execFileSync,
       isBeadsInitialized: deps.isBeadsInitialized,
+      runBdCommand: deps.runBdCommand,
+      spawn: deps.spawn,
     };
 
     return createIssueService({
@@ -140,6 +193,10 @@ module.exports = {
   runIssueOperation,
   buildBdArgs,
   extractErrorMessage,
+  getCommandErrorMessage,
+  getSpawnOptions,
   hasBdSoftFailure,
+  isHelpInvocation,
   normalizeExecOutput,
+  runBdCommand,
 };

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -14,8 +14,21 @@ const OPERATION_TO_BD = {
 function getExecOptions(projectRoot) {
   return {
     cwd: projectRoot,
-    stdio: 'inherit',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
   };
+}
+
+function normalizeExecOutput(output) {
+  if (typeof output === 'string') {
+    return output;
+  }
+
+  if (Buffer.isBuffer(output)) {
+    return output.toString('utf8');
+  }
+
+  return '';
 }
 
 function extractErrorMessage(error) {
@@ -47,8 +60,12 @@ async function runBeadsOperation(operation, args, context, deps) {
   const exec = deps.execFileSync || execFileSync;
 
   try {
-    exec('bd', buildBdArgs(operation, args), getExecOptions(context.projectRoot));
-    return { success: true, operation };
+    const output = exec('bd', buildBdArgs(operation, args), getExecOptions(context.projectRoot));
+    return {
+      success: true,
+      operation,
+      output: normalizeExecOutput(output),
+    };
   } catch (error) {
     return {
       success: false,
@@ -110,4 +127,5 @@ module.exports = {
   runIssueOperation,
   buildBdArgs,
   extractErrorMessage,
+  normalizeExecOutput,
 };

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -68,8 +68,23 @@ function buildBdArgs(operation, args) {
   return [bdCommand, ...args];
 }
 
-async function runBdCommand(args, projectRoot, deps = {}) {
+function shouldCaptureOutput(operation, args, deps = {}) {
+  if (deps.captureOutput === true) {
+    return true;
+  }
+
+  if (isHelpInvocation(args)) {
+    return true;
+  }
+
+  return operation === 'update';
+}
+
+async function runBdCommand(operation, args, projectRoot, deps = {}) {
   const spawnBd = deps.spawn || spawn;
+  const stdoutTarget = deps.stdout || process.stdout;
+  const stderrTarget = deps.stderr || process.stderr;
+  const captureOutput = shouldCaptureOutput(operation, args.slice(1), deps);
 
   return new Promise((resolve, reject) => {
     const child = spawnBd('bd', args, getSpawnOptions(projectRoot));
@@ -79,10 +94,18 @@ async function runBdCommand(args, projectRoot, deps = {}) {
     child.stdout?.setEncoding?.('utf8');
     child.stderr?.setEncoding?.('utf8');
     child.stdout?.on?.('data', chunk => {
-      stdout += normalizeExecOutput(chunk);
+      const normalizedChunk = normalizeExecOutput(chunk);
+      if (captureOutput) {
+        stdout += normalizedChunk;
+      }
+      stdoutTarget?.write?.(normalizedChunk);
     });
     child.stderr?.on?.('data', chunk => {
-      stderr += normalizeExecOutput(chunk);
+      const normalizedChunk = normalizeExecOutput(chunk);
+      if (captureOutput) {
+        stderr += normalizedChunk;
+      }
+      stderrTarget?.write?.(normalizedChunk);
     });
 
     child.on('error', reject);
@@ -104,7 +127,7 @@ async function runBeadsOperation(operation, args, context, deps) {
       error: 'Beads is not initialized in this project. Run forge setup before using forge issues.',
     };
   }
-  const runCommand = deps.runBdCommand || ((bdArgs, projectRoot) => runBdCommand(bdArgs, projectRoot, deps));
+  const runCommand = deps.runBdCommand || ((bdArgs, projectRoot) => runBdCommand(operation, bdArgs, projectRoot, deps));
 
   try {
     const result = await runCommand(buildBdArgs(operation, args), context.projectRoot);
@@ -130,6 +153,7 @@ async function runBeadsOperation(operation, args, context, deps) {
       success: true,
       operation,
       output: stdout,
+      stderr,
     };
   } catch (error) {
     return {
@@ -162,7 +186,7 @@ function createIssueService({ backend } = {}) {
         };
       }
 
-      return method(args, context);
+      return method.call(resolvedBackend, args, context);
     },
   };
 }

--- a/test/commands/issues.test.js
+++ b/test/commands/issues.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+describe('forge issues command', () => {
+  test('exports the canonical plural issues command module', () => {
+    const issues = require('../../lib/commands/issues');
+
+    expect(issues.name).toBe('issues');
+    expect(typeof issues.description).toBe('string');
+    expect(typeof issues.handler).toBe('function');
+    expect(issues.usage).toContain('forge issues');
+  });
+
+  test('returns help text when no subcommand is provided', async () => {
+    const issues = require('../../lib/commands/issues');
+
+    const result = await issues.handler([], {}, '/repo');
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('forge issues <subcommand>');
+    expect(result.output).toContain('create');
+    expect(result.output).toContain('list');
+    expect(result.output).toContain('show');
+    expect(result.output).toContain('close');
+  });
+
+  test('rejects unsupported subcommands with usage guidance', async () => {
+    const issues = require('../../lib/commands/issues');
+
+    const result = await issues.handler(['ready'], {}, '/repo');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unknown issue subcommand');
+    expect(result.error).toContain('forge issues <subcommand>');
+  });
+
+  test('dispatches create, list, show, and close through the issue service', async () => {
+    const issues = require('../../lib/commands/issues');
+    const calls = [];
+    const runIssueOperation = async (operation, args, projectRoot, deps) => {
+      calls.push({ operation, args, projectRoot, deps });
+      return { success: true, operation };
+    };
+
+    await expect(issues.handler(['create', '--title', 'New'], {}, '/repo', { runIssueOperation }))
+      .resolves.toEqual({ success: true, operation: 'create' });
+    await expect(issues.handler(['list', '--json'], {}, '/repo', { runIssueOperation }))
+      .resolves.toEqual({ success: true, operation: 'list' });
+    await expect(issues.handler(['show', 'forge-1'], {}, '/repo', { runIssueOperation }))
+      .resolves.toEqual({ success: true, operation: 'show' });
+    await expect(issues.handler(['close', 'forge-1'], {}, '/repo', { runIssueOperation }))
+      .resolves.toEqual({ success: true, operation: 'close' });
+
+    expect(calls).toHaveLength(4);
+    expect(calls[0]).toEqual({
+      operation: 'create',
+      args: ['--title', 'New'],
+      projectRoot: '/repo',
+      deps: { runIssueOperation },
+    });
+    expect(calls[3]).toEqual({
+      operation: 'close',
+      args: ['forge-1'],
+      projectRoot: '/repo',
+      deps: { runIssueOperation },
+    });
+  });
+});

--- a/test/commands/issues.test.js
+++ b/test/commands/issues.test.js
@@ -35,7 +35,7 @@ describe('forge issues command', () => {
     expect(result.error).toContain('forge issues <subcommand>');
   });
 
-  test('dispatches create, list, show, and close through the issue service', async () => {
+  test('dispatches create, list, show, close, and update through the issue service', async () => {
     const issues = require('../../lib/commands/issues');
     const calls = [];
     const runIssueOperation = async (operation, args, projectRoot, deps) => {
@@ -51,8 +51,10 @@ describe('forge issues command', () => {
       .resolves.toEqual({ success: true, operation: 'show' });
     await expect(issues.handler(['close', 'forge-1'], {}, '/repo', { runIssueOperation }))
       .resolves.toEqual({ success: true, operation: 'close' });
+    await expect(issues.handler(['update', 'forge-1', '--title', 'Renamed'], {}, '/repo', { runIssueOperation }))
+      .resolves.toEqual({ success: true, operation: 'update' });
 
-    expect(calls).toHaveLength(4);
+    expect(calls).toHaveLength(5);
     expect(calls[0]).toEqual({
       operation: 'create',
       args: ['--title', 'New'],
@@ -62,6 +64,12 @@ describe('forge issues command', () => {
     expect(calls[3]).toEqual({
       operation: 'close',
       args: ['forge-1'],
+      projectRoot: '/repo',
+      deps: { runIssueOperation },
+    });
+    expect(calls[4]).toEqual({
+      operation: 'update',
+      args: ['forge-1', '--title', 'Renamed'],
       projectRoot: '/repo',
       deps: { runIssueOperation },
     });

--- a/test/forge-cli-registry.test.js
+++ b/test/forge-cli-registry.test.js
@@ -11,6 +11,7 @@ const { describe, test, expect } = require('bun:test');
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 const { loadCommands } = require('../lib/commands/_registry');
 
 const forgePath = path.join(__dirname, '..', 'bin', 'forge.js');
@@ -51,7 +52,7 @@ describe('CLI Registry Integration', () => {
       expect(commands.has('dev')).toBe(true);
       expect(commands.has('validate')).toBe(true);
       expect(commands.has('ship')).toBe(true);
-    }, 15000);
+    });
 
     test('legacy and plural issue commands coexist in the registry', () => {
       const { commands } = loadCommands(path.join(__dirname, '..', 'lib', 'commands'));
@@ -91,6 +92,34 @@ describe('CLI Registry Integration', () => {
       expect(status).toBe(0);
       expect(stdout).toContain('Current Stage: validate - Validation');
       expect(stdout).toContain('Source: authoritative workflow state');
+    });
+
+    test('forge issues create --help reaches the issues handler instead of global help parsing', () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-bd-help-'));
+      const fakeBd = path.join(tempDir, process.platform === 'win32' ? 'bd.cmd' : 'bd');
+
+      fs.writeFileSync(
+        fakeBd,
+        process.platform === 'win32'
+          ? '@echo off\r\necho BD CREATE HELP\r\n'
+          : '#!/bin/sh\necho BD CREATE HELP\n',
+        'utf8'
+      );
+
+      if (process.platform !== 'win32') {
+        fs.chmodSync(fakeBd, 0o755);
+      }
+
+      const { stdout, stderr, status } = runForge(
+        ['issues', 'create', '--help'],
+        { PATH: `${tempDir}${path.delimiter}${process.env.PATH}` }
+      );
+
+      const combined = stdout + stderr;
+      expect(status).toBe(0);
+      expect(combined).toContain('BD CREATE HELP');
+      expect(combined).not.toContain('Usage:');
+      expect(combined).not.toContain('npx forge setup');
     });
   });
 

--- a/test/forge-cli-registry.test.js
+++ b/test/forge-cli-registry.test.js
@@ -51,6 +51,13 @@ describe('CLI Registry Integration', () => {
       expect(commands.has('dev')).toBe(true);
       expect(commands.has('validate')).toBe(true);
       expect(commands.has('ship')).toBe(true);
+    }, 15000);
+
+    test('legacy and plural issue commands coexist in the registry', () => {
+      const { commands } = loadCommands(path.join(__dirname, '..', 'lib', 'commands'));
+
+      expect(commands.has('issue')).toBe(true);
+      expect(commands.has('issues')).toBe(true);
     });
 
     test('forge sync dispatches to registry (not unknown command)', () => {

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+describe('forge issue service contract', () => {
+  test('exports service factory and operation runner', () => {
+    const forgeIssues = require('../lib/forge-issues');
+
+    expect(typeof forgeIssues.createIssueService).toBe('function');
+    expect(typeof forgeIssues.createBeadsIssueBackend).toBe('function');
+    expect(typeof forgeIssues.runIssueOperation).toBe('function');
+  });
+
+  test('routes supported operations through the configured backend', async () => {
+    const { createIssueService } = require('../lib/forge-issues');
+    const calls = [];
+    const backend = {
+      async create(args, context) {
+        calls.push({ operation: 'create', args, context });
+        return { success: true, operation: 'create' };
+      },
+      async list(args, context) {
+        calls.push({ operation: 'list', args, context });
+        return { success: true, operation: 'list' };
+      },
+      async show(args, context) {
+        calls.push({ operation: 'show', args, context });
+        return { success: true, operation: 'show' };
+      },
+      async close(args, context) {
+        calls.push({ operation: 'close', args, context });
+        return { success: true, operation: 'close' };
+      },
+      async update(args, context) {
+        calls.push({ operation: 'update', args, context });
+        return { success: true, operation: 'update' };
+      },
+    };
+
+    const service = createIssueService({ backend });
+    const context = { projectRoot: '/repo', deps: { source: 'test' } };
+
+    await expect(service.run('create', ['--title', 'Test'], context))
+      .resolves.toEqual({ success: true, operation: 'create' });
+    await expect(service.run('list', ['--json'], context))
+      .resolves.toEqual({ success: true, operation: 'list' });
+    await expect(service.run('show', ['forge-123'], context))
+      .resolves.toEqual({ success: true, operation: 'show' });
+    await expect(service.run('close', ['forge-123'], context))
+      .resolves.toEqual({ success: true, operation: 'close' });
+    await expect(service.run('update', ['forge-123', '--title', 'Renamed'], context))
+      .resolves.toEqual({ success: true, operation: 'update' });
+
+    expect(calls).toHaveLength(5);
+    expect(calls[0]).toEqual({
+      operation: 'create',
+      args: ['--title', 'Test'],
+      context,
+    });
+    expect(calls[4]).toEqual({
+      operation: 'update',
+      args: ['forge-123', '--title', 'Renamed'],
+      context,
+    });
+  });
+
+  test('rejects unsupported operations with a forge-level error', async () => {
+    const { createIssueService } = require('../lib/forge-issues');
+
+    const service = createIssueService({
+      backend: {
+        async list() {
+          return { success: true };
+        },
+      },
+    });
+
+    await expect(service.run('ready', [], { projectRoot: '/repo' })).resolves.toEqual({
+      success: false,
+      error: 'Unsupported issue operation: ready',
+    });
+  });
+
+  test('uses dependency injection in the top-level operation runner', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+    const calls = [];
+
+    const result = await runIssueOperation('show', ['forge-456'], '/repo', {
+      createService: () => ({
+        async run(operation, args, context) {
+          calls.push({ operation, args, context });
+          return { success: true, output: 'ok' };
+        },
+      }),
+      marker: 'injected',
+    });
+
+    expect(result).toEqual({ success: true, output: 'ok' });
+    expect(calls).toEqual([{
+      operation: 'show',
+      args: ['forge-456'],
+      context: {
+        projectRoot: '/repo',
+        deps: { createService: expect.any(Function), marker: 'injected' },
+      },
+    }]);
+  });
+});

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -105,4 +105,87 @@ describe('forge issue service contract', () => {
       },
     }]);
   });
+
+  test('default beads backend rejects issue operations when beads is not initialized', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => false,
+    });
+
+    await expect(backend.list([], { projectRoot: '/repo' })).resolves.toEqual({
+      success: false,
+      error: 'Beads is not initialized in this project. Run forge setup before using forge issues.',
+    });
+  });
+
+  test('default beads backend executes bd with mapped arguments', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+    const calls = [];
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      execFileSync: (command, args, options) => {
+        calls.push({ command, args, options });
+        return '';
+      },
+    });
+
+    await expect(backend.create(['--title', 'New issue'], { projectRoot: '/repo' }))
+      .resolves.toEqual({ success: true, operation: 'create' });
+    await expect(backend.list(['--json'], { projectRoot: '/repo' }))
+      .resolves.toEqual({ success: true, operation: 'list' });
+    await expect(backend.show(['forge-1'], { projectRoot: '/repo' }))
+      .resolves.toEqual({ success: true, operation: 'show' });
+    await expect(backend.close(['forge-1'], { projectRoot: '/repo' }))
+      .resolves.toEqual({ success: true, operation: 'close' });
+    await expect(backend.update(['forge-1', '--title', 'Renamed'], { projectRoot: '/repo' }))
+      .resolves.toEqual({ success: true, operation: 'update' });
+
+    expect(calls).toEqual([
+      {
+        command: 'bd',
+        args: ['create', '--title', 'New issue'],
+        options: { cwd: '/repo', stdio: 'inherit' },
+      },
+      {
+        command: 'bd',
+        args: ['list', '--json'],
+        options: { cwd: '/repo', stdio: 'inherit' },
+      },
+      {
+        command: 'bd',
+        args: ['show', 'forge-1'],
+        options: { cwd: '/repo', stdio: 'inherit' },
+      },
+      {
+        command: 'bd',
+        args: ['close', 'forge-1'],
+        options: { cwd: '/repo', stdio: 'inherit' },
+      },
+      {
+        command: 'bd',
+        args: ['update', 'forge-1', '--title', 'Renamed'],
+        options: { cwd: '/repo', stdio: 'inherit' },
+      },
+    ]);
+  });
+
+  test('default beads backend translates missing bd binary into a forge-level error', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      execFileSync: () => {
+        const error = new Error('spawn bd ENOENT');
+        error.code = 'ENOENT';
+        throw error;
+      },
+    });
+
+    await expect(backend.show(['forge-1'], { projectRoot: '/repo' })).resolves.toEqual({
+      success: false,
+      error: 'Beads (bd) command not found. Install or initialize Beads before using forge issues.',
+    });
+  });
 });

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -81,6 +81,30 @@ describe('forge issue service contract', () => {
     });
   });
 
+  test('preserves backend method binding during operation dispatch', async () => {
+    const { createIssueService } = require('../lib/forge-issues');
+
+    class TestBackend {
+      constructor() {
+        this.prefix = 'backend-bound';
+      }
+
+      async show(args) {
+        return {
+          success: true,
+          output: `${this.prefix}:${args[0]}`,
+        };
+      }
+    }
+
+    const service = createIssueService({ backend: new TestBackend() });
+
+    await expect(service.run('show', ['forge-123'], { projectRoot: '/repo' })).resolves.toEqual({
+      success: true,
+      output: 'backend-bound:forge-123',
+    });
+  });
+
   test('uses dependency injection in the top-level operation runner', async () => {
     const { runIssueOperation } = require('../lib/forge-issues');
     const calls = [];
@@ -132,15 +156,15 @@ describe('forge issue service contract', () => {
     });
 
     await expect(backend.create(['--title', 'New issue'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'create', output: 'mocked create output' });
+      .resolves.toEqual({ success: true, operation: 'create', output: 'mocked create output', stderr: '' });
     await expect(backend.list(['--json'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'list', output: 'mocked list output' });
+      .resolves.toEqual({ success: true, operation: 'list', output: 'mocked list output', stderr: '' });
     await expect(backend.show(['forge-1'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'show', output: 'mocked show output' });
+      .resolves.toEqual({ success: true, operation: 'show', output: 'mocked show output', stderr: '' });
     await expect(backend.close(['forge-1'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'close', output: 'mocked close output' });
+      .resolves.toEqual({ success: true, operation: 'close', output: 'mocked close output', stderr: '' });
     await expect(backend.update(['forge-1', '--title', 'Renamed'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'update', output: 'mocked update output' });
+      .resolves.toEqual({ success: true, operation: 'update', output: 'mocked update output', stderr: '' });
 
     expect(calls).toEqual([
       {
@@ -222,11 +246,68 @@ describe('forge issue service contract', () => {
       success: true,
       operation: 'create',
       output: 'bd create help output',
+      stderr: '',
     });
 
     expect(calls).toEqual([{
       args: ['create', '--help'],
       projectRoot: '/repo',
     }]);
+  });
+
+  test('default beads backend streams successful stderr passthrough output', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+    const writes = [];
+    let childRef;
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      spawn: (_command, _args, _options) => {
+        const events = {};
+        const stdoutHandlers = {};
+        const stderrHandlers = {};
+        childRef = {
+          stdout: {
+            setEncoding() {},
+            on(event, handler) {
+              stdoutHandlers[event] = handler;
+            },
+          },
+          stderr: {
+            setEncoding() {},
+            on(event, handler) {
+              stderrHandlers[event] = handler;
+            },
+          },
+          on(event, handler) {
+            events[event] = handler;
+          },
+          emitSuccess() {
+            stdoutHandlers.data?.('visible stdout\n');
+            stderrHandlers.data?.('visible stderr\n');
+            events.close?.(0);
+          },
+        };
+
+        return childRef;
+      },
+      stdout: { write: chunk => writes.push({ stream: 'stdout', chunk }) },
+      stderr: { write: chunk => writes.push({ stream: 'stderr', chunk }) },
+    });
+
+    const promise = backend.list([], { projectRoot: '/repo' });
+    childRef.emitSuccess();
+
+    await expect(promise).resolves.toEqual({
+      success: true,
+      operation: 'list',
+      output: '',
+      stderr: '',
+    });
+
+    expect(writes).toEqual([
+      { stream: 'stdout', chunk: 'visible stdout\n' },
+      { stream: 'stderr', chunk: 'visible stderr\n' },
+    ]);
   });
 });

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -226,6 +226,24 @@ describe('forge issue service contract', () => {
     });
   });
 
+  test('default beads backend treats empty show payloads as not-found failures', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      runBdCommand: async () => ({
+        code: 0,
+        stdout: '[]',
+        stderr: '',
+      }),
+    });
+
+    await expect(backend.show(['forge-missing', '--json'], { projectRoot: '/repo' })).resolves.toEqual({
+      success: false,
+      error: 'Issue not found: forge-missing',
+    });
+  });
+
   test('default beads backend bypasses init checks for bd help passthrough', async () => {
     const { createBeadsIssueBackend } = require('../lib/forge-issues');
     const calls = [];
@@ -309,5 +327,57 @@ describe('forge issue service contract', () => {
       { stream: 'stdout', chunk: 'visible stdout\n' },
       { stream: 'stderr', chunk: 'visible stderr\n' },
     ]);
+  });
+
+  test('default beads backend does not emit captured stdout before returning it', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+    const writes = [];
+    let childRef;
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      spawn: (_command, _args, _options) => {
+        const events = {};
+        const stdoutHandlers = {};
+        const stderrHandlers = {};
+        childRef = {
+          stdout: {
+            setEncoding() {},
+            on(event, handler) {
+              stdoutHandlers[event] = handler;
+            },
+          },
+          stderr: {
+            setEncoding() {},
+            on(event, handler) {
+              stderrHandlers[event] = handler;
+            },
+          },
+          on(event, handler) {
+            events[event] = handler;
+          },
+          emitSuccess() {
+            stdoutHandlers.data?.('captured stdout\n');
+            events.close?.(0);
+          },
+        };
+
+        return childRef;
+      },
+      stdout: { write: chunk => writes.push({ stream: 'stdout', chunk }) },
+      stderr: { write: chunk => writes.push({ stream: 'stderr', chunk }) },
+    });
+
+    const promise = backend.create(['--help'], { projectRoot: '/repo' });
+    childRef.emitSuccess();
+
+    await expect(promise).resolves.toEqual({
+      success: true,
+      operation: 'create',
+      output: 'captured stdout\n',
+      stderr: '',
+    });
+
+    expect(writes).toEqual([]);
   });
 });

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -125,9 +125,9 @@ describe('forge issue service contract', () => {
 
     const backend = createBeadsIssueBackend({
       isBeadsInitialized: () => true,
-      execFileSync: (command, args, options) => {
-        calls.push({ command, args, options });
-        return `mocked ${args[0]} output`;
+      runBdCommand: async (args, projectRoot) => {
+        calls.push({ args, projectRoot });
+        return { code: 0, stdout: `mocked ${args[0]} output`, stderr: '' };
       },
     });
 
@@ -144,29 +144,24 @@ describe('forge issue service contract', () => {
 
     expect(calls).toEqual([
       {
-        command: 'bd',
         args: ['create', '--title', 'New issue'],
-        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
+        projectRoot: '/repo',
       },
       {
-        command: 'bd',
         args: ['list', '--json'],
-        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
+        projectRoot: '/repo',
       },
       {
-        command: 'bd',
         args: ['show', 'forge-1'],
-        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
+        projectRoot: '/repo',
       },
       {
-        command: 'bd',
         args: ['close', 'forge-1'],
-        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
+        projectRoot: '/repo',
       },
       {
-        command: 'bd',
         args: ['update', 'forge-1', '--title', 'Renamed'],
-        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
+        projectRoot: '/repo',
       },
     ]);
   });
@@ -176,7 +171,7 @@ describe('forge issue service contract', () => {
 
     const backend = createBeadsIssueBackend({
       isBeadsInitialized: () => true,
-      execFileSync: () => {
+      runBdCommand: async () => {
         const error = new Error('spawn bd ENOENT');
         error.code = 'ENOENT';
         throw error;
@@ -194,12 +189,44 @@ describe('forge issue service contract', () => {
 
     const backend = createBeadsIssueBackend({
       isBeadsInitialized: () => true,
-      execFileSync: () => 'Error resolving/updating forge-missing: issue not found',
+      runBdCommand: async () => ({
+        code: 0,
+        stdout: 'Error resolving/updating forge-missing: issue not found',
+        stderr: '',
+      }),
     });
 
     await expect(backend.update(['forge-missing', '--title', 'Renamed'], { projectRoot: '/repo' })).resolves.toEqual({
       success: false,
       error: 'Error resolving/updating forge-missing: issue not found',
     });
+  });
+
+  test('default beads backend bypasses init checks for bd help passthrough', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+    const calls = [];
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => false,
+      runBdCommand: async (args, projectRoot) => {
+        calls.push({ args, projectRoot });
+        return {
+          code: 0,
+          stdout: 'bd create help output',
+          stderr: '',
+        };
+      },
+    });
+
+    await expect(backend.create(['--help'], { projectRoot: '/repo' })).resolves.toEqual({
+      success: true,
+      operation: 'create',
+      output: 'bd create help output',
+    });
+
+    expect(calls).toEqual([{
+      args: ['create', '--help'],
+      projectRoot: '/repo',
+    }]);
   });
 });

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -188,4 +188,18 @@ describe('forge issue service contract', () => {
       error: 'Beads (bd) command not found. Install or initialize Beads before using forge issues.',
     });
   });
+
+  test('default beads backend treats zero-exit bd soft failures as forge-level errors', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      execFileSync: () => 'Error resolving/updating forge-missing: issue not found',
+    });
+
+    await expect(backend.update(['forge-missing', '--title', 'Renamed'], { projectRoot: '/repo' })).resolves.toEqual({
+      success: false,
+      error: 'Error resolving/updating forge-missing: issue not found',
+    });
+  });
 });

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -244,6 +244,58 @@ describe('forge issue service contract', () => {
     });
   });
 
+  test('default beads backend captures successful show output for downstream consumers', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+    const writes = [];
+    let childRef;
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      spawn: (_command, _args, _options) => {
+        const events = {};
+        const stdoutHandlers = {};
+        const stderrHandlers = {};
+        childRef = {
+          stdout: {
+            setEncoding() {},
+            on(event, handler) {
+              stdoutHandlers[event] = handler;
+            },
+          },
+          stderr: {
+            setEncoding() {},
+            on(event, handler) {
+              stderrHandlers[event] = handler;
+            },
+          },
+          on(event, handler) {
+            events[event] = handler;
+          },
+          emitSuccess() {
+            stdoutHandlers.data?.('{"id":"forge-1"}');
+            events.close?.(0);
+          },
+        };
+
+        return childRef;
+      },
+      stdout: { write: chunk => writes.push({ stream: 'stdout', chunk }) },
+      stderr: { write: chunk => writes.push({ stream: 'stderr', chunk }) },
+    });
+
+    const promise = backend.show(['forge-1', '--json'], { projectRoot: '/repo' });
+    childRef.emitSuccess();
+
+    await expect(promise).resolves.toEqual({
+      success: true,
+      operation: 'show',
+      output: '{"id":"forge-1"}',
+      stderr: '',
+    });
+
+    expect(writes).toEqual([]);
+  });
+
   test('default beads backend bypasses init checks for bd help passthrough', async () => {
     const { createBeadsIssueBackend } = require('../lib/forge-issues');
     const calls = [];

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -127,46 +127,46 @@ describe('forge issue service contract', () => {
       isBeadsInitialized: () => true,
       execFileSync: (command, args, options) => {
         calls.push({ command, args, options });
-        return '';
+        return `mocked ${args[0]} output`;
       },
     });
 
     await expect(backend.create(['--title', 'New issue'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'create' });
+      .resolves.toEqual({ success: true, operation: 'create', output: 'mocked create output' });
     await expect(backend.list(['--json'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'list' });
+      .resolves.toEqual({ success: true, operation: 'list', output: 'mocked list output' });
     await expect(backend.show(['forge-1'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'show' });
+      .resolves.toEqual({ success: true, operation: 'show', output: 'mocked show output' });
     await expect(backend.close(['forge-1'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'close' });
+      .resolves.toEqual({ success: true, operation: 'close', output: 'mocked close output' });
     await expect(backend.update(['forge-1', '--title', 'Renamed'], { projectRoot: '/repo' }))
-      .resolves.toEqual({ success: true, operation: 'update' });
+      .resolves.toEqual({ success: true, operation: 'update', output: 'mocked update output' });
 
     expect(calls).toEqual([
       {
         command: 'bd',
         args: ['create', '--title', 'New issue'],
-        options: { cwd: '/repo', stdio: 'inherit' },
+        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
       },
       {
         command: 'bd',
         args: ['list', '--json'],
-        options: { cwd: '/repo', stdio: 'inherit' },
+        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
       },
       {
         command: 'bd',
         args: ['show', 'forge-1'],
-        options: { cwd: '/repo', stdio: 'inherit' },
+        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
       },
       {
         command: 'bd',
         args: ['close', 'forge-1'],
-        options: { cwd: '/repo', stdio: 'inherit' },
+        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
       },
       {
         command: 'bd',
         args: ['update', 'forge-1', '--title', 'Renamed'],
-        options: { cwd: '/repo', stdio: 'inherit' },
+        options: { cwd: '/repo', stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf8' },
       },
     ]);
   });


### PR DESCRIPTION
## Problem
Forge already had a legacy direct-`bd` issue command surface, but v2 Wave 1 needs Forge to become the authority layer for issue operations instead of exposing raw Beads behavior at the CLI edge.

## Root Cause
Issue operations were wired directly in the command layer through `lib/commands/_issue.js`, which meant the CLI itself owned Beads argument mapping and had no explicit backend seam for future GitHub Issues, Linear, or Jira adapters.

## Fix
This PR adds a new plural `forge issues` command backed by a Forge-owned issue service. The service owns operation dispatch and the default Beads backend, while the command stays a thin wrapper. The legacy singular `issue` and top-level alias commands remain unchanged in this wave so the new authority-layer seam can land without destabilizing the existing surface.

## Value
This establishes the v2 foundation for pluggable issue backends while keeping the current Beads-backed workflow working. It gives Forge a stable command boundary for future sync and authority work and keeps the migration path low-risk by introducing the new surface alongside the old one.

## Beads
Closes forge-f3lx

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 2886 passing
- Scenarios covered: service-level routing and error translation in `test/forge-issues.test.js`, plural command help/dispatch in `test/commands/issues.test.js`, registry coexistence in `test/forge-cli-registry.test.js`, plus the full repo suite via `bun run test`

### Security Review
- OWASP Top 10: low-risk CLI/service change; no auth or data-model changes, no secret handling added, and Beads execution remains argument-array based rather than shell-string interpolation
- Automated scan: `bun audit` passed with no vulnerabilities found

### Design Doc
See: `docs/plans/2026-04-13-forge-f3lx-issues-design.md`

### Key Decisions
- Added a new plural `issues` command instead of rewriting the legacy singular `issue` surface in place.
- Moved Beads command mapping into a Forge-owned service layer so the command module no longer builds `bd` argv directly.
- Kept Beads as the default backend for this wave, but defined the seam needed for future backend replacement.
- Preserved the existing `issue/create/show/list/close` commands to avoid destabilizing current workflows while v2 lands incrementally.

### Documentation Updated
- `docs/plans/2026-04-13-forge-f3lx-issues-design.md`
- `docs/plans/2026-04-13-forge-f3lx-issues-tasks.md`
- `docs/plans/2026-04-13-forge-f3lx-issues-decisions.md`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [ ] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — only P2 style findings remain.
- All P0/P1 issues from the previous review round are addressed. The two remaining findings are minor: an over-broad case-insensitive soft-failure regex in `hasBdSoftFailure` and a stale inline comment in `bin/forge.js`. Neither affects correctness or security for the current Beads-backed use case.
- No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/commands/issues.test.js`, line 448-478 ([link](https://github.com/harshanandak/forge/blob/588c589773794f911353ac75f1543aa7cb2f7b1e/test/commands/issues.test.js#L448-L478)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`update` subcommand not exercised in the dispatch test**

   The dispatch test covers `create`, `list`, `show`, and `close`, but `update` is listed in both `SUPPORTED_SUBCOMMANDS` and the help text and is a first-class operation in the service contract. Adding it to the assertions here ensures the command-layer dispatch path is verified for all advertised subcommands.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/commands/issues.test.js
   Line: 448-478

   Comment:
   **`update` subcommand not exercised in the dispatch test**

   The dispatch test covers `create`, `list`, `show`, and `close`, but `update` is listed in both `SUPPORTED_SUBCOMMANDS` and the help text and is a first-class operation in the service contract. Adding it to the assertions here ensures the command-layer dispatch path is verified for all advertised subcommands.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/forge-issues.js
Line: 33-35

Comment:
**`hasBdSoftFailure` regex may produce false positives**

The `i` (case-insensitive) flag combined with the bare `Error\b` alternative means any `bd` output line that begins with the word "error" — including issue titles like "Error handling in auth" rendered at the start of a line in text-format list output — would be treated as a soft failure even on exit code 0. Tightening the match to specific known error prefixes or removing the case-insensitive flag would reduce the risk.

```suggestion
function hasBdSoftFailure(output) {
  return /(^|\n)Error(?: resolving| updating| fetching| adding)\b/.test(output);
}
```

Removing the `i` flag and making the qualifying-word group non-optional scopes the heuristic to the known `bd` error patterns while avoiding spurious failures on user-supplied content.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: bin/forge.js
Line: 2554-2557

Comment:
**Stale comment — `forge issues` is not a direct `bd` passthrough**

The first comment line reads "Issue passthrough commands delegate all flags to bd," which is accurate for `create`, `update`, `claim`, etc., but misleading for the newly added `'issues'` (plural). That command routes through the Forge service layer, not directly to `bd`. A reader maintaining this list in the future might be confused about why the Forge-owned service command appears here.

```suggestion
  // Skip global flag parsing so flags like --type, -p, --help reach the handler intact.
  // Includes legacy bd-passthrough commands and the new `issues` service command, both of
  // which need their subcommand flags forwarded without global interception.
  const issuePassthroughCommands = ['create', 'update', 'claim', 'close', 'show', 'list', 'ready', 'issue', 'issues'];
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix: capture forge issues show output"](https://github.com/harshanandak/forge/commit/bf0c72069c18c2b758aa0f354385a70ccc40abbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28187758)</sub>

<!-- /greptile_comment -->