### PR TITLE
fix: honor Windows bd path overrides for forge issues

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -69,8 +69,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -70,7 +70,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -57,7 +57,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -107,7 +107,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -57,7 +57,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -166,10 +166,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -20,15 +20,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -77,10 +77,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -20,7 +20,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -26,7 +26,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.cline/workflows/dev.md
+++ b/.cline/workflows/dev.md
@@ -67,7 +67,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.cline/workflows/dev.md
+++ b/.cline/workflows/dev.md
@@ -66,8 +66,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.cline/workflows/plan.md
+++ b/.cline/workflows/plan.md
@@ -54,7 +54,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -104,7 +104,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.cline/workflows/plan.md
+++ b/.cline/workflows/plan.md
@@ -54,7 +54,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.cline/workflows/ship.md
+++ b/.cline/workflows/ship.md
@@ -163,10 +163,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.cline/workflows/status.md
+++ b/.cline/workflows/status.md
@@ -17,7 +17,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.cline/workflows/status.md
+++ b/.cline/workflows/status.md
@@ -17,15 +17,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -74,10 +74,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/.cline/workflows/status.md
+++ b/.cline/workflows/status.md
@@ -23,7 +23,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -69,8 +69,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -70,7 +70,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -57,7 +57,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -107,7 +107,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -57,7 +57,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -166,10 +166,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -20,15 +20,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -77,10 +77,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -20,7 +20,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -26,7 +26,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.cursor/commands/dev.md
+++ b/.cursor/commands/dev.md
@@ -67,7 +67,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.cursor/commands/dev.md
+++ b/.cursor/commands/dev.md
@@ -66,8 +66,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -54,7 +54,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -104,7 +104,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -54,7 +54,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -163,10 +163,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.cursor/commands/status.md
+++ b/.cursor/commands/status.md
@@ -17,7 +17,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.cursor/commands/status.md
+++ b/.cursor/commands/status.md
@@ -17,15 +17,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -74,10 +74,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/.cursor/commands/status.md
+++ b/.cursor/commands/status.md
@@ -23,7 +23,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-15T08:18:27.231Z",
+  "generatedAt": "2026-04-15T12:25:47.501Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-15T12:25:47.501Z",
+  "generatedAt": "2026-04-15T12:34:39.628Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-14T12:02:55.830Z",
+  "generatedAt": "2026-04-15T08:18:27.231Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-09T10:36:00.700Z",
+  "generatedAt": "2026-04-14T12:02:55.830Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-15T12:34:39.628Z",
+  "generatedAt": "2026-04-15T12:49:30.183Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.github/prompts/dev.prompt.md
+++ b/.github/prompts/dev.prompt.md
@@ -72,7 +72,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.github/prompts/dev.prompt.md
+++ b/.github/prompts/dev.prompt.md
@@ -71,8 +71,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -59,7 +59,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -109,7 +109,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -59,7 +59,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.github/prompts/ship.prompt.md
+++ b/.github/prompts/ship.prompt.md
@@ -168,10 +168,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -22,15 +22,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -79,10 +79,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -28,7 +28,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -22,7 +22,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.kilocode/workflows/dev.md
+++ b/.kilocode/workflows/dev.md
@@ -70,8 +70,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.kilocode/workflows/dev.md
+++ b/.kilocode/workflows/dev.md
@@ -71,7 +71,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.kilocode/workflows/plan.md
+++ b/.kilocode/workflows/plan.md
@@ -58,7 +58,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -108,7 +108,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.kilocode/workflows/plan.md
+++ b/.kilocode/workflows/plan.md
@@ -58,7 +58,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.kilocode/workflows/ship.md
+++ b/.kilocode/workflows/ship.md
@@ -167,10 +167,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.kilocode/workflows/status.md
+++ b/.kilocode/workflows/status.md
@@ -27,7 +27,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.kilocode/workflows/status.md
+++ b/.kilocode/workflows/status.md
@@ -21,7 +21,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.kilocode/workflows/status.md
+++ b/.kilocode/workflows/status.md
@@ -21,15 +21,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -78,10 +78,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/.opencode/commands/dev.md
+++ b/.opencode/commands/dev.md
@@ -69,8 +69,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.opencode/commands/dev.md
+++ b/.opencode/commands/dev.md
@@ -70,7 +70,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -57,7 +57,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -107,7 +107,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -57,7 +57,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -166,10 +166,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -20,15 +20,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -77,10 +77,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -20,7 +20,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -26,7 +26,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.roo/commands/dev.md
+++ b/.roo/commands/dev.md
@@ -70,8 +70,8 @@ Do NOT write any code until ALL confirmed:
 Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
