### PR TITLE
fix: harden worktree beads bootstrap and recovery

### DIFF
--- a/docs/plans/2026-04-13-wave1-worktree-beads-fixes-decisions.md
+++ b/docs/plans/2026-04-13-wave1-worktree-beads-fixes-decisions.md
@@ -1,0 +1,3 @@
+# Decisions Log
+
+Reserved for `/dev` decision-gate entries for `wave1-worktree-beads-fixes`.

--- a/docs/plans/2026-04-13-wave1-worktree-beads-fixes-design.md
+++ b/docs/plans/2026-04-13-wave1-worktree-beads-fixes-design.md
@@ -1,0 +1,132 @@
+## Feature
+
+- **Slug:** `wave1-worktree-beads-fixes`
+- **Date:** `2026-04-13`
+- **Status:** `implementation complete - ready for validation`
+
+## Purpose
+
+Wave 1 needs to remove three blockers to safe parallel development in worktrees:
+
+1. External worktrees can miss usable Beads state because only `forge worktree create` wires `.beads`.
+2. Worktrees can miss `lefthook`, which removes pre-push quality gates for raw `git push`.
+3. Beads auto-recovery still infers recovery state from the directory basename instead of the configured metadata.
+
+The goal is to harden the existing internal bootstrap and recovery logic without creating a new Beads wrapper layer and without touching the Forge CLI registry surface.
+
+## Verified Current State
+
+- `lib/commands/worktree.js:118-149` still owns a local `setupBeads()` helper that links or copies `.beads`, but it only runs during `forge worktree create`.
+- `lib/commands/worktree.js:158-162` already runs package-manager install inside the created worktree, so the missing-`lefthook` gap is not just the happy-path create flow.
+- `lib/commands/setup.js:2843-2908` calls `safeBeadsInit()` and restores `lefthook`, but the path is setup-oriented and not a general worktree bootstrap path.
+- `lib/beads-setup.js:272-340` preserves hooks and writes config for `bd init`, but it does not currently provide metadata-driven recovery helpers.
+- `lib/beads-health-check.js:63-140` is only a smoke test today; it does not attempt Beads recovery.
+- `scripts/smart-status.sh:129-156` auto-recovers from `database not found`, but it derives the recovery prefix from the repo basename.
+- The actual repo metadata file at `.beads/metadata.json` contains:
+  - `database: "dolt"`
+  - `backend: "dolt"`
+  - `dolt_mode: "server"`
+  - `dolt_database: "forge"`
+
+## Success Criteria
+
+1. A worktree created outside Forge can be repaired by Forge-owned bootstrap/recovery logic without manual `.beads` surgery.
+2. Worktree bootstrap prefers shared live Beads state, falls back to backup restore when necessary, and only fresh-inits as a last resort with an explicit warning.
+3. Recovery logic reads the configured database identity from `.beads/metadata.json` and stops depending on the worktree directory basename.
+4. Forge-owned repair/setup paths detect a declared-but-missing `lefthook` binary in worktrees and restore quality gates or emit a hard, actionable warning.
+5. The change set stays internal:
+  - no new Beads wrapper/API surface
+  - no edits to `bin/forge.js`
+  - no edits to `lib/commands/_registry.js`
+6. The three fixes land as separate commits on one feature branch.
+
+## Out Of Scope
+
+- Building or reshaping the parallel Beads wrapper layer tracked in `forge-f3lx`
+- Changing upstream `bd` command behavior directly
+- Introducing new top-level Forge commands
+- Shared Dolt launcher work from the larger WS3 track
+- Broad setup refactors unrelated to worktree/bootstrap/recovery behavior
+
+## Approach Selected
+
+Use one new internal helper module and three sequential fix tasks.
+
+### 1. External worktree bootstrap
+
+Add `lib/beads-bootstrap.js` as an internal helper, not a wrapper abstraction. It should centralize Forge-owned recovery decisions for missing or broken `.beads` state in a worktree:
+
+1. Detect whether the current directory is a worktree lacking usable Beads state.
+2. Prefer redirect/symlink/junction to the main repo `.beads`.
+3. Fall back to restoring from backup if the shared link path is not viable.
+4. Fresh-init only as a last resort, and return a warning instead of silently masking the failure mode.
+
+The first consumers should be the existing worktree/bootstrap code and the existing health/recovery flow, not any new public command surface.
+
+### 2. Worktree-local `lefthook` recovery
+
+Treat missing `lefthook` in a worktree as a safety failure, not cosmetic drift. The setup/health path should:
+
+- detect when the project declares `lefthook` but the worktree-local binary is missing
+- repair the binary using the worktree-local package-manager context when possible
+- preserve existing hook snapshot/restore semantics
+- emit a clear warning when repair cannot be completed automatically
+
+This keeps raw `git push` in worktrees behind the same quality-gate assumptions as the main checkout.
+
+### 3. Metadata-driven auto-recovery
+
+Replace basename-driven inference with metadata-driven recovery. The verified metadata source in this repo is `.beads/metadata.json`, and the recovery logic should prefer `dolt_database` when present. If metadata is missing or malformed, fallback order should be explicit and conservative rather than implicit basename guessing.
+
+For Wave 1, this includes the existing shell recovery path in `scripts/smart-status.sh` because that is a real current caller of the bad inference logic.
+
+## Constraints
+
+- Do not create a new Beads wrapper abstraction layer.
+- Do not modify `bin/forge.js` or `lib/commands/_registry.js`.
+- Keep new code internal and testable with dependency injection where the surrounding modules already use DI.
+- Preserve existing user-facing command names and return-shape expectations.
+- Prefer minimal cross-file overlap with the parallel wrapper track.
+- Separate commits by bug/fix:
+  - `forge-epkw`
+  - `forge-ujq.2`
+  - `forge-9ats`
+
+## Edge Cases
+
+- External worktree has no `.beads` directory at all.
+- Worktree `.beads` exists but points at stale or unreadable state.
+- Windows symlink/junction creation fails with `EPERM`.
+- Main repo `.beads/backup` is missing, empty, or restore fails.
+- `.beads/metadata.json` exists but is malformed JSON.
+- `.beads/metadata.json` exists without `dolt_database`.
+- Worktree has `package.json` with `lefthook` declared but no local binary.
+- Worktree has no detectable package manager, so `lefthook` cannot be auto-restored.
+- Repair succeeds for Beads but should not clobber existing git hooks.
+
+## OWASP Notes
+
+- **A01 Broken Access Control:** not directly in scope; no privilege or auth boundary changes.
+- **A03 Injection:** relevant because recovery code shells out to `bd`, package managers, and shell scripts. Keep commands argumentized and avoid interpolating metadata into unquoted shell fragments.
+- **A05 Security Misconfiguration:** relevant because missing `lefthook` removes enforcement. Treat missing worktree hooks as a configuration failure and surface it explicitly.
+- **A09 Security Logging and Monitoring Failures:** relevant for silent bootstrap fallback. Recovery helpers should return structured warnings so failures are visible in tests and CLI output.
+
+## Baseline Before Implementation
+
+Verified from the isolated worktree `C:\Users\harsha_befach\Downloads\forge\.worktrees\wave1-worktree-beads-fixes`:
+
+- `bun test test/beads-setup.test.js` — passed
+- `bun test test/beads-init-wrapper.test.js` — passed
+- `bun test test/beads-health-check.test.js` — passed
+- `bun test test/scripts/smart-status.test.js` — passed
+
+## Ambiguity Policy
+
+Use the `/dev` decision-gate rule:
+
+- `>= 80%` confidence: proceed conservatively and document the decision
+- `< 80%` confidence: stop and ask before implementing
+
+Current clarifications resolved in-session:
+
+- `forge-9ats` remains in scope for this branch, including `scripts/smart-status.sh`.

