### PR TITLE
fix: restore Windows forge issues help passthrough

### DIFF
--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -18,6 +18,15 @@ function getSpawnOptions(projectRoot) {
   };
 }
 
+function getBdCommandCandidates(deps = {}) {
+  const platform = deps.platform || process.platform;
+  if (platform === 'win32') {
+    return ['bd.cmd', 'bd.exe', 'bd'];
+  }
+
+  return ['bd'];
+}
+
 function normalizeExecOutput(output) {
   if (typeof output === 'string') {
     return output;
@@ -94,39 +103,52 @@ async function runBdCommand(operation, args, projectRoot, deps = {}) {
   const stdoutTarget = deps.stdout || process.stdout;
   const stderrTarget = deps.stderr || process.stderr;
   const captureOutput = shouldCaptureOutput(operation, args.slice(1), deps);
+  const commandCandidates = deps.commandCandidates || getBdCommandCandidates(deps);
+  let lastError;
 
-  return new Promise((resolve, reject) => {
-    const child = spawnBd('bd', args, getSpawnOptions(projectRoot));
-    let stdout = '';
-    let stderr = '';
+  for (const command of commandCandidates) {
+    try {
+      return await new Promise((resolve, reject) => {
+        const child = spawnBd(command, args, getSpawnOptions(projectRoot));
+        let stdout = '';
+        let stderr = '';
 
-    child.stdout?.setEncoding?.('utf8');
-    child.stderr?.setEncoding?.('utf8');
-    child.stdout?.on?.('data', chunk => {
-      const normalizedChunk = normalizeExecOutput(chunk);
-      if (captureOutput) {
-        stdout += normalizedChunk;
-      } else {
-        stdoutTarget?.write?.(normalizedChunk);
-      }
-    });
-    child.stderr?.on?.('data', chunk => {
-      const normalizedChunk = normalizeExecOutput(chunk);
-      if (captureOutput) {
-        stderr += normalizedChunk;
-      }
-      stderrTarget?.write?.(normalizedChunk);
-    });
+        child.stdout?.setEncoding?.('utf8');
+        child.stderr?.setEncoding?.('utf8');
+        child.stdout?.on?.('data', chunk => {
+          const normalizedChunk = normalizeExecOutput(chunk);
+          if (captureOutput) {
+            stdout += normalizedChunk;
+          } else {
+            stdoutTarget?.write?.(normalizedChunk);
+          }
+        });
+        child.stderr?.on?.('data', chunk => {
+          const normalizedChunk = normalizeExecOutput(chunk);
+          if (captureOutput) {
+            stderr += normalizedChunk;
+          }
+          stderrTarget?.write?.(normalizedChunk);
+        });
 
-    child.on('error', reject);
-    child.on('close', code => {
-      resolve({
-        code,
-        stdout,
-        stderr,
+        child.on('error', reject);
+        child.on('close', code => {
+          resolve({
+            code,
+            stdout,
+            stderr,
+          });
+        });
       });
-    });
-  });
+    } catch (error) {
+      lastError = error;
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError;
 }
 
 async function runBeadsOperation(operation, args, context, deps) {
@@ -241,4 +263,5 @@ module.exports = {
   isHelpInvocation,
   normalizeExecOutput,
   runBdCommand,
+  getBdCommandCandidates,
 };

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -432,4 +432,56 @@ describe('forge issue service contract', () => {
 
     expect(writes).toEqual([]);
   });
+
+  test('runBdCommand uses Windows bd command candidates until one succeeds', async () => {
+    const { runBdCommand } = require('../lib/forge-issues');
+    const calls = [];
+
+    const result = await runBdCommand('create', ['create', '--help'], '/repo', {
+      platform: 'win32',
+      spawn: (command, _args, _options) => {
+        calls.push(command);
+        const events = {};
+        const stdoutHandlers = {};
+        const stderrHandlers = {};
+
+        queueMicrotask(() => {
+          if (command === 'bd.cmd') {
+            const error = new Error('spawn bd ENOENT');
+            error.code = 'ENOENT';
+            events.error?.(error);
+            return;
+          }
+
+          stdoutHandlers.data?.('BD CREATE HELP\n');
+          events.close?.(0);
+        });
+
+        return {
+          stdout: {
+            setEncoding() {},
+            on(event, handler) {
+              stdoutHandlers[event] = handler;
+            },
+          },
+          stderr: {
+            setEncoding() {},
+            on(event, handler) {
+              stderrHandlers[event] = handler;
+            },
+          },
+          on(event, handler) {
+            events[event] = handler;
+          },
+        };
+      },
+    });
+
+    expect(result).toEqual({
+      code: 0,
+      stdout: 'BD CREATE HELP\n',
+      stderr: '',
+    });
+    expect(calls).toEqual(['bd.cmd', 'bd.exe']);
+  });
 });


### PR DESCRIPTION
## Problem
`master` is blocked in `/verify` because the Windows `Tests` workflow fails on `forge issues create --help`.

## Root Cause
The Forge issues backend switched to a spawned `bd` process, but on Windows the help passthrough path did not reliably resolve the executable name that the test injects via `PATH`. That made `forge issues create --help` exit through the backend-not-found path instead of forwarding help to Beads.

## Fix
Restore Windows help passthrough by trying the Windows Beads executable candidates in a safe order and keeping the first successful process. Add a focused regression test at the backend layer so the Windows command-resolution path is pinned directly.

## Value
This unblocks the failing `master` workflow, restores the advertised `forge issues ... --help` passthrough behavior on Windows, and reduces the chance of another command-resolution regression in the issue authority layer.

## Beads
Closes forge-rm1n

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 2 targeted regressions passing
- Scenarios covered: Windows `bd` candidate fallback in `runBdCommand`; `forge issues create --help` registry dispatch end-to-end

### Security Review
- OWASP Top 10: No new shell interpolation added. The change keeps array-based process spawning and only varies the executable candidate list on Windows.
- Automated scan: `npm audit` could not run in this repo because there is no lockfile (`ENOLOCK`)

### Design Doc
- N/A — hotfix for post-merge regression on `master`

### Key Decisions
- Prefer Windows-specific Beads executable candidates in this order: `bd.cmd`, `bd.exe`, `bd`
- Retry only on `ENOENT`; preserve existing behavior for real process failures
- Cover the fallback at the backend unit level instead of relying only on the slower CLI integration test

### Documentation Updated
- None — no doc-facing changes

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [ ] All tests passing
- [ ] Security review completed

Validation run details:
- `bun run typecheck`
- `bun run eslint lib/forge-issues.js test/forge-issues.test.js test/forge-cli-registry.test.js --max-warnings 0`
- `bun test test/forge-issues.test.js --test-name-pattern "runBdCommand uses Windows bd command candidates until one succeeds"`
- `bun test test/forge-cli-registry.test.js --test-name-pattern "forge issues create --help reaches the issues handler instead of global help parsing"`
- `bun test test/` still fails locally for unrelated pre-existing issues outside this hotfix (package-skills missing `inquirer`/`chalk`, plus existing timeout-based failures in other suites)

</details>

---

### Self-Review Checklist

- [ ] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [ ] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — focused hotfix with no production defects identified.
- All remaining findings are P2 style suggestions. The core candidate-retry logic is correct, ENOENT is the only condition that advances to the next candidate, and the direct runBdCommand unit test adequately pins the Windows fallback behavior.
- No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/forge-issues.js`, line 235-239 ([link](https://github.com/harshanandak/forge/blob/00839f43d044452d0b2a83102b3b75e404c6cd02/lib/forge-issues.js#L235-L239)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`platform` not forwarded through `backendDeps`**

   `runIssueOperation` builds `backendDeps` with only `isBeadsInitialized`, `runBdCommand`, and `spawn`. `platform` (and `commandCandidates`) are not forwarded, so a caller injecting `platform: 'win32'` into `deps` cannot exercise the Windows candidate list through the full `runIssueOperation` → `runBdCommand` chain. In production this is correct because `process.platform` is used, but it does mean cross-platform coverage at this entry point depends entirely on mocking `spawn` rather than the simpler `platform` override. Consider forwarding `platform` and `commandCandidates` here so all dep knobs available in `runBdCommand` are accessible end-to-end.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/forge-issues.js
   Line: 235-239

   Comment:
   **`platform` not forwarded through `backendDeps`**

   `runIssueOperation` builds `backendDeps` with only `isBeadsInitialized`, `runBdCommand`, and `spawn`. `platform` (and `commandCandidates`) are not forwarded, so a caller injecting `platform: 'win32'` into `deps` cannot exercise the Windows candidate list through the full `runIssueOperation` → `runBdCommand` chain. In production this is correct because `process.platform` is used, but it does mean cross-platform coverage at this entry point depends entirely on mocking `spawn` rather than the simpler `platform` override. Consider forwarding `platform` and `commandCandidates` here so all dep knobs available in `runBdCommand` are accessible end-to-end.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: lib/forge-issues.js
Line: 235-239

Comment:
**`platform` not forwarded through `backendDeps`**

`runIssueOperation` builds `backendDeps` with only `isBeadsInitialized`, `runBdCommand`, and `spawn`. `platform` (and `commandCandidates`) are not forwarded, so a caller injecting `platform: 'win32'` into `deps` cannot exercise the Windows candidate list through the full `runIssueOperation` → `runBdCommand` chain. In production this is correct because `process.platform` is used, but it does mean cross-platform coverage at this entry point depends entirely on mocking `spawn` rather than the simpler `platform` override. Consider forwarding `platform` and `commandCandidates` here so all dep knobs available in `runBdCommand` are accessible end-to-end.

```suggestion
    const backendDeps = {
      isBeadsInitialized: deps.isBeadsInitialized,
      runBdCommand: deps.runBdCommand,
      spawn: deps.spawn,
      platform: deps.platform,
      commandCandidates: deps.commandCandidates,
    };
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restore windows forge issues help p..."](https://github.com/harshanandak/forge/commit/00839f43d044452d0b2a83102b3b75e404c6cd02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28312323)</sub>

<!-- /greptile_comment -->