-# Auto-sync to get latest team state
-forge sync
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.roo/commands/dev.md
+++ b/.roo/commands/dev.md
@@ -71,7 +71,7 @@ Before starting the per-task loop, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with the current beads issue
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.roo/commands/plan.md
+++ b/.roo/commands/plan.md
@@ -58,7 +58,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-bash scripts/sync-utils.sh auto-sync
+forge sync
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>
@@ -108,7 +108,7 @@ If merge conflicts or unmet dependencies are found:
 Before starting planning, verify team identity is mapped:
 
 ```bash
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).

--- a/.roo/commands/plan.md
+++ b/.roo/commands/plan.md
@@ -58,7 +58,7 @@ Before proceeding to Phase 1, check for cross-developer conflicts:
 
 ```bash
 # Auto-sync to get latest team state
-forge sync
+forge sync || true
 
 # Check for conflicts with this issue's planned work area
 bash scripts/conflict-detect.sh --issue <beads-id>

--- a/.roo/commands/ship.md
+++ b/.roo/commands/ship.md
@@ -167,10 +167,10 @@ After PR is created, sync issue state to GitHub and verify 1:1 mapping:
 
 ```bash
 # Sync issue state to GitHub
-bash scripts/forge-team/index.sh sync 2>&1 || true
+forge team sync 2>&1 || true
 
 # Verify 1:1 mapping
-bash scripts/forge-team/index.sh verify 2>&1 || true
+forge team verify 2>&1 || true
 ```
 
 ## Example Output

--- a/.roo/commands/status.md
+++ b/.roo/commands/status.md
@@ -27,7 +27,7 @@ forge sync || true
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-forge status
+bash scripts/smart-status.sh
 ```
 This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 

--- a/.roo/commands/status.md
+++ b/.roo/commands/status.md
@@ -21,7 +21,7 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-forge sync
+forge sync || true
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)

--- a/.roo/commands/status.md
+++ b/.roo/commands/status.md
@@ -21,15 +21,15 @@ This command helps you understand the current state of the project before starti
 
 ```bash
 # Sync team state before showing status
-bash scripts/sync-utils.sh auto-sync
+forge sync
 ```
 
 ### Step 1: Smart Status (ranked issues with conflict detection)
 
 ```bash
-bash scripts/smart-status.sh
+forge status
 ```
-This script dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed — the script handles everything.
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
 
 For full context on any issue: `bd show <id>`
 
@@ -78,10 +78,10 @@ Show current developer's active work and team overview:
 
 ```bash
 # Show my active issues
-bash scripts/forge-team/index.sh workload --me 2>&1 || true
+forge team workload --me 2>&1 || true
 
 # One-line team summary