--- a/docs/plans/2026-04-13-wave1-worktree-beads-fixes-tasks.md
+++ b/docs/plans/2026-04-13-wave1-worktree-beads-fixes-tasks.md
@@ -1,0 +1,61 @@
+## Plan Summary
+
+- **Feature:** `wave1-worktree-beads-fixes`
+- **Branch:** `feat/wave1-worktree-beads-fixes`
+- **Worktree:** `C:\Users\harsha_befach\Downloads\forge\.worktrees\wave1-worktree-beads-fixes`
+- **Execution model:** one feature branch, three sequential bug-fix commits
+- **YAGNI check:** no tasks were flagged as scope creep; each task maps directly to one requested bug and the verified current code paths.
+
+## Task 1: Bootstrap Beads for external worktrees (`forge-epkw`)
+
+**File(s):** `lib/beads-bootstrap.js`, `lib/commands/worktree.js`, `lib/beads-health-check.js`, `test/commands/worktree.test.js`, `test/beads-health-check.test.js`  
+**OWNS:** `lib/beads-bootstrap.js`, `lib/commands/worktree.js`, `lib/beads-health-check.js`, `test/commands/worktree.test.js`, `test/beads-health-check.test.js`
+
+**What to implement:** Extract the current worktree-local `.beads` linking behavior into a new internal helper that can detect missing or unusable Beads state in external worktrees and attempt three-tier recovery: shared `.beads` link first, backup restore second, fresh init with warning last. Wire the helper into the existing Forge-owned worktree/bootstrap and health-check flow without introducing any new public wrapper/API layer.
+
+**TDD steps:**
+1. **Write test:** add cases in `test/commands/worktree.test.js` and `test/beads-health-check.test.js` for external worktrees with missing `.beads`, `EPERM` symlink failure, backup-restore fallback, and fresh-init warning behavior.
+2. **Run test:** confirm the new cases fail because no shared bootstrap helper exists and the current health check does not recover worktree state.
+3. **Implement:** add `lib/beads-bootstrap.js`, migrate `setupBeads()` usage in `lib/commands/worktree.js`, and extend `lib/beads-health-check.js` to consume the helper for Forge-owned recovery checks.
+4. **Run test:** confirm the targeted worktree/bootstrap tests pass.
+5. **Commit:** `fix: bootstrap beads for external worktrees`
+
+**Expected output:** Forge-owned worktree recovery paths repair a missing external-worktree `.beads` state with explicit tiered warnings instead of failing immediately.
+
+## Task 2: Restore worktree `lefthook` safety (`forge-ujq.2`)
+
+**File(s):** `lib/commands/setup.js`, `test/setup-lefthook-repair.test.js`, `test/runtime-health.test.js`  
+**OWNS:** `lib/commands/setup.js`, `test/setup-lefthook-repair.test.js`, `test/runtime-health.test.js`
+
+**What to implement:** Harden the setup/runtime repair path so a worktree with a declared `lefthook` dependency but missing local binary is treated as a recoverable safety failure. The implementation should repair the binary in the worktree-local environment when possible, preserve hook restoration behavior, and emit a hard actionable warning when auto-repair is not possible.
+
+**TDD steps:**
+1. **Write test:** extend `test/setup-lefthook-repair.test.js` and `test/runtime-health.test.js` for a worktree-local project that has `lefthook` declared but missing in `node_modules/.bin`, including a case where repair is impossible and must warn.
+2. **Run test:** confirm the new cases fail because the current setup/runtime path does not fully enforce worktree-local `lefthook` recovery semantics for this scenario.
+3. **Implement:** update `lib/commands/setup.js` to verify and repair `lefthook` in the worktree-local context while preserving existing hook snapshot/restore behavior.
+4. **Run test:** confirm the targeted `lefthook` repair and runtime-health tests pass.
+5. **Commit:** `fix: restore lefthook safety in worktrees`
+
+**Expected output:** A worktree with missing `lefthook` no longer silently loses pre-push safety; Forge repair paths either restore the binary or emit an explicit warning.
+
+## Task 3: Read Beads recovery identity from metadata (`forge-9ats`)
+
+**File(s):** `lib/beads-setup.js`, `scripts/smart-status.sh`, `test/beads-setup.test.js`, `test/scripts/smart-status.test.js`  
+**OWNS:** `lib/beads-setup.js`, `scripts/smart-status.sh`, `test/beads-setup.test.js`, `test/scripts/smart-status.test.js`
+
+**What to implement:** Add metadata-driven recovery helpers that read `.beads/metadata.json` and prefer `dolt_database` over basename-derived inference. Apply the logic to the existing JS recovery helpers and to `scripts/smart-status.sh` so auto-recovery uses configured metadata first and only falls back through explicit, conservative rules when metadata is missing or malformed.
+
+**TDD steps:**
+1. **Write test:** add JS and shell-level cases proving recovery reads `dolt_database` from `.beads/metadata.json`, ignores mismatched folder basenames, and handles missing/malformed metadata with an explicit fallback path.
+2. **Run test:** confirm the new cases fail because current recovery still depends on basename inference.
+3. **Implement:** add metadata readers in `lib/beads-setup.js` and update `scripts/smart-status.sh` recovery to consume the metadata-derived value.
+4. **Run test:** confirm the targeted metadata/recovery tests pass.
+5. **Commit:** `fix: read beads database from metadata during recovery`
+
+**Expected output:** Recovery behavior matches the configured Beads metadata even when the worktree folder name does not match the real database name.
+
+## Validation Focus For `/dev`
+
+- Run the targeted test files for each task before and after implementation.
+- Re-run the four baseline suites after Task 3.
+- Watch for overlap with the parallel wrapper track and keep changes internal-only.

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -3,6 +3,7 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { safeBeadsInit } = require('./beads-setup');
 
 function hasBackupJsonl(backupDir, fsApi) {
   try {
@@ -59,6 +60,7 @@ function bootstrapBeads(projectRoot, options = {}) {
   const exec = options._exec || execFileSync;
   const fsApi = options._fs || fs;
   const platform = options._platform || process.platform;
+  const runSafeBeadsInit = options._safeBeadsInit || safeBeadsInit;
   const mainProjectRoot = options.mainProjectRoot || resolveMainWorktree(projectRoot, exec);
   const beadsSource = path.resolve(mainProjectRoot, '.beads');
   const beadsDest = path.resolve(projectRoot, '.beads');
@@ -109,13 +111,21 @@ function bootstrapBeads(projectRoot, options = {}) {
     initArgs.push('--database', metadataDatabaseName);
   }
 
-  try {
-    exec('bd', initArgs, { cwd: projectRoot, stdio: 'pipe' });
-  } catch (initErr) {
+  const safeInitResult = runSafeBeadsInit(projectRoot, {
+    prefix: path.basename(mainProjectRoot),
+    execBdInit: (root) => {
+      exec('bd', initArgs, { cwd: root, stdio: 'pipe' });
+    }
+  });
+
+  if (!safeInitResult.success) {
+    const initMessage = safeInitResult.errors?.[0]
+      || safeInitResult.warnings?.[0]
+      || 'unknown safeBeadsInit failure';
     return {
       success: false,
       strategy: 'fresh-init-failed',
-      warning: `Beads bootstrap fresh init failed: ${initErr.message}`
+      warning: `Beads bootstrap fresh init failed: ${initMessage}`
     };
   }
   const backupDir = path.resolve(beadsSource, 'backup');

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -67,7 +67,15 @@ function bootstrapBeads(projectRoot, options = {}) {
     }
   }
 
-  exec('bd', ['init', '--force'], { cwd: projectRoot, stdio: 'pipe' });
+  try {
+    exec('bd', ['init', '--force'], { cwd: projectRoot, stdio: 'pipe' });
+  } catch (initErr) {
+    return {
+      success: false,
+      strategy: 'fresh-init-failed',
+      warning: `Beads bootstrap fresh init failed: ${initErr.message}`
+    };
+  }
   const backupDir = path.resolve(beadsSource, 'backup');
 
   if (hasBackupJsonl(backupDir, fsApi)) {

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -34,6 +34,27 @@ function isRecoverableBeadsError(error) {
   );
 }
 
+function readMetadataDatabaseName(projectRoot, fsApi) {
+  const metadataPath = path.resolve(projectRoot, '.beads', 'metadata.json');
+  if (!fsApi.existsSync(metadataPath)) {
+    return null;
+  }
+
+  try {
+    const metadata = JSON.parse(fsApi.readFileSync(metadataPath, 'utf8'));
+    if (typeof metadata.dolt_database === 'string' && metadata.dolt_database.trim()) {
+      return metadata.dolt_database.trim();
+    }
+    if (typeof metadata.database === 'string' && metadata.database.trim()) {
+      return metadata.database.trim();
+    }
+  } catch (_err) {
+    return null;
+  }
+
+  return null;
+}
+
 function bootstrapBeads(projectRoot, options = {}) {
   const exec = options._exec || execFileSync;
   const fsApi = options._fs || fs;
@@ -81,8 +102,15 @@ function bootstrapBeads(projectRoot, options = {}) {
     }
   }
 
+  const metadataDatabaseName = readMetadataDatabaseName(mainProjectRoot, fsApi)
+    || readMetadataDatabaseName(projectRoot, fsApi);
+  const initArgs = ['init', '--force'];
+  if (metadataDatabaseName) {
+    initArgs.push('--database', metadataDatabaseName);
+  }
+
   try {
-    exec('bd', ['init', '--force'], { cwd: projectRoot, stdio: 'pipe' });
+    exec('bd', initArgs, { cwd: projectRoot, stdio: 'pipe' });
   } catch (initErr) {
     return {
       success: false,

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function hasBackupJsonl(backupDir, fsApi) {
+  try {
+    return fsApi.readdirSync(backupDir).some((entry) => entry.endsWith('.jsonl'));
+  } catch (_err) {
+    return false;
+  }
+}
+
+function resolveMainWorktree(projectRoot, exec) {
+  try {
+    const commonDir = exec('git', ['rev-parse', '--git-common-dir'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+    return path.resolve(projectRoot, commonDir, '..');
+  } catch (_err) {
+    return projectRoot;
+  }
+}
+
+function isRecoverableBeadsError(error) {
+  const message = error?.message ?? String(error ?? '');
+  return (
+    message.includes('database not found') ||
+    message.includes('database forge not found') ||
+    message.includes('failed to open database') ||
+    message.includes('no beads configuration found')
+  );
+}
+
+function bootstrapBeads(projectRoot, options = {}) {
+  const exec = options._exec || execFileSync;
+  const fsApi = options._fs || fs;
+  const platform = options._platform || process.platform;
+  const mainProjectRoot = options.mainProjectRoot || resolveMainWorktree(projectRoot, exec);
+  const beadsSource = path.resolve(mainProjectRoot, '.beads');
+  const beadsDest = path.resolve(projectRoot, '.beads');
+
+  if (beadsSource === beadsDest) {
+    return { success: true, strategy: 'in-place', warning: null };
+  }
+
+  if (fsApi.existsSync(beadsDest) && typeof fsApi.rmSync === 'function') {
+    fsApi.rmSync(beadsDest, { recursive: true, force: true });
+  }
+
+  if (fsApi.existsSync(beadsSource)) {
+    try {
+      if (platform === 'win32') {
+        fsApi.symlinkSync(beadsSource, beadsDest, 'junction');
+      } else {
+        fsApi.symlinkSync(beadsSource, beadsDest);
+      }
+
+      return { success: true, strategy: 'linked', warning: null };
+    } catch (symlinkErr) {
+      if (symlinkErr.code !== 'EPERM') {
+        throw symlinkErr;
+      }
+    }
+  }
+
+  exec('bd', ['init', '--force'], { cwd: projectRoot, stdio: 'pipe' });
+  const backupDir = path.resolve(beadsSource, 'backup');
+
+  if (hasBackupJsonl(backupDir, fsApi)) {
+    try {
+      exec('bd', ['backup', 'restore', backupDir], { cwd: projectRoot, stdio: 'pipe' });
+      return {
+        success: true,
+        strategy: 'backup-restore',
+        warning: 'Beads bootstrap restored from backup'
+      };
+    } catch (restoreErr) {
+      return {
+        success: true,
+        strategy: 'fresh-init',
+        warning: `Beads bootstrap initialized fresh after backup restore failed: ${restoreErr.message}`
+      };
+    }
+  }
+
+  return {
+    success: true,
+    strategy: 'fresh-init',
+    warning: 'Beads bootstrap initialized fresh (no backup found)'
+  };
+}
+
+module.exports = {
+  bootstrapBeads,
+  hasBackupJsonl,
+  isRecoverableBeadsError,
+  resolveMainWorktree,
+};

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -76,6 +76,10 @@ function stageExistingBeadsDest(beadsDest, fsApi) {
   }
 
   const stagedDest = `${beadsDest}.bootstrap-backup`;
+  if (fsApi.existsSync(stagedDest) && typeof fsApi.rmSync === 'function') {
+    fsApi.rmSync(stagedDest, { recursive: true, force: true });
+  }
+
   if (typeof fsApi.renameSync === 'function') {
     fsApi.renameSync(beadsDest, stagedDest);
     return stagedDest;

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -28,8 +28,7 @@ function resolveMainWorktree(projectRoot, exec) {
 function isRecoverableBeadsError(error) {
   const message = error?.message ?? String(error ?? '');
   return (
-    message.includes('database not found') ||
-    message.includes('database forge not found') ||
+    /database(?:\s+[^\s]+)?\s+not found/i.test(message) ||
     message.includes('failed to open database') ||
     message.includes('no beads configuration found')
   );
@@ -47,20 +46,35 @@ function bootstrapBeads(projectRoot, options = {}) {
     return { success: true, strategy: 'in-place', warning: null };
   }
 
-  if (fsApi.existsSync(beadsDest) && typeof fsApi.rmSync === 'function') {
-    fsApi.rmSync(beadsDest, { recursive: true, force: true });
-  }
-
   if (fsApi.existsSync(beadsSource)) {
+    const existingDest = fsApi.existsSync(beadsDest);
+    const stagedDest = `${beadsDest}.bootstrap-backup`;
+    let stagedForRestore = false;
+
     try {
+      if (existingDest && typeof fsApi.renameSync === 'function') {
+        fsApi.renameSync(beadsDest, stagedDest);
+        stagedForRestore = true;
+      } else if (existingDest && typeof fsApi.rmSync === 'function') {
+        fsApi.rmSync(beadsDest, { recursive: true, force: true });
+      }
+
       if (platform === 'win32') {
         fsApi.symlinkSync(beadsSource, beadsDest, 'junction');
       } else {
         fsApi.symlinkSync(beadsSource, beadsDest);
       }
 
+      if (stagedForRestore && fsApi.existsSync(stagedDest) && typeof fsApi.rmSync === 'function') {
+        fsApi.rmSync(stagedDest, { recursive: true, force: true });
+      }
+
       return { success: true, strategy: 'linked', warning: null };
     } catch (symlinkErr) {
+      if (stagedForRestore && !fsApi.existsSync(beadsDest) && typeof fsApi.renameSync === 'function') {
+        fsApi.renameSync(stagedDest, beadsDest);
+      }
+
       if (symlinkErr.code !== 'EPERM') {
         throw symlinkErr;
       }

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -5,11 +5,22 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { safeBeadsInit } = require('./beads-setup');
 
+function isIgnorableFsError(error) {
+  return ['EACCES', 'ENOENT', 'ENOTDIR', 'EPERM'].includes(error?.code);
+}
+
+function isRecoverableCommandError(error) {
+  return error?.code === 'ENOENT' || typeof error?.status === 'number';
+}
+
 function hasBackupJsonl(backupDir, fsApi) {
   try {
     return fsApi.readdirSync(backupDir).some((entry) => entry.endsWith('.jsonl'));
-  } catch (_err) {
-    return false;
+  } catch (err) {
+    if (isIgnorableFsError(err)) {
+      return false;
+    }
+    throw err;
   }
 }
 
@@ -21,8 +32,11 @@ function resolveMainWorktree(projectRoot, exec) {
       stdio: 'pipe'
     }).trim();
     return path.resolve(projectRoot, commonDir, '..');
-  } catch (_err) {
-    return projectRoot;
+  } catch (err) {
+    if (isRecoverableCommandError(err)) {
+      return projectRoot;
+    }
+    throw err;
   }
 }
 
@@ -49,61 +63,76 @@ function readMetadataDatabaseName(projectRoot, fsApi) {
     if (typeof metadata.database === 'string' && metadata.database.trim()) {
       return metadata.database.trim();
     }
-  } catch (_err) {
-    return null;
+  } catch (err) {
+    if (err instanceof SyntaxError || isIgnorableFsError(err)) {
+      return null;
+    }
+    throw err;
   }
 
   return null;
 }
 
-function bootstrapBeads(projectRoot, options = {}) {
-  const exec = options._exec || execFileSync;
-  const fsApi = options._fs || fs;
-  const platform = options._platform || process.platform;
-  const runSafeBeadsInit = options._safeBeadsInit || safeBeadsInit;
-  const mainProjectRoot = options.mainProjectRoot || resolveMainWorktree(projectRoot, exec);
-  const beadsSource = path.resolve(mainProjectRoot, '.beads');
-  const beadsDest = path.resolve(projectRoot, '.beads');
-
-  if (beadsSource === beadsDest) {
-    return { success: true, strategy: 'in-place', warning: null };
+function stageExistingBeadsDest(beadsDest, fsApi) {
+  if (!fsApi.existsSync(beadsDest)) {
+    return null;
   }
 
-  if (fsApi.existsSync(beadsSource)) {
-    const existingDest = fsApi.existsSync(beadsDest);
-    const stagedDest = `${beadsDest}.bootstrap-backup`;
-    let stagedForRestore = false;
+  const stagedDest = `${beadsDest}.bootstrap-backup`;
+  if (typeof fsApi.renameSync === 'function') {
+    fsApi.renameSync(beadsDest, stagedDest);
+    return stagedDest;
+  }
 
-    try {
-      if (existingDest && typeof fsApi.renameSync === 'function') {
-        fsApi.renameSync(beadsDest, stagedDest);
-        stagedForRestore = true;
-      } else if (existingDest && typeof fsApi.rmSync === 'function') {
-        fsApi.rmSync(beadsDest, { recursive: true, force: true });
-      }
+  if (typeof fsApi.rmSync === 'function') {
+    fsApi.rmSync(beadsDest, { recursive: true, force: true });
+  }
 
-      if (platform === 'win32') {
-        fsApi.symlinkSync(beadsSource, beadsDest, 'junction');
-      } else {
-        fsApi.symlinkSync(beadsSource, beadsDest);
-      }
+  return null;
+}
 
-      if (stagedForRestore && fsApi.existsSync(stagedDest) && typeof fsApi.rmSync === 'function') {
-        fsApi.rmSync(stagedDest, { recursive: true, force: true });
-      }
+function restoreStagedBeadsDest(beadsDest, stagedDest, fsApi) {
+  if (!stagedDest || fsApi.existsSync(beadsDest) || typeof fsApi.renameSync !== 'function') {
+    return;
+  }
 
-      return { success: true, strategy: 'linked', warning: null };
-    } catch (symlinkErr) {
-      if (stagedForRestore && !fsApi.existsSync(beadsDest) && typeof fsApi.renameSync === 'function') {
-        fsApi.renameSync(stagedDest, beadsDest);
-      }
+  fsApi.renameSync(stagedDest, beadsDest);
+}
 
-      if (symlinkErr.code !== 'EPERM') {
-        throw symlinkErr;
-      }
+function cleanupStagedBeadsDest(stagedDest, fsApi) {
+  if (!stagedDest || !fsApi.existsSync(stagedDest) || typeof fsApi.rmSync !== 'function') {
+    return;
+  }
+
+  fsApi.rmSync(stagedDest, { recursive: true, force: true });
+}
+
+function tryLinkBeadsSource(beadsSource, beadsDest, platform, fsApi) {
+  if (!fsApi.existsSync(beadsSource)) {
+    return false;
+  }
+
+  const stagedDest = stageExistingBeadsDest(beadsDest, fsApi);
+
+  try {
+    if (platform === 'win32') {
+      fsApi.symlinkSync(beadsSource, beadsDest, 'junction');
+    } else {
+      fsApi.symlinkSync(beadsSource, beadsDest);
     }
-  }
 
+    cleanupStagedBeadsDest(stagedDest, fsApi);
+    return true;
+  } catch (symlinkErr) {
+    restoreStagedBeadsDest(beadsDest, stagedDest, fsApi);
+    if (symlinkErr.code !== 'EPERM') {
+      throw symlinkErr;
+    }
+    return false;
+  }
+}
+
+function buildInitArgs(mainProjectRoot, projectRoot, fsApi) {
   const metadataDatabaseName = readMetadataDatabaseName(mainProjectRoot, fsApi)
     || readMetadataDatabaseName(projectRoot, fsApi);
   const initArgs = ['init', '--force'];
@@ -111,6 +140,10 @@ function bootstrapBeads(projectRoot, options = {}) {
     initArgs.push('--database', metadataDatabaseName);
   }
 
+  return initArgs;
+}
+
+function runFreshInit(projectRoot, mainProjectRoot, beadsSource, initArgs, exec, runSafeBeadsInit, fsApi) {
   const safeInitResult = runSafeBeadsInit(projectRoot, {
     prefix: path.basename(mainProjectRoot),
     execBdInit: (root) => {
@@ -128,8 +161,8 @@ function bootstrapBeads(projectRoot, options = {}) {
       warning: `Beads bootstrap fresh init failed: ${initMessage}`
     };
   }
-  const backupDir = path.resolve(beadsSource, 'backup');
 
+  const backupDir = path.resolve(beadsSource, 'backup');
   if (hasBackupJsonl(backupDir, fsApi)) {
     try {
       exec('bd', ['backup', 'restore', backupDir], { cwd: projectRoot, stdio: 'pipe' });
@@ -152,6 +185,27 @@ function bootstrapBeads(projectRoot, options = {}) {
     strategy: 'fresh-init',
     warning: 'Beads bootstrap initialized fresh (no backup found)'
   };
+}
+
+function bootstrapBeads(projectRoot, options = {}) {
+  const exec = options._exec || execFileSync;
+  const fsApi = options._fs || fs;
+  const platform = options._platform || process.platform;
+  const runSafeBeadsInit = options._safeBeadsInit || safeBeadsInit;
+  const mainProjectRoot = options.mainProjectRoot || resolveMainWorktree(projectRoot, exec);
+  const beadsSource = path.resolve(mainProjectRoot, '.beads');
+  const beadsDest = path.resolve(projectRoot, '.beads');
+
+  if (beadsSource === beadsDest) {
+    return { success: true, strategy: 'in-place', warning: null };
+  }
+
+  if (tryLinkBeadsSource(beadsSource, beadsDest, platform, fsApi)) {
+    return { success: true, strategy: 'linked', warning: null };
+  }
+
+  const initArgs = buildInitArgs(mainProjectRoot, projectRoot, fsApi);
+  return runFreshInit(projectRoot, mainProjectRoot, beadsSource, initArgs, exec, runSafeBeadsInit, fsApi);
 }
 
 module.exports = {

--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -60,9 +60,6 @@ function readMetadataDatabaseName(projectRoot, fsApi) {
     if (typeof metadata.dolt_database === 'string' && metadata.dolt_database.trim()) {
       return metadata.dolt_database.trim();
     }
-    if (typeof metadata.database === 'string' && metadata.database.trim()) {
-      return metadata.database.trim();
-    }
   } catch (err) {
     if (err instanceof SyntaxError || isIgnorableFsError(err)) {
       return null;
@@ -159,6 +156,14 @@ function runFreshInit(projectRoot, mainProjectRoot, beadsSource, initArgs, exec,
       success: false,
       strategy: 'fresh-init-failed',
       warning: `Beads bootstrap fresh init failed: ${initMessage}`
+    };
+  }
+
+  if (safeInitResult.skipped) {
+    return {
+      success: true,
+      strategy: 'existing-state',
+      warning: 'Beads bootstrap reused existing initialized state'
     };
   }
 

--- a/lib/beads-health-check.js
+++ b/lib/beads-health-check.js
@@ -150,7 +150,8 @@ function beadsHealthCheck(projectRoot, options = {}) {
     exec('bd', ['sync'], execOpts);
   } catch (syncErr) {
     // Sync failure is non-fatal (no remote configured is common)
-    warning = `bd sync warning: ${syncErr.message}`;
+    const syncWarning = `bd sync warning: ${syncErr.message}`;
+    warning = warning ? `${warning}; ${syncWarning}` : syncWarning;
   }
 
   // Step d: Remove the test issue from JSONL

--- a/lib/beads-health-check.js
+++ b/lib/beads-health-check.js
@@ -50,6 +50,46 @@ function cleanupTestIssue(jsonlPath, issueId) {
   fs.writeFileSync(jsonlPath, filtered.length > 0 ? filtered.join('\n') + '\n' : '');
 }
 
+function appendWarning(existingWarning, nextWarning) {
+  return existingWarning ? `${existingWarning}; ${nextWarning}` : nextWarning;
+}
+
+function createHealthCheckIssue(exec, execOpts) {
+  return exec('bd', [
+    'create',
+    '--title=Setup verification',
+    '--type=task',
+    '--priority=4'
+  ], execOpts);
+}
+
+function createIssueWithRecovery(projectRoot, exec, execOpts, bootstrap) {
+  try {
+    return { output: createHealthCheckIssue(exec, execOpts), warning: null };
+  } catch (createErr) {
+    if (!isRecoverableBeadsError(createErr)) {
+      throw createErr;
+    }
+
+    const bootstrapResult = bootstrap(projectRoot);
+    if (!bootstrapResult?.success) {
+      const extra = bootstrapResult?.warning ? `; ${bootstrapResult.warning}` : '';
+      return {
+        error: `${createErr.message}${extra}`
+      };
+    }
+
+    const bootstrapWarning = bootstrapResult.warning
+      ? `bootstrap warning: ${bootstrapResult.warning}`
+      : `bootstrap warning: recovered via ${bootstrapResult.strategy}`;
+
+    return {
+      output: createHealthCheckIssue(exec, execOpts),
+      warning: bootstrapWarning
+    };
+  }
+}
+
 /**
  * Run a Beads health check smoke test.
  *
@@ -73,42 +113,18 @@ function beadsHealthCheck(projectRoot, options = {}) {
   /** @type {string|null} */
   let issueId;
   try {
-    let createOutput;
-    try {
-      createOutput = exec('bd', [
-        'create',
-        '--title=Setup verification',
-        '--type=task',
-        '--priority=4'
-      ], execOpts);
-    } catch (createErr) {
-      if (!isRecoverableBeadsError(createErr)) {
-        throw createErr;
-      }
-
-      const bootstrapResult = bootstrap(projectRoot);
-      if (!bootstrapResult?.success) {
-        const extra = bootstrapResult?.warning ? `; ${bootstrapResult.warning}` : '';
-        return {
-          healthy: false,
-          failedStep: 'create',
-          error: `${createErr.message}${extra}`
-        };
-      }
-
-      warning = bootstrapResult.warning
-        ? `bootstrap warning: ${bootstrapResult.warning}`
-        : `bootstrap warning: recovered via ${bootstrapResult.strategy}`;
-
-      createOutput = exec('bd', [
-        'create',
-        '--title=Setup verification',
-        '--type=task',
-        '--priority=4'
-      ], execOpts);
+    const createResult = createIssueWithRecovery(projectRoot, exec, execOpts, bootstrap);
+    if (createResult.error) {
+      return {
+        healthy: false,
+        failedStep: 'create',
+        error: createResult.error
+      };
     }
 
-    issueId = parseIssueId(createOutput);
+    warning = createResult.warning || warning;
+
+    issueId = parseIssueId(createResult.output);
     if (!issueId) {
       return {
         healthy: false,
@@ -150,8 +166,7 @@ function beadsHealthCheck(projectRoot, options = {}) {
     exec('bd', ['sync'], execOpts);
   } catch (syncErr) {
     // Sync failure is non-fatal (no remote configured is common)
-    const syncWarning = `bd sync warning: ${syncErr.message}`;
-    warning = warning ? `${warning}; ${syncWarning}` : syncWarning;
+    warning = appendWarning(warning, `bd sync warning: ${syncErr.message}`);
   }
 
   // Step d: Remove the test issue from JSONL
@@ -159,8 +174,7 @@ function beadsHealthCheck(projectRoot, options = {}) {
     cleanupTestIssue(path.join(projectRoot, '.beads', 'issues.jsonl'), issueId);
   } catch (cleanupErr) {
     // Cleanup failure is non-fatal
-    const cleanupWarning = `cleanup warning: ${cleanupErr.message}`;
-    warning = warning ? `${warning}; ${cleanupWarning}` : cleanupWarning;
+    warning = appendWarning(warning, `cleanup warning: ${cleanupErr.message}`);
   }
 
   return {

--- a/lib/beads-health-check.js
+++ b/lib/beads-health-check.js
@@ -10,6 +10,7 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { bootstrapBeads, isRecoverableBeadsError } = require('./beads-bootstrap');
 
 /**
  * @typedef {Object} HealthCheckResult
@@ -62,6 +63,7 @@ function cleanupTestIssue(jsonlPath, issueId) {
  */
 function beadsHealthCheck(projectRoot, options = {}) {
   const exec = options._exec || execFileSync;
+  const bootstrap = options._bootstrap || ((root) => bootstrapBeads(root, { _exec: exec }));
   const execOpts = { cwd: projectRoot, encoding: 'utf8' };
 
   /** @type {string|undefined} */
@@ -71,12 +73,40 @@ function beadsHealthCheck(projectRoot, options = {}) {
   /** @type {string|null} */
   let issueId;
   try {
-    const createOutput = exec('bd', [
-      'create',
-      '--title=Setup verification',
-      '--type=task',
-      '--priority=4'
-    ], execOpts);
+    let createOutput;
+    try {
+      createOutput = exec('bd', [
+        'create',
+        '--title=Setup verification',
+        '--type=task',
+        '--priority=4'
+      ], execOpts);
+    } catch (createErr) {
+      if (!isRecoverableBeadsError(createErr)) {
+        throw createErr;
+      }
+
+      const bootstrapResult = bootstrap(projectRoot);
+      if (!bootstrapResult?.success) {
+        const extra = bootstrapResult?.warning ? `; ${bootstrapResult.warning}` : '';
+        return {
+          healthy: false,
+          failedStep: 'create',
+          error: `${createErr.message}${extra}`
+        };
+      }
+
+      warning = bootstrapResult.warning
+        ? `bootstrap warning: ${bootstrapResult.warning}`
+        : `bootstrap warning: recovered via ${bootstrapResult.strategy}`;
+
+      createOutput = exec('bd', [
+        'create',
+        '--title=Setup verification',
+        '--type=task',
+        '--priority=4'
+      ], execOpts);
+    }
 
     issueId = parseIssueId(createOutput);
     if (!issueId) {

--- a/lib/beads-setup.js
+++ b/lib/beads-setup.js
@@ -157,6 +157,27 @@ function isBeadsInitialized(projectRoot) {
   return hasLegacyState || hasDoltState;
 }
 
+function readBeadsDatabaseName(projectRoot) {
+  const metadataPath = path.join(projectRoot, '.beads', 'metadata.json');
+  if (!fs.existsSync(metadataPath)) {
+    return null;
+  }
+
+  try {
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    if (typeof metadata.dolt_database === 'string' && metadata.dolt_database.trim()) {
+      return metadata.dolt_database.trim();
+    }
+    if (typeof metadata.database === 'string' && metadata.database.trim()) {
+      return metadata.database.trim();
+    }
+  } catch (_err) {
+    return null;
+  }
+
+  return null;
+}
+
 /**
  * Legacy compatibility shim for the removed JSONL pre-seed workaround.
  *
@@ -350,6 +371,7 @@ module.exports = {
   writeBeadsConfig,
   writeBeadsGitignore,
   isBeadsInitialized,
+  readBeadsDatabaseName,
   preSeedJsonl,
   safeBeadsInit
 };

--- a/lib/beads-setup.js
+++ b/lib/beads-setup.js
@@ -10,6 +10,15 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { secureExecFileSync } = require('./shell-utils');
+
+function isIgnorableFsError(error) {
+  return ['EACCES', 'ENOENT', 'ENOTDIR', 'EPERM'].includes(error?.code);
+}
+
+function isRecoverableCommandError(error) {
+  return error?.code === 'ENOENT' || typeof error?.status === 'number';
+}
 
 /**
  * Resolve a command to its full path to avoid relying on inherited PATH.
@@ -24,7 +33,10 @@ function resolveCommand(command) {
     if (result.status === 0 && result.stdout) {
       return result.stdout.trim().split(/\r?\n/)[0].trim();
     }
-  } catch (_e) {
+  } catch (error) {
+    if (!isRecoverableCommandError(error)) {
+      throw error;
+    }
     // Expected: command resolution may fail if 'which'/'where.exe' is unavailable — fall back to bare command name
   }
   return command;
@@ -171,8 +183,11 @@ function readBeadsDatabaseName(projectRoot) {
     if (typeof metadata.database === 'string' && metadata.database.trim()) {
       return metadata.database.trim();
     }
-  } catch (_err) {
-    return null;
+  } catch (error) {
+    if (error instanceof SyntaxError || isIgnorableFsError(error)) {
+      return null;
+    }
+    throw error;
   }
 
   return null;
@@ -258,8 +273,7 @@ function resolveHooksDir(projectRoot) {
   const fallbackHooksDir = path.join(projectRoot, '.git', 'hooks');
 
   try {
-    const { execFileSync } = require('node:child_process');
-    const gitHooksPath = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+    const gitHooksPath = secureExecFileSync(resolveCommand('git'), ['rev-parse', '--git-path', 'hooks'], {
       cwd: projectRoot,
       encoding: 'utf8',
       stdio: 'pipe'
@@ -272,8 +286,11 @@ function resolveHooksDir(projectRoot) {
     return path.isAbsolute(gitHooksPath)
       ? gitHooksPath
       : path.resolve(projectRoot, gitHooksPath);
-  } catch (_err) {
-    return fallbackHooksDir;
+  } catch (error) {
+    if (isRecoverableCommandError(error)) {
+      return fallbackHooksDir;
+    }
+    throw error;
   }
 }
 

--- a/lib/beads-setup.js
+++ b/lib/beads-setup.js
@@ -254,6 +254,29 @@ function restoreDirectory(dirPath, snapshot) {
   }
 }
 
+function resolveHooksDir(projectRoot) {
+  const fallbackHooksDir = path.join(projectRoot, '.git', 'hooks');
+
+  try {
+    const { execFileSync } = require('node:child_process');
+    const gitHooksPath = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+
+    if (!gitHooksPath) {
+      return fallbackHooksDir;
+    }
+
+    return path.isAbsolute(gitHooksPath)
+      ? gitHooksPath
+      : path.resolve(projectRoot, gitHooksPath);
+  } catch (_err) {
+    return fallbackHooksDir;
+  }
+}
+
 /**
  * Default bd init executor — calls `execFileSync('bd', ['init'])`.
  *
@@ -321,7 +344,7 @@ function safeBeadsInit(projectRoot, options = {}) {
   }
 
   // (d) Snapshot current .git/hooks/ directory
-  const hooksDir = path.join(projectRoot, '.git', 'hooks');
+  const hooksDir = resolveHooksDir(projectRoot);
   const hooksSnapshot = snapshotDirectory(hooksDir);
 
   // (e) Run bd init — wrapped in try/catch

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -2734,13 +2734,15 @@ function installGitHooks() { // NOSONAR — Extracted as-is from bin/forge.js; c
         execFileSync('lefthook', ['install'], { stdio: 'inherit', cwd: projectRoot });
         console.log('  ✓ Lefthook hooks installed (global)');
       }
-    } catch (err) {
-      console.warn('Lefthook installation failed:', err.message);
-      console.log('  ℹ Lefthook not found. Install it:');
-      console.log('    bun add -d lefthook  (recommended)');
-      console.log('    OR: bun add -g lefthook  (global)');
-      console.log('    Then run: bunx lefthook install');
-    }
+  } catch (err) {
+    console.warn('Lefthook installation failed:', err.message);
+    console.warn('  ⚠ Lefthook hooks were not installed; raw git push remains unsafe in this worktree.');
+    console.log('  ℹ Lefthook not found. Install it:');
+    console.log('    bun add -d lefthook  (recommended)');
+    console.log('    OR: bun add -g lefthook  (global)');
+    console.log('    Then run: bunx lefthook install');
+    console.log(`  Run ${PKG_MANAGER} install in this worktree, then rerun setup.`);
+  }
 
     console.log('');
 
@@ -2785,7 +2787,9 @@ function repairDeclaredLefthookDependency(selectedAgents) {
     return { attempted: true, repaired: true };
   } catch (err) {
     console.warn('Lefthook install failed:', err.message);
+    console.warn('  ⚠ Lefthook repair failed; raw git push remains unsafe in this worktree.');
     console.log(`  ⚠ ${status.message}`);
+    console.log(`  Run ${PKG_MANAGER} install in this worktree, then rerun setup.`);
     console.log('');
     return { attempted: true, repaired: false, error: err };
   }
@@ -3314,7 +3318,9 @@ function autoInstallLefthook() { // NOSONAR — Extracted as-is from bin/forge.j
       console.log('  ✓ Lefthook binary restored');
     } catch (err) {
       console.warn('Lefthook install failed:', err.message);
+      console.warn('  ⚠ Lefthook repair failed; raw git push remains unsafe in this worktree.');
       console.log(`  ⚠ ${status.message}`);
+      console.log(`  Run ${PKG_MANAGER} install in this worktree, then rerun setup.`);
     }
     console.log('');
     return;

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -11,8 +11,8 @@ const { bootstrapBeads } = require('../beads-bootstrap');
  * Uses execFileSync (not execSync) to prevent command injection (OWASP A03).
  *
  * Subcommands:
- *   create <slug> — Create worktree at .worktrees/<slug> with branch + beads + install
- *   remove <slug> — Remove worktree via git worktree remove
+ *   create <slug> - Create worktree at .worktrees/<slug> with branch + beads + install
+ *   remove <slug> - Remove worktree via git worktree remove
  *
  * @module commands/worktree
  */
@@ -35,7 +35,7 @@ function detectPackageManager(projectRoot, fsApi) {
 /**
  * Stop a Dolt server running in a worktree to release file locks.
  * Tries graceful `bd dolt stop` first, then falls back to PID-based kill
- * from lock files. Never kills ALL Dolt processes — only the specific PID.
+ * from lock files. Never kills ALL Dolt processes - only the specific PID.
  *
  * @param {string} worktreePath - Absolute path to the worktree
  * @param {object} [opts] - Options for dependency injection
@@ -92,51 +92,9 @@ function branchExists(branchName, runFile) {
   }
 }
 
-/**
- * Set up Beads integration for a new worktree (symlink/junction/copy).
- * @param {string} worktreePath - Absolute path to the new worktree
- * @param {string} projectRoot - Absolute path to the project root
- * @param {string} platform - OS platform string (e.g. 'win32')
- * @param {object} fsApi - fs module (for DI)
- * @param {Function} exec - execFileSync-compatible function
- * @returns {string|null} Warning message if beads setup had issues, null otherwise
- */
-function setupBeads(worktreePath, projectRoot, platform, fsApi, exec) {
-  const beadsSource = path.resolve(projectRoot, '.beads');
-  const beadsDest = path.resolve(worktreePath, '.beads');
-
-  if (!fsApi.existsSync(beadsSource)) {
-    return 'Beads not installed — skipping .beads setup';
-  }
-
-  // Try symlink first
-  try {
-    if (platform === 'win32') {
-      fsApi.symlinkSync(beadsSource, beadsDest, 'junction');
-    } else {
-      fsApi.symlinkSync(beadsSource, beadsDest);
-    }
-  } catch (symlinkErr) {
-    if (symlinkErr.code === 'EPERM') {
-      copyBeadsDir(beadsSource, beadsDest, fsApi);
-    } else {
-      throw symlinkErr;
-    }
-  }
-
-  // Verify beads accessible (warn if fails, don't block)
-  try {
-    exec('bd', ['--version'], { cwd: worktreePath, timeout: 5000, stdio: 'pipe' });
-  } catch (_bdErr) { /* intentional: bd may not be on PATH */ // NOSONAR S2486
-    return 'Beads verification failed — .beads linked but bd may not work';
-  }
-
-  return null;
-}
-
 function setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, exec) {
   if (!fsApi.existsSync(path.resolve(projectRoot, '.beads'))) {
-    return 'Beads not installed â€” skipping .beads setup';
+    return 'Beads not installed - skipping .beads setup';
   }
 
   const bootstrapResult = bootstrapBeads(worktreePath, {
@@ -149,7 +107,7 @@ function setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, exe
   try {
     exec('bd', ['--version'], { cwd: worktreePath, timeout: 5000, stdio: 'pipe' });
   } catch (_bdErr) { /* intentional: bd may not be on PATH */ // NOSONAR S2486
-    return 'Beads verification failed â€” .beads linked but bd may not work';
+    return 'Beads verification failed - .beads linked but bd may not work';
   }
 
   return bootstrapResult.warning;
@@ -186,7 +144,7 @@ async function handleCreate(slug, flags, projectRoot, opts) {
   const branchName = flags['--branch'] || flags.branch || `feat/${slug}`;
   const worktreesDir = path.resolve(projectRoot, '.worktrees');
 
-  // Guard: Detect bare repo state — worktrees created from bare repos produce broken branches
+  // Guard: Detect bare repo state - worktrees created from bare repos produce broken branches
   // git rev-parse --show-toplevel throws in a bare repo (no working tree)
   try {
     runFile('git', ['-C', projectRoot, 'rev-parse', '--show-toplevel'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -3,6 +3,7 @@
 const { execFileSync, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { bootstrapBeads } = require('../beads-bootstrap');
 
 /**
  * Forge Worktree Command
@@ -29,21 +30,6 @@ function detectPackageManager(projectRoot, fsApi) {
   if (fsApi.existsSync(path.join(projectRoot, 'package-lock.json'))) return 'npm';
   if (fsApi.existsSync(path.join(projectRoot, 'package.json'))) return 'npm';
   return null;
-}
-
-/**
- * Copy .beads/ directory excluding daemon.lock.
- * @param {string} source - Source .beads path
- * @param {string} dest - Destination .beads path
- * @param {object} fsApi - fs module (for DI)
- */
-function copyBeadsDir(source, dest, fsApi) {
-  fsApi.mkdirSync(dest, { recursive: true });
-  const entries = fsApi.readdirSync(source);
-  for (const entry of entries) {
-    if (entry === 'daemon.lock') continue;
-    fsApi.cpSync(path.join(source, entry), path.join(dest, entry), { recursive: true });
-  }
 }
 
 /**
@@ -148,6 +134,27 @@ function setupBeads(worktreePath, projectRoot, platform, fsApi, exec) {
   return null;
 }
 
+function setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, exec) {
+  if (!fsApi.existsSync(path.resolve(projectRoot, '.beads'))) {
+    return 'Beads not installed â€” skipping .beads setup';
+  }
+
+  const bootstrapResult = bootstrapBeads(worktreePath, {
+    _exec: exec,
+    _fs: fsApi,
+    _platform: platform,
+    mainProjectRoot: projectRoot,
+  });
+
+  try {
+    exec('bd', ['--version'], { cwd: worktreePath, timeout: 5000, stdio: 'pipe' });
+  } catch (_bdErr) { /* intentional: bd may not be on PATH */ // NOSONAR S2486
+    return 'Beads verification failed â€” .beads linked but bd may not work';
+  }
+
+  return bootstrapResult.warning;
+}
+
 /**
  * Run package install in the new worktree if a package manager is detected.
  * @param {string} worktreePath - Absolute path to the new worktree
@@ -217,7 +224,7 @@ async function handleCreate(slug, flags, projectRoot, opts) {
   }
 
   // Step 3: Beads integration
-  const beadsWarning = setupBeads(worktreePath, projectRoot, platform, fsApi, runFile);
+  const beadsWarning = setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, runFile);
 
   // Step 4: Run package install
   runInstall(worktreePath, projectRoot, runSpawn, fsApi);

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -92,7 +92,7 @@ function branchExists(branchName, runFile) {
   }
 }
 
-function setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, exec) {
+function setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, exec, options = {}) {
   if (!fsApi.existsSync(path.resolve(projectRoot, '.beads'))) {
     return 'Beads not installed - skipping .beads setup';
   }
@@ -102,6 +102,7 @@ function setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, exe
     _fs: fsApi,
     _platform: platform,
     mainProjectRoot: projectRoot,
+    _safeBeadsInit: options._safeBeadsInit,
   });
 
   try {
@@ -185,7 +186,7 @@ async function handleCreate(slug, flags, projectRoot, opts) {
   }
 
   // Step 3: Beads integration
-  const beadsWarning = setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, runFile);
+  const beadsWarning = setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, runFile, opts);
 
   // Step 4: Run package install
   runInstall(worktreePath, projectRoot, runSpawn, fsApi);

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -107,6 +107,9 @@ function setupBeadsWithBootstrap(worktreePath, projectRoot, platform, fsApi, exe
   try {
     exec('bd', ['--version'], { cwd: worktreePath, timeout: 5000, stdio: 'pipe' });
   } catch (_bdErr) { /* intentional: bd may not be on PATH */ // NOSONAR S2486
+    if (bootstrapResult.success === false && bootstrapResult.warning) {
+      return bootstrapResult.warning;
+    }
     return 'Beads verification failed - .beads linked but bd may not work';
   }
 

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -142,7 +142,7 @@ if printf '%s' "$_bd_list_err" | grep -qi "database.*not found"; then
   _metadata_path="$_repo_root/.beads/metadata.json"
   _bd_prefix=""
   if [ -f "$_metadata_path" ]; then
-    if _metadata_prefix="$(jq -r '(.dolt_database // .database // "") | strings' "$_metadata_path" 2>/dev/null)"; then
+    if _metadata_prefix="$(jq -r '(.dolt_database // "") | strings' "$_metadata_path" 2>/dev/null)"; then
       _bd_prefix="$(printf '%s' "$_metadata_prefix" | tr -d '\r')"
     fi
   fi

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -138,9 +138,15 @@ fi
 
 _bd_list_err="$("$BD" list --json --limit 0 2>&1 >/dev/null || true)"
 if printf '%s' "$_bd_list_err" | grep -qi "database.*not found"; then
-  # Derive prefix from repo root directory name (not pwd, which could be a subdirectory)
   _repo_root="$("$GIT" rev-parse --show-toplevel 2>/dev/null || pwd)"
-  _bd_prefix="$(basename "$_repo_root" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]-' '-' | sed 's/^-//;s/-$//')"
+  _metadata_path="$_repo_root/.beads/metadata.json"
+  _bd_prefix=""
+  if [ -f "$_metadata_path" ]; then
+    _bd_prefix="$(jq -r '(.dolt_database // .database // "") | strings' "$_metadata_path" 2>/dev/null | tr -d '\r')"
+  fi
+  if [ -z "$_bd_prefix" ]; then
+    _bd_prefix="$(basename "$_repo_root" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]-' '-' | sed 's/^-//;s/-$//')"
+  fi
   echo "Beads database not found — attempting auto-recovery..." >&2
   if "$BD" init --force --prefix "$_bd_prefix" >/dev/null 2>&1; then
     if [ -d "$_repo_root/.beads/backup" ] && ls "$_repo_root/.beads/backup"/*.jsonl >/dev/null 2>&1; then

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -142,7 +142,9 @@ if printf '%s' "$_bd_list_err" | grep -qi "database.*not found"; then
   _metadata_path="$_repo_root/.beads/metadata.json"
   _bd_prefix=""
   if [ -f "$_metadata_path" ]; then
-    _bd_prefix="$(jq -r '(.dolt_database // .database // "") | strings' "$_metadata_path" 2>/dev/null | tr -d '\r')"
+    if _metadata_prefix="$(jq -r '(.dolt_database // .database // "") | strings' "$_metadata_path" 2>/dev/null)"; then
+      _bd_prefix="$(printf '%s' "$_metadata_prefix" | tr -d '\r')"
+    fi
   fi
   if [ -z "$_bd_prefix" ]; then
     _bd_prefix="$(basename "$_repo_root" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]-' '-' | sed 's/^-//;s/-$//')"

--- a/test/beads-bootstrap.test.js
+++ b/test/beads-bootstrap.test.js
@@ -4,6 +4,17 @@ const path = require('node:path');
 const { describe, test, expect } = require('bun:test');
 const { bootstrapBeads, isRecoverableBeadsError } = require('../lib/beads-bootstrap');
 
+function createMockSafeBeadsInit() {
+  return (root, options) => {
+    try {
+      options.execBdInit(root);
+      return { success: true, skipped: false, warnings: [], errors: [] };
+    } catch (error) {
+      return { success: false, skipped: false, warnings: [], errors: [error.message] };
+    }
+  };
+}
+
 describe('bootstrapBeads', () => {
   test('returns a warning instead of throwing when EPERM fallback cannot run bd init', () => {
     const calls = [];
@@ -32,6 +43,7 @@ describe('bootstrapBeads', () => {
       _fs: mockFs,
       _platform: 'linux',
       mainProjectRoot: '/main',
+      _safeBeadsInit: createMockSafeBeadsInit(),
     });
 
     expect(result).toEqual({
@@ -104,6 +116,66 @@ describe('bootstrapBeads', () => {
     });
   });
 
+  test('does not treat metadata.database backend field as the recovery database name', () => {
+    const calls = [];
+    const mockExec = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'bd' && args[0] === 'init') {
+        return '';
+      }
+      if (cmd === 'git' && args[0] === 'rev-parse') {
+        return '.git';
+      }
+      throw new Error(`unexpected exec ${cmd}`);
+    };
+    const mockFs = {
+      existsSync: (targetPath) => {
+        return [
+          path.resolve('/main', '.beads'),
+          path.resolve('/main', '.beads', 'metadata.json')
+        ].includes(targetPath);
+      },
+      readFileSync: (targetPath) => {
+        if (targetPath === path.resolve('/main', '.beads', 'metadata.json')) {
+          return JSON.stringify({ database: 'dolt' });
+        }
+        throw new Error(`unexpected read ${targetPath}`);
+      },
+      readdirSync: () => [],
+      rmSync: () => {},
+      symlinkSync: () => {
+        const err = new Error('Operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      },
+    };
+
+    const result = bootstrapBeads('/worktree', {
+      _exec: mockExec,
+      _fs: mockFs,
+      _platform: 'linux',
+      mainProjectRoot: '/main',
+      _safeBeadsInit: (root, options) => {
+        options.execBdInit(root);
+        return { success: true, skipped: false, warnings: [], errors: [] };
+      }
+    });
+
+    expect(result).toEqual({
+      success: true,
+      strategy: 'fresh-init',
+      warning: 'Beads bootstrap initialized fresh (no backup found)'
+    });
+    expect(calls).toContainEqual({
+      cmd: 'bd',
+      args: ['init', '--force']
+    });
+    expect(calls).not.toContainEqual({
+      cmd: 'bd',
+      args: ['init', '--force', '--database', 'dolt']
+    });
+  });
+
   test('restores an existing .beads directory when symlink bootstrap fails with a non-EPERM error', () => {
     const calls = [];
     const renames = [];
@@ -152,6 +224,54 @@ describe('bootstrapBeads', () => {
     expect(removed).toEqual([]);
     expect(existing.has(path.resolve('/worktree', '.beads'))).toBe(true);
     expect(calls).toEqual([]);
+  });
+
+  test('skips backup restore when safeBeadsInit reports existing initialized state', () => {
+    const calls = [];
+    const mockExec = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'git' && args[0] === 'rev-parse') {
+        return '.git';
+      }
+      if (cmd === 'bd' && args[0] === 'backup' && args[1] === 'restore') {
+        throw new Error('backup restore should not run');
+      }
+      return '';
+    };
+    const mockFs = {
+      existsSync: (targetPath) => {
+        return [
+          path.resolve('/main', '.beads'),
+          path.resolve('/worktree', '.beads')
+        ].includes(targetPath);
+      },
+      renameSync: () => {},
+      rmSync: () => {},
+      symlinkSync: () => {
+        const err = new Error('Operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      },
+      readdirSync: () => ['issues.jsonl'],
+    };
+
+    const result = bootstrapBeads('/worktree', {
+      _exec: mockExec,
+      _fs: mockFs,
+      _platform: 'linux',
+      mainProjectRoot: '/main',
+      _safeBeadsInit: () => ({ success: true, skipped: true, warnings: [], errors: [] })
+    });
+
+    expect(result).toEqual({
+      success: true,
+      strategy: 'existing-state',
+      warning: 'Beads bootstrap reused existing initialized state'
+    });
+    expect(calls).not.toContainEqual({
+      cmd: 'bd',
+      args: ['backup', 'restore', path.resolve('/main', '.beads', 'backup')]
+    });
   });
 });
 

--- a/test/beads-bootstrap.test.js
+++ b/test/beads-bootstrap.test.js
@@ -226,6 +226,63 @@ describe('bootstrapBeads', () => {
     expect(calls).toEqual([]);
   });
 
+  test('clears a stale bootstrap-backup directory before staging the current .beads state', () => {
+    const calls = [];
+    const renames = [];
+    const removed = [];
+    const backupPath = path.resolve('/worktree', '.beads.bootstrap-backup');
+    const mockExec = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'git' && args[0] === 'rev-parse') {
+        return '.git';
+      }
+      throw new Error(`unexpected exec ${cmd}`);
+    };
+    const existing = new Set([
+      path.resolve('/main', '.beads'),
+      path.resolve('/worktree', '.beads'),
+      backupPath,
+    ]);
+    const mockFs = {
+      existsSync: (targetPath) => existing.has(targetPath),
+      renameSync: (fromPath, toPath) => {
+        renames.push([fromPath, toPath]);
+        existing.delete(fromPath);
+        existing.add(toPath);
+      },
+      rmSync: (targetPath) => {
+        removed.push(targetPath);
+        existing.delete(targetPath);
+      },
+      symlinkSync: () => {
+        const err = new Error('Operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      },
+      readdirSync: () => [],
+    };
+
+    const result = bootstrapBeads('/worktree', {
+      _exec: mockExec,
+      _fs: mockFs,
+      _platform: 'linux',
+      mainProjectRoot: '/main',
+      _safeBeadsInit: () => ({ success: true, skipped: true, warnings: [], errors: [] })
+    });
+
+    expect(result).toEqual({
+      success: true,
+      strategy: 'existing-state',
+      warning: 'Beads bootstrap reused existing initialized state'
+    });
+    expect(removed).toEqual([backupPath]);
+    expect(renames).toEqual([
+      [path.resolve('/worktree', '.beads'), backupPath],
+      [backupPath, path.resolve('/worktree', '.beads')]
+    ]);
+    expect(calls).toEqual([]);
+  });
+
   test('skips backup restore when safeBeadsInit reports existing initialized state', () => {
     const calls = [];
     const mockExec = (cmd, args) => {

--- a/test/beads-bootstrap.test.js
+++ b/test/beads-bootstrap.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const path = require('node:path');
+const { describe, test, expect } = require('bun:test');
+const { bootstrapBeads } = require('../lib/beads-bootstrap');
+
+describe('bootstrapBeads', () => {
+  test('returns a warning instead of throwing when EPERM fallback cannot run bd init', () => {
+    const calls = [];
+    const mockExec = (cmd, args, _opts) => {
+      calls.push({ cmd, args });
+      if (cmd === 'bd' && args[0] === 'init') {
+        throw new Error('spawn bd ENOENT');
+      }
+      if (cmd === 'git' && args[0] === 'rev-parse') {
+        return '.git';
+      }
+      return '';
+    };
+    const mockFs = {
+      existsSync: (targetPath) => targetPath === path.resolve('/main', '.beads'),
+      rmSync: () => {},
+      symlinkSync: () => {
+        const err = new Error('Operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      },
+    };
+
+    const result = bootstrapBeads('/worktree', {
+      _exec: mockExec,
+      _fs: mockFs,
+      _platform: 'linux',
+      mainProjectRoot: '/main',
+    });
+
+    expect(result).toEqual({
+      success: false,
+      strategy: 'fresh-init-failed',
+      warning: 'Beads bootstrap fresh init failed: spawn bd ENOENT'
+    });
+    expect(calls).toContainEqual({
+      cmd: 'bd',
+      args: ['init', '--force']
+    });
+  });
+});

--- a/test/beads-bootstrap.test.js
+++ b/test/beads-bootstrap.test.js
@@ -45,6 +45,58 @@ describe('bootstrapBeads', () => {
     });
   });
 
+  test('passes metadata-derived database name to bd init during EPERM fallback', () => {
+    const calls = [];
+    const mockExec = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'bd' && args[0] === 'init') {
+        return '';
+      }
+      if (cmd === 'git' && args[0] === 'rev-parse') {
+        return '.git';
+      }
+      throw new Error(`unexpected exec ${cmd}`);
+    };
+    const mockFs = {
+      existsSync: (targetPath) => {
+        return [
+          path.resolve('/main', '.beads'),
+          path.resolve('/main', '.beads', 'metadata.json')
+        ].includes(targetPath);
+      },
+      readFileSync: (targetPath) => {
+        if (targetPath === path.resolve('/main', '.beads', 'metadata.json')) {
+          return JSON.stringify({ dolt_database: 'forge-shared-db' });
+        }
+        throw new Error(`unexpected read ${targetPath}`);
+      },
+      readdirSync: () => [],
+      rmSync: () => {},
+      symlinkSync: () => {
+        const err = new Error('Operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      },
+    };
+
+    const result = bootstrapBeads('/worktree', {
+      _exec: mockExec,
+      _fs: mockFs,
+      _platform: 'linux',
+      mainProjectRoot: '/main',
+    });
+
+    expect(result).toEqual({
+      success: true,
+      strategy: 'fresh-init',
+      warning: 'Beads bootstrap initialized fresh (no backup found)'
+    });
+    expect(calls).toContainEqual({
+      cmd: 'bd',
+      args: ['init', '--force', '--database', 'forge-shared-db']
+    });
+  });
+
   test('restores an existing .beads directory when symlink bootstrap fails with a non-EPERM error', () => {
     const calls = [];
     const renames = [];

--- a/test/beads-bootstrap.test.js
+++ b/test/beads-bootstrap.test.js
@@ -47,6 +47,7 @@ describe('bootstrapBeads', () => {
 
   test('passes metadata-derived database name to bd init during EPERM fallback', () => {
     const calls = [];
+    let safeInitCall;
     const mockExec = (cmd, args) => {
       calls.push({ cmd, args });
       if (cmd === 'bd' && args[0] === 'init') {
@@ -84,6 +85,11 @@ describe('bootstrapBeads', () => {
       _fs: mockFs,
       _platform: 'linux',
       mainProjectRoot: '/main',
+      _safeBeadsInit: (root, options) => {
+        safeInitCall = { root, options };
+        options.execBdInit(root);
+        return { success: true, skipped: false, warnings: [], errors: [] };
+      }
     });
 
     expect(result).toEqual({
@@ -91,6 +97,7 @@ describe('bootstrapBeads', () => {
       strategy: 'fresh-init',
       warning: 'Beads bootstrap initialized fresh (no backup found)'
     });
+    expect(safeInitCall.root).toBe('/worktree');
     expect(calls).toContainEqual({
       cmd: 'bd',
       args: ['init', '--force', '--database', 'forge-shared-db']

--- a/test/beads-bootstrap.test.js
+++ b/test/beads-bootstrap.test.js
@@ -2,7 +2,7 @@
 
 const path = require('node:path');
 const { describe, test, expect } = require('bun:test');
-const { bootstrapBeads } = require('../lib/beads-bootstrap');
+const { bootstrapBeads, isRecoverableBeadsError } = require('../lib/beads-bootstrap');
 
 describe('bootstrapBeads', () => {
   test('returns a warning instead of throwing when EPERM fallback cannot run bd init', () => {
@@ -43,5 +43,61 @@ describe('bootstrapBeads', () => {
       cmd: 'bd',
       args: ['init', '--force']
     });
+  });
+
+  test('restores an existing .beads directory when symlink bootstrap fails with a non-EPERM error', () => {
+    const calls = [];
+    const renames = [];
+    const removed = [];
+    const backupPath = path.resolve('/worktree', '.beads.bootstrap-backup');
+    const mockExec = (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'git' && args[0] === 'rev-parse') {
+        return '.git';
+      }
+      throw new Error(`unexpected exec ${cmd}`);
+    };
+    const existing = new Set([
+      path.resolve('/main', '.beads'),
+      path.resolve('/worktree', '.beads'),
+    ]);
+    const mockFs = {
+      existsSync: (targetPath) => existing.has(targetPath),
+      renameSync: (fromPath, toPath) => {
+        renames.push([fromPath, toPath]);
+        existing.delete(fromPath);
+        existing.add(toPath);
+      },
+      rmSync: (targetPath) => {
+        removed.push(targetPath);
+        existing.delete(targetPath);
+      },
+      symlinkSync: () => {
+        const err = new Error('Read-only filesystem');
+        err.code = 'EROFS';
+        throw err;
+      },
+    };
+
+    expect(() => bootstrapBeads('/worktree', {
+      _exec: mockExec,
+      _fs: mockFs,
+      _platform: 'linux',
+      mainProjectRoot: '/main',
+    })).toThrow('Read-only filesystem');
+
+    expect(renames).toEqual([
+      [path.resolve('/worktree', '.beads'), backupPath],
+      [backupPath, path.resolve('/worktree', '.beads')]
+    ]);
+    expect(removed).toEqual([]);
+    expect(existing.has(path.resolve('/worktree', '.beads'))).toBe(true);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('isRecoverableBeadsError', () => {
+  test('matches missing database errors for metadata-driven database prefixes', () => {
+    expect(isRecoverableBeadsError(new Error('database forge-shared-db not found'))).toBe(true);
   });
 });

--- a/test/beads-health-check.test.js
+++ b/test/beads-health-check.test.js
@@ -129,6 +129,45 @@ describe('beadsHealthCheck', () => {
     expect(result.warning).toContain('sync');
   });
 
+  test('preserves bootstrap warning when sync also fails after recovery', () => {
+    const projectRoot = setupTmpDir([
+      JSON.stringify({ id: 'forge-0001', title: 'Setup verification', status: 'open' })
+    ]);
+    let createAttempts = 0;
+
+    const mockExec = (cmd, args, _opts) => {
+      const subcommand = args[0];
+      if (subcommand === 'create') {
+        createAttempts += 1;
+        if (createAttempts === 1) {
+          throw new Error('database forge-shared-db not found');
+        }
+        return 'Created issue: forge-0001\n';
+      }
+      if (subcommand === 'close') {
+        return 'Closed issue: forge-0001\n';
+      }
+      if (subcommand === 'sync') {
+        throw new Error('fatal: no remote configured');
+      }
+      return '';
+    };
+
+    const result = beadsHealthCheck(projectRoot, {
+      _exec: mockExec,
+      _bootstrap: () => ({
+        success: true,
+        strategy: 'fresh-init',
+        warning: 'Beads bootstrap initialized fresh (no backup found)'
+      })
+    });
+
+    expect(result.healthy).toBe(true);
+    expect(result.failedStep).toBeNull();
+    expect(result.warning).toContain('bootstrap warning: Beads bootstrap initialized fresh');
+    expect(result.warning).toContain('bd sync warning: fatal: no remote configured');
+  });
+
   test('cleanup removes only the test issue line from JSONL', () => {
     const issueLines = [
       JSON.stringify({ id: 'forge-0042', title: 'Setup verification', status: 'open' }),

--- a/test/beads-health-check.test.js
+++ b/test/beads-health-check.test.js
@@ -194,4 +194,62 @@ describe('beadsHealthCheck', () => {
     expect(result.healthy).toBe(true);
     expect(result.failedStep).toBeNull();
   });
+
+  test('retries create after bootstrap when beads database is missing', () => {
+    const projectRoot = setupTmpDir([
+      JSON.stringify({ id: 'forge-0002', title: 'Real issue', status: 'open' })
+    ]);
+    let createAttempts = 0;
+    let bootstrapCalls = 0;
+    const mockExec = (cmd, args, _opts) => {
+      const subcommand = args[0];
+      if (subcommand === 'create') {
+        createAttempts += 1;
+        if (createAttempts === 1) {
+          throw new Error('database forge not found');
+        }
+        return 'Created issue: forge-0001\n';
+      }
+      if (subcommand === 'close') return 'Closed issue: forge-0001\n';
+      if (subcommand === 'sync') return 'Synced\n';
+      return '';
+    };
+
+    const result = beadsHealthCheck(projectRoot, {
+      _exec: mockExec,
+      _bootstrap: (root) => {
+        bootstrapCalls += 1;
+        expect(root).toBe(projectRoot);
+        return { success: true, strategy: 'linked', warning: null };
+      }
+    });
+
+    expect(result.healthy).toBe(true);
+    expect(createAttempts).toBe(2);
+    expect(bootstrapCalls).toBe(1);
+    expect(result.warning).toContain('bootstrap');
+  });
+
+  test('returns create failure when bootstrap cannot repair missing beads database', () => {
+    const projectRoot = setupTmpDir();
+    let bootstrapCalls = 0;
+    const result = beadsHealthCheck(projectRoot, {
+      _exec: createMockExec({
+        create: { error: new Error('database forge not found') }
+      }),
+      _bootstrap: () => {
+        bootstrapCalls += 1;
+        return {
+          success: false,
+          warning: 'initialized fresh but verification failed'
+        };
+      }
+    });
+
+    expect(result.healthy).toBe(false);
+    expect(result.failedStep).toBe('create');
+    expect(result.error).toContain('database forge not found');
+    expect(result.error).toContain('initialized fresh');
+    expect(bootstrapCalls).toBe(1);
+  });
 });

--- a/test/beads-init-wrapper.test.js
+++ b/test/beads-init-wrapper.test.js
@@ -2,6 +2,7 @@ const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { execFileSync } = require('node:child_process');
 
 const { safeBeadsInit } = require('../lib/beads-setup');
 
@@ -243,6 +244,47 @@ describe('safeBeadsInit — hooks preservation', () => {
     if (fs.existsSync(hooksDir)) {
       const files = fs.readdirSync(hooksDir);
       expect(files.length).toBe(0);
+    }
+  });
+
+  test('restores the effective hooks path when called from a git worktree', () => {
+    const mainRepo = makeTmpDir();
+    const worktreeDir = path.join(mainRepo, 'parallel-worktree');
+
+    try {
+      execFileSync('git', ['init'], { cwd: mainRepo, stdio: 'pipe' });
+      execFileSync('git', ['config', 'user.name', 'Forge Tests'], { cwd: mainRepo, stdio: 'pipe' });
+      execFileSync('git', ['config', 'user.email', 'forge-tests@example.com'], { cwd: mainRepo, stdio: 'pipe' });
+      fs.writeFileSync(path.join(mainRepo, 'README.md'), 'seed\n');
+      execFileSync('git', ['add', 'README.md'], { cwd: mainRepo, stdio: 'pipe' });
+      execFileSync('git', ['commit', '-m', 'seed'], { cwd: mainRepo, stdio: 'pipe' });
+      execFileSync('git', ['worktree', 'add', worktreeDir, '-b', 'feat/test-hooks'], { cwd: mainRepo, stdio: 'pipe' });
+
+      const hooksDir = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+        cwd: worktreeDir,
+        encoding: 'utf8',
+        stdio: 'pipe'
+      }).trim();
+      fs.mkdirSync(hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, 'pre-push'), '#!/bin/sh\necho "keep me"', { mode: 0o755 });
+
+      safeBeadsInit(worktreeDir, {
+        prefix: 'proj',
+        execBdInit: (root) => {
+          const effectiveHooksDir = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+            cwd: root,
+            encoding: 'utf8',
+            stdio: 'pipe'
+          }).trim();
+          fs.writeFileSync(path.join(effectiveHooksDir, 'pre-push'), '#!/bin/sh\nbd hook pre-push', { mode: 0o755 });
+        }
+      });
+
+      expect(fs.readFileSync(path.join(hooksDir, 'pre-push'), 'utf8'))
+        .toBe('#!/bin/sh\necho "keep me"');
+    } finally {
+      rmrf(worktreeDir);
+      rmrf(mainRepo);
     }
   });
 });

--- a/test/beads-setup.test.js
+++ b/test/beads-setup.test.js
@@ -8,7 +8,8 @@ const {
   writeBeadsConfig,
   writeBeadsGitignore,
   isBeadsInitialized,
-  preSeedJsonl
+  preSeedJsonl,
+  readBeadsDatabaseName
 } = require('../lib/beads-setup');
 
 /**
@@ -272,5 +273,45 @@ describe('preSeedJsonl', () => {
     preSeedJsonl(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, '.beads'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readBeadsDatabaseName
+// ---------------------------------------------------------------------------
+describe('readBeadsDatabaseName', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    fs.mkdirSync(path.join(tmpDir, '.beads'), { recursive: true });
+  });
+  afterEach(() => {
+    rmrf(tmpDir);
+  });
+
+  test('prefers dolt_database from metadata.json', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.beads', 'metadata.json'),
+      JSON.stringify({ database: 'dolt', dolt_database: 'forge-shared' }, null, 2),
+    );
+
+    expect(readBeadsDatabaseName(tmpDir)).toBe('forge-shared');
+  });
+
+  test('falls back to database when dolt_database is absent', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.beads', 'metadata.json'),
+      JSON.stringify({ database: 'forge-fallback' }, null, 2),
+    );
+
+    expect(readBeadsDatabaseName(tmpDir)).toBe('forge-fallback');
+  });
+
+  test('returns null when metadata.json is missing or malformed', () => {
+    expect(readBeadsDatabaseName(tmpDir)).toBeNull();
+
+    fs.writeFileSync(path.join(tmpDir, '.beads', 'metadata.json'), '{not-json');
+    expect(readBeadsDatabaseName(tmpDir)).toBeNull();
   });
 });

--- a/test/commands/worktree.test.js
+++ b/test/commands/worktree.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { describe, test, expect } = require('bun:test');
+const path = require('path');
 
 // ---------------------------------------------------------------------------
 // forge worktree command — test/forge-worktree.test.js
@@ -93,11 +94,12 @@ describe('forge worktree command', () => {
     expect(symlinkCalls[0].type).toBe('junction');
   });
 
-  // (d) create: falls back to copy on EPERM
-  test('create falls back to copy when symlink throws EPERM', async () => {
+  // (d) create: falls back to backup restore on EPERM
+  test('create restores from backup when symlink throws EPERM', async () => {
     const mod = require('../../lib/commands/worktree');
-    let copyCalled = false;
+    const calls = [];
     const mockExec = (cmd, args, _opts) => {
+      calls.push({ cmd, args });
       if (cmd === 'git' && args[0] === 'branch' && args[1] === '--list') return Buffer.from('');
       if (cmd === 'bd') return Buffer.from('beads 1.0.0\n');
       return Buffer.from('');
@@ -111,8 +113,10 @@ describe('forge worktree command', () => {
         err.code = 'EPERM';
         throw err;
       },
-      readdirSync: (_p) => ['issue-abc.json', 'daemon.lock', 'config.json'],
-      cpSync: () => { copyCalled = true; },
+      readdirSync: (_p) => ['issues.jsonl'],
+      cpSync: () => {
+        throw new Error('copy fallback should not be used');
+      },
     };
 
     const result = await mod.handler(
@@ -121,7 +125,55 @@ describe('forge worktree command', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(copyCalled).toBe(true);
+    expect(calls).toContainEqual({
+      cmd: 'bd',
+      args: ['init', '--force']
+    });
+    expect(calls).toContainEqual({
+      cmd: 'bd',
+      args: ['backup', 'restore', path.resolve('/fake/root', '.beads', 'backup')]
+    });
+    expect(result.beadsWarning).toContain('restored from backup');
+  });
+
+  test('create warns after fresh init when backup restore is unavailable', async () => {
+    const mod = require('../../lib/commands/worktree');
+    const calls = [];
+    const mockExec = (cmd, args, _opts) => {
+      calls.push({ cmd, args });
+      if (cmd === 'git' && args[0] === 'branch' && args[1] === '--list') return Buffer.from('');
+      if (cmd === 'bd' && args[0] === '--version') return Buffer.from('beads 1.0.0\n');
+      if (cmd === 'bd' && args[0] === 'backup' && args[1] === 'restore') {
+        throw new Error('no backup files found');
+      }
+      return Buffer.from('');
+    };
+    const mockSpawn = () => ({ status: 0 });
+    const mockFs = {
+      mkdirSync: () => {},
+      existsSync: (p) => p.endsWith('.beads'),
+      symlinkSync: () => {
+        const err = new Error('Operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      },
+      readdirSync: (_p) => [],
+      cpSync: () => {
+        throw new Error('copy fallback should not be used');
+      },
+    };
+
+    const result = await mod.handler(
+      ['create', 'fresh-init'], {}, '/fake/root',
+      { _exec: mockExec, _spawn: mockSpawn, _fs: mockFs, _platform: 'linux' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(calls).toContainEqual({
+      cmd: 'bd',
+      args: ['init', '--force']
+    });
+    expect(result.beadsWarning).toContain('initialized fresh');
   });
 
   // (e) create: skips beads setup when .beads doesn't exist

--- a/test/commands/worktree.test.js
+++ b/test/commands/worktree.test.js
@@ -3,6 +3,17 @@
 const { describe, test, expect } = require('bun:test');
 const path = require('path');
 
+function createMockSafeBeadsInit() {
+  return (root, options) => {
+    try {
+      options.execBdInit(root);
+      return { success: true, skipped: false, warnings: [], errors: [] };
+    } catch (error) {
+      return { success: false, skipped: false, warnings: [], errors: [error.message] };
+    }
+  };
+}
+
 // ---------------------------------------------------------------------------
 // forge worktree command — test/forge-worktree.test.js
 // ---------------------------------------------------------------------------
@@ -121,7 +132,13 @@ describe('forge worktree command', () => {
 
     const result = await mod.handler(
       ['create', 'perm-test'], {}, '/fake/root',
-      { _exec: mockExec, _spawn: mockSpawn, _fs: mockFs, _platform: 'linux' }
+      {
+        _exec: mockExec,
+        _spawn: mockSpawn,
+        _fs: mockFs,
+        _platform: 'linux',
+        _safeBeadsInit: createMockSafeBeadsInit()
+      }
     );
 
     expect(result.success).toBe(true);
@@ -165,7 +182,13 @@ describe('forge worktree command', () => {
 
     const result = await mod.handler(
       ['create', 'fresh-init'], {}, '/fake/root',
-      { _exec: mockExec, _spawn: mockSpawn, _fs: mockFs, _platform: 'linux' }
+      {
+        _exec: mockExec,
+        _spawn: mockSpawn,
+        _fs: mockFs,
+        _platform: 'linux',
+        _safeBeadsInit: createMockSafeBeadsInit()
+      }
     );
 
     expect(result.success).toBe(true);
@@ -204,7 +227,13 @@ describe('forge worktree command', () => {
 
     const result = await mod.handler(
       ['create', 'missing-bd'], {}, '/fake/root',
-      { _exec: mockExec, _spawn: mockSpawn, _fs: mockFs, _platform: 'linux' }
+      {
+        _exec: mockExec,
+        _spawn: mockSpawn,
+        _fs: mockFs,
+        _platform: 'linux',
+        _safeBeadsInit: createMockSafeBeadsInit()
+      }
     );
 
     expect(result.success).toBe(true);

--- a/test/commands/worktree.test.js
+++ b/test/commands/worktree.test.js
@@ -176,6 +176,45 @@ describe('forge worktree command', () => {
     expect(result.beadsWarning).toContain('initialized fresh');
   });
 
+  test('create keeps going with a warning when EPERM fallback cannot run bd init', async () => {
+    const mod = require('../../lib/commands/worktree');
+    const calls = [];
+    const mockExec = (cmd, args, _opts) => {
+      calls.push({ cmd, args });
+      if (cmd === 'git' && args[0] === 'branch' && args[1] === '--list') return Buffer.from('');
+      if (cmd === 'bd' && args[0] === 'init') {
+        throw new Error('spawn bd ENOENT');
+      }
+      if (cmd === 'bd' && args[0] === '--version') {
+        throw new Error('spawn bd ENOENT');
+      }
+      return Buffer.from('');
+    };
+    const mockSpawn = () => ({ status: 0 });
+    const mockFs = {
+      mkdirSync: () => {},
+      existsSync: (p) => p.endsWith('.beads'),
+      symlinkSync: () => {
+        const err = new Error('Operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      },
+      readdirSync: (_p) => [],
+    };
+
+    const result = await mod.handler(
+      ['create', 'missing-bd'], {}, '/fake/root',
+      { _exec: mockExec, _spawn: mockSpawn, _fs: mockFs, _platform: 'linux' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(calls).toContainEqual({
+      cmd: 'bd',
+      args: ['init', '--force']
+    });
+    expect(result.beadsWarning).toContain('fresh init failed');
+  });
+
   // (e) create: skips beads setup when .beads doesn't exist
   test('create skips beads setup when .beads does not exist', async () => {
     const mod = require('../../lib/commands/worktree');

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -71,6 +71,30 @@ describe('runtime health checks', () => {
     expect(result.checks.lefthook.state).toBe('missing-dependency');
   });
 
+  test('missing lefthook binary produces a hard-stop diagnostic with the worktree repair hint', () => {
+    const projectRoot = createProjectRoot({ lefthookDependency: true, lefthookBinary: false });
+
+    const lefthookStatus = checkLefthookStatus(projectRoot);
+    expect(lefthookStatus.state).toBe('missing-binary');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub(),
+      platform: 'linux',
+      shellRuntime: { available: true, command: '/bin/sh', policy: 'system-shell' }
+    });
+
+    expect(result.healthy).toBe(false);
+    expect(result.hardStop).toBe(true);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'LEFTHOOK_MISSING',
+        severity: 'hard-stop'
+      })
+    );
+    expect(result.checks.lefthook.state).toBe('missing-binary');
+    expect(result.checks.lefthook.message).toContain('bun install');
+  });
+
   test('missing bd produces a hard-stop diagnostic', () => {
     const projectRoot = createProjectRoot();
 

--- a/test/scripts/smart-status.test.js
+++ b/test/scripts/smart-status.test.js
@@ -161,7 +161,7 @@ REAL_JQ="${realJq}"
   return { tmpDir, wrapperPath };
 }
 
-function createMetadataRecoveryMocks({ repoRoot, databaseName }) {
+function createMetadataRecoveryMocks({ repoRoot, databaseName, metadata }) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smart-status-recovery-'));
   const bdScript = path.join(tmpDir, 'bd');
   const gitScript = path.join(tmpDir, 'git');
@@ -171,7 +171,7 @@ function createMetadataRecoveryMocks({ repoRoot, databaseName }) {
   fs.mkdirSync(path.join(repoRoot, '.beads', 'backup'), { recursive: true });
   fs.writeFileSync(
     path.join(repoRoot, '.beads', 'metadata.json'),
-    JSON.stringify({ database: 'dolt', dolt_database: databaseName }, null, 2),
+    JSON.stringify(metadata || { database: 'dolt', dolt_database: databaseName }, null, 2),
   );
   fs.writeFileSync(path.join(repoRoot, '.beads', 'backup', 'issues.jsonl'), '{"id":"forge-1"}\n');
 
@@ -272,7 +272,7 @@ describe('smart-status.sh', () => {
     });
 
   test('uses .beads/metadata.json dolt_database for auto-recovery instead of the repo basename', () => {
-    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'basename-mismatch-'));
+    const repoRoot = fs.mkdtempSync(path.join(PROJECT_ROOT, '.tmp-basename-mismatch-'));
     const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
       repoRoot,
       databaseName: 'forge-shared-db',
@@ -294,7 +294,7 @@ describe('smart-status.sh', () => {
   });
 
   test('falls back to the repo basename when .beads/metadata.json is malformed', () => {
-    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'malformed-metadata-'));
+    const repoRoot = fs.mkdtempSync(path.join(PROJECT_ROOT, '.tmp-malformed-metadata-'));
     const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
       repoRoot,
       databaseName: 'forge-shared-db',
@@ -315,6 +315,33 @@ describe('smart-status.sh', () => {
       expect(result.status).toBe(0);
       expect(fs.readFileSync(capturePath, 'utf8')).toContain(`--prefix ${fallbackPrefix}`);
       expect(fs.readFileSync(capturePath, 'utf8')).not.toContain('forge-shared-db');
+    } finally {
+      cleanupTmpDir(tmpDir);
+      cleanupTmpDir(repoRoot);
+    }
+  });
+
+  test('falls back to the repo basename when metadata only has the backend database field', () => {
+    const repoRoot = fs.mkdtempSync(path.join(PROJECT_ROOT, '.tmp-backend-only-metadata-'));
+    const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
+      repoRoot,
+      metadata: { database: 'dolt' },
+    });
+
+    try {
+      const fallbackPrefix = path.basename(repoRoot)
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+      const result = runSmartStatus(['--json'], {
+        BD_CMD: bdScript,
+        GIT_CMD: gitScript,
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.readFileSync(capturePath, 'utf8')).toContain(`--prefix ${fallbackPrefix}`);
+      expect(fs.readFileSync(capturePath, 'utf8')).not.toContain('--prefix dolt');
     } finally {
       cleanupTmpDir(tmpDir);
       cleanupTmpDir(repoRoot);

--- a/test/scripts/smart-status.test.js
+++ b/test/scripts/smart-status.test.js
@@ -293,6 +293,34 @@ describe('smart-status.sh', () => {
     }
   });
 
+  test('falls back to the repo basename when .beads/metadata.json is malformed', () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'malformed-metadata-'));
+    const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
+      repoRoot,
+      databaseName: 'forge-shared-db',
+    });
+
+    try {
+      fs.writeFileSync(path.join(repoRoot, '.beads', 'metadata.json'), '{"dolt_database":');
+      const fallbackPrefix = path.basename(repoRoot)
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+      const result = runSmartStatus(['--json'], {
+        BD_CMD: bdScript,
+        GIT_CMD: gitScript,
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.readFileSync(capturePath, 'utf8')).toContain(`--prefix ${fallbackPrefix}`);
+      expect(fs.readFileSync(capturePath, 'utf8')).not.toContain('forge-shared-db');
+    } finally {
+      cleanupTmpDir(tmpDir);
+      cleanupTmpDir(repoRoot);
+    }
+  });
+
   describe('scoring factors', () => {
     test('priority_weight: P0=5 > P1=4 > P2=3 > P3=2 > P4=1', () => {
       const mockData = {

--- a/test/scripts/smart-status.test.js
+++ b/test/scripts/smart-status.test.js
@@ -161,6 +161,58 @@ REAL_JQ="${realJq}"
   return { tmpDir, wrapperPath };
 }
 
+function createMetadataRecoveryMocks({ repoRoot, databaseName }) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smart-status-recovery-'));
+  const bdScript = path.join(tmpDir, 'bd');
+  const gitScript = path.join(tmpDir, 'git');
+  const capturePath = path.join(tmpDir, 'init-args.txt');
+  const restoredFlag = path.join(tmpDir, 'restored.flag');
+
+  fs.mkdirSync(path.join(repoRoot, '.beads', 'backup'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoRoot, '.beads', 'metadata.json'),
+    JSON.stringify({ database: 'dolt', dolt_database: databaseName }, null, 2),
+  );
+  fs.writeFileSync(path.join(repoRoot, '.beads', 'backup', 'issues.jsonl'), '{"id":"forge-1"}\n');
+
+  fs.writeFileSync(bdScript, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "list" ]]; then
+  if [[ -f ${JSON.stringify(toBashPath(restoredFlag))} ]]; then
+    echo "[]"
+    exit 0
+  fi
+  echo "database repo-root not found" >&2
+  exit 1
+fi
+if [[ "$1" == "init" ]]; then
+  printf '%s' "$*" > ${JSON.stringify(toBashPath(capturePath))}
+  exit 0
+fi
+if [[ "$1" == "backup" && "$2" == "restore" ]]; then
+  touch ${JSON.stringify(toBashPath(restoredFlag))}
+  exit 0
+fi
+if [[ "$1" == "children" ]]; then
+  echo "[]"
+  exit 0
+fi
+echo "[]"
+`, { mode: 0o755 });
+
+  fs.writeFileSync(gitScript, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "rev-parse" && "$2" == "--show-toplevel" ]]; then
+  printf '%s\\n' ${JSON.stringify(toBashPath(repoRoot))}
+  exit 0
+fi
+echo "unexpected git args: $*" >&2
+exit 1
+`, { mode: 0o755 });
+
+  return { tmpDir, bdScript, gitScript, capturePath };
+}
+
 // Generate ISO date string N days ago
 function daysAgo(n) {
   const d = new Date();
@@ -218,6 +270,28 @@ describe('smart-status.sh', () => {
         cleanupTmpDir(jqTmpDir);
       }
     });
+
+  test('uses .beads/metadata.json dolt_database for auto-recovery instead of the repo basename', () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'basename-mismatch-'));
+    const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
+      repoRoot,
+      databaseName: 'forge-shared-db',
+    });
+
+    try {
+      const result = runSmartStatus(['--json'], {
+        BD_CMD: bdScript,
+        GIT_CMD: gitScript,
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.readFileSync(capturePath, 'utf8')).toContain('--prefix forge-shared-db');
+      expect(fs.readFileSync(capturePath, 'utf8')).not.toContain(path.basename(repoRoot));
+    } finally {
+      cleanupTmpDir(tmpDir);
+      cleanupTmpDir(repoRoot);
+    }
+  });
 
   describe('scoring factors', () => {
     test('priority_weight: P0=5 > P1=4 > P2=3 > P3=2 > P4=1', () => {

--- a/test/setup-lefthook-repair.test.js
+++ b/test/setup-lefthook-repair.test.js
@@ -171,4 +171,37 @@ exit 1
     expect(checkLefthookStatus(tmpDir).binaryAvailable).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, 'node_modules', '.bin', 'lefthook'))).toBe(true);
   });
+
+  test('setup emits a hard actionable warning when declared lefthook cannot be repaired in the worktree', async () => {
+    const tmpDir = makeTempDir();
+    const mockBinDir = path.join(tmpDir, '.mock-bin');
+    fs.mkdirSync(mockBinDir, { recursive: true });
+
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({
+      name: 'repair-warning-fixture',
+      version: '1.0.0',
+      devDependencies: {
+        lefthook: '^2.1.4',
+      },
+    }, null, 2));
+
+    writeExecutable(path.join(mockBinDir, 'npm'), `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "install" ]; then
+  echo "install failed" >&2
+  exit 1
+fi
+echo "unexpected npm args: $*" >&2
+exit 1
+`);
+
+    const result = await runSetup(['--agents', 'claude', '--skip-external'], tmpDir, {
+      PATH: `${mockBinDir}${path.delimiter}${process.env.PATH || ''}`,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Installing lefthook dependencies (binary missing)');
+    expect(result.stderr).toContain('raw git push remains unsafe in this worktree');
+    expect(result.stdout).toContain('Run npm install in this worktree');
+  });
 });


### PR DESCRIPTION
## Problem
Wave 1 still had three worktree and Beads integration gaps that blocked safe parallel development: external worktrees could miss usable `.beads` state, worktrees could silently lose `lefthook`-backed push safety, and Beads auto-recovery still inferred the database name from the directory basename instead of configured metadata.

## Root Cause
The recovery logic was split across command-specific paths and still relied on stale assumptions from the main checkout. `forge worktree create` had local Beads wiring that external worktrees never received, the worktree repair path did not consistently treat a missing `lefthook` binary as a safety failure, and metadata-driven recovery was not used in the existing shell auto-recovery path.

## Fix
This PR hardens the internal worktree bootstrap and recovery flow without introducing a new Beads wrapper surface. It adds an internal bootstrap helper for tiered `.beads` recovery, extends Forge-owned recovery paths to repair or explicitly warn on missing `lefthook`, and switches Beads identity recovery to `.beads/metadata.json` with `dolt_database` preferred over basename inference.

## Value
Parallel worktrees are safer and more reliable: external worktrees can self-recover their Beads state, raw `git push` from a worktree is less likely to bypass project quality gates, and Beads recovery now follows configured metadata instead of guessing from folder names.

## Beads
Closes forge-epkw
Closes forge-ujq.2
Closes forge-9ats

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 2883 passing, 31 skipped
- Scenarios covered: external worktree bootstrap recovery, EPERM backup-restore fallback, fresh-init warning path, Beads health-check retry after bootstrap, missing `lefthook` repair and warning flow, metadata-driven smart-status recovery, and runtime diagnostics for missing binaries

### Security Review
- OWASP Top 10: Reviewed A03 injection handling in recovery paths, A05 misconfiguration risk around missing hooks, and A09 silent-fallback visibility; command execution remains argumentized and recovery failures now surface structured warnings
- Automated scan: `bun audit` passed with no vulnerabilities found

### Design Doc
See: `docs/plans/2026-04-13-wave1-worktree-beads-fixes-design.md`

### Key Decisions
- Add `lib/beads-bootstrap.js` as an internal helper only, with no new public Beads wrapper or CLI surface
- Use a three-tier Beads recovery order: shared `.beads` link first, backup restore second, fresh init with warning last
- Treat declared-but-missing `lefthook` in a worktree as a safety failure that must be repaired or surfaced explicitly
- Read recovery identity from `.beads/metadata.json`, preferring `dolt_database` over basename inference
- Keep the change set away from `bin/forge.js` and `lib/commands/_registry.js` to avoid overlap with the parallel wrapper track

### Documentation Updated
- `docs/plans/2026-04-13-wave1-worktree-beads-fixes-design.md`
- `docs/plans/2026-04-13-wave1-worktree-beads-fixes-tasks.md`
- `docs/plans/2026-04-13-wave1-worktree-beads-fixes-decisions.md`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [ ] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge; all remaining findings are P2 style/consistency items that do not block correctness or safety.
- The primary fix in `beads-bootstrap.js` is correct and well-tested. The addressed P1 from the prior round (unguarded `bd init` in EPERM path) is properly handled via `safeBeadsInit`. Remaining findings are P2: a flag-name mismatch in the shell recovery path that has no new runtime regression (the `--prefix` flag was already broken before this PR), and a misleading-but-harmless health check warning for transparent bootstrap strategies.
- No files require special attention for merge, but `scripts/smart-status.sh` and `lib/beads-health-check.js` have minor follow-up items worth addressing before the next wave of recovery work.
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/beads-health-check.js`, line 151-154 ([link](https://github.com/harshanandak/forge/blob/d3c6f6b49dffb3a640f0d192c41c7248f4069cb7/lib/beads-health-check.js#L151-L154)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Bootstrap warning is silently dropped when `bd sync` also fails**

   The `sync` catch block unconditionally overwrites `warning` rather than appending to it. If bootstrap set `warning = "bootstrap warning: recovered via linked"` and `bd sync` subsequently fails, the returned result only surfaces the sync error — the bootstrap recovery event is silently lost. The cleanup handler at line 161 correctly uses the combiner pattern; the sync catch should match it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/beads-health-check.js
   Line: 151-154

   Comment:
   **Bootstrap warning is silently dropped when `bd sync` also fails**

   The `sync` catch block unconditionally overwrites `warning` rather than appending to it. If bootstrap set `warning = "bootstrap warning: recovered via linked"` and `bd sync` subsequently fails, the returned result only surfaces the sync error — the bootstrap recovery event is silently lost. The cleanup handler at line 161 correctly uses the combiner pattern; the sync catch should match it.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/smart-status.sh
Line: 145-153

Comment:
**`--prefix` vs `--database` flag mismatch across recovery paths**

`smart-status.sh` reads `dolt_database` from metadata and passes it as `--prefix` to `bd init`, while the new `beads-bootstrap.js` reads the same field and passes it as `--database`. These are semantically different flags. More importantly, `docs/plans/2026-03-22-upstream-beads-issues.md` documents that `bd init --prefix` is a known-broken upstream flag that does **not** persist to `config.yaml` — the Forge workaround is to write `config.yaml` directly via `writeBeadsConfig`. The `beads-bootstrap.js` path handles this correctly (calls `safeBeadsInit` which writes `config.yaml` + uses `--database`), but `smart-status.sh` still passes a `dolt_database` value to the broken `--prefix` flag without a corresponding `config.yaml` write, so the prefix won't be correctly set after shell-path recovery.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: lib/beads-health-check.js
Line: 82-85

Comment:
**Misleading warning generated for transparent bootstrap strategies**

When `bootstrapResult.warning` is `null` (which it is for the `linked` and `in-place` strategies — normal, transparent cases), the ternary falls to the else branch and produces `"bootstrap warning: recovered via linked"`. This string is then surfaced in the `HealthCheckResult` as if something went wrong. Any monitoring or logging that alerts on warning fields would fire a false alarm.

Consider omitting the warning entirely when bootstrap was transparent:

```suggestion
    const bootstrapWarning = bootstrapResult.warning
      ? `bootstrap warning: ${bootstrapResult.warning}`
      : bootstrapResult.strategy !== 'linked' && bootstrapResult.strategy !== 'in-place'
        ? `bootstrap warning: recovered via ${bootstrapResult.strategy}`
        : null;
```

Or more simply, only attach a warning when `bootstrapResult.warning` is non-null.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (9): Last reviewed commit: ["fix: tolerate stale beads bootstrap back..."](https://github.com/harshanandak/forge/commit/b3e6539a7cb85f534c5d4940f52d3b351b2f778c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28191016)</sub>

<!-- /greptile_comment -->