-bash scripts/forge-team/index.sh dashboard 2>&1 | head -5 || true
+forge team dashboard 2>&1 | head -5 || true
 ```
 
 ## Next Steps

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -37,7 +37,9 @@ function resolveWindowsCommandCandidates(commandNames, deps = {}) {
 
   for (const dir of pathEntries) {
     for (const commandName of commandNames) {
-      const fullPath = path.win32.join(dir, commandName);
+      const fullPath = isWindowsPathEntry(dir)
+        ? path.win32.join(dir, commandName)
+        : path.posix.join(dir, commandName);
       const dedupeKey = fullPath.toLowerCase();
       if (!seen.has(dedupeKey) && fileExists(fullPath)) {
         seen.add(dedupeKey);
@@ -47,6 +49,10 @@ function resolveWindowsCommandCandidates(commandNames, deps = {}) {
   }
 
   return resolved;
+}
+
+function isWindowsPathEntry(entry = '') {
+  return /^(?:[a-zA-Z]:[\\/]|\\\\)/.test(entry) || entry.includes('\\');
 }
 
 function getBdCommandCandidates(deps = {}) {

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -20,10 +20,10 @@ function getSpawnOptions(projectRoot) {
   };
 }
 
-function getPathEntries(env = process.env) {
+function getPathEntries(env = process.env, delimiter = path.delimiter) {
   const rawPath = env.PATH || env.Path || '';
   return rawPath
-    .split(path.delimiter)
+    .split(delimiter)
     .map(entry => entry.trim().replace(/^"(.*)"$/, '$1'))
     .filter(Boolean);
 }
@@ -33,8 +33,9 @@ function resolveWindowsCommandCandidates(commandNames, deps = {}) {
   const fileExists = deps.existsSync || existsSync;
   const resolved = [];
   const seen = new Set();
+  const pathEntries = getPathEntries(env, ';');
 
-  for (const dir of getPathEntries(env)) {
+  for (const dir of pathEntries) {
     for (const commandName of commandNames) {
       const fullPath = path.join(dir, commandName);
       const dedupeKey = fullPath.toLowerCase();

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { spawn } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const path = require('node:path');
 const { isBeadsInitialized } = require('./beads-setup');
 
 const OPERATION_TO_BD = {
@@ -18,13 +20,39 @@ function getSpawnOptions(projectRoot) {
   };
 }
 
+function getPathEntries(env = process.env) {
+  const rawPath = env.PATH || env.Path || '';
+  return rawPath
+    .split(path.delimiter)
+    .map(entry => entry.trim().replace(/^"(.*)"$/, '$1'))
+    .filter(Boolean);
+}
+
+function resolveWindowsCommandCandidates(commandNames, deps = {}) {
+  const env = deps.env || process.env;
+  const fileExists = deps.existsSync || existsSync;
+  const resolved = [];
+  const seen = new Set();
+
+  for (const dir of getPathEntries(env)) {
+    for (const commandName of commandNames) {
+      const fullPath = path.join(dir, commandName);
+      const dedupeKey = fullPath.toLowerCase();
+      if (!seen.has(dedupeKey) && fileExists(fullPath)) {
+        seen.add(dedupeKey);
+        resolved.push(fullPath);
+      }
+    }
+  }
+
+  return resolved;
+}
+
 function getBdCommandCandidates(deps = {}) {
   const platform = deps.platform || process.platform;
   if (platform === 'win32') {
-    // Prefer native executables (no shell needed) over .cmd scripts.
-    // bd.exe works with spawn() directly; bd.cmd would require shell:true
-    // which introduces command injection risk.
-    return ['bd.exe', 'bd'];
+    const resolved = resolveWindowsCommandCandidates(['bd.cmd', 'bd.exe'], deps);
+    return resolved.length > 0 ? resolved : ['bd.exe', 'bd'];
   }
 
   return ['bd'];
@@ -268,4 +296,6 @@ module.exports = {
   normalizeExecOutput,
   runBdCommand,
   getBdCommandCandidates,
+  getPathEntries,
+  resolveWindowsCommandCandidates,
 };

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -37,7 +37,7 @@ function resolveWindowsCommandCandidates(commandNames, deps = {}) {
 
   for (const dir of pathEntries) {
     for (const commandName of commandNames) {
-      const fullPath = path.join(dir, commandName);
+      const fullPath = path.win32.join(dir, commandName);
       const dedupeKey = fullPath.toLowerCase();
       if (!seen.has(dedupeKey) && fileExists(fullPath)) {
         seen.add(dedupeKey);

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -52,8 +52,8 @@ function resolveWindowsCommandCandidates(commandNames, deps = {}) {
 function getBdCommandCandidates(deps = {}) {
   const platform = deps.platform || process.platform;
   if (platform === 'win32') {
-    const resolved = resolveWindowsCommandCandidates(['bd.cmd', 'bd.exe'], deps);
-    return resolved.length > 0 ? resolved : ['bd.exe', 'bd'];
+    const resolved = resolveWindowsCommandCandidates(['bd.exe', 'bd.cmd'], deps);
+    return [...new Set([...resolved, 'bd.exe', 'bd'])];
   }
 
   return ['bd'];
@@ -174,8 +174,8 @@ async function runBdCommand(operation, args, projectRoot, deps = {}) {
       });
     } catch (error) {
       lastError = error;
-      // ENOENT means this candidate binary doesn't exist — try next
-      if (error?.code !== 'ENOENT') {
+      // ENOENT/EINVAL means this candidate is not directly spawnable — try next.
+      if (error?.code !== 'ENOENT' && error?.code !== 'EINVAL') {
         throw error;
       }
     }

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -269,6 +269,8 @@ async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
       isBeadsInitialized: deps.isBeadsInitialized,
       runBdCommand: deps.runBdCommand,
       spawn: deps.spawn,
+      platform: deps.platform,
+      env: deps.env,
     };
 
     return createIssueService({

--- a/scripts/beads-context.test.js
+++ b/scripts/beads-context.test.js
@@ -470,7 +470,7 @@ describe('/dev command integration with beads-context.sh', () => {
 	});
 });
 
-describe('/status command integration with smart-status.sh', () => {
+describe('/status command integration with forge status', () => {
 	const STATUS_MD_PATH = path.join(
 		__dirname,
 		'..',
@@ -484,8 +484,9 @@ describe('/status command integration with smart-status.sh', () => {
 		statusContent = fs.readFileSync(STATUS_MD_PATH, 'utf-8');
 	});
 
-	test('status.md should reference smart-status.sh as the primary status command', () => {
-		expect(statusContent).toContain('smart-status.sh');
+	test('status.md should reference forge status as the primary status command', () => {
+		expect(statusContent).toContain('forge status');
+		expect(statusContent).not.toContain('bash scripts/smart-status.sh');
 	});
 
 	test('status.md should include hint to use bd show for full context', () => {

--- a/scripts/beads-context.test.js
+++ b/scripts/beads-context.test.js
@@ -470,7 +470,7 @@ describe('/dev command integration with beads-context.sh', () => {
 	});
 });
 
-describe('/status command integration with forge status', () => {
+describe('/status command integration with smart-status', () => {
 	const STATUS_MD_PATH = path.join(
 		__dirname,
 		'..',
@@ -484,9 +484,8 @@ describe('/status command integration with forge status', () => {
 		statusContent = fs.readFileSync(STATUS_MD_PATH, 'utf-8');
 	});
 
-	test('status.md should reference forge status as the primary status command', () => {
-		expect(statusContent).toContain('forge status');
-		expect(statusContent).not.toContain('bash scripts/smart-status.sh');
+	test('status.md should reference smart-status.sh as the primary status command', () => {
+		expect(statusContent).toContain('bash scripts/smart-status.sh');
 	});
 
 	test('status.md should include hint to use bd show for full context', () => {

--- a/test/commands/status-smart.test.js
+++ b/test/commands/status-smart.test.js
@@ -4,13 +4,12 @@ const { join } = require("node:path");
 
 const ROOT = join(__dirname, "../..");
 
-describe("/status command - forge status integration", () => {
+describe("/status command - smart-status integration", () => {
   const statusPath = join(ROOT, ".claude/commands/status.md");
   const content = readFileSync(statusPath, "utf-8");
 
-  it("references forge status as the primary status command", () => {
-    expect(content).toContain("forge status");
-    expect(content).not.toContain("bash scripts/smart-status.sh");
+  it("references smart-status.sh as the primary status command", () => {
+    expect(content).toContain("bash scripts/smart-status.sh");
   });
 
   it("does NOT use 'bd list --status in_progress' as the primary step", () => {
@@ -27,14 +26,13 @@ describe("/status command - forge status integration", () => {
     expect(content).toContain("git log");
   });
 
-  it("agent copies (.cursor, .roo) also reference forge status", () => {
+  it("agent copies (.cursor, .roo) also reference smart-status.sh", () => {
     const agentDirs = [".cursor", ".roo"];
     for (const dir of agentDirs) {
       const agentPath = join(ROOT, dir, "commands/status.md");
       expect(existsSync(agentPath)).toBe(true);
       const agentContent = readFileSync(agentPath, "utf-8");
-      expect(agentContent).toContain("forge status");
-      expect(agentContent).not.toContain("bash scripts/smart-status.sh");
+      expect(agentContent).toContain("bash scripts/smart-status.sh");
     }
   });
 

--- a/test/commands/status-smart.test.js
+++ b/test/commands/status-smart.test.js
@@ -4,17 +4,16 @@ const { join } = require("node:path");
 
 const ROOT = join(__dirname, "../..");
 
-describe("/status command — smart-status integration", () => {
+describe("/status command - forge status integration", () => {
   const statusPath = join(ROOT, ".claude/commands/status.md");
   const content = readFileSync(statusPath, "utf-8");
 
-  it("references smart-status.sh as the primary status command", () => {
-    expect(content).toContain("smart-status.sh");
+  it("references forge status as the primary status command", () => {
+    expect(content).toContain("forge status");
+    expect(content).not.toContain("bash scripts/smart-status.sh");
   });
 
   it("does NOT use 'bd list --status in_progress' as the primary step", () => {
-    // The old Step 2 used bd list --status in_progress as the main command.
-    // It should no longer appear as a standalone step command.
     const lines = content.split("\n");
     const hasPrimaryBdList = lines.some(
       (line) =>
@@ -28,13 +27,14 @@ describe("/status command — smart-status integration", () => {
     expect(content).toContain("git log");
   });
 
-  it("agent copies (.cursor, .roo) also reference smart-status.sh", () => {
+  it("agent copies (.cursor, .roo) also reference forge status", () => {
     const agentDirs = [".cursor", ".roo"];
     for (const dir of agentDirs) {
       const agentPath = join(ROOT, dir, "commands/status.md");
       expect(existsSync(agentPath)).toBe(true);
       const agentContent = readFileSync(agentPath, "utf-8");
-      expect(agentContent).toContain("smart-status.sh");
+      expect(agentContent).toContain("forge status");
+      expect(agentContent).not.toContain("bash scripts/smart-status.sh");
     }
   });
 

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -133,6 +133,61 @@ describe('forge issue service contract', () => {
     }]);
   });
 
+  test('top-level operation runner forwards injected Windows platform and PATH overrides', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+    const calls = [];
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-run-issue-win32-'));
+
+    try {
+      const exePath = path.join(tempDir, 'bd.exe');
+      fs.writeFileSync(exePath, '', 'utf8');
+
+      const result = await runIssueOperation('create', ['--help'], '/repo', {
+        platform: 'win32',
+        env: { PATH: tempDir },
+        spawn: (command, _args, _options) => {
+          calls.push(command);
+          const events = {};
+          const stdoutHandlers = {};
+          const stderrHandlers = {};
+
+          queueMicrotask(() => {
+            stdoutHandlers.data?.('BD CREATE HELP\n');
+            events.close?.(0);
+          });
+
+          return {
+            stdout: {
+              setEncoding() {},
+              on(event, handler) {
+                stdoutHandlers[event] = handler;
+              },
+            },
+            stderr: {
+              setEncoding() {},
+              on(event, handler) {
+                stderrHandlers[event] = handler;
+              },
+            },
+            on(event, handler) {
+              events[event] = handler;
+            },
+          };
+        },
+      });
+
+      expect(result).toEqual({
+        success: true,
+        operation: 'create',
+        output: 'BD CREATE HELP\n',
+        stderr: '',
+      });
+      expect(calls).toEqual([exePath]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test('default beads backend rejects issue operations when beads is not initialized', async () => {
     const { createBeadsIssueBackend } = require('../lib/forge-issues');
 

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 describe('forge issue service contract', () => {
   test('exports service factory and operation runner', () => {
@@ -436,9 +439,16 @@ describe('forge issue service contract', () => {
   test('runBdCommand uses Windows bd command candidates until one succeeds', async () => {
     const { runBdCommand } = require('../lib/forge-issues');
     const calls = [];
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-bd-candidates-'));
+    const cmdPath = path.join(tempDir, 'bd.cmd');
+    const exePath = path.join(tempDir, 'bd.exe');
+
+    fs.writeFileSync(cmdPath, '@echo off\r\n', 'utf8');
+    fs.writeFileSync(exePath, '', 'utf8');
 
     const result = await runBdCommand('create', ['create', '--help'], '/repo', {
       platform: 'win32',
+      env: { PATH: tempDir },
       spawn: (command, _args, _options) => {
         calls.push(command);
         const events = {};
@@ -446,7 +456,7 @@ describe('forge issue service contract', () => {
         const stderrHandlers = {};
 
         queueMicrotask(() => {
-          if (command === 'bd.exe') {
+          if (command === cmdPath) {
             const error = new Error('spawn bd ENOENT');
             error.code = 'ENOENT';
             events.error?.(error);
@@ -482,6 +492,6 @@ describe('forge issue service contract', () => {
       stdout: 'BD CREATE HELP\n',
       stderr: '',
     });
-    expect(calls).toEqual(['bd.exe', 'bd']);
+    expect(calls).toEqual([cmdPath, exePath]);
   });
 });

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -578,6 +578,28 @@ describe('forge issue service contract', () => {
     expect(candidates).toEqual(['C:\\tools\\bd.exe', 'bd.exe', 'bd']);
   });
 
+  test('getBdCommandCandidates preserves POSIX temp paths while simulating win32', () => {
+    const { getBdCommandCandidates } = require('../lib/forge-issues');
+    const seen = [];
+
+    const candidates = getBdCommandCandidates({
+      platform: 'win32',
+      env: { PATH: '/tmp/forge-bin;/tmp/other-bin' },
+      existsSync: candidate => {
+        seen.push(candidate);
+        return candidate === '/tmp/forge-bin/bd.exe';
+      },
+    });
+
+    expect(seen).toEqual([
+      '/tmp/forge-bin/bd.exe',
+      '/tmp/forge-bin/bd.cmd',
+      '/tmp/other-bin/bd.exe',
+      '/tmp/other-bin/bd.cmd',
+    ]);
+    expect(candidates).toEqual(['/tmp/forge-bin/bd.exe', 'bd.exe', 'bd']);
+  });
+
   test('runBdCommand falls back when a Windows cmd shim is not directly spawnable', async () => {
     const { runBdCommand } = require('../lib/forge-issues');
     const calls = [];

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -436,7 +436,7 @@ describe('forge issue service contract', () => {
     expect(writes).toEqual([]);
   });
 
-  test('runBdCommand uses Windows bd command candidates until one succeeds', async () => {
+  test('runBdCommand prefers Windows exe candidates before cmd shims', async () => {
     const { runBdCommand } = require('../lib/forge-issues');
     const calls = [];
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-bd-candidates-'));
@@ -457,13 +457,6 @@ describe('forge issue service contract', () => {
           const stderrHandlers = {};
 
           queueMicrotask(() => {
-            if (command === cmdPath) {
-              const error = new Error('spawn bd ENOENT');
-              error.code = 'ENOENT';
-              events.error?.(error);
-              return;
-            }
-
             stdoutHandlers.data?.('BD CREATE HELP\n');
             events.close?.(0);
           });
@@ -493,7 +486,7 @@ describe('forge issue service contract', () => {
         stdout: 'BD CREATE HELP\n',
         stderr: '',
       });
-      expect(calls).toEqual([cmdPath, exePath]);
+      expect(calls).toEqual([exePath]);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -506,5 +499,58 @@ describe('forge issue service contract', () => {
       'C:\\tools',
       'D:\\bin',
     ]);
+  });
+
+  test('runBdCommand falls back when a Windows cmd shim is not directly spawnable', async () => {
+    const { runBdCommand } = require('../lib/forge-issues');
+    const calls = [];
+
+    const result = await runBdCommand('create', ['create', '--help'], '/repo', {
+      platform: 'win32',
+      commandCandidates: ['C:\\tools\\bd.cmd', 'bd.exe'],
+      spawn: (command, _args, _options) => {
+        calls.push(command);
+        const events = {};
+        const stdoutHandlers = {};
+        const stderrHandlers = {};
+
+        queueMicrotask(() => {
+          if (command.endsWith('.cmd')) {
+            const error = new Error('spawn bd.cmd EINVAL');
+            error.code = 'EINVAL';
+            events.error?.(error);
+            return;
+          }
+
+          stdoutHandlers.data?.('BD CREATE HELP\n');
+          events.close?.(0);
+        });
+
+        return {
+          stdout: {
+            setEncoding() {},
+            on(event, handler) {
+              stdoutHandlers[event] = handler;
+            },
+          },
+          stderr: {
+            setEncoding() {},
+            on(event, handler) {
+              stderrHandlers[event] = handler;
+            },
+          },
+          on(event, handler) {
+            events[event] = handler;
+          },
+        };
+      },
+    });
+
+    expect(result).toEqual({
+      code: 0,
+      stdout: 'BD CREATE HELP\n',
+      stderr: '',
+    });
+    expect(calls).toEqual(['C:\\tools\\bd.cmd', 'bd.exe']);
   });
 });

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -556,6 +556,28 @@ describe('forge issue service contract', () => {
     ]);
   });
 
+  test('getBdCommandCandidates uses win32 path joining for injected Windows overrides off-host', () => {
+    const { getBdCommandCandidates } = require('../lib/forge-issues');
+    const seen = [];
+
+    const candidates = getBdCommandCandidates({
+      platform: 'win32',
+      env: { PATH: 'C:\\tools;D:\\bin' },
+      existsSync: candidate => {
+        seen.push(candidate);
+        return candidate === 'C:\\tools\\bd.exe';
+      },
+    });
+
+    expect(seen).toEqual([
+      'C:\\tools\\bd.exe',
+      'C:\\tools\\bd.cmd',
+      'D:\\bin\\bd.exe',
+      'D:\\bin\\bd.cmd',
+    ]);
+    expect(candidates).toEqual(['C:\\tools\\bd.exe', 'bd.exe', 'bd']);
+  });
+
   test('runBdCommand falls back when a Windows cmd shim is not directly spawnable', async () => {
     const { runBdCommand } = require('../lib/forge-issues');
     const calls = [];

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -440,58 +440,71 @@ describe('forge issue service contract', () => {
     const { runBdCommand } = require('../lib/forge-issues');
     const calls = [];
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-bd-candidates-'));
-    const cmdPath = path.join(tempDir, 'bd.cmd');
-    const exePath = path.join(tempDir, 'bd.exe');
+    try {
+      const cmdPath = path.join(tempDir, 'bd.cmd');
+      const exePath = path.join(tempDir, 'bd.exe');
 
-    fs.writeFileSync(cmdPath, '@echo off\r\n', 'utf8');
-    fs.writeFileSync(exePath, '', 'utf8');
+      fs.writeFileSync(cmdPath, '@echo off\r\n', 'utf8');
+      fs.writeFileSync(exePath, '', 'utf8');
 
-    const result = await runBdCommand('create', ['create', '--help'], '/repo', {
-      platform: 'win32',
-      env: { PATH: tempDir },
-      spawn: (command, _args, _options) => {
-        calls.push(command);
-        const events = {};
-        const stdoutHandlers = {};
-        const stderrHandlers = {};
+      const result = await runBdCommand('create', ['create', '--help'], '/repo', {
+        platform: 'win32',
+        env: { PATH: tempDir },
+        spawn: (command, _args, _options) => {
+          calls.push(command);
+          const events = {};
+          const stdoutHandlers = {};
+          const stderrHandlers = {};
 
-        queueMicrotask(() => {
-          if (command === cmdPath) {
-            const error = new Error('spawn bd ENOENT');
-            error.code = 'ENOENT';
-            events.error?.(error);
-            return;
-          }
+          queueMicrotask(() => {
+            if (command === cmdPath) {
+              const error = new Error('spawn bd ENOENT');
+              error.code = 'ENOENT';
+              events.error?.(error);
+              return;
+            }
 
-          stdoutHandlers.data?.('BD CREATE HELP\n');
-          events.close?.(0);
-        });
+            stdoutHandlers.data?.('BD CREATE HELP\n');
+            events.close?.(0);
+          });
 
-        return {
-          stdout: {
-            setEncoding() {},
-            on(event, handler) {
-              stdoutHandlers[event] = handler;
+          return {
+            stdout: {
+              setEncoding() {},
+              on(event, handler) {
+                stdoutHandlers[event] = handler;
+              },
             },
-          },
-          stderr: {
-            setEncoding() {},
-            on(event, handler) {
-              stderrHandlers[event] = handler;
+            stderr: {
+              setEncoding() {},
+              on(event, handler) {
+                stderrHandlers[event] = handler;
+              },
             },
-          },
-          on(event, handler) {
-            events[event] = handler;
-          },
-        };
-      },
-    });
+            on(event, handler) {
+              events[event] = handler;
+            },
+          };
+        },
+      });
 
-    expect(result).toEqual({
-      code: 0,
-      stdout: 'BD CREATE HELP\n',
-      stderr: '',
-    });
-    expect(calls).toEqual([cmdPath, exePath]);
+      expect(result).toEqual({
+        code: 0,
+        stdout: 'BD CREATE HELP\n',
+        stderr: '',
+      });
+      expect(calls).toEqual([cmdPath, exePath]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('getPathEntries honors Windows PATH delimiters for injected win32 behavior', () => {
+    const { getPathEntries } = require('../lib/forge-issues');
+
+    expect(getPathEntries({ PATH: 'C:\\tools;D:\\bin' }, ';')).toEqual([
+      'C:\\tools',
+      'D:\\bin',
+    ]);
   });
 });

--- a/test/structural/command-files.test.js
+++ b/test/structural/command-files.test.js
@@ -207,7 +207,7 @@ describe('dead reference checks', () => {
     const wrapperExpectations = [
       {
         pattern: /bash scripts\/sync-utils\.sh auto-sync/,
-        replacement: 'forge sync',
+        replacement: 'forge sync || true',
       },
       {
         pattern: /bash scripts\/smart-status\.sh/,

--- a/test/structural/command-files.test.js
+++ b/test/structural/command-files.test.js
@@ -202,4 +202,42 @@ describe('dead reference checks', () => {
     const hits = findMatches(/9-stage|nine.stage/i);
     expect(hits).toEqual([]);
   });
+
+  test('canonical command docs use Forge wrappers for supported team-state commands', () => {
+    const wrapperExpectations = [
+      {
+        pattern: /bash scripts\/sync-utils\.sh auto-sync/,
+        replacement: 'forge sync',
+      },
+      {
+        pattern: /bash scripts\/smart-status\.sh/,
+        replacement: 'forge status',
+      },
+      {
+        pattern: /bash scripts\/forge-team\/index\.sh sync/,
+        replacement: 'forge team sync',
+      },
+      {
+        pattern: /bash scripts\/forge-team\/index\.sh verify/,
+        replacement: 'forge team verify',
+      },
+      {
+        pattern: /bash scripts\/forge-team\/index\.sh workload --me/,
+        replacement: 'forge team workload --me',
+      },
+      {
+        pattern: /bash scripts\/forge-team\/index\.sh dashboard/,
+        replacement: 'forge team dashboard',
+      },
+    ];
+
+    const violations = [];
+    for (const { pattern, replacement } of wrapperExpectations) {
+      for (const hit of findMatches(pattern)) {
+        violations.push(`${hit} -> use "${replacement}"`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
 });

--- a/test/structural/command-files.test.js
+++ b/test/structural/command-files.test.js
@@ -210,10 +210,6 @@ describe('dead reference checks', () => {
         replacement: 'forge sync || true',
       },
       {
-        pattern: /bash scripts\/smart-status\.sh/,
-        replacement: 'forge status',
-      },
-      {
         pattern: /bash scripts\/forge-team\/index\.sh sync/,
         replacement: 'forge team sync',
       },


### PR DESCRIPTION
## Summary
- resolve Windows orge issues command candidates from the active PATH before falling back to generic d lookup
- preserve PATH-prepended d.cmd overrides so orge issues create --help reaches the intended issues handler on Windows CI
- make the Windows issue-service test deterministic with a temp PATH fixture

## Verification
- un test test/forge-issues.test.js --timeout 30000
- un test test/forge-cli-registry.test.js --timeout 30000
- 
ode bin/forge.js issues create --help
- 
ode bin/forge.js issues list

Closes forge-rm1n.

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the Windows PATH resolution is correct, the test is deterministic with proper cleanup, and no blocking issues were found.

All findings are P2 or lower. The core logic in `resolveWindowsCommandCandidates` correctly iterates PATH entries and deduplicates by lowercased path, `getBdCommandCandidates` falls back gracefully, and the previous temp-dir leak concern is resolved by the `try/finally` block. No correctness, security, or data-integrity issues were identified.

No files require special attention.
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `lib/forge-issues.js`, line 265-282 ([link](https://github.com/harshanandak/forge/blob/b3780f6ddbdbc0f3e5ad017662c599c552eca68e/lib/forge-issues.js#L265-L282)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Windows deps silently dropped in `runIssueOperation`**

   `backendDeps` is assembled by hand and only carries `isBeadsInitialized`, `runBdCommand`, and `spawn` — the three new Windows-resolution props (`platform`, `env`, `existsSync`) are never added. Any caller that injects `{ platform: 'win32', env: { PATH: '...' } }` at the `runIssueOperation` level will have those values silently ignored, because `getBdCommandCandidates(backendDeps)` will fall back to `process.platform` / `process.env`. No production regression today, but it makes writing a full-stack Windows integration test through `runIssueOperation` impossible without reaching past it to `runBdCommand` directly.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: lib/forge-issues.js
   Line: 265-282

   Comment:
   **Windows deps silently dropped in `runIssueOperation`**

   `backendDeps` is assembled by hand and only carries `isBeadsInitialized`, `runBdCommand`, and `spawn` — the three new Windows-resolution props (`platform`, `env`, `existsSync`) are never added. Any caller that injects `{ platform: 'win32', env: { PATH: '...' } }` at the `runIssueOperation` level will have those values silently ignored, because `getBdCommandCandidates(backendDeps)` will fall back to `process.platform` / `process.env`. No production regression today, but it makes writing a full-stack Windows integration test through `runIssueOperation` impossible without reaching past it to `runBdCommand` directly.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: address review feedback on forge is..."](https://github.com/harshanandak/forge/commit/5c338f8b4ab5ae887ae18c97fc9879f7ebf0e741) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28339965)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized command examples to use Forge CLI across guides and workflows; team sync/verify examples updated and sync described as best-effort (non-blocking).

* **Bug Fixes**
  * Improved Windows executable resolution so Forge-related commands are located and invoked reliably.

* **Tests**
  * Added structural tests to enforce documentation command standards and updated tests to validate Forge CLI usage and Windows command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->