### PR TITLE
feat: normalize Forge GitHub shared issue sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Normalized shared GitHub/Beads issue sync state** (PR #134, forge-nlgg): added canonical link reconciliation and shared import primitives so steady-state GitHub sync and existing-issue import use the same normalized issue contract
+
 ### Fixed
 
 - **Plan file path contract** (forge-ddk3): Unified all references from `.claude/plans/` to `docs/plans/` across all 7 agent directories, tests, and source code

--- a/docs/BEADS_GITHUB_SYNC.md
+++ b/docs/BEADS_GITHUB_SYNC.md
@@ -69,6 +69,32 @@ Three guards prevent infinite ping-pong:
 2. **Commit message prefix** -- Phase 2 workflow skips commits starting with `chore(beads):`
 3. **Opt-out label** -- `skip-beads-sync` label on any issue disables sync entirely
 
+### Normalized Core
+
+GitHub-owned shared fields are the only fields that steady-state pull and initial import are allowed to overwrite:
+
+- `github.number`
+- `github.nodeId`
+- `github.url`
+- `shared.title`
+- `shared.body`
+- `shared.state`
+- `shared.assignees`
+- `shared.labels`
+- `shared.milestone`
+- `sync.remoteUpdatedAt`
+
+Forge-owned workflow context stays local in Beads. That includes workflow stage, dependencies, progress notes, decisions, and other issue-engine metadata.
+
+Both ongoing pull sync and the `forge-ij1` import bootstrap use the same primitive layer:
+
+- `lib/issue-sync/link-store.js` resolves canonical GitHub/Beads links.
+- `lib/issue-sync/github-pull.js` normalizes remote GitHub issues into shared records.
+- `lib/issue-sync/reconcile.js` applies GitHub-owned fields and materializes the local cache row.
+- `lib/issue-sync/import-primitives.js` exposes `listRemoteIssues`, `normalizeRemoteIssue`, `resolveSharedLink`, and `materializeLocalIssue` for import backfill.
+
+`forge-ij1` depends on these primitives directly. It does not use a separate import-specific sync contract or an alternate reconciliation path.
+
 ---
 
 ## Setup

--- a/docs/plans/2026-04-24-forge-nlgg-decisions.md
+++ b/docs/plans/2026-04-24-forge-nlgg-decisions.md
@@ -1,0 +1,8 @@
+# Decisions Log: forge-nlgg
+
+- Feature: `forge-nlgg`
+- Date: `2026-04-24`
+- Issue: `forge-nlgg`
+- Branch: `feat/f3lx`
+- Worktree: `.worktrees/f3lx`
+

--- a/docs/plans/2026-04-24-forge-nlgg-design.md
+++ b/docs/plans/2026-04-24-forge-nlgg-design.md
@@ -1,0 +1,214 @@
+# Feature
+
+- Slug: `forge-nlgg`
+- Date: `2026-04-24`
+- Status: `planned`
+- Issue: `forge-nlgg`
+- Parent Epic: `forge-f3lx`
+- Branch: `feat/f3lx`
+- Worktree: `.worktrees/f3lx`
+- Research: `docs/research/forge-nlgg.md`
+
+## Purpose
+
+Define the normalized bidirectional Forge-GitHub sync model that turns GitHub into the shared team-visible issue surface without making GitHub the owner of Forge workflow semantics or replacing Beads as the local backend.
+
+This issue is the missing layer between:
+
+- `forge-ya9l`, which established the first Forge-owned issue command seam in `lib/commands/issues.js` and `lib/forge-issues.js`, and
+- `forge-ij1`, which needs stable GitHub pull/materialization primitives before it can import existing issues safely.
+
+## Success Criteria
+
+1. A Forge-owned normalized shared issue record exists with an explicit authority matrix for GitHub-owned fields, Forge-owned fields, and Beads' cache role.
+2. Shared-field sync is defined at field level, not as ad hoc direct `bd` and `gh` mutations.
+3. The link contract between Forge issues and GitHub issues has one canonical representation, with current mapping/comment/state/url mechanisms treated as migration inputs only.
+4. Push triggers and pull triggers are defined through Forge-owned command paths (`forge issues`, `forge sync`, daemon/status refresh), not scattered shell scripts.
+5. `forge-ij1` can consume the resulting list/reconcile/materialize primitives without inventing a separate import-specific sync model.
+6. GitHub Projects / board visibility remains derived or additive; GitHub is not made the authority for workflow stage, memory, or handoff data.
+
+## Out Of Scope
+
+- Full import/backfill orchestration for existing GitHub issues. That is the follow-on implementation tracked by `forge-ij1`.
+- Full mirroring of every Beads field into GitHub.
+- Storing workflow stage, progress notes, acceptance criteria, handoff context, or agent memory in GitHub.
+- Replacing Beads as the local issue engine.
+- Treating GitHub Projects v2 as the system of record.
+- Solving the broader Dolt/worktree runtime issues unrelated to the shared sync contract.
+
+## Approach Selected
+
+Implement a Forge-owned `shared issue` layer that sits between command surfaces and adapters:
+
+1. **Normalize**
+   - Build one canonical `SharedIssueRecord` from GitHub snapshots, Forge metadata, and legacy link hints.
+   - Separate the record into `github`, `shared`, `forge`, `cache`, and `sync` sections.
+2. **Reconcile**
+   - Apply field-level ownership rules:
+     - GitHub owns shared identity/state fields.
+     - Forge owns workflow semantics and local metadata.
+     - Beads stores the materialized local record and search/query surface.
+   - Resolve identity conflicts by stable key precedence and collapse legacy link sources into one record.
+3. **Project**
+   - Outbound Forge writes mutate the local backend first, then enqueue GitHub projection only for shared fields.
+   - Inbound GitHub pulls materialize the latest shared snapshot into local state without overwriting Forge-owned fields.
+4. **Reuse**
+   - Expose `listRemoteIssues`, `normalizeRemoteIssue`, `resolveSharedLink`, and `materializeLocalIssue` primitives.
+   - `forge-ij1` uses those same primitives for initial import instead of a separate backfill pipeline.
+
+### Authority Split
+
+#### GitHub = shared identity/state
+
+- Issue identity: number, node ID, URL
+- Team-visible content: title and canonical issue body/summary
+- Team-visible state: open/closed
+- Shared coordination metadata: assignees, labels, milestone
+- Remote timestamps used for pull cursors and drift checks
+
+#### Forge = workflow rules
+
+- Forge issue ID and internal link metadata
+- Parent/child/dependency graph
+- Workflow stage and derived ready/blocked semantics
+- Acceptance criteria, progress notes, stage-transition context, decisions, memory
+- Sync bookkeeping such as pending outbound writes, last pull cursor, and drift diagnostics
+
+#### Beads = local cache/backend
+
+- Materializes the combined local issue state that Forge commands query and mutate
+- Stores the Forge-owned metadata plus a cached GitHub shared snapshot
+- Does not define the authority rules for shared fields
+
+### Sync Model
+
+#### Shared fields that sync
+
+- `github.number`
+- `github.nodeId`
+- `github.url`
+- `shared.title`
+- `shared.body`
+- `shared.state`
+- `shared.assignees`
+- `shared.labels`
+- `shared.milestone`
+- `sync.remoteUpdatedAt`
+
+#### Local-only fields that do not sync to GitHub
+
+- Forge issue ID / local backend IDs
+- Workflow stage and stage-transition metadata
+- Dependencies and parent/child relationships
+- Acceptance criteria, progress notes, handoff context, memory
+- Drift logs and sync cursors
+
+#### Conflict resolution
+
+1. Determine the owning field.
+2. For GitHub-owned fields, remote GitHub state wins on pull.
+3. For Forge-owned fields, local Forge state wins and survives pull.
+4. Local changes to GitHub-owned fields are legal only through Forge write paths that also emit outbound GitHub sync.
+5. If the same shared field differs locally and remotely, store the GitHub value, preserve the local audit trail, and log drift instead of last-write-wins.
+
+### Push / Pull Triggers
+
+#### Push
+
+- `forge issues create`
+- `forge issues update` when the updated field belongs to the shared set
+- `forge issues close`
+- Legacy wrappers such as `forge claim` once routed through the same shared core
+- `forge sync` explicit flush
+
+#### Pull
+
+- `forge sync`
+- `forge status` / `forge board` freshness checks
+- Daemon/background refresh
+- `forge-ij1` import bootstrap through paginated GitHub listing
+
+### Why this approach
+
+- It matches the authority split requested in the issue and user prompt.
+- It preserves the backend seam created in `forge-ya9l` instead of regressing to direct `bd` and `gh` writes.
+- It gives `forge-ij1` a stable base: import becomes an initial pull over the same normalization and reconciliation code used every day.
+
+## Alternatives Considered
+
+### Option A: GitHub as the source of truth for everything
+
+Rejected.
+
+- It violates the explicit scope that Forge owns workflow rules and rich agent context.
+- It would push workflow-specific data into a surface meant for shared team coordination.
+
+### Option B: Keep current mixed link model and tighten scripts
+
+Rejected.
+
+- The current model already has too many identity links (`mapping`, `github_issue`, `externalRef`, comments, description URLs).
+- Hardening each script separately would preserve drift rather than remove it.
+
+### Option C: Field-level authority with a Forge-owned shared record
+
+Selected.
+
+- It cleanly separates shared team-visible state from Forge workflow metadata.
+- It gives both bidirectional sync and initial import the same primitives.
+
+## Constraints
+
+- The existing `forge issues` service seam in `lib/forge-issues.js` should remain the entry point for new shared-field behavior.
+- Legacy wrappers that still mutate shared fields must be folded into the same shared sync core before this issue is considered complete.
+- GitHub Projects / board state must stay derived or additive, not authoritative.
+- The design must accommodate existing legacy link data during migration without creating duplicate issues.
+- Sync logic must translate downstream errors into Forge-level diagnostics rather than surfacing raw `bd` / `gh` failures directly.
+
+## Edge Cases
+
+- A local issue has both a mapping-file entry and a `github_issue` state value that disagree.
+- A GitHub issue is renamed or relabeled while a developer has stale local cache.
+- A Forge local-only update (workflow stage, dependency change, progress note) occurs alongside a remote GitHub label change.
+- A GitHub issue exists with no local mirror yet; import should materialize it without bypassing the canonical link store.
+- A GitHub issue is closed remotely while the local issue still has in-progress Forge workflow metadata.
+- Legacy wrappers (`forge claim`, shell hooks) mutate GitHub directly before they are fully rerouted through the shared core.
+
+## Ambiguity Policy
+
+Use the repo's `/dev` decision-gate rubric.
+
+- If confidence is `>= 80%`, choose the conservative option, document it in the decisions log during implementation, and continue.
+- If confidence is `< 80%`, stop and ask before changing the ownership matrix, shared-field set, or link resolution precedence.
+
+## Technical Research
+
+### Current Repo Findings
+
+- `lib/commands/issues.js` and `lib/forge-issues.js` already define the initial Forge-owned issue seam from `forge-ya9l`.
+- `lib/commands/_issue.js` still bypasses that seam for legacy commands including `claim`.
+- `scripts/github-beads-sync/index.mjs` currently handles GitHub-opened and GitHub-closed events using `.github/beads-mapping.json`, sync comments, and `externalRef`.
+- `scripts/github-beads-sync/reverse-sync.mjs` currently closes GitHub issues by parsing issue URLs from Beads descriptions.
+- `scripts/forge-team/lib/sync-github.sh` currently relies on `github_issue` state in Beads and directly mutates labels/assignees on GitHub.
+
+### Design Inputs From Existing Docs
+
+- `docs/plans/2026-04-06-forge-v2-unified-strategy.md` requires a shared issue core with CLI/MCP parity and explicitly describes `bd create + GitHub sync queue`.
+- The same strategy doc frames WS3 as "wrap beads + shared Dolt + GitHub sync", not as a beads rewrite.
+- `docs/plans/2026-04-13-forge-f3lx-issues-design.md` intentionally leaves sync, reconciliation, and import work to later child issues.
+- `docs/research/forge-nlgg.md` captures the verified current-state overlap and the strategic need for a normalized shared record.
+
+### Baseline / Planning Preconditions
+
+- The requested worktree already existed at `.worktrees/f3lx` on branch `feat/f3lx`.
+- `bd update forge-f3lx --claim` succeeded from the main workspace.
+- The repo's current `forge plan forge-nlgg` adapter initially blocked on runtime prerequisites, then on a missing `docs/research/forge-nlgg.md` artifact. It still assumes the older flow that creates a new Beads issue/branch, so this child-issue plan is documented directly under the existing epic worktree instead of using that adapter to create a duplicate issue.
+- Baseline validation in this worktree currently reports `719 pass / 36 skip / 1 fail` via `node scripts/test.js --validate`. The remaining failure is `CLI Registry Integration > non-registry stage enforcement > forge verify still invokes stage enforcement outside the registry`. Because this plan is docs-only, the baseline failure is recorded here and implementation should either tolerate it as pre-existing or fix it separately before `/ship`.
+
+## TDD Scenarios
+
+1. Pull sync updates GitHub-owned shared fields in the local cache while preserving Forge-owned workflow context.
+2. Outbound Forge writes project only shared-field changes to GitHub and never push local-only workflow metadata.
+3. Link reconciliation collapses legacy sources (`mapping`, `github_issue`, sync comments, `externalRef`, description URL) into one canonical link record.
+4. A local workflow-only update does not trigger outbound GitHub mutation.
+5. `forge-ij1` import uses the same normalize/reconcile/materialize primitives as ongoing pull sync.

--- a/docs/plans/2026-04-24-forge-nlgg-tasks.md
+++ b/docs/plans/2026-04-24-forge-nlgg-tasks.md
@@ -1,0 +1,120 @@
+# Task List: forge-nlgg
+
+- Design: `docs/plans/2026-04-24-forge-nlgg-design.md`
+- Research: `docs/research/forge-nlgg.md`
+- Issue: `forge-nlgg`
+- Parent Epic: `forge-f3lx`
+- Branch: `feat/f3lx`
+- Worktree: `.worktrees/f3lx`
+
+## Task 1: Define the normalized shared issue schema and authority matrix
+
+File(s): `lib/issue-sync/schema.js`, `lib/issue-sync/authority.js`, `test/issue-sync/schema.test.js`, `test/issue-sync/authority.test.js`
+OWNS: `lib/issue-sync/schema.js`, `lib/issue-sync/authority.js`, `test/issue-sync/schema.test.js`, `test/issue-sync/authority.test.js`
+What to implement: Add the Forge-owned `SharedIssueRecord` shape plus helpers that classify each field as `github`, `forge`, or `cache`. The schema must include canonical identity, the shared-field set, sync bookkeeping, and explicit migration slots for legacy link hints.
+TDD steps:
+1. Write test: `test/issue-sync/schema.test.js` asserts a normalized record contains `github`, `shared`, `forge`, `cache`, and `sync` sections with stable defaults.
+2. Run test: confirm it fails because the schema module does not exist.
+3. Implement: `lib/issue-sync/schema.js` with record builders and default-value helpers.
+4. Run test: confirm it passes.
+5. Write test: `test/issue-sync/authority.test.js` asserts shared fields map to GitHub authority and workflow fields map to Forge authority.
+6. Run test: confirm it fails on missing field-classification helpers.
+7. Implement: `lib/issue-sync/authority.js` with field ownership lookups and guard helpers.
+8. Run test: confirm it passes.
+9. Commit: `feat: define normalized shared issue schema`
+Expected output: Code can build a canonical shared record and answer "who owns this field?" deterministically.
+
+## Task 2: Build canonical link resolution over current legacy sync markers
+
+File(s): `lib/issue-sync/link-store.js`, `lib/issue-sync/legacy-link-bridge.js`, `test/issue-sync/link-store.test.js`, `test/issue-sync/legacy-link-bridge.test.js`
+OWNS: `lib/issue-sync/link-store.js`, `lib/issue-sync/legacy-link-bridge.js`, `test/issue-sync/link-store.test.js`, `test/issue-sync/legacy-link-bridge.test.js`
+What to implement: Create one canonical link store keyed by Forge issue ID and GitHub node/number, then add bridge code that can ingest existing `.github/beads-mapping.json`, `github_issue` state, sync comments, `externalRef`, and description URLs without creating duplicates.
+TDD steps:
+1. Write test: `test/issue-sync/link-store.test.js` asserts a link can be resolved by Forge issue ID, GitHub node ID, and GitHub number.
+2. Run test: confirm it fails because the link store does not exist.
+3. Implement: `lib/issue-sync/link-store.js` with canonical read/write helpers.
+4. Run test: confirm it passes.
+5. Write test: `test/issue-sync/legacy-link-bridge.test.js` seeds conflicting legacy link hints and expects one canonical record plus a drift diagnostic.
+6. Run test: confirm it fails because there is no bridge layer.
+7. Implement: `lib/issue-sync/legacy-link-bridge.js` with precedence rules and duplicate-collapsing logic.
+8. Run test: confirm it passes.
+9. Commit: `feat: add canonical GitHub link resolution`
+Expected output: Any current legacy link source resolves to one stable Forge-owned mapping record.
+
+## Task 3: Implement inbound GitHub pull and reconciliation primitives
+
+File(s): `lib/issue-sync/github-pull.js`, `lib/issue-sync/reconcile.js`, `test/issue-sync/github-pull.test.js`, `test/issue-sync/reconcile.test.js`
+OWNS: `lib/issue-sync/github-pull.js`, `lib/issue-sync/reconcile.js`, `test/issue-sync/github-pull.test.js`, `test/issue-sync/reconcile.test.js`
+What to implement: Add pull-side primitives that normalize GitHub issue payloads into `SharedIssueRecord` inputs, reconcile GitHub-owned shared fields into the local cache, preserve Forge-owned fields, and emit drift diagnostics when stale local shared values differ from remote GitHub state.
+TDD steps:
+1. Write test: `test/issue-sync/github-pull.test.js` asserts a GitHub issue payload is normalized into the shared-field set used by Forge.
+2. Run test: confirm it fails because no pull normalizer exists.
+3. Implement: `lib/issue-sync/github-pull.js` with GitHub payload normalization helpers.
+4. Run test: confirm it passes.
+5. Write test: `test/issue-sync/reconcile.test.js` asserts GitHub-owned fields change on pull while Forge-owned workflow fields remain unchanged.
+6. Run test: confirm it fails because there is no reconciler.
+7. Implement: `lib/issue-sync/reconcile.js` with field-level authority enforcement and drift recording.
+8. Run test: confirm it passes.
+9. Commit: `feat: add inbound GitHub reconciliation primitives`
+Expected output: Pulling a GitHub issue produces a reconciled local record without overwriting workflow-only state.
+
+## Task 4: Project Forge write paths through the shared sync core
+
+File(s): `lib/forge-issues.js`, `lib/commands/issues.js`, `lib/commands/_issue.js`, `lib/issue-sync/project-github.js`, `test/forge-issues-sync.test.js`, `test/commands/issues.test.js`, `test/commands/_issue.test.js`
+OWNS: `lib/forge-issues.js`, `lib/commands/issues.js`, `lib/commands/_issue.js`, `lib/issue-sync/project-github.js`, `test/forge-issues-sync.test.js`
+What to implement: Route shared-field mutations through the new sync core so Forge writes update the local backend first and queue outbound GitHub projections only when a shared field changes. Legacy wrappers such as `forge claim` must stop bypassing the shared authority layer for shared-field updates.
+TDD steps:
+1. Write test: `test/forge-issues-sync.test.js` asserts `runIssueOperation('create'|'update'|'close')` invokes the local backend and emits outbound GitHub projection only for shared-field changes.
+2. Run test: confirm it fails because the sync projector does not exist.
+3. Implement: `lib/issue-sync/project-github.js` and wire `lib/forge-issues.js` to use it.
+4. Run test: confirm it passes.
+5. Write test: extend `test/commands/_issue.test.js` so `forge claim` routes shared-field changes through the shared sync core instead of direct GitHub shell logic.
+6. Run test: confirm it fails because the legacy wrapper still bypasses the new path.
+7. Implement: the legacy wrapper bridge in `lib/commands/_issue.js`.
+8. Run test: confirm command tests pass.
+9. Commit: `feat: route Forge issue writes through shared sync core`
+Expected output: Forge command writes have one local-first path and one outbound GitHub projection path for shared fields.
+
+## Task 5: Collapse existing GitHub sync adapters onto the normalized core
+
+File(s): `scripts/github-beads-sync/index.mjs`, `scripts/github-beads-sync/reverse-sync.mjs`, `scripts/github-beads-sync/mapping.mjs`, `scripts/forge-team/lib/sync-github.sh`, `test/scripts/github-beads-sync/index.test.js`, `test/scripts/github-beads-sync/reverse-sync.test.js`, `scripts/forge-team/tests/sync-github.test.sh`
+OWNS: `scripts/github-beads-sync/index.mjs`, `scripts/github-beads-sync/reverse-sync.mjs`, `scripts/github-beads-sync/mapping.mjs`, `scripts/forge-team/lib/sync-github.sh`, `test/scripts/github-beads-sync/index.test.js`, `test/scripts/github-beads-sync/reverse-sync.test.js`, `scripts/forge-team/tests/sync-github.test.sh`
+What to implement: Rework the current GitHub-facing scripts so they read and write through the canonical link store and reconciliation/projector helpers instead of directly depending on mapping files, description URLs, or `github_issue` state as primary identity.
+TDD steps:
+1. Write test: update `test/scripts/github-beads-sync/index.test.js` to assert opened/closed event handlers resolve links through the canonical link store instead of ad hoc mapping-only logic.
+2. Run test: confirm it fails because the old script still depends on direct mapping/comment logic.
+3. Implement: adapter wiring in `scripts/github-beads-sync/index.mjs` and `scripts/github-beads-sync/reverse-sync.mjs`.
+4. Run test: confirm it passes.
+5. Write test: extend `scripts/forge-team/tests/sync-github.test.sh` so shell-driven sync reads canonical shared records and stops assuming `github_issue` state is the source of truth.
+6. Run test: confirm it fails because the shell adapter still reads direct state.
+7. Implement: `scripts/forge-team/lib/sync-github.sh` as a thin adapter over the new normalized core.
+8. Run test: confirm it passes.
+9. Commit: `refactor: route GitHub sync adapters through normalized core`
+Expected output: Existing automation uses the same shared link and reconciliation rules as Forge commands.
+
+## Task 6: Expose import-ready pull/materialization primitives for forge-ij1
+
+File(s): `lib/issue-sync/import-primitives.js`, `test/issue-sync/import-primitives.test.js`, `docs/BEADS_GITHUB_SYNC.md`
+OWNS: `lib/issue-sync/import-primitives.js`, `test/issue-sync/import-primitives.test.js`, `docs/BEADS_GITHUB_SYNC.md`
+What to implement: Publish a stable primitive layer for `forge-ij1` that can list remote GitHub issues, normalize them into shared records, resolve canonical links, and materialize local cache rows without a separate import-specific sync contract. Document the dependency explicitly.
+TDD steps:
+1. Write test: `test/issue-sync/import-primitives.test.js` asserts a remote GitHub issue page can be normalized and materialized into a local record using the same reconciliation path as steady-state pull.
+2. Run test: confirm it fails because import primitives do not exist.
+3. Implement: `lib/issue-sync/import-primitives.js` with `listRemoteIssues`, `normalizeRemoteIssue`, `resolveSharedLink`, and `materializeLocalIssue`.
+4. Run test: confirm it passes.
+5. Update docs: `docs/BEADS_GITHUB_SYNC.md` to describe the normalized core, field ownership, and the fact that `forge-ij1` depends on these primitives.
+6. Commit: `docs: document import-ready sync primitives`
+Expected output: `forge-ij1` can build initial GitHub backfill on the exact same normalize/reconcile/materialize flow used by ongoing sync.
+
+## Ordering Notes
+
+- Tasks 1-3 define the core contract and reconciliation behavior.
+- Task 4 wires Forge command paths onto that contract.
+- Task 5 migrates the existing GitHub-facing adapters.
+- Task 6 intentionally lands last so `forge-ij1` builds on stable primitives instead of shaping them.
+
+## Baseline Note
+
+- Baseline validation in this worktree currently reports `719 pass / 36 skip / 1 fail` via `node scripts/test.js --validate`.
+- The remaining pre-existing failure is `CLI Registry Integration > non-registry stage enforcement > forge verify still invokes stage enforcement outside the registry`.
+- Because `/plan` is docs-only here, implementation can start with that baseline documented, but `/ship` should not ignore it.

--- a/docs/research/forge-nlgg.md
+++ b/docs/research/forge-nlgg.md
@@ -1,0 +1,150 @@
+# Research: forge-nlgg
+
+- Feature: `forge-nlgg`
+- Date: `2026-04-24`
+- Status: `complete`
+- Parent: `forge-f3lx`
+- Worktree: `.worktrees/f3lx`
+- Branch: `feat/f3lx`
+
+## Problem
+
+Forge now has the first authority-layer seam from `forge-ya9l`: `lib/commands/issues.js` routes issue operations through `lib/forge-issues.js` instead of building `bd` argv at the command edge. The next missing layer is a normalized GitHub sync model.
+
+Today the repo uses multiple overlapping link and sync mechanisms:
+
+- `scripts/github-beads-sync/index.mjs` creates and closes Beads issues from GitHub issue events.
+- `scripts/github-beads-sync/reverse-sync.mjs` closes GitHub issues by parsing issue URLs back out of Beads descriptions.
+- `scripts/forge-team/lib/sync-github.sh` reads `github_issue:N` state from `bd show`, then mutates GitHub assignees, labels, and state directly.
+- `.github/beads-mapping.json`, bot comments, `externalRef`, `github_issue` state, and description URLs all act as partial identity links.
+
+That overlap is the dual-write drift problem in a different form: GitHub, Forge, and Beads can all mutate related state, but there is no single Forge-owned shared model that decides which fields are shared, which system owns each field, or how pull and push reconcile.
+
+## Scope Assessment
+
+**Strategic/Tactical**: Strategic
+
+**Why**: This work defines the cross-system authority model and the sync primitives that later issues depend on. It changes architecture, command behavior, and data ownership rules across multiple modules.
+
+## Verified Repo Findings
+
+### Forge issue authority seam already exists
+
+- `lib/commands/issues.js` is a thin command adapter that delegates to `runIssueOperation(...)` in `lib/forge-issues.js`.
+- `lib/forge-issues.js` currently exposes only a Beads-backed backend with `create`, `list`, `show`, `close`, and `update`.
+- `lib/commands/_issue.js` still provides legacy direct wrappers such as `forge claim`, `forge close`, and `forge show`, so not all write paths go through the new authority seam yet.
+
+### Current GitHub sync uses multiple link primitives
+
+- `scripts/github-beads-sync/index.mjs` uses `.github/beads-mapping.json`, sync comments, and `externalRef=gh-<number>` to create or close Beads issues from GitHub issue events.
+- `scripts/github-beads-sync/reverse-sync.mjs` parses GitHub issue URLs from Beads descriptions to close GitHub issues.
+- `scripts/forge-team/lib/sync-github.sh` stores and reads `github_issue=<number>` in Beads state, then edits GitHub issue labels/assignees directly.
+
+### Prior design intent already points toward a Forge-owned shared core
+
+- `docs/plans/2026-04-06-forge-v2-unified-strategy.md` defines WS3 as a beads wrapper plus GitHub-backed coordination, not a beads replacement.
+- The same strategy doc requires CLI/MCP parity through a shared issue core and explicitly calls for `bd create + GitHub sync queue`.
+- `docs/plans/2026-04-13-forge-f3lx-issues-design.md` intentionally stops at the backend seam and leaves sync, reconciliation, and import to later children such as `forge-nlgg`.
+
+## Key Decisions
+
+### Decision 1: Use field-level authority, not system-level last-write-wins
+
+**Reasoning**: The user asked for a specific split: GitHub owns shared identity/state, Beads is a local cache/backend, Forge owns workflow rules. That cannot be modeled safely with "the most recent system wins." The reconciliation rule needs to be "the owning field wins."
+
+### Decision 2: Introduce a Forge-owned normalized shared record
+
+**Reasoning**: The repo currently spreads identity and sync state across mapping files, comments, Beads metadata, and description URLs. `forge-nlgg` should collapse those into one canonical Forge-owned record that is persisted locally and can project to GitHub and Beads.
+
+### Decision 3: Keep workflow context out of GitHub
+
+**Reasoning**: The epic and child issue both explicitly exclude pushing rich workflow state, agent memory, and handoff context into GitHub. GitHub should carry team-visible issue state, not become the storage layer for Forge internals.
+
+### Decision 4: Make import a consumer of sync primitives, not a second sync system
+
+**Reasoning**: `forge-ij1` should not invent its own backfill rules. It should call the same GitHub listing, link resolution, shared-record building, and local materialization primitives that ongoing pull sync uses. That keeps initial import and steady-state sync aligned.
+
+## Proposed Shared Model
+
+### GitHub-owned shared fields
+
+- GitHub issue identity: `number`, `nodeId`, `url`
+- GitHub-visible content: `title`, canonical issue body/summary
+- GitHub-visible state: `open` / `closed`
+- Shared coordination fields: assignees, labels, milestone
+- GitHub timestamps used for pull cursors and drift detection
+
+### Forge-owned fields
+
+- Forge issue ID and local/backend identifiers
+- Parent/child relationships and dependency graph
+- Workflow stage, ready/blocked semantics, and stage-transition metadata
+- Acceptance criteria, progress notes, handoff context, and memory
+- Sync bookkeeping: last pulled cursor, last pushed shared hash, pending outbound operations, drift diagnostics
+
+### Beads-owned role
+
+- Local execution backend and query surface for Forge
+- Materialized cache of GitHub-owned shared fields plus Forge-owned workflow state
+- No direct authority over shared fields beyond acting as Forge's local store
+
+## Conflict Resolution Model
+
+1. Resolve ownership first.
+2. If a GitHub-owned field changes remotely, GitHub wins and the local cache is updated on pull.
+3. If a Forge-owned field changes locally, GitHub pull must not overwrite it.
+4. Local writes to GitHub-owned fields should happen only through Forge write paths that also enqueue outbound sync.
+5. If local cache and GitHub diverge on a GitHub-owned field, keep the GitHub value and log a drift event instead of silently merging.
+6. Identity conflicts resolve by stable key precedence:
+   - `github.nodeId`
+   - GitHub issue number in the same repo
+   - Existing Forge link record
+   - Legacy bridges: `externalRef`, `github_issue`, mapping file, sync comment, description URL
+
+## Push / Pull Trigger Model
+
+### Push triggers
+
+- `forge issues create`
+- `forge issues update` when the updated field belongs to the shared set
+- `forge issues close`
+- Legacy wrappers that still mutate shared fields, such as `forge claim` and `forge close`, once routed through the shared core
+- `forge sync` as an explicit flush path
+
+### Pull triggers
+
+- `forge sync`
+- `forge status` / `forge board` cache refresh hooks
+- Startup / periodic daemon poll
+- `forge-ij1` bulk import bootstrap, which should use the exact same pull primitives with pagination
+
+## Risks
+
+| Risk | Why it matters | Mitigation |
+| --- | --- | --- |
+| Duplicate link records | Existing repo already has several link sources | Centralize on one Forge link store and treat legacy values as migration inputs only |
+| Shared/local field bleed | Current shell scripts mutate GitHub labels from local state directly | Make the authority matrix explicit in code and tests |
+| Import drift | A dedicated import path can diverge from steady-state pull sync | Make `forge-ij1` consume the same list/reconcile/materialize primitives |
+| Legacy wrapper bypass | `forge claim` still bypasses the new `forge issues` seam | Route all shared-field mutations through the sync core before calling GitHub adapters |
+
+## TDD Test Scenarios
+
+### Scenario 1: GitHub-owned field wins on pull
+
+Given a linked issue where the local cache has stale labels, when GitHub labels change remotely, pull sync updates the local cache to the GitHub value and records the sync cursor.
+
+### Scenario 2: Forge-owned workflow context survives pull
+
+Given a linked issue with local workflow stage, dependencies, and progress notes, when GitHub title or assignee changes, pull sync keeps all Forge-owned fields unchanged.
+
+### Scenario 3: Outbound write enqueues only shared-field changes
+
+Given a Forge issue update, when the changed field is in the shared set, push sync emits a GitHub projection; when the change is local-only workflow state, no outbound GitHub mutation is queued.
+
+### Scenario 4: Legacy link sources collapse into one canonical record
+
+Given an issue with a mapping-file entry, a `github_issue` state value, and a sync comment, reconciliation resolves them to one canonical link record instead of creating duplicates.
+
+### Scenario 5: Import reuses pull primitives
+
+Given a page of existing GitHub issues with no local counterparts, the import path uses the same normalize-and-materialize primitives as steady-state pull sync and produces link records ready for ongoing sync.

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { execFileSync } = require('node:child_process');
+const { runIssueOperation } = require('../forge-issues');
 
 const SUBCOMMANDS = {
   create: {
@@ -110,13 +111,22 @@ function buildBdArgs(subcommand, rawArgs) {
   return spec.buildBdArgs(args);
 }
 
+const WRITE_SUBCOMMANDS = new Set(['create', 'update', 'claim', 'close']);
+
 async function runIssueSubcommand(subcommand, args, projectRoot, opts = {}) {
-  const exec = opts._exec || execFileSync;
   const bdArgs = buildBdArgs(subcommand, args);
 
   if (!Array.isArray(bdArgs)) {
     return { success: false, error: bdArgs.error };
   }
+
+  if (WRITE_SUBCOMMANDS.has(subcommand)) {
+    const runner = opts.runIssueOperation || runIssueOperation;
+    const operation = subcommand === 'claim' ? 'update' : subcommand;
+    return runner(operation, bdArgs.slice(1), projectRoot, opts);
+  }
+
+  const exec = opts._exec || execFileSync;
 
   try {
     exec('bd', bdArgs, getExecOptions(projectRoot));

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -4,6 +4,7 @@ const { spawn } = require('node:child_process');
 const { existsSync } = require('node:fs');
 const path = require('node:path');
 const { isBeadsInitialized } = require('./beads-setup');
+const { createGitHubProjectionPlan } = require('./issue-sync/project-github');
 
 const OPERATION_TO_BD = {
   create: 'create',
@@ -285,10 +286,25 @@ async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
   });
 
   const service = createService();
-  return service.run(operation, rawArgs, {
+  const result = await service.run(operation, rawArgs, {
     projectRoot,
     deps,
   });
+
+  const queueGitHubProjection = deps.enqueueGitHubProjection || deps.queueGitHubProjection;
+  if (result?.success && typeof queueGitHubProjection === 'function') {
+    const projectionPlan = createGitHubProjectionPlan(operation, rawArgs);
+    if (projectionPlan) {
+      await queueGitHubProjection(projectionPlan, {
+        operation,
+        args: rawArgs,
+        projectRoot,
+        result,
+      });
+    }
+  }
+
+  return result;
 }
 
 module.exports = {

--- a/lib/issue-sync/authority.js
+++ b/lib/issue-sync/authority.js
@@ -8,6 +8,7 @@ const GITHUB_OWNED_FIELDS = new Set([
   'shared.assignees',
   'shared.labels',
   'shared.milestone',
+  'sync.remoteUpdatedAt',
 ]);
 
 const FORGE_OWNED_FIELDS = new Set([
@@ -21,7 +22,6 @@ const FORGE_OWNED_FIELDS = new Set([
   'forge.stageTransitions',
   'forge.decisions',
   'forge.memory',
-  'sync.remoteUpdatedAt',
   'sync.lastPulledAt',
   'sync.lastPushedAt',
   'sync.pendingOutbound',

--- a/lib/issue-sync/authority.js
+++ b/lib/issue-sync/authority.js
@@ -1,0 +1,100 @@
+const GITHUB_OWNED_FIELDS = new Set([
+  'github.number',
+  'github.nodeId',
+  'github.url',
+  'shared.title',
+  'shared.body',
+  'shared.state',
+  'shared.assignees',
+  'shared.labels',
+  'shared.milestone',
+]);
+
+const FORGE_OWNED_FIELDS = new Set([
+  'forge.issueId',
+  'forge.dependencies',
+  'forge.parentId',
+  'forge.childIds',
+  'forge.workflowStage',
+  'forge.acceptanceCriteria',
+  'forge.progressNotes',
+  'forge.stageTransitions',
+  'forge.decisions',
+  'forge.memory',
+  'sync.remoteUpdatedAt',
+  'sync.lastPulledAt',
+  'sync.lastPushedAt',
+  'sync.pendingOutbound',
+  'sync.drift',
+]);
+
+const CACHE_FIELDS = new Set([
+  'cache.githubSnapshot',
+  'cache.materializedIssue',
+  'cache.legacyLinkHints.mapping',
+  'cache.legacyLinkHints.githubIssue',
+  'cache.legacyLinkHints.syncComments',
+  'cache.legacyLinkHints.externalRef',
+  'cache.legacyLinkHints.descriptionUrl',
+]);
+
+function matchesFieldPath(fieldPath, knownFieldPath) {
+  return fieldPath === knownFieldPath || fieldPath.startsWith(`${knownFieldPath}.`);
+}
+
+function hasFieldPath(fieldPath, fieldSet) {
+  if (typeof fieldPath !== 'string' || fieldPath.length === 0) {
+    return false;
+  }
+
+  for (const knownFieldPath of fieldSet) {
+    if (matchesFieldPath(fieldPath, knownFieldPath)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getFieldAuthority(fieldPath) {
+  if (hasFieldPath(fieldPath, GITHUB_OWNED_FIELDS)) {
+    return 'github';
+  }
+
+  if (hasFieldPath(fieldPath, FORGE_OWNED_FIELDS)) {
+    return 'forge';
+  }
+
+  if (hasFieldPath(fieldPath, CACHE_FIELDS)) {
+    return 'cache';
+  }
+
+  return null;
+}
+
+function isGitHubOwnedField(fieldPath) {
+  return getFieldAuthority(fieldPath) === 'github';
+}
+
+function isForgeOwnedField(fieldPath) {
+  return getFieldAuthority(fieldPath) === 'forge';
+}
+
+function isCacheField(fieldPath) {
+  return getFieldAuthority(fieldPath) === 'cache';
+}
+
+function isSharedField(fieldPath) {
+  return typeof fieldPath === 'string' && fieldPath.startsWith('shared.') && isGitHubOwnedField(fieldPath);
+}
+
+module.exports = {
+  CACHE_FIELDS,
+  FORGE_OWNED_FIELDS,
+  GITHUB_OWNED_FIELDS,
+  getFieldAuthority,
+  isCacheField,
+  isForgeOwnedField,
+  isGitHubOwnedField,
+  isSharedField,
+};

--- a/lib/issue-sync/github-pull.js
+++ b/lib/issue-sync/github-pull.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const { normalizeGitHubNumber } = require('./link-store.js');
+
+const GITHUB_OWNED_FIELD_PATHS = [
+  'github.number',
+  'github.nodeId',
+  'github.url',
+  'shared.title',
+  'shared.body',
+  'shared.state',
+  'shared.assignees',
+  'shared.labels',
+  'shared.milestone',
+  'sync.remoteUpdatedAt',
+];
+
+function cloneValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+
+  if (value && typeof value === 'object') {
+    const copy = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      copy[key] = cloneValue(nestedValue);
+    }
+
+    return copy;
+  }
+
+  return value;
+}
+
+function normalizeText(value, fallback = '') {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function normalizeState(value) {
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+
+  return 'open';
+}
+
+function normalizeNameList(values) {
+  const source = Array.isArray(values) ? values : values ? [values] : [];
+  const normalized = [];
+  const seen = new Set();
+
+  for (const entry of source) {
+    const name = typeof entry === 'string'
+      ? entry
+      : entry?.login ?? entry?.name ?? entry?.title ?? null;
+
+    if (typeof name !== 'string' || name.length === 0 || seen.has(name)) {
+      continue;
+    }
+
+    seen.add(name);
+    normalized.push(name);
+  }
+
+  return normalized;
+}
+
+function normalizeMilestone(milestone) {
+  if (!milestone) {
+    return null;
+  }
+
+  if (typeof milestone === 'string') {
+    return milestone;
+  }
+
+  return milestone.title ?? milestone.name ?? null;
+}
+
+function normalizeRemoteIssue(issue = {}) {
+  const assignees = normalizeNameList(
+    Array.isArray(issue.assignees) && issue.assignees.length > 0
+      ? issue.assignees
+      : issue.assignee,
+  );
+
+  return {
+    github: {
+      number: normalizeGitHubNumber(issue.number ?? issue.issue_number ?? issue.issueNumber),
+      nodeId: issue.node_id ?? issue.nodeId ?? null,
+      url: issue.html_url ?? issue.url ?? null,
+    },
+    shared: {
+      title: normalizeText(issue.title),
+      body: normalizeText(issue.body),
+      state: normalizeState(issue.state),
+      assignees,
+      labels: normalizeNameList(issue.labels),
+      milestone: normalizeMilestone(issue.milestone),
+    },
+    sync: {
+      remoteUpdatedAt: issue.updated_at ?? issue.updatedAt ?? null,
+    },
+  };
+}
+
+const normalizeGitHubIssuePayload = normalizeRemoteIssue;
+
+module.exports = {
+  GITHUB_OWNED_FIELD_PATHS,
+  cloneValue,
+  normalizeGitHubIssuePayload,
+  normalizeMilestone,
+  normalizeNameList,
+  normalizeRemoteIssue,
+  normalizeState,
+};

--- a/lib/issue-sync/github-pull.js
+++ b/lib/issue-sync/github-pull.js
@@ -102,6 +102,40 @@ function normalizeMilestone(milestone) {
   return milestone.title ?? milestone.name ?? null;
 }
 
+function normalizeNodeId(issue = {}) {
+  if (typeof issue.node_id === 'string' && issue.node_id.length > 0) {
+    return issue.node_id;
+  }
+
+  if (typeof issue.nodeId === 'string' && issue.nodeId.length > 0) {
+    return issue.nodeId;
+  }
+
+  if (typeof issue.id === 'string' && issue.id.length > 0) {
+    return issue.id;
+  }
+
+  return null;
+}
+
+function normalizeIssueUrl(issue = {}) {
+  const candidates = [issue.html_url, issue.htmlUrl, issue.url];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string' || candidate.length === 0) {
+      continue;
+    }
+
+    if (/^https:\/\/api\.github\.com\//iu.test(candidate)) {
+      continue;
+    }
+
+    return candidate;
+  }
+
+  return null;
+}
+
 function normalizeAssignees(issue = {}) {
   const assignees = normalizeNameList(issue.assignees);
 
@@ -116,8 +150,8 @@ function normalizeRemoteIssue(issue = {}) {
   return {
     github: {
       number: normalizeGitHubNumber(issue.number ?? issue.issue_number ?? issue.issueNumber),
-      nodeId: issue.node_id ?? issue.nodeId ?? null,
-      url: issue.html_url ?? issue.htmlUrl ?? null,
+      nodeId: normalizeNodeId(issue),
+      url: normalizeIssueUrl(issue),
     },
     shared: {
       title: normalizeText(issue.title),
@@ -141,8 +175,10 @@ module.exports = {
   normalizeGitHubIssuePayload,
   normalizeAssignees,
   normalizeCollectionEntries,
+  normalizeIssueUrl,
   normalizeMilestone,
   normalizeNameList,
+  normalizeNodeId,
   normalizeRemoteIssue,
   normalizeState,
 };

--- a/lib/issue-sync/github-pull.js
+++ b/lib/issue-sync/github-pull.js
@@ -89,7 +89,7 @@ function normalizeRemoteIssue(issue = {}) {
     github: {
       number: normalizeGitHubNumber(issue.number ?? issue.issue_number ?? issue.issueNumber),
       nodeId: issue.node_id ?? issue.nodeId ?? null,
-      url: issue.html_url ?? issue.url ?? null,
+      url: issue.html_url ?? issue.htmlUrl ?? null,
     },
     shared: {
       title: normalizeText(issue.title),

--- a/lib/issue-sync/github-pull.js
+++ b/lib/issue-sync/github-pull.js
@@ -45,8 +45,32 @@ function normalizeState(value) {
   return 'open';
 }
 
+function normalizeCollectionEntries(values) {
+  if (Array.isArray(values)) {
+    return values;
+  }
+
+  if (!values) {
+    return [];
+  }
+
+  if (typeof values === 'object') {
+    if (Array.isArray(values.nodes)) {
+      return values.nodes;
+    }
+
+    if (Array.isArray(values.edges)) {
+      return values.edges
+        .map((edge) => edge?.node ?? edge)
+        .filter((entry) => entry != null);
+    }
+  }
+
+  return [values];
+}
+
 function normalizeNameList(values) {
-  const source = Array.isArray(values) ? values : values ? [values] : [];
+  const source = normalizeCollectionEntries(values);
   const normalized = [];
   const seen = new Set();
 
@@ -78,13 +102,17 @@ function normalizeMilestone(milestone) {
   return milestone.title ?? milestone.name ?? null;
 }
 
-function normalizeRemoteIssue(issue = {}) {
-  const assignees = normalizeNameList(
-    Array.isArray(issue.assignees) && issue.assignees.length > 0
-      ? issue.assignees
-      : issue.assignee,
-  );
+function normalizeAssignees(issue = {}) {
+  const assignees = normalizeNameList(issue.assignees);
 
+  if (assignees.length > 0) {
+    return assignees;
+  }
+
+  return normalizeNameList(issue.assignee);
+}
+
+function normalizeRemoteIssue(issue = {}) {
   return {
     github: {
       number: normalizeGitHubNumber(issue.number ?? issue.issue_number ?? issue.issueNumber),
@@ -95,7 +123,7 @@ function normalizeRemoteIssue(issue = {}) {
       title: normalizeText(issue.title),
       body: normalizeText(issue.body),
       state: normalizeState(issue.state),
-      assignees,
+      assignees: normalizeAssignees(issue),
       labels: normalizeNameList(issue.labels),
       milestone: normalizeMilestone(issue.milestone),
     },
@@ -111,6 +139,8 @@ module.exports = {
   GITHUB_OWNED_FIELD_PATHS,
   cloneValue,
   normalizeGitHubIssuePayload,
+  normalizeAssignees,
+  normalizeCollectionEntries,
   normalizeMilestone,
   normalizeNameList,
   normalizeRemoteIssue,

--- a/lib/issue-sync/import-primitives.js
+++ b/lib/issue-sync/import-primitives.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { cloneValue, normalizeRemoteIssue: normalizeSharedRemoteIssue } = require('./github-pull.js');
+const { reconcileSharedIssueRecord } = require('./reconcile.js');
+const { resolveCanonicalLink } = require('./link-store.js');
+
+function toIssueArray(page = {}) {
+  if (Array.isArray(page)) {
+    return page;
+  }
+
+  if (!page || typeof page !== 'object') {
+    return [];
+  }
+
+  if (Array.isArray(page.nodes)) {
+    return page.nodes;
+  }
+
+  if (Array.isArray(page.items)) {
+    return page.items;
+  }
+
+  if (Array.isArray(page.issues)) {
+    return page.issues;
+  }
+
+  if (Array.isArray(page.edges)) {
+    return page.edges.map((edge) => edge?.node).filter(Boolean);
+  }
+
+  const nestedNodes = page.data?.repository?.issues?.nodes;
+  if (Array.isArray(nestedNodes)) {
+    return nestedNodes;
+  }
+
+  const nestedEdges = page.data?.repository?.issues?.edges;
+  if (Array.isArray(nestedEdges)) {
+    return nestedEdges.map((edge) => edge?.node).filter(Boolean);
+  }
+
+  return [];
+}
+
+function listRemoteIssues(page = {}) {
+  return toIssueArray(page).map(cloneValue);
+}
+
+function normalizeRemoteIssue(issue = {}) {
+  return normalizeSharedRemoteIssue(issue);
+}
+
+function resolveSharedLink(linkStore, remoteIssue = {}) {
+  if (!linkStore) {
+    return null;
+  }
+
+  const lookup = {
+    githubNodeId: remoteIssue.github?.nodeId ?? remoteIssue.node_id ?? remoteIssue.nodeId ?? null,
+    githubNumber: remoteIssue.github?.number ?? remoteIssue.number ?? remoteIssue.issue_number ?? remoteIssue.issueNumber ?? null,
+  };
+
+  if (typeof linkStore.resolveCanonicalLink === 'function') {
+    return linkStore.resolveCanonicalLink(lookup);
+  }
+
+  if (typeof linkStore === 'object' && typeof linkStore.byGitHubNumber?.get === 'function') {
+    return resolveCanonicalLink(linkStore, lookup);
+  }
+
+  return null;
+}
+
+function materializeLocalIssue(localRecord = {}, remoteIssue = {}, linkStore, options = {}) {
+  const normalizedRemoteIssue = remoteIssue?.github && remoteIssue?.shared && remoteIssue?.sync
+    ? cloneValue(remoteIssue)
+    : normalizeRemoteIssue(remoteIssue);
+
+  const link = resolveSharedLink(linkStore, normalizedRemoteIssue);
+  const { record, diagnostics } = reconcileSharedIssueRecord(
+    localRecord,
+    normalizedRemoteIssue,
+    options.reconcileOptions ?? {},
+  );
+
+  return {
+    link,
+    diagnostics,
+    record,
+  };
+}
+
+module.exports = {
+  listRemoteIssues,
+  materializeLocalIssue,
+  normalizeRemoteIssue,
+  resolveSharedLink,
+};

--- a/lib/issue-sync/legacy-link-bridge.js
+++ b/lib/issue-sync/legacy-link-bridge.js
@@ -324,21 +324,75 @@ function chooseCanonicalUrl(existingLink, sources, selectedNumber) {
     }
   }
 
-  const templateSource = sources.find((source) => source.url);
-  if (!templateSource?.url || selectedNumber === null || selectedNumber === undefined) {
-    return null;
+  return null;
+}
+
+function shouldSeedLegacyMappingEntries(legacyHints = {}) {
+  const mapping = legacyHints.mapping;
+  const explicitGithub = legacyHints.github ?? {};
+
+  return (
+    !legacyHints.forgeIssueId &&
+    mapping &&
+    typeof mapping === 'object' &&
+    !Array.isArray(mapping) &&
+    !hasStructuredMappingEntry(mapping) &&
+    !explicitGithub.nodeId &&
+    normalizeGitHubNumber(explicitGithub.number) === null &&
+    legacyHints.githubIssue == null &&
+    legacyHints.github_issue == null &&
+    (legacyHints.syncComments ?? []).length === 0 &&
+    !legacyHints.externalRef &&
+    !legacyHints.description &&
+    !legacyHints.descriptionUrl
+  );
+}
+
+function seedLegacyMappingEntries(store, mapping) {
+  const links = [];
+  const diagnostics = [];
+
+  for (const [issueNumber, forgeIssueId] of Object.entries(mapping)) {
+    if (typeof forgeIssueId !== 'string' || forgeIssueId.length === 0) {
+      continue;
+    }
+
+    const githubNumber = normalizeGitHubNumber(issueNumber);
+    if (githubNumber === null) {
+      continue;
+    }
+
+    const result = bridgeLegacyLinkHints(
+      {
+        forgeIssueId,
+        mapping: githubNumber,
+      },
+      { store },
+    );
+
+    if (result.link) {
+      links.push(result.link);
+    }
+
+    if (Array.isArray(result.diagnostics)) {
+      diagnostics.push(...result.diagnostics);
+    }
   }
 
-  const parsed = extractGitHubIssueUrl(templateSource.url);
-  if (!parsed) {
-    return null;
-  }
-
-  return `https://github.com/${parsed.owner}/${parsed.repo}/issues/${selectedNumber}`;
+  return { links, diagnostics };
 }
 
 function bridgeLegacyLinkHints(legacyHints, options = {}) {
   const store = options.store ?? createLinkStore();
+  if (shouldSeedLegacyMappingEntries(legacyHints)) {
+    const { links, diagnostics } = seedLegacyMappingEntries(store, legacyHints.mapping);
+    return {
+      link: links.at(-1) ?? null,
+      diagnostics,
+      links,
+    };
+  }
+
   const sources = collectLegacySources(legacyHints);
   const existingLink = findExistingLink(store, legacyHints, sources);
 

--- a/lib/issue-sync/legacy-link-bridge.js
+++ b/lib/issue-sync/legacy-link-bridge.js
@@ -1,0 +1,328 @@
+const {
+  createLinkStore,
+  resolveCanonicalLink,
+  upsertCanonicalLink,
+} = require('./link-store.js');
+
+const SOURCE_PRECEDENCE = new Map([
+  ['existing', 0],
+  ['githubNodeId', 1],
+  ['githubNumber', 2],
+  ['externalRef', 3],
+  ['githubIssue', 4],
+  ['mapping', 5],
+  ['syncComment', 6],
+  ['descriptionUrl', 7],
+]);
+
+function precedenceFor(source) {
+  return SOURCE_PRECEDENCE.get(source) ?? Number.MAX_SAFE_INTEGER;
+}
+
+function normalizeGitHubNumber(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseExternalRef(externalRef) {
+  if (typeof externalRef !== 'string') {
+    return null;
+  }
+
+  const match = externalRef.match(/\bgh-(\d+)\b/i);
+  return match ? normalizeGitHubNumber(match[1]) : null;
+}
+
+function extractGitHubIssueUrl(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const match = value.match(/https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    owner: match[1],
+    repo: match[2],
+    number: normalizeGitHubNumber(match[3]),
+    url: match[0],
+  };
+}
+
+function parseSyncComment(comment) {
+  const issueUrl = extractGitHubIssueUrl(comment?.body);
+  const githubNumber = normalizeGitHubNumber(
+    comment?.githubNumber ?? comment?.issueNumber ?? issueUrl?.number ?? parseExternalRef(comment?.body),
+  );
+
+  return {
+    forgeIssueId: comment?.forgeIssueId ?? comment?.beadsId ?? null,
+    githubNumber,
+    githubNodeId: comment?.githubNodeId ?? comment?.nodeId ?? null,
+    url: issueUrl?.url ?? null,
+  };
+}
+
+function buildSourceRecord(source, input = {}) {
+  const record = { source };
+
+  if (input.githubNumber !== null && input.githubNumber !== undefined) {
+    record.githubNumber = normalizeGitHubNumber(input.githubNumber);
+  }
+
+  if (input.githubNodeId) {
+    record.githubNodeId = input.githubNodeId;
+  }
+
+  if (input.forgeIssueId) {
+    record.forgeIssueId = input.forgeIssueId;
+  }
+
+  if (input.url) {
+    record.url = input.url;
+  }
+
+  return record;
+}
+
+function collectLegacySources(legacyHints) {
+  const sources = [];
+  const forgeIssueId = legacyHints.forgeIssueId ?? null;
+
+  const explicitGithub = legacyHints.github ?? {};
+  if (explicitGithub.nodeId) {
+    sources.push(buildSourceRecord('githubNodeId', {
+      forgeIssueId,
+      githubNodeId: explicitGithub.nodeId,
+      githubNumber: explicitGithub.number,
+      url: explicitGithub.url,
+    }));
+  } else if (explicitGithub.number) {
+    sources.push(buildSourceRecord('githubNumber', {
+      forgeIssueId,
+      githubNumber: explicitGithub.number,
+      url: explicitGithub.url,
+    }));
+  }
+
+  if (legacyHints.mapping !== undefined && legacyHints.mapping !== null) {
+    if (typeof legacyHints.mapping === 'object') {
+      sources.push(buildSourceRecord('mapping', {
+        forgeIssueId: legacyHints.mapping.forgeIssueId ?? forgeIssueId,
+        githubNumber: legacyHints.mapping.githubNumber ?? legacyHints.mapping.issueNumber,
+        githubNodeId: legacyHints.mapping.githubNodeId ?? legacyHints.mapping.nodeId,
+        url: legacyHints.mapping.url,
+      }));
+    } else {
+      sources.push(buildSourceRecord('mapping', {
+        forgeIssueId,
+        githubNumber: legacyHints.mapping,
+      }));
+    }
+  }
+
+  if (legacyHints.githubIssue !== undefined && legacyHints.githubIssue !== null) {
+    if (typeof legacyHints.githubIssue === 'object') {
+      sources.push(buildSourceRecord('githubIssue', {
+        forgeIssueId: legacyHints.githubIssue.forgeIssueId ?? forgeIssueId,
+        githubNumber: legacyHints.githubIssue.githubNumber ?? legacyHints.githubIssue.issueNumber,
+        githubNodeId: legacyHints.githubIssue.githubNodeId ?? legacyHints.githubIssue.nodeId,
+        url: legacyHints.githubIssue.url,
+      }));
+    } else {
+      sources.push(buildSourceRecord('githubIssue', {
+        forgeIssueId,
+        githubNumber: legacyHints.githubIssue,
+      }));
+    }
+  }
+
+  for (const comment of legacyHints.syncComments ?? []) {
+    const parsed = parseSyncComment(comment);
+    sources.push(buildSourceRecord('syncComment', {
+      forgeIssueId: parsed.forgeIssueId ?? forgeIssueId,
+      githubNumber: parsed.githubNumber,
+      githubNodeId: parsed.githubNodeId,
+      url: parsed.url,
+    }));
+  }
+
+  const externalRefNumber = parseExternalRef(legacyHints.externalRef);
+  if (externalRefNumber !== null) {
+    sources.push(buildSourceRecord('externalRef', {
+      forgeIssueId,
+      githubNumber: externalRefNumber,
+    }));
+  }
+
+  const descriptionMatch = extractGitHubIssueUrl(legacyHints.description ?? legacyHints.descriptionUrl);
+  if (descriptionMatch) {
+    sources.push(buildSourceRecord('descriptionUrl', {
+      forgeIssueId,
+      githubNumber: descriptionMatch.number,
+      url: descriptionMatch.url,
+    }));
+  }
+
+  return sources.filter((source) =>
+    source.forgeIssueId || source.githubNodeId || source.githubNumber || source.url);
+}
+
+function findExistingLink(store, legacyHints, sources) {
+  const forgeIssueId = legacyHints.forgeIssueId ?? null;
+
+  if (forgeIssueId) {
+    const existing = resolveCanonicalLink(store, { forgeIssueId });
+    if (existing) {
+      return existing;
+    }
+  }
+
+  for (const source of sources) {
+    if (source.githubNodeId) {
+      const existing = resolveCanonicalLink(store, { githubNodeId: source.githubNodeId });
+      if (existing) {
+        return existing;
+      }
+    }
+
+    if (source.githubNumber) {
+      const existing = resolveCanonicalLink(store, { githubNumber: source.githubNumber });
+      if (existing) {
+        return existing;
+      }
+    }
+  }
+
+  return null;
+}
+
+function pickPreferredCandidate(candidates, fieldName) {
+  const fieldKey = fieldName === 'github.nodeId' ? 'githubNodeId' : 'githubNumber';
+  const filtered = candidates.filter((candidate) => candidate[fieldKey] !== null && candidate[fieldKey] !== undefined);
+
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  filtered.sort((left, right) => precedenceFor(left.source) - precedenceFor(right.source));
+  return filtered[0];
+}
+
+function buildDriftDiagnostics(candidates, selectedNumberCandidate) {
+  if (!selectedNumberCandidate) {
+    return [];
+  }
+
+  const conflicts = [];
+  const seenValues = new Set();
+
+  for (const candidate of candidates) {
+    if (candidate.githubNumber === null || candidate.githubNumber === undefined) {
+      continue;
+    }
+
+    if (candidate.githubNumber === selectedNumberCandidate.githubNumber) {
+      continue;
+    }
+
+    const key = `${candidate.source}:${candidate.githubNumber}`;
+    if (seenValues.has(key)) {
+      continue;
+    }
+
+    seenValues.add(key);
+    conflicts.push({
+      source: candidate.source,
+      value: candidate.githubNumber,
+    });
+  }
+
+  if (conflicts.length === 0) {
+    return [];
+  }
+
+  return [{
+    type: 'legacy-link-drift',
+    field: 'github.number',
+    selected: {
+      source: selectedNumberCandidate.source,
+      value: selectedNumberCandidate.githubNumber,
+    },
+    conflicts,
+  }];
+}
+
+function chooseCanonicalUrl(existingLink, sources, selectedNumber) {
+  if (existingLink?.github?.url && existingLink.github.number === selectedNumber) {
+    return existingLink.github.url;
+  }
+
+  for (const source of sources) {
+    if (source.url && source.githubNumber === selectedNumber) {
+      return source.url;
+    }
+  }
+
+  const templateSource = sources.find((source) => source.url);
+  if (!templateSource?.url || selectedNumber === null || selectedNumber === undefined) {
+    return null;
+  }
+
+  const parsed = extractGitHubIssueUrl(templateSource.url);
+  if (!parsed) {
+    return null;
+  }
+
+  return `https://github.com/${parsed.owner}/${parsed.repo}/issues/${selectedNumber}`;
+}
+
+function bridgeLegacyLinkHints(legacyHints, options = {}) {
+  const store = options.store ?? createLinkStore();
+  const sources = collectLegacySources(legacyHints);
+  const existingLink = findExistingLink(store, legacyHints, sources);
+
+  const candidates = existingLink ? [
+    buildSourceRecord('existing', {
+      forgeIssueId: existingLink.forgeIssueId,
+      githubNumber: existingLink.github.number,
+      githubNodeId: existingLink.github.nodeId,
+      url: existingLink.github.url,
+    }),
+    ...sources,
+  ] : sources;
+
+  const selectedNodeCandidate = pickPreferredCandidate(candidates, 'github.nodeId');
+  const selectedNumberCandidate = pickPreferredCandidate(candidates, 'github.number');
+  const diagnostics = buildDriftDiagnostics(candidates, selectedNumberCandidate);
+
+  const link = upsertCanonicalLink(store, {
+    forgeIssueId: legacyHints.forgeIssueId ?? existingLink?.forgeIssueId ?? null,
+    github: {
+      nodeId: selectedNodeCandidate?.githubNodeId ?? existingLink?.github?.nodeId ?? null,
+      number: selectedNumberCandidate?.githubNumber ?? existingLink?.github?.number ?? null,
+      url: chooseCanonicalUrl(existingLink, sources, selectedNumberCandidate?.githubNumber ?? null),
+    },
+    sources,
+    diagnostics,
+  });
+
+  return {
+    link,
+    diagnostics: link.diagnostics,
+  };
+}
+
+module.exports = {
+  bridgeLegacyLinkHints,
+  buildSourceRecord,
+  collectLegacySources,
+  extractGitHubIssueUrl,
+  parseExternalRef,
+};

--- a/lib/issue-sync/legacy-link-bridge.js
+++ b/lib/issue-sync/legacy-link-bridge.js
@@ -215,24 +215,25 @@ function pickPreferredCandidate(candidates, fieldName) {
   return filtered[0];
 }
 
-function buildDriftDiagnostics(candidates, selectedNumberCandidate) {
-  if (!selectedNumberCandidate) {
+function buildFieldDriftDiagnostic(candidates, fieldName, selectedCandidate) {
+  if (!selectedCandidate) {
     return [];
   }
 
+  const fieldKey = fieldName === 'github.nodeId' ? 'githubNodeId' : 'githubNumber';
   const conflicts = [];
   const seenValues = new Set();
 
   for (const candidate of candidates) {
-    if (candidate.githubNumber === null || candidate.githubNumber === undefined) {
+    if (candidate[fieldKey] === null || candidate[fieldKey] === undefined) {
       continue;
     }
 
-    if (candidate.githubNumber === selectedNumberCandidate.githubNumber) {
+    if (candidate[fieldKey] === selectedCandidate[fieldKey]) {
       continue;
     }
 
-    const key = `${candidate.source}:${candidate.githubNumber}`;
+    const key = `${candidate.source}:${candidate[fieldKey]}`;
     if (seenValues.has(key)) {
       continue;
     }
@@ -240,7 +241,7 @@ function buildDriftDiagnostics(candidates, selectedNumberCandidate) {
     seenValues.add(key);
     conflicts.push({
       source: candidate.source,
-      value: candidate.githubNumber,
+      value: candidate[fieldKey],
     });
   }
 
@@ -250,13 +251,20 @@ function buildDriftDiagnostics(candidates, selectedNumberCandidate) {
 
   return [{
     type: 'legacy-link-drift',
-    field: 'github.number',
+    field: fieldName,
     selected: {
-      source: selectedNumberCandidate.source,
-      value: selectedNumberCandidate.githubNumber,
+      source: selectedCandidate.source,
+      value: selectedCandidate[fieldKey],
     },
     conflicts,
   }];
+}
+
+function buildDriftDiagnostics(candidates, selectedNodeCandidate, selectedNumberCandidate) {
+  return [
+    ...buildFieldDriftDiagnostic(candidates, 'github.nodeId', selectedNodeCandidate),
+    ...buildFieldDriftDiagnostic(candidates, 'github.number', selectedNumberCandidate),
+  ];
 }
 
 function chooseCanonicalUrl(existingLink, sources, selectedNumber) {
@@ -300,7 +308,7 @@ function bridgeLegacyLinkHints(legacyHints, options = {}) {
 
   const selectedNodeCandidate = pickPreferredCandidate(candidates, 'github.nodeId');
   const selectedNumberCandidate = pickPreferredCandidate(candidates, 'github.number');
-  const diagnostics = buildDriftDiagnostics(candidates, selectedNumberCandidate);
+  const diagnostics = buildDriftDiagnostics(candidates, selectedNodeCandidate, selectedNumberCandidate);
 
   const link = upsertCanonicalLink(store, {
     forgeIssueId: legacyHints.forgeIssueId ?? existingLink?.forgeIssueId ?? null,

--- a/lib/issue-sync/legacy-link-bridge.js
+++ b/lib/issue-sync/legacy-link-bridge.js
@@ -1,13 +1,14 @@
 const {
   createLinkStore,
+  normalizeGitHubNumber,
   resolveCanonicalLink,
   upsertCanonicalLink,
 } = require('./link-store.js');
 
 const SOURCE_PRECEDENCE = new Map([
-  ['existing', 0],
-  ['githubNodeId', 1],
-  ['githubNumber', 2],
+  ['githubNodeId', 0],
+  ['githubNumber', 1],
+  ['existing', 2],
   ['externalRef', 3],
   ['githubIssue', 4],
   ['mapping', 5],
@@ -17,15 +18,6 @@ const SOURCE_PRECEDENCE = new Map([
 
 function precedenceFor(source) {
   return SOURCE_PRECEDENCE.get(source) ?? Number.MAX_SAFE_INTEGER;
-}
-
-function normalizeGitHubNumber(value) {
-  if (value === null || value === undefined || value === '') {
-    return null;
-  }
-
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function parseExternalRef(externalRef) {
@@ -91,6 +83,69 @@ function buildSourceRecord(source, input = {}) {
   return record;
 }
 
+function hasStructuredMappingEntry(mapping) {
+  if (!mapping || typeof mapping !== 'object' || Array.isArray(mapping)) {
+    return false;
+  }
+
+  return [
+    'forgeIssueId',
+    'githubNumber',
+    'issueNumber',
+    'githubNodeId',
+    'nodeId',
+    'url',
+  ].some((key) => Object.hasOwn(mapping, key));
+}
+
+function collectMappingSources(mapping, forgeIssueId, explicitGitHubNumber) {
+  if (mapping === undefined || mapping === null) {
+    return [];
+  }
+
+  if (typeof mapping === 'object' && !Array.isArray(mapping)) {
+    if (hasStructuredMappingEntry(mapping)) {
+      return [buildSourceRecord('mapping', {
+        forgeIssueId: mapping.forgeIssueId ?? forgeIssueId,
+        githubNumber: mapping.githubNumber ?? mapping.issueNumber,
+        githubNodeId: mapping.githubNodeId ?? mapping.nodeId,
+        url: mapping.url,
+      })];
+    }
+
+    const sources = [];
+
+    for (const [issueNumber, beadsId] of Object.entries(mapping)) {
+      const githubNumber = normalizeGitHubNumber(issueNumber);
+      if (githubNumber === null || typeof beadsId !== 'string' || beadsId.length === 0) {
+        continue;
+      }
+
+      if (forgeIssueId && beadsId === forgeIssueId) {
+        sources.push(buildSourceRecord('mapping', {
+          forgeIssueId: beadsId,
+          githubNumber,
+        }));
+        continue;
+      }
+
+      if (!forgeIssueId && explicitGitHubNumber !== null && githubNumber === explicitGitHubNumber) {
+        sources.push(buildSourceRecord('mapping', {
+          forgeIssueId: beadsId,
+          githubNumber,
+        }));
+      }
+    }
+
+    return sources;
+  }
+
+  return [buildSourceRecord('mapping', {
+    forgeIssueId,
+    githubNumber: mapping,
+  })];
+}
+
 function collectLegacySources(legacyHints) {
   const sources = [];
   const forgeIssueId = legacyHints.forgeIssueId ?? null;
@@ -111,34 +166,25 @@ function collectLegacySources(legacyHints) {
     }));
   }
 
-  if (legacyHints.mapping !== undefined && legacyHints.mapping !== null) {
-    if (typeof legacyHints.mapping === 'object') {
-      sources.push(buildSourceRecord('mapping', {
-        forgeIssueId: legacyHints.mapping.forgeIssueId ?? forgeIssueId,
-        githubNumber: legacyHints.mapping.githubNumber ?? legacyHints.mapping.issueNumber,
-        githubNodeId: legacyHints.mapping.githubNodeId ?? legacyHints.mapping.nodeId,
-        url: legacyHints.mapping.url,
-      }));
-    } else {
-      sources.push(buildSourceRecord('mapping', {
-        forgeIssueId,
-        githubNumber: legacyHints.mapping,
-      }));
-    }
-  }
+  sources.push(...collectMappingSources(
+    legacyHints.mapping,
+    forgeIssueId,
+    normalizeGitHubNumber(explicitGithub.number),
+  ));
 
-  if (legacyHints.githubIssue !== undefined && legacyHints.githubIssue !== null) {
-    if (typeof legacyHints.githubIssue === 'object') {
+  const githubIssueState = legacyHints.githubIssue ?? legacyHints.github_issue;
+  if (githubIssueState !== undefined && githubIssueState !== null) {
+    if (typeof githubIssueState === 'object') {
       sources.push(buildSourceRecord('githubIssue', {
-        forgeIssueId: legacyHints.githubIssue.forgeIssueId ?? forgeIssueId,
-        githubNumber: legacyHints.githubIssue.githubNumber ?? legacyHints.githubIssue.issueNumber,
-        githubNodeId: legacyHints.githubIssue.githubNodeId ?? legacyHints.githubIssue.nodeId,
-        url: legacyHints.githubIssue.url,
+        forgeIssueId: githubIssueState.forgeIssueId ?? forgeIssueId,
+        githubNumber: githubIssueState.githubNumber ?? githubIssueState.issueNumber,
+        githubNodeId: githubIssueState.githubNodeId ?? githubIssueState.nodeId,
+        url: githubIssueState.url,
       }));
     } else {
       sources.push(buildSourceRecord('githubIssue', {
         forgeIssueId,
-        githubNumber: legacyHints.githubIssue,
+        githubNumber: githubIssueState,
       }));
     }
   }

--- a/lib/issue-sync/link-store.js
+++ b/lib/issue-sync/link-store.js
@@ -1,0 +1,208 @@
+function createDefaultCanonicalLink() {
+  return {
+    forgeIssueId: null,
+    github: {
+      nodeId: null,
+      number: null,
+      url: null,
+    },
+    sources: [],
+    diagnostics: [],
+  };
+}
+
+function cloneValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+
+  if (value && typeof value === 'object') {
+    const copy = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      copy[key] = cloneValue(nestedValue);
+    }
+
+    return copy;
+  }
+
+  return value;
+}
+
+function normalizeGitHubNumber(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function buildCanonicalLink(input = {}) {
+  const link = createDefaultCanonicalLink();
+  const github = input.github ?? {};
+
+  if (input.forgeIssueId) {
+    link.forgeIssueId = input.forgeIssueId;
+  }
+
+  if (github.nodeId) {
+    link.github.nodeId = github.nodeId;
+  }
+
+  link.github.number = normalizeGitHubNumber(github.number);
+
+  if (github.url) {
+    link.github.url = github.url;
+  }
+
+  if (Array.isArray(input.sources)) {
+    link.sources = input.sources.map(cloneValue);
+  }
+
+  if (Array.isArray(input.diagnostics)) {
+    link.diagnostics = input.diagnostics.map(cloneValue);
+  }
+
+  return link;
+}
+
+function createLinkStore(initialLinks = []) {
+  const store = {
+    records: [],
+    byForgeIssueId: new Map(),
+    byGitHubNodeId: new Map(),
+    byGitHubNumber: new Map(),
+  };
+
+  for (const link of initialLinks) {
+    upsertCanonicalLink(store, link);
+  }
+
+  return store;
+}
+
+function setIndexValue(index, key, record) {
+  if (key !== null && key !== undefined && key !== '') {
+    index.set(key, record);
+  }
+}
+
+function indexRecord(store, record) {
+  setIndexValue(store.byForgeIssueId, record.forgeIssueId, record);
+  setIndexValue(store.byGitHubNodeId, record.github.nodeId, record);
+  setIndexValue(store.byGitHubNumber, record.github.number, record);
+}
+
+function removeRecord(store, record) {
+  store.records = store.records.filter((candidate) => candidate !== record);
+
+  if (record.forgeIssueId) {
+    store.byForgeIssueId.delete(record.forgeIssueId);
+  }
+
+  if (record.github.nodeId) {
+    store.byGitHubNodeId.delete(record.github.nodeId);
+  }
+
+  if (record.github.number !== null) {
+    store.byGitHubNumber.delete(record.github.number);
+  }
+}
+
+function mergeUniqueEntries(existingEntries, incomingEntries) {
+  const merged = [];
+  const seen = new Set();
+
+  for (const entry of [...existingEntries, ...incomingEntries]) {
+    const key = JSON.stringify(entry);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    merged.push(cloneValue(entry));
+  }
+
+  return merged;
+}
+
+function mergeCanonicalLinkRecords(baseRecord, incomingRecord) {
+  return {
+    forgeIssueId: incomingRecord.forgeIssueId ?? baseRecord.forgeIssueId,
+    github: {
+      nodeId: incomingRecord.github.nodeId ?? baseRecord.github.nodeId,
+      number: incomingRecord.github.number ?? baseRecord.github.number,
+      url: incomingRecord.github.url ?? baseRecord.github.url,
+    },
+    sources: mergeUniqueEntries(baseRecord.sources, incomingRecord.sources),
+    diagnostics: mergeUniqueEntries(baseRecord.diagnostics, incomingRecord.diagnostics),
+  };
+}
+
+function collectMatchedRecords(store, link) {
+  const matches = new Set();
+
+  if (link.forgeIssueId && store.byForgeIssueId.has(link.forgeIssueId)) {
+    matches.add(store.byForgeIssueId.get(link.forgeIssueId));
+  }
+
+  if (link.github.nodeId && store.byGitHubNodeId.has(link.github.nodeId)) {
+    matches.add(store.byGitHubNodeId.get(link.github.nodeId));
+  }
+
+  if (link.github.number !== null && store.byGitHubNumber.has(link.github.number)) {
+    matches.add(store.byGitHubNumber.get(link.github.number));
+  }
+
+  return [...matches];
+}
+
+function upsertCanonicalLink(store, input) {
+  const incomingRecord = buildCanonicalLink(input);
+  const matchedRecords = collectMatchedRecords(store, incomingRecord);
+
+  let mergedRecord = incomingRecord;
+  for (const record of matchedRecords) {
+    mergedRecord = mergeCanonicalLinkRecords(record, mergedRecord);
+  }
+
+  for (const record of matchedRecords) {
+    removeRecord(store, record);
+  }
+
+  store.records.push(mergedRecord);
+  indexRecord(store, mergedRecord);
+
+  return mergedRecord;
+}
+
+function resolveCanonicalLink(store, lookup = {}) {
+  if (lookup.forgeIssueId && store.byForgeIssueId.has(lookup.forgeIssueId)) {
+    return store.byForgeIssueId.get(lookup.forgeIssueId);
+  }
+
+  if (lookup.githubNodeId && store.byGitHubNodeId.has(lookup.githubNodeId)) {
+    return store.byGitHubNodeId.get(lookup.githubNodeId);
+  }
+
+  const githubNumber = normalizeGitHubNumber(lookup.githubNumber);
+  if (githubNumber !== null && store.byGitHubNumber.has(githubNumber)) {
+    return store.byGitHubNumber.get(githubNumber);
+  }
+
+  return null;
+}
+
+function listCanonicalLinks(store) {
+  return store.records.map(cloneValue);
+}
+
+module.exports = {
+  buildCanonicalLink,
+  createDefaultCanonicalLink,
+  createLinkStore,
+  listCanonicalLinks,
+  resolveCanonicalLink,
+  upsertCanonicalLink,
+};

--- a/lib/issue-sync/link-store.js
+++ b/lib/issue-sync/link-store.js
@@ -67,6 +67,22 @@ function buildCanonicalLink(input = {}) {
   return link;
 }
 
+function getLinkPriority(link) {
+  if (link.github.nodeId) {
+    return 0;
+  }
+
+  if (link.github.number !== null) {
+    return 1;
+  }
+
+  if (link.forgeIssueId) {
+    return 2;
+  }
+
+  return 3;
+}
+
 function createLinkStore(initialLinks = []) {
   const store = {
     records: [],
@@ -127,47 +143,113 @@ function mergeUniqueEntries(existingEntries, incomingEntries) {
   return merged;
 }
 
-function mergeCanonicalLinkRecords(baseRecord, incomingRecord) {
-  return {
-    forgeIssueId: incomingRecord.forgeIssueId ?? baseRecord.forgeIssueId,
-    github: {
-      nodeId: incomingRecord.github.nodeId ?? baseRecord.github.nodeId,
-      number: incomingRecord.github.number ?? baseRecord.github.number,
-      url: incomingRecord.github.url ?? baseRecord.github.url,
-    },
-    sources: mergeUniqueEntries(baseRecord.sources, incomingRecord.sources),
-    diagnostics: mergeUniqueEntries(baseRecord.diagnostics, incomingRecord.diagnostics),
-  };
-}
-
 function collectMatchedRecords(store, link) {
-  const matches = new Set();
+  const matches = new Map();
+
+  function registerMatch(record, priority) {
+    if (!record) {
+      return;
+    }
+
+    const existingPriority = matches.get(record);
+    if (existingPriority === undefined || priority < existingPriority) {
+      matches.set(record, priority);
+    }
+  }
 
   if (link.forgeIssueId && store.byForgeIssueId.has(link.forgeIssueId)) {
-    matches.add(store.byForgeIssueId.get(link.forgeIssueId));
+    registerMatch(store.byForgeIssueId.get(link.forgeIssueId), 0);
   }
 
   if (link.github.nodeId && store.byGitHubNodeId.has(link.github.nodeId)) {
-    matches.add(store.byGitHubNodeId.get(link.github.nodeId));
+    registerMatch(store.byGitHubNodeId.get(link.github.nodeId), 1);
   }
 
   if (link.github.number !== null && store.byGitHubNumber.has(link.github.number)) {
-    matches.add(store.byGitHubNumber.get(link.github.number));
+    registerMatch(store.byGitHubNumber.get(link.github.number), 2);
   }
 
-  return [...matches];
+  return [...matches.entries()].map(([record, priority]) => ({ record, priority }));
+}
+
+function mergeCandidateEntries(candidates, fieldName) {
+  let mergedEntries = [];
+
+  for (const candidate of candidates) {
+    mergedEntries = mergeUniqueEntries(mergedEntries, candidate.record[fieldName] ?? []);
+  }
+
+  return mergedEntries;
+}
+
+function mergeCanonicalLinkCandidates(candidates) {
+  const mergedRecord = createDefaultCanonicalLink();
+
+  for (const candidate of candidates) {
+    const { record } = candidate;
+
+    if (mergedRecord.forgeIssueId === null && record.forgeIssueId) {
+      mergedRecord.forgeIssueId = record.forgeIssueId;
+    }
+
+    if (mergedRecord.github.nodeId === null && record.github.nodeId) {
+      mergedRecord.github.nodeId = record.github.nodeId;
+    }
+
+    if (mergedRecord.github.number === null && record.github.number !== null) {
+      mergedRecord.github.number = record.github.number;
+    }
+
+    if (mergedRecord.github.url === null && record.github.url) {
+      mergedRecord.github.url = record.github.url;
+    }
+  }
+
+  mergedRecord.sources = mergeCandidateEntries(candidates, 'sources');
+  mergedRecord.diagnostics = mergeCandidateEntries(candidates, 'diagnostics');
+
+  return mergedRecord;
+}
+
+function buildMergeCandidates(store, matchedRecords, incomingRecord) {
+  const existingOrder = new Map(store.records.map((record, index) => [record, index]));
+  const candidates = matchedRecords.map(({ record, priority }) => ({
+    record,
+    priority,
+    incoming: false,
+    order: existingOrder.get(record) ?? Number.MAX_SAFE_INTEGER,
+  }));
+
+  candidates.push({
+    record: incomingRecord,
+    priority: getLinkPriority(incomingRecord),
+    incoming: true,
+    order: Number.MAX_SAFE_INTEGER,
+  });
+
+  candidates.sort((left, right) => {
+    if (left.priority !== right.priority) {
+      return left.priority - right.priority;
+    }
+
+    if (left.incoming !== right.incoming) {
+      return left.incoming ? -1 : 1;
+    }
+
+    return left.order - right.order;
+  });
+
+  return candidates;
 }
 
 function upsertCanonicalLink(store, input) {
   const incomingRecord = buildCanonicalLink(input);
   const matchedRecords = collectMatchedRecords(store, incomingRecord);
+  const mergedRecord = mergeCanonicalLinkCandidates(
+    buildMergeCandidates(store, matchedRecords, incomingRecord),
+  );
 
-  let mergedRecord = incomingRecord;
-  for (const record of matchedRecords) {
-    mergedRecord = mergeCanonicalLinkRecords(record, mergedRecord);
-  }
-
-  for (const record of matchedRecords) {
+  for (const { record } of matchedRecords) {
     removeRecord(store, record);
   }
 
@@ -202,7 +284,9 @@ module.exports = {
   buildCanonicalLink,
   createDefaultCanonicalLink,
   createLinkStore,
+  getLinkPriority,
   listCanonicalLinks,
+  normalizeGitHubNumber,
   resolveCanonicalLink,
   upsertCanonicalLink,
 };

--- a/lib/issue-sync/project-github.js
+++ b/lib/issue-sync/project-github.js
@@ -28,33 +28,29 @@ function isHelpInvocation(args = []) {
   return Array.isArray(args) && args.some(arg => arg === '--help' || arg === '-h');
 }
 
-function collectSharedFieldPaths(operation, args = []) {
-  if (typeof operation !== 'string' || operation.length === 0) {
-    return [];
-  }
-
-  if (isHelpInvocation(args)) {
-    return [];
-  }
-
-  const fieldPaths = [];
-
+function appendDefaultSharedFields(operation, fieldPaths) {
   for (const defaultField of OPERATIONS_WITH_DEFAULT_SHARED_FIELDS.get(operation) || []) {
     if (isSharedField(defaultField)) {
       uniquePush(fieldPaths, defaultField);
     }
   }
+}
 
-  if (!Array.isArray(args)) {
-    return fieldPaths;
+function inferCreateTitleField(operation, args = []) {
+  if (operation !== 'create' || !Array.isArray(args) || args.length === 0) {
+    return null;
   }
 
-  if (operation === 'create' && args.length > 0) {
-    const firstNonFlagArg = args.find(arg => typeof arg === 'string' && !arg.startsWith('-'));
-    if (firstNonFlagArg !== undefined) {
-      uniquePush(fieldPaths, 'shared.title');
-    }
+  const firstNonFlagArg = args.find(arg => typeof arg === 'string' && !arg.startsWith('-'));
+  if (firstNonFlagArg === undefined) {
+    return null;
   }
+
+  return 'shared.title';
+}
+
+function collectSharedFieldsFromFlags(args = []) {
+  const fieldPaths = [];
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -77,6 +73,30 @@ function collectSharedFieldPaths(operation, args = []) {
     if (flagKey.startsWith('--') && !arg.includes('=')) {
       index += 1;
     }
+  }
+
+  return fieldPaths;
+}
+
+function collectSharedFieldPaths(operation, args = []) {
+  if (typeof operation !== 'string' || operation.length === 0) {
+    return [];
+  }
+
+  if (isHelpInvocation(args)) {
+    return [];
+  }
+
+  const fieldPaths = [];
+  appendDefaultSharedFields(operation, fieldPaths);
+
+  if (!Array.isArray(args)) {
+    return fieldPaths;
+  }
+
+  uniquePush(fieldPaths, inferCreateTitleField(operation, args));
+  for (const fieldPath of collectSharedFieldsFromFlags(args)) {
+    uniquePush(fieldPaths, fieldPath);
   }
 
   return fieldPaths;

--- a/lib/issue-sync/project-github.js
+++ b/lib/issue-sync/project-github.js
@@ -62,18 +62,19 @@ function collectSharedFieldPaths(operation, args = []) {
       continue;
     }
 
-    const fieldPath = FLAG_TO_SHARED_FIELD.get(arg);
+    const flagKey = arg.startsWith('--') ? arg.split('=')[0] : arg;
+    const fieldPath = FLAG_TO_SHARED_FIELD.get(flagKey);
     if (!fieldPath || !isSharedField(fieldPath)) {
       continue;
     }
 
     uniquePush(fieldPaths, fieldPath);
 
-    if (arg === '--claim') {
+    if (flagKey === '--claim') {
       continue;
     }
 
-    if (arg.startsWith('--')) {
+    if (flagKey.startsWith('--') && !arg.includes('=')) {
       index += 1;
     }
   }

--- a/lib/issue-sync/project-github.js
+++ b/lib/issue-sync/project-github.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { isSharedField } = require('./authority.js');
+
+const FLAG_TO_SHARED_FIELD = new Map([
+  ['--title', 'shared.title'],
+  ['--body', 'shared.body'],
+  ['--state', 'shared.state'],
+  ['--assignee', 'shared.assignees'],
+  ['--assignees', 'shared.assignees'],
+  ['--label', 'shared.labels'],
+  ['--labels', 'shared.labels'],
+  ['--milestone', 'shared.milestone'],
+  ['--claim', 'shared.assignees'],
+]);
+
+const OPERATIONS_WITH_DEFAULT_SHARED_FIELDS = new Map([
+  ['close', ['shared.state']],
+]);
+
+function uniquePush(items, value) {
+  if (value && !items.includes(value)) {
+    items.push(value);
+  }
+}
+
+function collectSharedFieldPaths(operation, args = []) {
+  if (typeof operation !== 'string' || operation.length === 0) {
+    return [];
+  }
+
+  const fieldPaths = [];
+
+  for (const defaultField of OPERATIONS_WITH_DEFAULT_SHARED_FIELDS.get(operation) || []) {
+    if (isSharedField(defaultField)) {
+      uniquePush(fieldPaths, defaultField);
+    }
+  }
+
+  if (!Array.isArray(args)) {
+    return fieldPaths;
+  }
+
+  if (operation === 'create' && args.length > 0) {
+    const firstNonFlagArg = args.find(arg => typeof arg === 'string' && !arg.startsWith('-'));
+    if (firstNonFlagArg !== undefined) {
+      uniquePush(fieldPaths, 'shared.title');
+    }
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (typeof arg !== 'string') {
+      continue;
+    }
+
+    const fieldPath = FLAG_TO_SHARED_FIELD.get(arg);
+    if (!fieldPath || !isSharedField(fieldPath)) {
+      continue;
+    }
+
+    uniquePush(fieldPaths, fieldPath);
+
+    if (arg === '--claim') {
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      index += 1;
+    }
+  }
+
+  return fieldPaths;
+}
+
+function createGitHubProjectionPlan(operation, args = []) {
+  const fieldPaths = collectSharedFieldPaths(operation, args);
+
+  if (fieldPaths.length === 0) {
+    return null;
+  }
+
+  return {
+    operation,
+    args: Array.isArray(args) ? [...args] : [],
+    fieldPaths,
+  };
+}
+
+module.exports = {
+  collectSharedFieldPaths,
+  createGitHubProjectionPlan,
+};

--- a/lib/issue-sync/project-github.js
+++ b/lib/issue-sync/project-github.js
@@ -24,8 +24,16 @@ function uniquePush(items, value) {
   }
 }
 
+function isHelpInvocation(args = []) {
+  return Array.isArray(args) && args.some(arg => arg === '--help' || arg === '-h');
+}
+
 function collectSharedFieldPaths(operation, args = []) {
   if (typeof operation !== 'string' || operation.length === 0) {
+    return [];
+  }
+
+  if (isHelpInvocation(args)) {
     return [];
   }
 
@@ -90,4 +98,5 @@ function createGitHubProjectionPlan(operation, args = []) {
 module.exports = {
   collectSharedFieldPaths,
   createGitHubProjectionPlan,
+  isHelpInvocation,
 };

--- a/lib/issue-sync/reconcile.js
+++ b/lib/issue-sync/reconcile.js
@@ -6,6 +6,8 @@ const {
   cloneValue,
 } = require('./github-pull.js');
 
+const MAX_DRIFT_HISTORY = 50;
+
 function readField(record, fieldPath) {
   switch (fieldPath) {
     case 'github.number':
@@ -132,6 +134,24 @@ function buildMaterializedIssueSnapshot(record) {
   return snapshot;
 }
 
+function mergeDriftDiagnostics(existingDiagnostics = [], newDiagnostics = []) {
+  const merged = [];
+  const seen = new Set();
+
+  for (const diagnostic of [...existingDiagnostics, ...newDiagnostics]) {
+    const clonedDiagnostic = cloneValue(diagnostic);
+    const key = JSON.stringify(clonedDiagnostic);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    merged.push(clonedDiagnostic);
+  }
+
+  return merged.slice(-MAX_DRIFT_HISTORY);
+}
+
 function reconcileSharedIssueRecord(localRecord = {}, remoteSnapshot = {}, options = {}) {
   const existingRecord = buildSharedIssueRecord(localRecord);
   const remoteRecord = buildSharedIssueRecord(remoteSnapshot);
@@ -149,14 +169,13 @@ function reconcileSharedIssueRecord(localRecord = {}, remoteSnapshot = {}, optio
     writeField(reconciledRecord, fieldPath, cloneValue(remoteValue));
   }
 
+  // Some import/materialization flows need to retain the last local pull
+  // watermark instead of overwriting it with the fresh GitHub timestamp.
   if (options.preserveRemoteUpdatedAt === false && existingRecord.sync.remoteUpdatedAt !== null) {
     reconciledRecord.sync.remoteUpdatedAt = existingRecord.sync.remoteUpdatedAt;
   }
 
-  reconciledRecord.sync.drift = [
-    ...cloneValue(existingRecord.sync.drift ?? []),
-    ...diagnostics,
-  ];
+  reconciledRecord.sync.drift = mergeDriftDiagnostics(existingRecord.sync.drift ?? [], diagnostics);
   reconciledRecord.cache.githubSnapshot = cloneValue(remoteSnapshot);
   reconciledRecord.cache.materializedIssue = buildMaterializedIssueSnapshot(reconciledRecord);
 

--- a/lib/issue-sync/reconcile.js
+++ b/lib/issue-sync/reconcile.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const { buildSharedIssueRecord } = require('./schema.js');
+const {
+  GITHUB_OWNED_FIELD_PATHS,
+  cloneValue,
+} = require('./github-pull.js');
+
+function readField(record, fieldPath) {
+  switch (fieldPath) {
+    case 'github.number':
+      return record.github.number;
+    case 'github.nodeId':
+      return record.github.nodeId;
+    case 'github.url':
+      return record.github.url;
+    case 'shared.title':
+      return record.shared.title;
+    case 'shared.body':
+      return record.shared.body;
+    case 'shared.state':
+      return record.shared.state;
+    case 'shared.assignees':
+      return record.shared.assignees;
+    case 'shared.labels':
+      return record.shared.labels;
+    case 'shared.milestone':
+      return record.shared.milestone;
+    case 'sync.remoteUpdatedAt':
+      return record.sync.remoteUpdatedAt;
+    default:
+      return undefined;
+  }
+}
+
+function writeField(record, fieldPath, value) {
+  switch (fieldPath) {
+    case 'github.number':
+      record.github.number = value;
+      break;
+    case 'github.nodeId':
+      record.github.nodeId = value;
+      break;
+    case 'github.url':
+      record.github.url = value;
+      break;
+    case 'shared.title':
+      record.shared.title = value;
+      break;
+    case 'shared.body':
+      record.shared.body = value;
+      break;
+    case 'shared.state':
+      record.shared.state = value;
+      break;
+    case 'shared.assignees':
+      record.shared.assignees = value;
+      break;
+    case 'shared.labels':
+      record.shared.labels = value;
+      break;
+    case 'shared.milestone':
+      record.shared.milestone = value;
+      break;
+    case 'sync.remoteUpdatedAt':
+      record.sync.remoteUpdatedAt = value;
+      break;
+    default:
+      break;
+  }
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function deepEqual(left, right) {
+  if (left === right) {
+    return true;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) {
+      return false;
+    }
+
+    for (let index = 0; index < left.length; index += 1) {
+      if (!deepEqual(left[index], right[index])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+
+    if (leftKeys.length !== rightKeys.length) {
+      return false;
+    }
+
+    for (const key of leftKeys) {
+      if (!Object.hasOwn(right, key) || !deepEqual(left[key], right[key])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+function createDriftDiagnostic(field, localValue, remoteValue) {
+  return {
+    type: 'github-shared-drift',
+    field,
+    localValue: cloneValue(localValue),
+    remoteValue: cloneValue(remoteValue),
+  };
+}
+
+function buildMaterializedIssueSnapshot(record) {
+  const snapshot = cloneValue(record);
+
+  if (snapshot?.cache) {
+    snapshot.cache.materializedIssue = null;
+  }
+
+  return snapshot;
+}
+
+function reconcileSharedIssueRecord(localRecord = {}, remoteSnapshot = {}, options = {}) {
+  const existingRecord = buildSharedIssueRecord(localRecord);
+  const remoteRecord = buildSharedIssueRecord(remoteSnapshot);
+  const reconciledRecord = buildSharedIssueRecord(existingRecord);
+  const diagnostics = [];
+
+  for (const fieldPath of GITHUB_OWNED_FIELD_PATHS) {
+    const localValue = readField(existingRecord, fieldPath);
+    const remoteValue = readField(remoteRecord, fieldPath);
+
+    if (!deepEqual(localValue, remoteValue)) {
+      diagnostics.push(createDriftDiagnostic(fieldPath, localValue, remoteValue));
+    }
+
+    writeField(reconciledRecord, fieldPath, cloneValue(remoteValue));
+  }
+
+  if (options.preserveRemoteUpdatedAt === false && existingRecord.sync.remoteUpdatedAt !== null) {
+    reconciledRecord.sync.remoteUpdatedAt = existingRecord.sync.remoteUpdatedAt;
+  }
+
+  reconciledRecord.sync.drift = [
+    ...cloneValue(existingRecord.sync.drift ?? []),
+    ...diagnostics,
+  ];
+  reconciledRecord.cache.githubSnapshot = cloneValue(remoteSnapshot);
+  reconciledRecord.cache.materializedIssue = buildMaterializedIssueSnapshot(reconciledRecord);
+
+  return {
+    record: reconciledRecord,
+    diagnostics,
+  };
+}
+
+module.exports = {
+  buildMaterializedIssueSnapshot,
+  createDriftDiagnostic,
+  deepEqual,
+  reconcileSharedIssueRecord,
+  readField,
+  writeField,
+};

--- a/lib/issue-sync/schema.js
+++ b/lib/issue-sync/schema.js
@@ -1,0 +1,126 @@
+function createDefaultGitHubSection() {
+  return {
+    number: null,
+    nodeId: null,
+    url: null,
+  };
+}
+
+function createDefaultSharedSection() {
+  return {
+    title: '',
+    body: '',
+    state: 'open',
+    assignees: [],
+    labels: [],
+    milestone: null,
+  };
+}
+
+function createDefaultForgeSection() {
+  return {
+    issueId: null,
+    dependencies: [],
+    parentId: null,
+    childIds: [],
+    workflowStage: null,
+    acceptanceCriteria: [],
+    progressNotes: [],
+    stageTransitions: [],
+    decisions: [],
+    memory: [],
+  };
+}
+
+function createDefaultCacheSection() {
+  return {
+    githubSnapshot: null,
+    materializedIssue: null,
+    legacyLinkHints: {
+      mapping: null,
+      githubIssue: null,
+      syncComments: [],
+      externalRef: null,
+      descriptionUrl: null,
+    },
+  };
+}
+
+function createDefaultSyncSection() {
+  return {
+    remoteUpdatedAt: null,
+    lastPulledAt: null,
+    lastPushedAt: null,
+    pendingOutbound: [],
+    drift: [],
+  };
+}
+
+function createDefaultSharedIssueRecord() {
+  return {
+    github: createDefaultGitHubSection(),
+    shared: createDefaultSharedSection(),
+    forge: createDefaultForgeSection(),
+    cache: createDefaultCacheSection(),
+    sync: createDefaultSyncSection(),
+  };
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+
+  if (isPlainObject(value)) {
+    const result = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      result[key] = cloneValue(nestedValue);
+    }
+
+    return result;
+  }
+
+  return value;
+}
+
+function mergeRecordSections(baseValue, overrideValue) {
+  if (overrideValue === undefined) {
+    return cloneValue(baseValue);
+  }
+
+  if (Array.isArray(overrideValue)) {
+    return overrideValue.map(cloneValue);
+  }
+
+  if (!isPlainObject(baseValue) || !isPlainObject(overrideValue)) {
+    return cloneValue(overrideValue);
+  }
+
+  const merged = {};
+  const keys = new Set([...Object.keys(baseValue), ...Object.keys(overrideValue)]);
+
+  for (const key of keys) {
+    merged[key] = mergeRecordSections(baseValue[key], overrideValue[key]);
+  }
+
+  return merged;
+}
+
+function buildSharedIssueRecord(overrides = {}) {
+  return mergeRecordSections(createDefaultSharedIssueRecord(), overrides);
+}
+
+module.exports = {
+  buildSharedIssueRecord,
+  createDefaultCacheSection,
+  createDefaultForgeSection,
+  createDefaultGitHubSection,
+  createDefaultSharedIssueRecord,
+  createDefaultSharedSection,
+  createDefaultSyncSection,
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:ci:shard": "node scripts/test-ci-shard.js",
     "typecheck": "echo 'No TypeScript in project - skipping type check'",
     "lint": "eslint . --max-warnings 0",
-    "check": "bash scripts/validate.sh",
+    "check": "node scripts/validate.js",
     "prepare": "lefthook install || echo 'Note: lefthook not installed. Git hooks disabled. Run: bun add -d lefthook'",
     "setup": "node ./bin/forge.js setup",
     "help": "node ./bin/forge.js --help",

--- a/scripts/beads-context.sh
+++ b/scripts/beads-context.sh
@@ -41,11 +41,95 @@ die() {
   exit 1
 }
 
+# Resolve a Windows bd.exe installation for bash-based helper flows.
+# This covers WSL/Git Bash cases where PowerShell can run bd.exe but bash PATH
+# does not include the Windows install directory.
+convert_windows_path() {
+  local raw="${1%$'\r'}"
+
+  if [[ -z "$raw" ]]; then
+    return 1
+  fi
+
+  if [[ ! "$raw" =~ ^[A-Za-z]:\\ ]]; then
+    printf '%s' "$raw"
+    return 0
+  fi
+
+  if command -v wslpath >/dev/null 2>&1; then
+    wslpath -u "$raw" 2>/dev/null && return 0
+  fi
+
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$raw" 2>/dev/null && return 0
+  fi
+
+  local drive rest
+  drive="$(printf '%s' "$raw" | cut -c1 | tr '[:upper:]' '[:lower:]')"
+  rest="${raw:2}"
+  rest="${rest//\\//}"
+  printf '/mnt/%s%s' "$drive" "$rest"
+}
+
+resolve_bd_cmd() {
+  local candidate=""
+  local converted=""
+
+  if [[ -n "${BD_CMD:-}" ]]; then
+    printf '%s' "$BD_CMD"
+    return 0
+  fi
+
+  if command -v bd >/dev/null 2>&1; then
+    printf '%s' "bd"
+    return 0
+  fi
+
+  if command -v bd.exe >/dev/null 2>&1; then
+    printf '%s' "bd.exe"
+    return 0
+  fi
+
+  for candidate in \
+    "$HOME/.local/bin/bd" \
+    "$HOME/.local/bin/bd.exe" \
+    "$HOME/.bun/bin/bd" \
+    "$HOME/.bun/bin/bd.exe"
+  do
+    if [[ -n "$candidate" && ( -f "$candidate" || -x "$candidate" ) ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  if command -v where.exe >/dev/null 2>&1; then
+    while IFS= read -r candidate; do
+      candidate="${candidate%$'\r'}"
+      [[ -z "$candidate" ]] && continue
+
+      converted="$(convert_windows_path "$candidate")"
+      if [[ -n "$converted" && ( -f "$converted" || -x "$converted" ) ]]; then
+        printf '%s' "$converted"
+        return 0
+      fi
+
+      if [[ -f "$candidate" || -x "$candidate" ]]; then
+        printf '%s' "$candidate"
+        return 0
+      fi
+    done < <(where.exe bd 2>/dev/null || true)
+  fi
+
+  return 1
+}
+
+BD="$(resolve_bd_cmd)" || die "bd is required but not found"
+
 # Run bd update and check for errors in both exit code and output.
 # bd update exits 0 even for non-existent issues, so we check stdout too.
 bd_update() {
   local output
-  output="$(bd update "$@" 2>&1)"
+  output="$("$BD" update "$@" 2>&1)"
   local rc=$?
 
   if [[ $rc -ne 0 ]]; then
@@ -67,7 +151,7 @@ bd_update() {
 # Run bd comments add and check for errors similarly.
 bd_comment() {
   local output
-  output="$(bd comments add "$@" 2>&1)"
+  output="$("$BD" comments add "$@" 2>&1)"
   local rc=$?
 
   if [[ $rc -ne 0 ]]; then
@@ -175,7 +259,7 @@ cmd_parse_progress() {
 
   # Get the issue JSON — detect non-existent issues
   local json
-  json="$(bd show "$issue_id" --json 2>&1)" || die "Failed to show issue ${issue_id}"
+  json="$("$BD" show "$issue_id" --json 2>&1)" || die "Failed to show issue ${issue_id}"
 
   # bd show may exit 0 but print an error for non-existent issues
   # Match specific bd error patterns, not the word "error" in data fields
@@ -323,7 +407,7 @@ cmd_validate() {
 
   # Get issue JSON
   local json
-  json="$(bd show "$issue_id" --json 2>&1)" || {
+  json="$("$BD" show "$issue_id" --json 2>&1)" || {
     echo "Error: Failed to retrieve issue ${issue_id}" >&2
     exit 1
   }
@@ -357,7 +441,7 @@ cmd_validate() {
 
   # Get comments to check for stage transitions
   local comments
-  comments="$(bd comments list "$issue_id" 2>/dev/null || true)"
+  comments="$("$BD" comments list "$issue_id" 2>/dev/null || true)"
 
   # Check 2: At least one stage transition exists
   local has_transition=false

--- a/scripts/beads-context.sh
+++ b/scripts/beads-context.sh
@@ -441,7 +441,7 @@ cmd_validate() {
 
   # Get comments to check for stage transitions
   local comments
-  comments="$("$BD" comments list "$issue_id" 2>/dev/null || true)"
+  comments="$("$BD" comments "$issue_id" 2>/dev/null || true)"
 
   # Check 2: At least one stage transition exists
   local has_transition=false

--- a/scripts/beads-context.sh
+++ b/scripts/beads-context.sh
@@ -71,11 +71,30 @@ convert_windows_path() {
   printf '/mnt/%s%s' "$drive" "$rest"
 }
 
+is_runnable_bd_candidate() {
+  local candidate="${1:-}"
+
+  if [[ -z "$candidate" || ! -f "$candidate" ]]; then
+    return 1
+  fi
+
+  [[ -x "$candidate" || "$candidate" == *.exe ]]
+}
+
 resolve_bd_cmd() {
   local candidate=""
   local converted=""
 
   if [[ -n "${BD_CMD:-}" ]]; then
+    if [[ "${BD_CMD}" == *"/"* || "${BD_CMD}" == *"\\"* ]]; then
+      converted="$(convert_windows_path "$BD_CMD")"
+      if is_runnable_bd_candidate "$converted"; then
+        printf '%s' "$converted"
+        return 0
+      fi
+
+      is_runnable_bd_candidate "$BD_CMD" || return 1
+    fi
     printf '%s' "$BD_CMD"
     return 0
   fi
@@ -96,7 +115,7 @@ resolve_bd_cmd() {
     "$HOME/.bun/bin/bd" \
     "$HOME/.bun/bin/bd.exe"
   do
-    if [[ -n "$candidate" && ( -f "$candidate" || -x "$candidate" ) ]]; then
+    if is_runnable_bd_candidate "$candidate"; then
       printf '%s' "$candidate"
       return 0
     fi
@@ -108,12 +127,12 @@ resolve_bd_cmd() {
       [[ -z "$candidate" ]] && continue
 
       converted="$(convert_windows_path "$candidate")"
-      if [[ -n "$converted" && ( -f "$converted" || -x "$converted" ) ]]; then
+      if is_runnable_bd_candidate "$converted"; then
         printf '%s' "$converted"
         return 0
       fi
 
-      if [[ -f "$candidate" || -x "$candidate" ]]; then
+      if is_runnable_bd_candidate "$candidate"; then
         printf '%s' "$candidate"
         return 0
       fi
@@ -123,13 +142,23 @@ resolve_bd_cmd() {
   return 1
 }
 
-BD="$(resolve_bd_cmd)" || die "bd is required but not found"
+BD=""
+
+get_bd_cmd() {
+  if [[ -z "$BD" ]]; then
+    BD="$(resolve_bd_cmd)" || die "bd is required but not found"
+  fi
+
+  printf '%s' "$BD"
+}
 
 # Run bd update and check for errors in both exit code and output.
 # bd update exits 0 even for non-existent issues, so we check stdout too.
 bd_update() {
+  local bd_cmd
+  bd_cmd="$(get_bd_cmd)"
   local output
-  output="$("$BD" update "$@" 2>&1)"
+  output="$("$bd_cmd" update "$@" 2>&1)"
   local rc=$?
 
   if [[ $rc -ne 0 ]]; then
@@ -150,8 +179,10 @@ bd_update() {
 
 # Run bd comments add and check for errors similarly.
 bd_comment() {
+  local bd_cmd
+  bd_cmd="$(get_bd_cmd)"
   local output
-  output="$("$BD" comments add "$@" 2>&1)"
+  output="$("$bd_cmd" comments add "$@" 2>&1)"
   local rc=$?
 
   if [[ $rc -ne 0 ]]; then
@@ -256,10 +287,12 @@ cmd_parse_progress() {
   fi
 
   local issue_id="$1"
+  local bd_cmd
+  bd_cmd="$(get_bd_cmd)"
 
   # Get the issue JSON — detect non-existent issues
   local json
-  json="$("$BD" show "$issue_id" --json 2>&1)" || die "Failed to show issue ${issue_id}"
+  json="$("$bd_cmd" show "$issue_id" --json 2>&1)" || die "Failed to show issue ${issue_id}"
 
   # bd show may exit 0 but print an error for non-existent issues
   # Match specific bd error patterns, not the word "error" in data fields
@@ -404,10 +437,12 @@ cmd_validate() {
 
   local issue_id="$1"
   local warnings=0
+  local bd_cmd
+  bd_cmd="$(get_bd_cmd)"
 
   # Get issue JSON
   local json
-  json="$("$BD" show "$issue_id" --json 2>&1)" || {
+  json="$("$bd_cmd" show "$issue_id" --json 2>&1)" || {
     echo "Error: Failed to retrieve issue ${issue_id}" >&2
     exit 1
   }
@@ -441,7 +476,7 @@ cmd_validate() {
 
   # Get comments to check for stage transitions
   local comments
-  comments="$("$BD" comments "$issue_id" 2>/dev/null || true)"
+  comments="$("$bd_cmd" comments "$issue_id" 2>/dev/null || true)"
 
   # Check 2: At least one stage transition exists
   local has_transition=false

--- a/scripts/beads-context.test.js
+++ b/scripts/beads-context.test.js
@@ -31,11 +31,15 @@ function shouldRunBeadsIntegration() {
  * Returns { exitCode, stdout, stderr }.
  */
 async function run(...args) {
+	return runWithEnv(args);
+}
+
+async function runWithEnv(args, envOverrides = {}) {
 	const proc = Bun.spawn([resolveBashCommand(), SCRIPT_PATH, ...args], {
 		cwd: WORKTREE_ROOT,
 		stdout: 'pipe',
 		stderr: 'pipe',
-		env: { ...process.env },
+		env: { ...process.env, ...envOverrides },
 	});
 	const stdout = await new Response(proc.stdout).text();
 	const stderr = await new Response(proc.stderr).text();
@@ -58,6 +62,15 @@ async function bd(...args) {
 	const exitCode = await proc.exited;
 	return { exitCode, stdout, stderr };
 }
+
+describe('scripts/beads-context.sh command resolution', () => {
+	test('script includes Windows-aware bd resolution fallback', () => {
+		const content = fs.readFileSync(SCRIPT_PATH, 'utf8');
+		expect(content).toContain('resolve_bd_cmd');
+		expect(content).toContain('where.exe');
+		expect(content).toContain('$HOME/.local/bin/bd.exe');
+	});
+});
 
 describe.skipIf(!shouldRunBeadsIntegration())('scripts/beads-context.sh', () => {
 	let testIssueId;

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -7,7 +7,7 @@
 #   sync_issue_status  <beads-id> <status>    — Update status label on GitHub
 #   sync_issue_close   <beads-id>             — Close GitHub issue
 #   sync_issue_deps    <beads-id-a> <beads-id-b> — Add "Blocked by" comment
-#   _get_github_issue_number <beads-id>       — Extract github_issue from bd show
+#   _get_github_issue_number <beads-id>       — Extract canonical GitHub issue from bd show
 #
 # Env overrides (for testing):
 #   GH_CMD  — Path to gh binary (default: gh)
@@ -73,7 +73,6 @@ _safe_sanitize() {
 
 # ── _get_github_issue_number ─────────────────────────────────────────────
 # Extracts the canonical GitHub issue number from `bd show <id> --json`.
-# Falls back to legacy `github_issue:` state only as a migration bridge.
 # Returns the number or empty string (exit 1 if not found).
 _get_github_issue_number() {
   local beads_id="${1:-}"
@@ -98,8 +97,6 @@ _get_github_issue_number() {
       const issue = Array.isArray(data) ? data[0] : data;
       const value = issue?.github?.number
         ?? issue?.githubNumber
-        ?? issue?.github_issue
-        ?? issue?.githubIssue
         ?? issue?.issueNumber
         ?? null;
       if (value != null && value !== "") {
@@ -109,15 +106,6 @@ _get_github_issue_number() {
       process.exitCode = 0;
     }
   ')"
-
-  if [[ -z "$issue_num" ]]; then
-    local legacy_show_output
-    legacy_show_output="$("$bd_cmd" show "$beads_id" 2>/dev/null)" || {
-      _sync_error "Failed to get beads info for $beads_id"
-      return 1
-    }
-    issue_num="$(printf '%s' "$legacy_show_output" | grep -oP 'github_issue:\K[0-9]+' | head -1)"
-  fi
 
   if [[ -z "$issue_num" ]]; then
     _sync_error "No canonical GitHub number found for $beads_id"
@@ -157,7 +145,6 @@ _get_issue_title() {
 
 # sync_issue_create <beads-id>
 # Creates GitHub issue from Beads issue data.
-# Stores GitHub issue number back via `bd set-state`.
 # Returns 0 on success, 1 on failure.
 sync_issue_create() {
   local beads_id="${1:-}"
@@ -195,12 +182,6 @@ sync_issue_create() {
     _sync_error "Could not extract issue number from: $gh_output"
     return 1
   fi
-
-  # Store issue number in Beads
-  "$bd_cmd" set-state "$beads_id" "github_issue=$issue_num" >/dev/null 2>&1 || {
-    _sync_error "Failed to store github_issue=$issue_num for $beads_id"
-    return 1
-  }
 
   return 0
 }

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -126,6 +126,65 @@ _extract_issue_title_from_show() {
   '
 }
 
+_sync_mapping_file() {
+  local root="${TEAM_MAP_ROOT:-.}"
+  printf '%s' "${SYNC_MAPPING_FILE:-$root/.github/beads-mapping.json}"
+}
+
+_persist_issue_mapping() {
+  local beads_id="${1:-}"
+  local issue_num="${2:-}"
+  local mapping_file
+  mapping_file="$(_sync_mapping_file)"
+
+  node - "$mapping_file" "$issue_num" "$beads_id" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const [mappingPath, issueNum, beadsId] = process.argv.slice(2);
+let data = {};
+
+if (fs.existsSync(mappingPath)) {
+  const raw = fs.readFileSync(mappingPath, 'utf8').trim();
+  if (raw) {
+    data = JSON.parse(raw);
+  }
+}
+
+fs.mkdirSync(path.dirname(mappingPath), { recursive: true });
+data[String(issueNum)] = beadsId;
+fs.writeFileSync(mappingPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+NODE
+}
+
+_get_issue_number_from_mapping() {
+  local beads_id="${1:-}"
+  local mapping_file
+  mapping_file="$(_sync_mapping_file)"
+
+  node - "$mapping_file" "$beads_id" <<'NODE'
+const fs = require('node:fs');
+
+const [mappingPath, beadsId] = process.argv.slice(2);
+if (!fs.existsSync(mappingPath)) {
+  process.exit(0);
+}
+
+const raw = fs.readFileSync(mappingPath, 'utf8').trim();
+if (!raw) {
+  process.exit(0);
+}
+
+const data = JSON.parse(raw);
+for (const [issueNum, mappedBeadsId] of Object.entries(data)) {
+  if (mappedBeadsId === beadsId) {
+    process.stdout.write(String(issueNum));
+    break;
+  }
+}
+NODE
+}
+
 # ── _get_github_issue_number ─────────────────────────────────────────────
 # Extracts the canonical GitHub issue number from `bd show <id> --json`.
 # Returns the number or empty string (exit 1 if not found).
@@ -161,6 +220,10 @@ _get_github_issue_number() {
       process.exitCode = 0;
     }
   ')"
+
+  if [[ -z "$issue_num" ]]; then
+    issue_num="$(_get_issue_number_from_mapping "$beads_id" 2>/dev/null || true)"
+  fi
 
   if [[ -z "$issue_num" ]]; then
     _sync_error "No canonical GitHub number found for $beads_id"
@@ -229,6 +292,11 @@ sync_issue_create() {
 
   if [[ -z "$issue_num" ]]; then
     _sync_error "Could not extract issue number from: $gh_output"
+    return 1
+  fi
+
+  if ! _persist_issue_mapping "$beads_id" "$issue_num"; then
+    _sync_error "Failed to persist GitHub link for $beads_id"
     return 1
   fi
 

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -212,6 +212,7 @@ _get_github_issue_number() {
       const value = issue?.github?.number
         ?? issue?.githubNumber
         ?? issue?.issueNumber
+        ?? issue?.github_issue
         ?? null;
       if (value != null && value !== "") {
         process.stdout.write(String(value));

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -106,12 +106,22 @@ _extract_issue_title_from_show() {
       process.exit(0);
     }
 
-    const summaryMatch = summaryLine.match(
-      /^[^\-\u00B7\u2022]*(?:\s+-\s+|\s+[\u00B7\u2022]\s+)(.+?)(?:\s+\[[^\]]*\]\s*)?$/u,
-    );
+    const separators = [" - ", " \u00B7 ", " \u2022 "];
+    for (const separator of separators) {
+      const separatorIndex = summaryLine.indexOf(separator);
+      if (separatorIndex === -1) {
+        continue;
+      }
 
-    if (summaryMatch) {
-      process.stdout.write(summaryMatch[1].trimEnd());
+      const candidate = summaryLine
+        .slice(separatorIndex + separator.length)
+        .replace(/\s+\[[^\]]*\]\s*$/u, "")
+        .trim();
+
+      if (candidate.length > 0) {
+        process.stdout.write(candidate);
+        break;
+      }
     }
   '
 }

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -72,8 +72,8 @@ _safe_sanitize() {
 }
 
 # ── _get_github_issue_number ─────────────────────────────────────────────
-# Extracts github_issue number from `bd show <id>` output.
-# Looks for `github_issue:N` pattern.
+# Extracts the canonical GitHub issue number from `bd show <id> --json`.
+# Falls back to legacy `github_issue:` state only as a migration bridge.
 # Returns the number or empty string (exit 1 if not found).
 _get_github_issue_number() {
   local beads_id="${1:-}"
@@ -84,16 +84,43 @@ _get_github_issue_number() {
 
   local bd_cmd="${BD_CMD:-bd}"
   local show_output
-  show_output="$("$bd_cmd" show "$beads_id" 2>/dev/null)" || {
+  show_output="$("$bd_cmd" show "$beads_id" --json 2>/dev/null)" || {
     _sync_error "Failed to get beads info for $beads_id"
     return 1
   }
 
   local issue_num
-  issue_num="$(printf '%s' "$show_output" | grep -oP 'github_issue:\K[0-9]+' | head -1)"
+  issue_num="$(printf '%s' "$show_output" | node -e '
+    const fs = require("node:fs");
+    const input = fs.readFileSync(0, "utf8");
+    try {
+      const data = JSON.parse(input);
+      const issue = Array.isArray(data) ? data[0] : data;
+      const value = issue?.github?.number
+        ?? issue?.githubNumber
+        ?? issue?.github_issue
+        ?? issue?.githubIssue
+        ?? issue?.issueNumber
+        ?? null;
+      if (value != null && value !== "") {
+        process.stdout.write(String(value));
+      }
+    } catch (_err) {
+      process.exitCode = 0;
+    }
+  ')"
 
   if [[ -z "$issue_num" ]]; then
-    _sync_error "No github_issue found for $beads_id"
+    local legacy_show_output
+    legacy_show_output="$("$bd_cmd" show "$beads_id" 2>/dev/null)" || {
+      _sync_error "Failed to get beads info for $beads_id"
+      return 1
+    }
+    issue_num="$(printf '%s' "$legacy_show_output" | grep -oP 'github_issue:\K[0-9]+' | head -1)"
+  fi
+
+  if [[ -z "$issue_num" ]]; then
+    _sync_error "No canonical GitHub number found for $beads_id"
     return 1
   fi
 
@@ -174,17 +201,6 @@ sync_issue_create() {
     _sync_error "Failed to store github_issue=$issue_num for $beads_id"
     return 1
   }
-
-  # Update beads-mapping.json for verify Check 4
-  local mapping_file=".github/beads-mapping.json"
-  if [[ -f "$mapping_file" ]]; then
-    local updated
-    updated="$(jq --arg num "$issue_num" --arg id "$beads_id" '.[$num] = $id' "$mapping_file")"
-    printf '%s\n' "$updated" > "$mapping_file"
-  else
-    mkdir -p .github
-    printf '%s\n' "{\"$issue_num\":\"$beads_id\"}" > "$mapping_file"
-  fi
 
   return 0
 }

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -257,6 +257,8 @@ _get_issue_title() {
 
 # sync_issue_create <beads-id>
 # Creates GitHub issue from Beads issue data.
+# Persists both the canonical mapping file and the legacy github_issue state
+# until downstream hook and verify flows stop reading bd show output.
 # Returns 0 on success, 1 on failure.
 sync_issue_create() {
   local beads_id="${1:-}"
@@ -297,6 +299,11 @@ sync_issue_create() {
 
   if ! _persist_issue_mapping "$beads_id" "$issue_num"; then
     _sync_error "Failed to persist GitHub link for $beads_id"
+    return 1
+  fi
+
+  if ! "$bd_cmd" set-state "$beads_id" "github_issue=$issue_num" >/dev/null 2>&1; then
+    _sync_error "Failed to store github_issue=$issue_num for $beads_id"
     return 1
   fi
 

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -176,11 +176,21 @@ if (!raw) {
 }
 
 const data = JSON.parse(raw);
+let newestIssueNum = null;
 for (const [issueNum, mappedBeadsId] of Object.entries(data)) {
-  if (mappedBeadsId === beadsId) {
-    process.stdout.write(String(issueNum));
-    break;
+  if (mappedBeadsId !== beadsId) {
+    continue;
   }
+  const parsedIssueNum = Number.parseInt(issueNum, 10);
+  if (!Number.isFinite(parsedIssueNum)) {
+    continue;
+  }
+  if (newestIssueNum == null || parsedIssueNum > newestIssueNum) {
+    newestIssueNum = parsedIssueNum;
+  }
+}
+if (newestIssueNum != null) {
+  process.stdout.write(String(newestIssueNum));
 }
 NODE
 }

--- a/scripts/forge-team/lib/sync-github.sh
+++ b/scripts/forge-team/lib/sync-github.sh
@@ -71,6 +71,51 @@ _safe_sanitize() {
   printf '%s' "$input"
 }
 
+_extract_issue_number_from_url() {
+  local input="${1:-}"
+  local suffix="${input##*/issues/}"
+
+  if [[ "$suffix" == "$input" ]]; then
+    return 1
+  fi
+
+  suffix="${suffix%%[^0-9]*}"
+  if [[ -z "$suffix" ]]; then
+    return 1
+  fi
+
+  printf '%s' "$suffix"
+}
+
+_extract_issue_title_from_show() {
+  local input="${1:-}"
+
+  printf '%s' "$input" | node -e '
+    const fs = require("node:fs");
+    const input = fs.readFileSync(0, "utf8");
+    const lines = input.split(/\r?\n/);
+    const titledLine = lines.find((line) => /^Title:\s*/.test(line));
+
+    if (titledLine) {
+      process.stdout.write(titledLine.replace(/^Title:\s*/, "").trim());
+      process.exit(0);
+    }
+
+    const summaryLine = lines.find((line) => line.trim().length > 0);
+    if (!summaryLine) {
+      process.exit(0);
+    }
+
+    const summaryMatch = summaryLine.match(
+      /^[^\-\u00B7\u2022]*(?:\s+-\s+|\s+[\u00B7\u2022]\s+)(.+?)(?:\s+\[[^\]]*\]\s*)?$/u,
+    );
+
+    if (summaryMatch) {
+      process.stdout.write(summaryMatch[1].trimEnd());
+    }
+  '
+}
+
 # ── _get_github_issue_number ─────────────────────────────────────────────
 # Extracts the canonical GitHub issue number from `bd show <id> --json`.
 # Returns the number or empty string (exit 1 if not found).
@@ -126,13 +171,7 @@ _get_issue_title() {
   show_output="$("$bd_cmd" show "$beads_id" 2>/dev/null)" || return 1
 
   local title
-  # Try "Title: ..." line first
-  title="$(printf '%s' "$show_output" | grep -oP '^Title:\s*\K.*' | head -1)"
-
-  if [[ -z "$title" ]]; then
-    # Fallback: extract from summary line "○ <id> · <title> [...]"
-    title="$(printf '%s' "$show_output" | grep -oP '·\s*\K[^\[]+' | head -1 | sed 's/[[:space:]]*$//')"
-  fi
+  title="$(_extract_issue_title_from_show "$show_output")"
 
   if [[ -z "$title" ]]; then
     title="$beads_id"
@@ -176,7 +215,7 @@ sync_issue_create() {
 
   # Extract issue number from URL (e.g., https://github.com/.../issues/42)
   local issue_num
-  issue_num="$(printf '%s' "$gh_output" | grep -oP '/issues/\K[0-9]+' | head -1)"
+  issue_num="$(_extract_issue_number_from_url "$gh_output")"
 
   if [[ -z "$issue_num" ]]; then
     _sync_error "Could not extract issue number from: $gh_output"

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -283,5 +283,33 @@ assert_contains "gh issue create called without PCRE grep" "issue create" "$log_
 export PATH="$ORIGINAL_PATH"
 
 echo
+echo "== Test 11: sync_issue_create with summary-only bd show =="
+cat > "$mock_dir/bd-summary-only" << 'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$LOG_FILE"
+case "$1" in
+  show)
+    if [[ "${3:-}" == "--json" ]]; then
+      cat <<'JSON'
+{"id":"beads-summary","github":{"number":77,"url":"https://github.com/test/repo/issues/77"},"shared":{"title":"Summary Only Title"}}
+JSON
+    else
+      echo "o $2 - Summary Only Title"
+    fi
+    ;;
+  set-state) echo "State set" ;;
+esac
+MOCK
+chmod +x "$mock_dir/bd-summary-only"
+export BD_CMD="$mock_dir/bd-summary-only"
+> "$log_file"
+rc=0
+sync_issue_create "beads-summary" || rc=$?
+assert_exit "sync_issue_create works with summary-only bd show" 0 "$rc"
+log_contents="$(cat "$log_file")"
+assert_contains "summary-only title is passed to gh issue create" "Summary Only Title" "$log_contents"
+export BD_CMD="$mock_dir/bd"
+
+echo
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -85,6 +85,7 @@ export LOG_FILE="$log_file"
 export GH_CMD="$mock_dir/gh"
 export BD_CMD="$mock_dir/bd"
 export TEAM_MAP_ROOT="$TEST_TMP"
+mapping_file="$TEAM_MAP_ROOT/.github/beads-mapping.json"
 
 source "$SCRIPT_DIR/lib/sync-github.sh"
 
@@ -146,6 +147,7 @@ assert_contains "title includes Test Issue" "Test Issue" "$log_contents"
 assert_contains "body includes beads-001" "beads-001" "$log_contents"
 assert_not_contains "sync create no longer writes legacy github_issue state" "github_issue=42" "$log_contents"
 assert_not_contains "sync create no longer calls set-state for canonical linkage" "set-state" "$log_contents"
+assert_contains "sync create persists mapping entry" '"42": "beads-001"' "$(cat "$mapping_file")"
 
 echo
 echo "== Test 2: sync_issue_claim =="
@@ -202,7 +204,21 @@ log_contents="$(cat "$log_file")"
 assert_contains "_get_github_issue_number uses JSON" "--json" "$log_contents"
 
 echo
-echo "== Test 7: Missing canonical GitHub number =="
+echo "== Test 7: Mapping fallback when canonical GitHub number missing =="
+mkdir -p "$(dirname "$mapping_file")"
+cat > "$mapping_file" << 'JSON'
+{
+  "77": "beads-999"
+}
+JSON
+export BD_CMD="$mock_dir/bd-no-gh"
+result="$(_get_github_issue_number "beads-999")"
+assert_eq "mapping fallback returns issue number 77" "77" "$result"
+export BD_CMD="$mock_dir/bd"
+
+echo
+echo "== Test 8: Missing canonical GitHub number =="
+rm -f "$mapping_file"
 export BD_CMD="$mock_dir/bd-no-gh"
 rc=0
 result="$(_get_github_issue_number "beads-999" 2>/dev/null)" || rc=$?
@@ -210,7 +226,7 @@ assert_exit "returns error when no canonical github number" 1 "$rc"
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 8: Legacy github_issue state ignored =="
+echo "== Test 9: Legacy github_issue state ignored =="
 cat > "$mock_dir/bd-legacy" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
@@ -237,7 +253,7 @@ assert_exit "legacy github_issue is ignored" 1 "$rc"
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 9: Injection in title sanitized =="
+echo "== Test 10: Injection in title sanitized =="
 cat > "$mock_dir/bd-inject" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
@@ -272,7 +288,7 @@ fi
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 10: sync_issue_create without grep -P =="
+echo "== Test 11: sync_issue_create without grep -P =="
 export PATH="$portable_bin:$ORIGINAL_PATH"
 > "$log_file"
 rc=0
@@ -283,7 +299,7 @@ assert_contains "gh issue create called without PCRE grep" "issue create" "$log_
 export PATH="$ORIGINAL_PATH"
 
 echo
-echo "== Test 11: sync_issue_create with summary-only bd show =="
+echo "== Test 12: sync_issue_create with summary-only bd show =="
 cat > "$mock_dir/bd-summary-only" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -226,7 +226,7 @@ assert_exit "returns error when no canonical github number" 1 "$rc"
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 9: Legacy github_issue state ignored =="
+echo "== Test 9: Legacy github_issue state fallback =="
 cat > "$mock_dir/bd-legacy" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
@@ -249,7 +249,8 @@ chmod +x "$mock_dir/bd-legacy"
 export BD_CMD="$mock_dir/bd-legacy"
 rc=0
 result="$(_get_github_issue_number "beads-legacy" 2>/dev/null)" || rc=$?
-assert_exit "legacy github_issue is ignored" 1 "$rc"
+assert_exit "legacy github_issue exits successfully" 0 "$rc"
+assert_eq "legacy github_issue returns number" "43" "$result"
 export BD_CMD="$mock_dir/bd"
 
 echo

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -145,8 +145,8 @@ log_contents="$(cat "$log_file")"
 assert_contains "gh issue create called" "issue create" "$log_contents"
 assert_contains "title includes Test Issue" "Test Issue" "$log_contents"
 assert_contains "body includes beads-001" "beads-001" "$log_contents"
-assert_not_contains "sync create no longer writes legacy github_issue state" "github_issue=42" "$log_contents"
-assert_not_contains "sync create no longer calls set-state for canonical linkage" "set-state" "$log_contents"
+assert_contains "sync create writes legacy github_issue state" "github_issue=42" "$log_contents"
+assert_contains "sync create calls set-state for hook compatibility" "set-state" "$log_contents"
 assert_contains "sync create persists mapping entry" '"42": "beads-001"' "$(cat "$mapping_file")"
 
 echo

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -7,8 +7,12 @@ TEST_TMP="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMP" "$mock_dir"' EXIT
 
 mock_dir="$(mktemp -d)"
+portable_bin="$(mktemp -d)"
 log_file="$mock_dir/calls.log"
 touch "$log_file"
+REAL_GREP="$(command -v grep)"
+ORIGINAL_PATH="$PATH"
+export REAL_GREP
 
 cat > "$mock_dir/gh" << 'MOCK'
 #!/usr/bin/env bash
@@ -62,6 +66,20 @@ JSON
 esac
 MOCK
 chmod +x "$mock_dir/bd-no-gh"
+
+cat > "$portable_bin/grep" << 'MOCK'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    -P|--perl-regexp|-*P*)
+      echo "grep: PCRE support disabled for test" >&2
+      exit 2
+      ;;
+  esac
+done
+exec "$REAL_GREP" "$@"
+MOCK
+chmod +x "$portable_bin/grep"
 
 export LOG_FILE="$log_file"
 export GH_CMD="$mock_dir/gh"
@@ -252,6 +270,17 @@ else
   echo "  PASS: injection sanitized - no \$\(rm in gh call"
 fi
 export BD_CMD="$mock_dir/bd"
+
+echo
+echo "== Test 10: sync_issue_create without grep -P =="
+export PATH="$portable_bin:$ORIGINAL_PATH"
+> "$log_file"
+rc=0
+sync_issue_create "beads-001" || rc=$?
+assert_exit "sync_issue_create works when grep -P is unavailable" 0 "$rc"
+log_contents="$(cat "$log_file")"
+assert_contains "gh issue create called without PCRE grep" "issue create" "$log_contents"
+export PATH="$ORIGINAL_PATH"
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -217,7 +217,21 @@ assert_eq "mapping fallback returns issue number 77" "77" "$result"
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 8: Missing canonical GitHub number =="
+echo "== Test 8: Mapping fallback returns newest issue number =="
+cat > "$mapping_file" << 'JSON'
+{
+  "77": "beads-999",
+  "91": "beads-999",
+  "88": "beads-other"
+}
+JSON
+export BD_CMD="$mock_dir/bd-no-gh"
+result="$(_get_github_issue_number "beads-999")"
+assert_eq "mapping fallback returns newest matching issue number" "91" "$result"
+export BD_CMD="$mock_dir/bd"
+
+echo
+echo "== Test 9: Missing canonical GitHub number =="
 rm -f "$mapping_file"
 export BD_CMD="$mock_dir/bd-no-gh"
 rc=0
@@ -226,7 +240,7 @@ assert_exit "returns error when no canonical github number" 1 "$rc"
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 9: Legacy github_issue state fallback =="
+echo "== Test 10: Legacy github_issue state fallback =="
 cat > "$mock_dir/bd-legacy" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
@@ -254,7 +268,7 @@ assert_eq "legacy github_issue returns number" "43" "$result"
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 10: Injection in title sanitized =="
+echo "== Test 11: Injection in title sanitized =="
 cat > "$mock_dir/bd-inject" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -3,16 +3,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# ── Setup temp dir for test isolation ────────────────────────────────────
 TEST_TMP="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMP" "$mock_dir"' EXIT
 
-# ── Create mock dir and log file ─────────────────────────────────────────
-mock_dir="$(mktemp -d /c/tmp/forge-sync-test.XXXXXX)"
+mock_dir="$(mktemp -d)"
 log_file="$mock_dir/calls.log"
 touch "$log_file"
 
-# ── Mock gh ──────────────────────────────────────────────────────────────
 cat > "$mock_dir/gh" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
@@ -23,45 +20,54 @@ case "$1 $2" in
   "issue comment") echo ""; exit 0 ;;
   "api user") echo "testuser"; exit 0 ;;
 esac
-echo "unknown gh command: $*" >&2; exit 1
+echo "unknown gh command: $*" >&2
+exit 1
 MOCK
 chmod +x "$mock_dir/gh"
 
-# ── Mock bd ──────────────────────────────────────────────────────────────
 cat > "$mock_dir/bd" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
 case "$1" in
   show)
-    echo "○ $2 · Test Issue [github_issue:42]"
-    echo "Title: Test Issue"
+    if [[ "${3:-}" == "--json" ]]; then
+      cat <<'JSON'
+{"id":"beads-001","github":{"number":42,"nodeId":"I_kwDOForge42","url":"https://github.com/test/repo/issues/42"},"shared":{"title":"Test Issue"}}
+JSON
+    else
+      echo "o $2 - Test Issue"
+      echo "Title: Test Issue"
+    fi
     ;;
   set-state) echo "State set" ;;
 esac
 MOCK
 chmod +x "$mock_dir/bd"
 
-# ── Mock bd that returns NO github_issue ─────────────────────────────────
 cat > "$mock_dir/bd-no-gh" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
 case "$1" in
   show)
-    echo "○ $2 · Test Issue"
-    echo "Title: Test Issue"
+    if [[ "${3:-}" == "--json" ]]; then
+      cat <<'JSON'
+{"id":"beads-999","shared":{"title":"Test Issue"}}
+JSON
+    else
+      echo "o $2 - Test Issue"
+      echo "Title: Test Issue"
+    fi
     ;;
   set-state) echo "State set" ;;
 esac
 MOCK
 chmod +x "$mock_dir/bd-no-gh"
 
-# Export env for mocks
 export LOG_FILE="$log_file"
 export GH_CMD="$mock_dir/gh"
 export BD_CMD="$mock_dir/bd"
 export TEAM_MAP_ROOT="$TEST_TMP"
 
-# Source the library under test
 source "$SCRIPT_DIR/lib/sync-github.sh"
 
 PASS=0
@@ -70,119 +76,125 @@ FAIL=0
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [[ "$actual" == "$expected" ]]; then
-    PASS=$((PASS + 1)); echo "  PASS: $label"
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
   else
-    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected '$expected', got '$actual')"
   fi
 }
 
 assert_contains() {
   local label="$1" expected="$2" actual="$3"
   if [[ "$actual" == *"$expected"* ]]; then
-    PASS=$((PASS + 1)); echo "  PASS: $label"
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
   else
-    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected to contain '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected to contain '$expected', got '$actual')"
   fi
 }
 
 assert_exit() {
   local label="$1" expected="$2" actual="$3"
   if [[ "$actual" -eq "$expected" ]]; then
-    PASS=$((PASS + 1)); echo "  PASS: $label"
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
   else
-    FAIL=$((FAIL + 1)); echo "  FAIL: $label (expected exit $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (expected exit $expected, got $actual)"
   fi
 }
 
-# ── Test 1: sync_issue_create — creates GitHub issue, calls bd set-state ─
-echo "── Test 1: sync_issue_create ──"
-> "$log_file"  # clear log
+echo "== Test 1: sync_issue_create =="
+> "$log_file"
 rc=0
 sync_issue_create "beads-001" || rc=$?
 assert_exit "exit code 0" 0 "$rc"
-# Check gh was called with issue create
 log_contents="$(cat "$log_file")"
 assert_contains "gh issue create called" "issue create" "$log_contents"
 assert_contains "title includes Test Issue" "Test Issue" "$log_contents"
 assert_contains "body includes beads-001" "beads-001" "$log_contents"
-# Check bd set-state was called with github_issue=42
 assert_contains "bd set-state called" "set-state" "$log_contents"
 assert_contains "github_issue=42 set" "github_issue=42" "$log_contents"
 
-# ── Test 2: sync_issue_claim — updates GitHub assignee ───────────────────
-echo ""
-echo "── Test 2: sync_issue_claim ──"
+echo
+echo "== Test 2: sync_issue_claim =="
 > "$log_file"
 unset _GITHUB_USER_CACHE
 rc=0
 sync_issue_claim "beads-001" || rc=$?
 assert_exit "exit code 0" 0 "$rc"
 log_contents="$(cat "$log_file")"
+assert_contains "canonical lookup uses --json" "--json" "$log_contents"
 assert_contains "gh issue edit called" "issue edit" "$log_contents"
 assert_contains "add-assignee used" "--add-assignee" "$log_contents"
 assert_contains "assignee is testuser" "testuser" "$log_contents"
 
-# ── Test 3: sync_issue_status — removes old labels, adds new one ─────────
-echo ""
-echo "── Test 3: sync_issue_status ──"
+echo
+echo "== Test 3: sync_issue_status =="
 > "$log_file"
 rc=0
 sync_issue_status "beads-001" "in_progress" || rc=$?
 assert_exit "exit code 0" 0 "$rc"
 log_contents="$(cat "$log_file")"
+assert_contains "canonical lookup uses --json" "--json" "$log_contents"
 assert_contains "gh issue edit called" "issue edit" "$log_contents"
 assert_contains "removes status/open" "--remove-label status/open" "$log_contents"
 assert_contains "adds status/in-progress" "--add-label status/in-progress" "$log_contents"
 
-# ── Test 4: sync_issue_close — closes GitHub issue ───────────────────────
-echo ""
-echo "── Test 4: sync_issue_close ──"
+echo
+echo "== Test 4: sync_issue_close =="
 > "$log_file"
 rc=0
 sync_issue_close "beads-001" || rc=$?
 assert_exit "exit code 0" 0 "$rc"
 log_contents="$(cat "$log_file")"
+assert_contains "canonical lookup uses --json" "--json" "$log_contents"
 assert_contains "gh issue close called" "issue close" "$log_contents"
 assert_contains "closes issue 42" " 42" "$log_contents"
 
-# ── Test 5: sync_issue_deps — adds comment on GitHub issue ───────────────
-echo ""
-echo "── Test 5: sync_issue_deps ──"
+echo
+echo "== Test 5: sync_issue_deps =="
 > "$log_file"
 rc=0
 sync_issue_deps "beads-001" "beads-002" || rc=$?
 assert_exit "exit code 0" 0 "$rc"
 log_contents="$(cat "$log_file")"
+assert_contains "canonical lookup uses --json" "--json" "$log_contents"
 assert_contains "gh issue comment called" "issue comment" "$log_contents"
 assert_contains "Blocked by referenced" "Blocked by #42" "$log_contents"
 
-# ── Test 6: _get_github_issue_number — extracts number from bd show ──────
-echo ""
-echo "── Test 6: _get_github_issue_number ──"
+echo
+echo "== Test 6: _get_github_issue_number =="
 result="$(_get_github_issue_number "beads-001")"
 assert_eq "extracts issue number 42" "42" "$result"
+log_contents="$(cat "$log_file")"
+assert_contains "_get_github_issue_number uses JSON" "--json" "$log_contents"
 
-# ── Test 7: Missing GitHub issue number → returns error ──────────────────
-echo ""
-echo "── Test 7: Missing GitHub issue number ──"
+echo
+echo "== Test 7: Missing canonical GitHub number =="
 export BD_CMD="$mock_dir/bd-no-gh"
 rc=0
 result="$(_get_github_issue_number "beads-999" 2>/dev/null)" || rc=$?
-assert_exit "returns error when no github_issue" 1 "$rc"
-# Restore normal bd mock
+assert_exit "returns error when no canonical github number" 1 "$rc"
 export BD_CMD="$mock_dir/bd"
 
-# ── Test 8: Injection in issue title → sanitized before gh call ──────────
-echo ""
-echo "── Test 8: Injection in title sanitized ──"
-# Create a bd mock that returns injection-laden title
+echo
+echo "== Test 8: Injection in title sanitized =="
 cat > "$mock_dir/bd-inject" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"
 case "$1" in
   show)
-    echo '○ beads-inject · Evil $(rm -rf /) Issue [github_issue:99]'
-    echo 'Title: Evil $(rm -rf /) Issue'
+    if [[ "${3:-}" == "--json" ]]; then
+      cat <<'JSON'
+{"id":"beads-inject","github":{"number":99,"url":"https://github.com/test/repo/issues/99"},"shared":{"title":"Evil $(rm -rf /) Issue"}}
+JSON
+    else
+      echo 'o beads-inject - Evil $(rm -rf /) Issue'
+      echo 'Title: Evil $(rm -rf /) Issue'
+    fi
     ;;
   set-state) echo "State set" ;;
 esac
@@ -194,16 +206,15 @@ rc=0
 sync_issue_create "beads-inject" || rc=$?
 assert_exit "exit code 0 with injection" 0 "$rc"
 log_contents="$(cat "$log_file")"
-# The $(...) pattern must NOT appear in the gh call
 if [[ "$log_contents" == *'$(rm'* ]]; then
-  FAIL=$((FAIL + 1)); echo "  FAIL: injection NOT sanitized — \$(rm found in gh call"
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: injection NOT sanitized - \$\(rm found in gh call"
 else
-  PASS=$((PASS + 1)); echo "  PASS: injection sanitized — no \$(rm in gh call"
+  PASS=$((PASS + 1))
+  echo "  PASS: injection sanitized - no \$\(rm in gh call"
 fi
-# Restore normal bd mock
 export BD_CMD="$mock_dir/bd"
 
-# ── Results ──────────────────────────────────────────────────────────────
-echo ""
+echo
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/scripts/forge-team/tests/sync-github.test.sh
+++ b/scripts/forge-team/tests/sync-github.test.sh
@@ -95,6 +95,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local label="$1" unexpected="$2" actual="$3"
+  if [[ "$actual" == *"$unexpected"* ]]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label (did not expect '$unexpected', got '$actual')"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  fi
+}
+
 assert_exit() {
   local label="$1" expected="$2" actual="$3"
   if [[ "$actual" -eq "$expected" ]]; then
@@ -115,8 +126,8 @@ log_contents="$(cat "$log_file")"
 assert_contains "gh issue create called" "issue create" "$log_contents"
 assert_contains "title includes Test Issue" "Test Issue" "$log_contents"
 assert_contains "body includes beads-001" "beads-001" "$log_contents"
-assert_contains "bd set-state called" "set-state" "$log_contents"
-assert_contains "github_issue=42 set" "github_issue=42" "$log_contents"
+assert_not_contains "sync create no longer writes legacy github_issue state" "github_issue=42" "$log_contents"
+assert_not_contains "sync create no longer calls set-state for canonical linkage" "set-state" "$log_contents"
 
 echo
 echo "== Test 2: sync_issue_claim =="
@@ -181,7 +192,34 @@ assert_exit "returns error when no canonical github number" 1 "$rc"
 export BD_CMD="$mock_dir/bd"
 
 echo
-echo "== Test 8: Injection in title sanitized =="
+echo "== Test 8: Legacy github_issue state ignored =="
+cat > "$mock_dir/bd-legacy" << 'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$LOG_FILE"
+case "$1" in
+  show)
+    if [[ "${3:-}" == "--json" ]]; then
+      cat <<'JSON'
+{"id":"beads-legacy","github_issue":43,"shared":{"title":"Legacy Issue"}}
+JSON
+    else
+      echo "o $2 - Legacy Issue"
+      echo "github_issue:43"
+      echo "Title: Legacy Issue"
+    fi
+    ;;
+  set-state) echo "State set" ;;
+esac
+MOCK
+chmod +x "$mock_dir/bd-legacy"
+export BD_CMD="$mock_dir/bd-legacy"
+rc=0
+result="$(_get_github_issue_number "beads-legacy" 2>/dev/null)" || rc=$?
+assert_exit "legacy github_issue is ignored" 1 "$rc"
+export BD_CMD="$mock_dir/bd"
+
+echo
+echo "== Test 9: Injection in title sanitized =="
 cat > "$mock_dir/bd-inject" << 'MOCK'
 #!/usr/bin/env bash
 echo "$*" >> "$LOG_FILE"

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -7,22 +7,15 @@
 
 import { readFileSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { createRequire } from 'node:module';
 import { loadConfig } from './config.mjs';
 import { sanitizeTitle } from './sanitize.mjs';
 import { mapLabels } from './label-mapper.mjs';
-import { readMapping } from './mapping.mjs';
+import { resolveCanonicalBeadsLink, upsertCanonicalBeadsLink } from './mapping.mjs';
 import { bdCreate as realBdCreate, bdClose as realBdClose, bdShow as realBdShow } from './run-bd.mjs';
 import { buildComment } from './comment.mjs';
 import { createOrEditComment as realCreateOrEditComment } from './github-api.mjs';
 
-const require = createRequire(import.meta.url);
-const {
-  createLinkStore,
-  resolveCanonicalLink: resolveLinkInStore,
-  upsertCanonicalLink: upsertLinkInStore,
-} = require('../../lib/issue-sync/link-store.js');
-const { bridgeLegacyLinkHints } = require('../../lib/issue-sync/legacy-link-bridge.js');
+const DEFAULT_MAPPING_PATH = '.github/beads-mapping.json';
 
 function isBot(login) {
   if (!login) return false;
@@ -46,45 +39,25 @@ function getGitHubLink(issue = {}) {
 }
 
 function createCanonicalLinkStore(mappingPath) {
-  const store = createLinkStore();
-  const mapping = mappingPath ? readMapping(mappingPath) : {};
-
-  if (Object.keys(mapping).length > 0) {
-    bridgeLegacyLinkHints({ mapping }, { store });
-  }
-
   return {
     resolveCanonicalLink(lookup) {
-      return resolveLinkInStore(store, lookup);
+      return resolveCanonicalBeadsLink(mappingPath, lookup);
     },
     upsertCanonicalLink(link) {
-      return upsertLinkInStore(store, link);
+      return upsertCanonicalBeadsLink(mappingPath, link);
     },
   };
 }
 
 function getCanonicalLinkStore(options = {}) {
-  const defaultStore = createCanonicalLinkStore(options.mappingPath ?? '.github/beads-mapping.json');
+  const defaultStore = createCanonicalLinkStore(options.mappingPath ?? DEFAULT_MAPPING_PATH);
 
   if (
     options.linkStore &&
-    (typeof options.linkStore.resolveCanonicalLink === 'function' ||
-      typeof options.linkStore.upsertCanonicalLink === 'function')
+    typeof options.linkStore.resolveCanonicalLink === 'function' &&
+    typeof options.linkStore.upsertCanonicalLink === 'function'
   ) {
-    return {
-      resolveCanonicalLink(lookup) {
-        if (typeof options.linkStore.resolveCanonicalLink === 'function') {
-          return options.linkStore.resolveCanonicalLink(lookup);
-        }
-        return defaultStore.resolveCanonicalLink(lookup);
-      },
-      upsertCanonicalLink(link) {
-        if (typeof options.linkStore.upsertCanonicalLink === 'function') {
-          return options.linkStore.upsertCanonicalLink(link);
-        }
-        return defaultStore.upsertCanonicalLink(link);
-      },
-    };
+    return options.linkStore;
   }
 
   return defaultStore;
@@ -291,7 +264,7 @@ if (process.argv[1] === __filename) {
 
   const options = {
     configPath: process.env.BEADS_SYNC_CONFIG || undefined,
-    mappingPath: process.env.BEADS_SYNC_MAPPING || '.github/beads-mapping.json',
+    mappingPath: process.env.BEADS_SYNC_MAPPING || DEFAULT_MAPPING_PATH,
     owner,
     repo,
   };

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -7,19 +7,21 @@
 
 import { readFileSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { loadConfig } from './config.mjs';
 import { sanitizeTitle } from './sanitize.mjs';
 import { mapLabels } from './label-mapper.mjs';
 import { bdCreate as realBdCreate, bdClose as realBdClose, bdShow as realBdShow } from './run-bd.mjs';
-import {
-  resolveCanonicalBeadsLink as realResolveCanonicalBeadsLink,
-  upsertCanonicalBeadsLink as realUpsertCanonicalBeadsLink,
-} from './mapping.mjs';
-import { buildComment, parseComment } from './comment.mjs';
-import {
-  findSyncComment as realFindSyncComment,
-  createOrEditComment as realCreateOrEditComment,
-} from './github-api.mjs';
+import { buildComment } from './comment.mjs';
+import { createOrEditComment as realCreateOrEditComment } from './github-api.mjs';
+
+const require = createRequire(import.meta.url);
+const {
+  createLinkStore,
+  resolveCanonicalLink: resolveLinkInStore,
+  upsertCanonicalLink: upsertLinkInStore,
+} = require('../../lib/issue-sync/link-store.js');
+const { bridgeLegacyLinkHints } = require('../../lib/issue-sync/legacy-link-bridge.js');
 
 function isBot(login) {
   if (!login) return false;
@@ -42,35 +44,61 @@ function getGitHubLink(issue = {}) {
   };
 }
 
-function resolveCanonicalLink(options, issue) {
-  const lookup = {
-    githubNodeId: issue.node_id ?? issue.nodeId ?? null,
-    githubNumber: issue.number,
-  };
-
-  if (
-    options.linkStore &&
-    typeof options.linkStore.resolveCanonicalLink === 'function'
-  ) {
-    return options.linkStore.resolveCanonicalLink(lookup);
+function readLegacyMapping(mappingPath) {
+  if (!mappingPath) {
+    return {};
   }
 
-  const mappingPath = options.mappingPath ?? '.github/beads-mapping.json';
-  return realResolveCanonicalBeadsLink(mappingPath, lookup);
+  try {
+    return JSON.parse(readFileSync(mappingPath, 'utf8'));
+  } catch (_err) {
+    return {};
+  }
 }
 
-function upsertCanonicalLink(options, issue, link) {
-  if (
-    options.linkStore &&
-    typeof options.linkStore.upsertCanonicalLink === 'function'
-  ) {
-    return options.linkStore.upsertCanonicalLink(link);
+function createCanonicalLinkStore(mappingPath) {
+  const store = createLinkStore();
+  const mapping = readLegacyMapping(mappingPath);
+
+  if (Object.keys(mapping).length > 0) {
+    bridgeLegacyLinkHints({ mapping }, { store });
   }
 
-  const mappingPath = options.mappingPath ?? '.github/beads-mapping.json';
-  return realUpsertCanonicalBeadsLink(mappingPath, link, {
-    github: getGitHubLink(issue),
-  });
+  return {
+    resolveCanonicalLink(lookup) {
+      return resolveLinkInStore(store, lookup);
+    },
+    upsertCanonicalLink(link) {
+      return upsertLinkInStore(store, link);
+    },
+  };
+}
+
+function getCanonicalLinkStore(options = {}) {
+  const defaultStore = createCanonicalLinkStore(options.mappingPath ?? '.github/beads-mapping.json');
+
+  if (
+    options.linkStore &&
+    (typeof options.linkStore.resolveCanonicalLink === 'function' ||
+      typeof options.linkStore.upsertCanonicalLink === 'function')
+  ) {
+    return {
+      resolveCanonicalLink(lookup) {
+        if (typeof options.linkStore.resolveCanonicalLink === 'function') {
+          return options.linkStore.resolveCanonicalLink(lookup);
+        }
+        return defaultStore.resolveCanonicalLink(lookup);
+      },
+      upsertCanonicalLink(link) {
+        if (typeof options.linkStore.upsertCanonicalLink === 'function') {
+          return options.linkStore.upsertCanonicalLink(link);
+        }
+        return defaultStore.upsertCanonicalLink(link);
+      },
+    };
+  }
+
+  return defaultStore;
 }
 
 /**
@@ -99,8 +127,8 @@ export function handleOpened(event, options = {}) {
   } = options;
 
   const bdCreate = bd.bdCreate ?? realBdCreate;
-  const findSyncComment = github.findSyncComment ?? realFindSyncComment;
   const createOrEditComment = github.createOrEditComment ?? realCreateOrEditComment;
+  const canonicalLinkStore = getCanonicalLinkStore(options);
 
   let config = loadConfig(configPath);
   if (configOverride) {
@@ -144,25 +172,16 @@ export function handleOpened(event, options = {}) {
     }
   }
 
-  const canonicalLink = resolveCanonicalLink(options, issue);
+  const canonicalLink = canonicalLinkStore.resolveCanonicalLink({
+    githubNodeId: issue.node_id ?? issue.nodeId ?? null,
+    githubNumber: issue.number,
+  });
   if (canonicalLink) {
     return {
       skipped: true,
       reason: 'already synced (canonical link)',
       beadsId: canonicalLink.forgeIssueId,
     };
-  }
-
-  const existingComment = findSyncComment(owner, repo, issueNumber);
-  if (existingComment) {
-    const parsed = parseComment(existingComment.body);
-    if (parsed?.beadsId) {
-      return {
-        skipped: true,
-        reason: 'already synced (comment)',
-        beadsId: parsed.beadsId,
-      };
-    }
   }
 
   const { sanitized: sanitizedTitle, warnings: titleWarnings } = sanitizeTitle(rawTitle);
@@ -185,7 +204,7 @@ export function handleOpened(event, options = {}) {
     return { success: false, reason: 'bd create failed - no beads ID returned', issueNumber };
   }
 
-  upsertCanonicalLink(options, issue, {
+  canonicalLinkStore.upsertCanonicalLink({
     forgeIssueId: beadsId,
     github: getGitHubLink(issue),
     sources: [
@@ -228,7 +247,7 @@ export function handleClosed(event, options = {}) {
 
   const bdClose = bd.bdClose ?? realBdClose;
   const bdShow = bd.bdShow ?? realBdShow;
-  const findSyncComment = github.findSyncComment ?? realFindSyncComment;
+  const canonicalLinkStore = getCanonicalLinkStore(options);
 
   const issue = event.issue;
   const issueNumber = issue.number;
@@ -247,18 +266,11 @@ export function handleClosed(event, options = {}) {
     return { skipped: true, reason: `closed as ${stateReason}` };
   }
 
-  const canonicalLink = resolveCanonicalLink(options, issue);
+  const canonicalLink = canonicalLinkStore.resolveCanonicalLink({
+    githubNodeId: issue.node_id ?? issue.nodeId ?? null,
+    githubNumber: issue.number,
+  });
   let beadsId = canonicalLink?.forgeIssueId ?? null;
-
-  if (!beadsId) {
-    const comment = findSyncComment(owner, repo, issueNumber);
-    if (comment) {
-      const parsed = parseComment(comment.body);
-      if (parsed && parsed.issueNumber === issueNumber) {
-        beadsId = parsed.beadsId;
-      }
-    }
-  }
 
   if (!beadsId) {
     return { skipped: true, reason: 'no beads link found' };

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -11,33 +11,65 @@ import { loadConfig } from './config.mjs';
 import { sanitizeTitle } from './sanitize.mjs';
 import { mapLabels } from './label-mapper.mjs';
 import { bdCreate as realBdCreate, bdClose as realBdClose, bdShow as realBdShow } from './run-bd.mjs';
-import { getBeadsId as realGetBeadsId, setBeadsId as realSetBeadsId } from './mapping.mjs';
+import {
+  resolveCanonicalBeadsLink as realResolveCanonicalBeadsLink,
+  upsertCanonicalBeadsLink as realUpsertCanonicalBeadsLink,
+} from './mapping.mjs';
 import { buildComment, parseComment } from './comment.mjs';
 import {
   findSyncComment as realFindSyncComment,
   createOrEditComment as realCreateOrEditComment,
 } from './github-api.mjs';
 
-/**
- * Check if a sender login matches known bot patterns.
- * @param {string} login - GitHub sender login
- * @returns {boolean}
- */
 function isBot(login) {
   if (!login) return false;
   return login.includes('[bot]') || login === 'github-actions';
 }
 
-/**
- * Check if an issue has the skip-beads-sync label.
- * @param {Array<{name: string}|string>} labels
- * @returns {boolean}
- */
 function hasSkipLabel(labels) {
   if (!labels) return false;
   return labels.some((l) => {
     const name = typeof l === 'string' ? l : l.name;
     return name === 'skip-beads-sync';
+  });
+}
+
+function getGitHubLink(issue = {}) {
+  return {
+    nodeId: issue.node_id ?? issue.nodeId ?? null,
+    number: issue.number ?? null,
+    url: issue.html_url ?? null,
+  };
+}
+
+function resolveCanonicalLink(options, issue) {
+  const lookup = {
+    githubNodeId: issue.node_id ?? issue.nodeId ?? null,
+    githubNumber: issue.number,
+  };
+
+  if (
+    options.linkStore &&
+    typeof options.linkStore.resolveCanonicalLink === 'function'
+  ) {
+    return options.linkStore.resolveCanonicalLink(lookup);
+  }
+
+  const mappingPath = options.mappingPath ?? '.github/beads-mapping.json';
+  return realResolveCanonicalBeadsLink(mappingPath, lookup);
+}
+
+function upsertCanonicalLink(options, issue, link) {
+  if (
+    options.linkStore &&
+    typeof options.linkStore.upsertCanonicalLink === 'function'
+  ) {
+    return options.linkStore.upsertCanonicalLink(link);
+  }
+
+  const mappingPath = options.mappingPath ?? '.github/beads-mapping.json';
+  return realUpsertCanonicalBeadsLink(mappingPath, link, {
+    github: getGitHubLink(issue),
   });
 }
 
@@ -52,35 +84,29 @@ function hasSkipLabel(labels) {
  * @param {string} options.repo - Repository name
  * @param {object} [options.bd] - Dependency injection for bd functions
  * @param {object} [options.github] - Dependency injection for github-api functions
- * @param {object} [options.mapping] - Dependency injection for mapping functions
+ * @param {object} [options.linkStore] - Dependency injection for canonical link store
  * @param {object} [options.configOverride] - Merge into loaded config (for testing)
  * @returns {object} Result object
  */
 export function handleOpened(event, options = {}) {
   const {
     configPath,
-    mappingPath,
     owner,
     repo,
     bd = {},
     github = {},
-    mapping = {},
     configOverride,
   } = options;
 
   const bdCreate = bd.bdCreate ?? realBdCreate;
   const findSyncComment = github.findSyncComment ?? realFindSyncComment;
   const createOrEditComment = github.createOrEditComment ?? realCreateOrEditComment;
-  const getBeadsId = mapping.getBeadsId ?? realGetBeadsId;
-  const setBeadsId = mapping.setBeadsId ?? realSetBeadsId;
 
-  // 1. Load config
   let config = loadConfig(configPath);
   if (configOverride) {
     config = { ...config, ...configOverride };
   }
 
-  // 2. Extract event data
   const issue = event.issue;
   const issueNumber = issue.number;
   const rawTitle = issue.title;
@@ -90,22 +116,18 @@ export function handleOpened(event, options = {}) {
   const body = issue.body ?? '';
   const authorAssociation = issue.author_association;
 
-  // 3. Guard: bot actor
   if (isBot(event.sender?.login)) {
     return { skipped: true, reason: 'bot actor' };
   }
 
-  // 4. Guard: skip label
   if (hasSkipLabel(labels)) {
     return { skipped: true, reason: 'skip label' };
   }
 
-  // 5. Guard: no-beads body
   if (body.includes('no-beads')) {
     return { skipped: true, reason: 'no-beads in body' };
   }
 
-  // 6. Guard: public repo gate
   if (config.publicRepoGate === 'author_association') {
     const allowed = config.gateAssociations || [];
     if (!allowed.includes(authorAssociation)) {
@@ -122,47 +144,33 @@ export function handleOpened(event, options = {}) {
     }
   }
 
-  // 7. Idempotency — check mapping file first (fast, survives comment deletion)
-  const existingBeadsId = getBeadsId(mappingPath, issueNumber);
-  if (existingBeadsId) {
-    // Mapping exists — ensure the GitHub comment is present (repair if deleted)
-    const existingComment = findSyncComment(owner, repo, issueNumber);
-    if (!existingComment) {
-      const externalRef = `gh-${issueNumber}`;
-      const commentBody = buildComment(existingBeadsId, issueNumber, { externalRef });
-      createOrEditComment(owner, repo, issueNumber, commentBody);
-    }
+  const canonicalLink = resolveCanonicalLink(options, issue);
+  if (canonicalLink) {
     return {
       skipped: true,
-      reason: 'already synced (mapping file)',
-      beadsId: existingBeadsId,
+      reason: 'already synced (canonical link)',
+      beadsId: canonicalLink.forgeIssueId,
     };
   }
 
-  // 7b. Fallback idempotency — check for existing sync comment
   const existingComment = findSyncComment(owner, repo, issueNumber);
   if (existingComment) {
     const parsed = parseComment(existingComment.body);
-    // Repair mapping file from comment
     if (parsed?.beadsId) {
-      setBeadsId(mappingPath, issueNumber, parsed.beadsId);
+      return {
+        skipped: true,
+        reason: 'already synced (comment)',
+        beadsId: parsed.beadsId,
+      };
     }
-    return {
-      skipped: true,
-      reason: 'already synced (comment)',
-      beadsId: parsed?.beadsId ?? null,
-    };
   }
 
-  // 8. Sanitize title (labels mapped from raw names — sanitization only needed for CLI args)
   const { sanitized: sanitizedTitle, warnings: titleWarnings } = sanitizeTitle(rawTitle);
   if (titleWarnings.length) console.warn('sanitize:', titleWarnings);
 
-  // 9. Map labels using raw names (case-insensitive matching in mapLabels handles normalization)
   const rawLabelNames = labels.map((l) => (typeof l === 'string' ? l : l.name));
   const { type, priority } = mapLabels(rawLabelNames, config);
 
-  // 10. Create beads issue
   const externalRef = `gh-${issueNumber}`;
   const beadsId = bdCreate({
     title: sanitizedTitle,
@@ -174,17 +182,26 @@ export function handleOpened(event, options = {}) {
   });
 
   if (!beadsId) {
-    return { success: false, reason: 'bd create failed — no beads ID returned', issueNumber };
+    return { success: false, reason: 'bd create failed - no beads ID returned', issueNumber };
   }
 
-  // 11. Update mapping
-  setBeadsId(mappingPath, issueNumber, beadsId);
+  upsertCanonicalLink(options, issue, {
+    forgeIssueId: beadsId,
+    github: getGitHubLink(issue),
+    sources: [
+      {
+        source: 'externalRef',
+        forgeIssueId: beadsId,
+        githubNumber: issueNumber,
+        url: htmlUrl,
+      },
+    ],
+    diagnostics: [],
+  });
 
-  // 12. Build and post comment
   const commentBody = buildComment(beadsId, issueNumber, { type, priority, externalRef });
   createOrEditComment(owner, repo, issueNumber, commentBody);
 
-  // 13. Return success
   return { success: true, beadsId, issueNumber };
 }
 
@@ -198,65 +215,55 @@ export function handleOpened(event, options = {}) {
  * @param {string} options.repo - Repository name
  * @param {object} [options.bd] - Dependency injection for bd functions
  * @param {object} [options.github] - Dependency injection for github-api functions
- * @param {object} [options.mapping] - Dependency injection for mapping functions
+ * @param {object} [options.linkStore] - Dependency injection for canonical link store
  * @returns {object} Result object
  */
 export function handleClosed(event, options = {}) {
   const {
-    mappingPath,
     owner,
     repo,
     bd = {},
     github = {},
-    mapping = {},
   } = options;
 
   const bdClose = bd.bdClose ?? realBdClose;
   const bdShow = bd.bdShow ?? realBdShow;
-  const getBeadsId = mapping.getBeadsId ?? realGetBeadsId;
   const findSyncComment = github.findSyncComment ?? realFindSyncComment;
 
-  // 1. Extract issue number, labels, and state reason
-  const issueNumber = event.issue.number;
-  const labels = event.issue.labels || [];
-  const stateReason = event.issue.state_reason;
+  const issue = event.issue;
+  const issueNumber = issue.number;
+  const labels = issue.labels || [];
+  const stateReason = issue.state_reason;
 
-  // 2. Guard: bot actor
   if (isBot(event.sender?.login)) {
     return { skipped: true, reason: 'bot actor' };
   }
 
-  // 3. Guard: skip label
   if (hasSkipLabel(labels)) {
     return { skipped: true, reason: 'skip label' };
   }
 
-  // 4. Guard: skip "not planned" closures (only close on "completed")
   if (stateReason && stateReason !== 'completed') {
     return { skipped: true, reason: `closed as ${stateReason}` };
   }
 
-  // 5. Read mapping
-  let beadsId = getBeadsId(mappingPath, issueNumber);
+  const canonicalLink = resolveCanonicalLink(options, issue);
+  let beadsId = canonicalLink?.forgeIssueId ?? null;
 
-  // 6. Fallback: find via sync comment
   if (!beadsId) {
     const comment = findSyncComment(owner, repo, issueNumber);
     if (comment) {
       const parsed = parseComment(comment.body);
-      // Verify the comment's tagged issue number matches current issue (prevents cross-issue close)
       if (parsed && parsed.issueNumber === issueNumber) {
         beadsId = parsed.beadsId;
       }
     }
   }
 
-  // 7. No beads link found
   if (!beadsId) {
     return { skipped: true, reason: 'no beads link found' };
   }
 
-  // 8. Check if already closed
   const status = bdShow(beadsId);
   if (status === null) {
     return { skipped: true, reason: 'could not determine beads status' };
@@ -265,16 +272,11 @@ export function handleClosed(event, options = {}) {
     return { skipped: true, reason: 'already closed' };
   }
 
-  // 9. Close beads issue
   bdClose(beadsId, `Closed via GitHub issue #${issueNumber}`);
 
-  // 10. Return success
   return { success: true, beadsId, issueNumber };
 }
 
-// ---------------------------------------------------------------------------
-// CLI entry point
-// ---------------------------------------------------------------------------
 const __filename = fileURLToPath(import.meta.url);
 if (process.argv[1] === __filename) {
   const action = process.argv[2];
@@ -296,7 +298,6 @@ if (process.argv[1] === __filename) {
     repo,
   };
 
-  // Validate action explicitly — only allow known actions
   const VALID_ACTIONS = ['opened', 'closed'];
   if (!VALID_ACTIONS.includes(action)) {
     console.error(`Unknown action: "${action}". Expected one of: ${VALID_ACTIONS.join(', ')}`);
@@ -309,13 +310,11 @@ if (process.argv[1] === __filename) {
     .then((result) => {
       console.log(JSON.stringify(result, null, 2));
 
-      // Exit non-zero on logical failure (e.g., bdCreate returned null)
       if (result.success === false) {
         console.error(`Sync failed: ${result.reason || 'unknown'}`);
         process.exit(1);
       }
 
-      // Write to GITHUB_OUTPUT if available
       const outputPath = process.env.GITHUB_OUTPUT;
       if (outputPath) {
         for (const [key, value] of Object.entries(result)) {

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -11,6 +11,7 @@ import { createRequire } from 'node:module';
 import { loadConfig } from './config.mjs';
 import { sanitizeTitle } from './sanitize.mjs';
 import { mapLabels } from './label-mapper.mjs';
+import { readMapping } from './mapping.mjs';
 import { bdCreate as realBdCreate, bdClose as realBdClose, bdShow as realBdShow } from './run-bd.mjs';
 import { buildComment } from './comment.mjs';
 import { createOrEditComment as realCreateOrEditComment } from './github-api.mjs';
@@ -44,21 +45,9 @@ function getGitHubLink(issue = {}) {
   };
 }
 
-function readLegacyMapping(mappingPath) {
-  if (!mappingPath) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(readFileSync(mappingPath, 'utf8'));
-  } catch (_err) {
-    return {};
-  }
-}
-
 function createCanonicalLinkStore(mappingPath) {
   const store = createLinkStore();
-  const mapping = readLegacyMapping(mappingPath);
+  const mapping = mappingPath ? readMapping(mappingPath) : {};
 
   if (Object.keys(mapping).length > 0) {
     bridgeLegacyLinkHints({ mapping }, { store });

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -267,7 +267,7 @@ export function handleClosed(event, options = {}) {
 
   if (!beadsId) {
     const syncCommentLink = parseComment(findSyncComment(options.owner, options.repo, issueNumber)?.body);
-    if (syncCommentLink?.beadsId) {
+    if (syncCommentLink?.beadsId && syncCommentLink.issueNumber === issueNumber) {
       canonicalLinkStore.upsertCanonicalLink({
         forgeIssueId: syncCommentLink.beadsId,
         github: getGitHubLink(issue),

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -239,6 +239,7 @@ export function handleClosed(event, options = {}) {
 
   const bdClose = bd.bdClose ?? realBdClose;
   const bdShow = bd.bdShow ?? realBdShow;
+  const findSyncComment = options.github?.findSyncComment ?? realFindSyncComment;
   const canonicalLinkStore = getCanonicalLinkStore(options);
 
   const issue = event.issue;
@@ -263,6 +264,26 @@ export function handleClosed(event, options = {}) {
     githubNumber: issue.number,
   });
   let beadsId = canonicalLink?.forgeIssueId ?? null;
+
+  if (!beadsId) {
+    const syncCommentLink = parseComment(findSyncComment(options.owner, options.repo, issueNumber)?.body);
+    if (syncCommentLink?.beadsId) {
+      canonicalLinkStore.upsertCanonicalLink({
+        forgeIssueId: syncCommentLink.beadsId,
+        github: getGitHubLink(issue),
+        sources: [
+          {
+            source: 'syncComment',
+            forgeIssueId: syncCommentLink.beadsId,
+            githubNumber: issueNumber,
+            url: issue.html_url ?? null,
+          },
+        ],
+        diagnostics: [],
+      });
+      beadsId = syncCommentLink.beadsId;
+    }
+  }
 
   if (!beadsId) {
     return { skipped: true, reason: 'no beads link found' };

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -12,8 +12,8 @@ import { sanitizeTitle } from './sanitize.mjs';
 import { mapLabels } from './label-mapper.mjs';
 import { resolveCanonicalBeadsLink, upsertCanonicalBeadsLink } from './mapping.mjs';
 import { bdCreate as realBdCreate, bdClose as realBdClose, bdShow as realBdShow } from './run-bd.mjs';
-import { buildComment } from './comment.mjs';
-import { createOrEditComment as realCreateOrEditComment } from './github-api.mjs';
+import { buildComment, parseComment } from './comment.mjs';
+import { createOrEditComment as realCreateOrEditComment, findSyncComment as realFindSyncComment } from './github-api.mjs';
 
 const DEFAULT_MAPPING_PATH = '.github/beads-mapping.json';
 
@@ -90,6 +90,7 @@ export function handleOpened(event, options = {}) {
 
   const bdCreate = bd.bdCreate ?? realBdCreate;
   const createOrEditComment = github.createOrEditComment ?? realCreateOrEditComment;
+  const findSyncComment = github.findSyncComment ?? realFindSyncComment;
   const canonicalLinkStore = getCanonicalLinkStore(options);
 
   let config = loadConfig(configPath);
@@ -152,6 +153,34 @@ export function handleOpened(event, options = {}) {
       skipped: true,
       reason: 'already synced (canonical link)',
       beadsId: canonicalLink.forgeIssueId,
+    };
+  }
+
+  const existingSyncComment = parseComment(findSyncComment(owner, repo, issueNumber)?.body);
+  if (existingSyncComment?.beadsId) {
+    canonicalLinkStore.upsertCanonicalLink({
+      forgeIssueId: existingSyncComment.beadsId,
+      github: getGitHubLink(issue),
+      sources: [
+        {
+          source: 'syncComment',
+          forgeIssueId: existingSyncComment.beadsId,
+          githubNumber: issueNumber,
+          url: htmlUrl,
+        },
+      ],
+      diagnostics: [],
+    });
+    const commentBody = buildComment(existingSyncComment.beadsId, issueNumber, {
+      type,
+      priority,
+      externalRef,
+    });
+    createOrEditComment(owner, repo, issueNumber, commentBody);
+    return {
+      skipped: true,
+      reason: 'already synced (sync comment)',
+      beadsId: existingSyncComment.beadsId,
     };
   }
 

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -105,6 +105,9 @@ export function handleOpened(event, options = {}) {
   const htmlUrl = issue.html_url;
   const body = issue.body ?? '';
   const authorAssociation = issue.author_association;
+  const rawLabelNames = labels.map((l) => (typeof l === 'string' ? l : l.name));
+  const { type, priority } = mapLabels(rawLabelNames, config);
+  const externalRef = `gh-${issueNumber}`;
 
   if (isBot(event.sender?.login)) {
     return { skipped: true, reason: 'bot actor' };
@@ -139,6 +142,12 @@ export function handleOpened(event, options = {}) {
     githubNumber: issue.number,
   });
   if (canonicalLink) {
+    const commentBody = buildComment(canonicalLink.forgeIssueId, issueNumber, {
+      type,
+      priority,
+      externalRef,
+    });
+    createOrEditComment(owner, repo, issueNumber, commentBody);
     return {
       skipped: true,
       reason: 'already synced (canonical link)',
@@ -148,11 +157,6 @@ export function handleOpened(event, options = {}) {
 
   const { sanitized: sanitizedTitle, warnings: titleWarnings } = sanitizeTitle(rawTitle);
   if (titleWarnings.length) console.warn('sanitize:', titleWarnings);
-
-  const rawLabelNames = labels.map((l) => (typeof l === 'string' ? l : l.name));
-  const { type, priority } = mapLabels(rawLabelNames, config);
-
-  const externalRef = `gh-${issueNumber}`;
   const beadsId = bdCreate({
     title: sanitizedTitle,
     type,

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -228,10 +228,7 @@ export function handleOpened(event, options = {}) {
  */
 export function handleClosed(event, options = {}) {
   const {
-    owner,
-    repo,
     bd = {},
-    github = {},
   } = options;
 
   const bdClose = bd.bdClose ?? realBdClose;

--- a/scripts/github-beads-sync/mapping.mjs
+++ b/scripts/github-beads-sync/mapping.mjs
@@ -9,6 +9,11 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createLinkStore, resolveCanonicalLink, upsertCanonicalLink } = require('../../lib/issue-sync/link-store.js');
+const { bridgeLegacyLinkHints } = require('../../lib/issue-sync/legacy-link-bridge.js');
 
 /**
  * Reads the mapping file and returns parsed JSON.
@@ -75,4 +80,53 @@ export function setBeadsId(mappingPath, issueNumber, beadsId) {
   const key = String(issueNumber);
   data[key] = beadsId;
   writeMapping(mappingPath, data);
+}
+
+/**
+ * Loads a canonical link store seeded from the legacy mapping file plus any
+ * optional migration hints.
+ *
+ * @param {string} mappingPath - Path to the legacy mapping file
+ * @param {object} [legacyHints] - Additional migration hints to bridge
+ * @returns {ReturnType<typeof createLinkStore>}
+ */
+export function loadCanonicalLinkStore(mappingPath, legacyHints = {}) {
+  const store = createLinkStore();
+  const mapping = readMapping(mappingPath);
+  bridgeLegacyLinkHints({ ...legacyHints, mapping }, { store });
+  return store;
+}
+
+/**
+ * Resolves the canonical link record for a GitHub lookup using the legacy
+ * mapping file only as a bridge input.
+ *
+ * @param {string} mappingPath - Path to the legacy mapping file
+ * @param {object} lookup - Canonical lookup values
+ * @param {object} [legacyHints] - Additional migration hints to bridge
+ * @returns {object|null}
+ */
+export function resolveCanonicalBeadsLink(mappingPath, lookup = {}, legacyHints = {}) {
+  const store = loadCanonicalLinkStore(mappingPath, legacyHints);
+  return resolveCanonicalLink(store, lookup);
+}
+
+/**
+ * Upserts a canonical link and mirrors it into the legacy mapping file for
+ * compatibility during migration.
+ *
+ * @param {string} mappingPath - Path to the legacy mapping file
+ * @param {object} link - Canonical link record
+ * @param {object} [legacyHints] - Additional migration hints to bridge
+ * @returns {object}
+ */
+export function upsertCanonicalBeadsLink(mappingPath, link, legacyHints = {}) {
+  const store = loadCanonicalLinkStore(mappingPath, legacyHints);
+  const canonical = upsertCanonicalLink(store, link);
+
+  if (canonical?.github?.number != null && canonical.forgeIssueId) {
+    setBeadsId(mappingPath, canonical.github.number, canonical.forgeIssueId);
+  }
+
+  return canonical;
 }

--- a/scripts/github-beads-sync/reverse-sync.mjs
+++ b/scripts/github-beads-sync/reverse-sync.mjs
@@ -28,6 +28,24 @@ function parseJsonlLines(lines) {
   return results;
 }
 
+function extractCanonicalGitHubLink(issue = {}) {
+  const github = issue.github ?? {};
+  if (typeof github.url === 'string' && github.url.length > 0) {
+    const match = github.url.match(
+      /https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/,
+    );
+    if (match) {
+      return {
+        owner: match[1],
+        repo: match[2],
+        issueNumber: parseInt(match[3], 10),
+      };
+    }
+  }
+
+  return extractGitHubUrl(issue.description);
+}
+
 /**
  * Detect Beads issues that transitioned to "closed" status.
  * Only detects transitions: issue must exist in oldLines as non-closed,
@@ -109,13 +127,16 @@ export function handleBeadsClosed(oldContent, newContent, deps = {}) {
   const newLines = newContent.split('\n');
 
   const transitions = detectClosedIssues(oldLines, newLines);
+  const latestIssues = new Map(
+    parseJsonlLines(newLines).map((issue) => [issue.id, issue]),
+  );
 
   const closed = [];
   const skipped = [];
   const errors = [];
 
   for (const issue of transitions) {
-    const parsed = extractGitHubUrl(issue.description);
+    const parsed = extractCanonicalGitHubLink(latestIssues.get(issue.id) ?? issue);
     if (!parsed) {
       skipped.push({ beadsId: issue.id, reason: 'no GitHub URL' });
       continue;

--- a/scripts/github-beads-sync/reverse-sync.mjs
+++ b/scripts/github-beads-sync/reverse-sync.mjs
@@ -45,6 +45,10 @@ function extractCanonicalGitHubLink(issue = {}) {
   return null;
 }
 
+function extractPreferredGitHubLink(issue = {}) {
+  return extractCanonicalGitHubLink(issue) ?? extractGitHubUrl(issue.description);
+}
+
 /**
  * Detect Beads issues that transitioned to "closed" status.
  * Only detects transitions: issue must exist in oldLines as non-closed,
@@ -135,7 +139,7 @@ export function handleBeadsClosed(oldContent, newContent, deps = {}) {
   const errors = [];
 
   for (const issue of transitions) {
-    const parsed = extractCanonicalGitHubLink(latestIssues.get(issue.id) ?? issue);
+    const parsed = extractPreferredGitHubLink(latestIssues.get(issue.id) ?? issue);
     if (!parsed) {
       skipped.push({ beadsId: issue.id, reason: 'no GitHub URL' });
       continue;

--- a/scripts/github-beads-sync/reverse-sync.mjs
+++ b/scripts/github-beads-sync/reverse-sync.mjs
@@ -42,8 +42,7 @@ function extractCanonicalGitHubLink(issue = {}) {
       };
     }
   }
-
-  return extractGitHubUrl(issue.description);
+  return null;
 }
 
 /**

--- a/scripts/test-ci-shard.js
+++ b/scripts/test-ci-shard.js
@@ -180,7 +180,8 @@ function getShardPlan(args, { allUnitTests, durationMap }) {
 function runTests(label, files) {
   fs.mkdirSync(reportDir, { recursive: true });
   const junitPath = path.join(reportDir, `${label}.xml`);
-  const result = spawnSync('bun', [
+  const bunCommand = process.env.BUN_EXE || 'bun';
+  const result = spawnSync(bunCommand, [
     'test',
     '--reporter=junit',
     '--reporter-outfile',

--- a/scripts/test-full-suite.js
+++ b/scripts/test-full-suite.js
@@ -106,12 +106,13 @@ function buildShardSpecs(allTests, shardTotal, durationMap = new Map()) {
 function spawnShard(shard, options = {}) {
   const spawn = options.spawn || defaultSpawn;
   const env = options.env || process.env;
+  const bunCommand = options.bunCommand || env.BUN_EXE || process.env.BUN_EXE || 'bun';
   const labelPrefix = options.labelPrefix || 'local-full';
   fs.mkdirSync(reportDir, { recursive: true });
   const junitPath = path.join(reportDir, `${labelPrefix}-shard-${shard.index}.xml`);
 
   return new Promise((resolve, reject) => {
-    const child = spawn('bun', [
+    const child = spawn(bunCommand, [
       'test',
       '--reporter=junit',
       '--reporter-outfile',
@@ -147,6 +148,7 @@ async function runFullSuiteInParallel(args = {}, deps = {}) {
 
   console.log(`Running local full suite in ${shardSpecs.length} shard(s)`);
   const results = await Promise.all(shardSpecs.map((shard) => spawnShard(shard, {
+    bunCommand: deps.bunCommand,
     env: deps.env,
     labelPrefix: args.labelPrefix,
     spawn: deps.spawn,

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -189,6 +189,7 @@ function runTestExecutionPlan(plan, deps = {}) {
   const spawnSync = deps.spawnSync || defaultSpawnSync;
   const pkgManager = deps.pkgManager || detectPackageManager();
   const env = deps.env || stripGitHookEnv(process.env);
+  const bunCommand = deps.bunCommand || env.BUN_EXE || process.env.BUN_EXE || 'bun';
   const label = deps.label || 'tests';
 
   console.log(`Running ${label} (${pkgManager})...`);
@@ -200,19 +201,20 @@ function runTestExecutionPlan(plan, deps = {}) {
       if (status !== 0) return status;
     } else if (plan.testTargets.length > 0) {
       console.log(`  Mode: targeted (${plan.testTargets.length} test file${plan.testTargets.length === 1 ? '' : 's'})`);
-      const status = runCommand(pkgManager, ['run', 'test', ...plan.testTargets], { env }, spawnSync);
+      const command = pkgManager === 'bun' ? bunCommand : pkgManager;
+      const status = runCommand(command, ['run', 'test', ...plan.testTargets], { env }, spawnSync);
       if (status !== 0) return status;
     }
 
     if (!plan.runFullSuite && plan.runE2E) {
       console.log('  Extra: running affected e2e tests');
-      const status = runCommand('bun', ['test', 'test/e2e/'], { env }, spawnSync);
+      const status = runCommand(bunCommand, ['test', 'test/e2e/'], { env }, spawnSync);
       if (status !== 0) return status;
     }
 
     if (!plan.runFullSuite && plan.runTestEnv) {
       console.log('  Extra: running affected edge-case tests');
-      const status = runCommand('bun', ['test', 'test-env/'], { env }, spawnSync);
+      const status = runCommand(bunCommand, ['test', 'test-env/'], { env }, spawnSync);
       if (status !== 0) return status;
     }
 

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -47,6 +47,17 @@ function combinedOutput(result) {
   return [result.stdout, result.stderr].filter(Boolean).join('');
 }
 
+function hasBlockingAuditSeverity(output = '') {
+  if (typeof output !== 'string' || output.length === 0) {
+    return false;
+  }
+
+  return [
+    /\b(?:critical|high)\s+severity\b/i,
+    /\bseverity\s*:?\s*(?:critical|high)\b/i,
+  ].some((pattern) => pattern.test(output));
+}
+
 function main(options = {}) {
   const runCommand = options.runCommand ?? run;
   const activeBunCommand = options.bunCommand ?? bunCommand;
@@ -91,7 +102,7 @@ function main(options = {}) {
       process.stdout.write('\n');
     }
   }
-  if (/critical|high/i.test(auditOutput)) {
+  if (hasBlockingAuditSeverity(auditOutput)) {
     printStatus('error', 'Security audit found critical/high vulnerabilities');
     return 1;
   }
@@ -124,6 +135,7 @@ if (require.main === module) {
 module.exports = {
   color,
   combinedOutput,
+  hasBlockingAuditSeverity,
   main,
   printHeader,
   printStatus,

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -47,14 +47,16 @@ function combinedOutput(result) {
   return [result.stdout, result.stderr].filter(Boolean).join('');
 }
 
-function main() {
+function main(options = {}) {
+  const runCommand = options.runCommand ?? run;
+  const activeBunCommand = options.bunCommand ?? bunCommand;
   console.log('');
   console.log(color('0;34', '╔═══════════════════════════════════════════╗'));
   console.log(color('0;34', '║   Forge Quality Gate - Running Checks    ║'));
   console.log(color('0;34', '╚═══════════════════════════════════════════╝'));
 
   printHeader('1/4: Type Check');
-  const typecheck = run(bunCommand, ['run', 'typecheck']);
+  const typecheck = runCommand(activeBunCommand, ['run', 'typecheck']);
   if ((typecheck.status ?? 1) !== 0) {
     printStatus('error', 'Type check failed');
     return 1;
@@ -62,7 +64,7 @@ function main() {
   printStatus('warning', 'SKIPPED (no TypeScript in project)');
 
   printHeader('2/4: Lint');
-  const lint = run(bunCommand, ['run', 'lint']);
+  const lint = runCommand(activeBunCommand, ['run', 'lint']);
   if ((lint.status ?? 1) !== 0) {
     printStatus('error', 'Lint failed');
     return 1;
@@ -70,7 +72,7 @@ function main() {
   printStatus('success', 'Lint passed');
 
   printHeader('3/4: Security Audit');
-  const audit = run(bunCommand, ['audit'], { captureOutput: true });
+  const audit = runCommand(activeBunCommand, ['audit'], { captureOutput: true });
   const auditOutput = combinedOutput(audit);
   if (auditOutput) {
     process.stdout.write(auditOutput);
@@ -89,7 +91,7 @@ function main() {
   }
 
   printHeader('4/4: Tests');
-  const tests = run('node', ['scripts/test.js', '--validate']);
+  const tests = runCommand('node', ['scripts/test.js', '--validate']);
   if ((tests.status ?? 1) !== 0) {
     printStatus('error', 'Tests failed');
     return 1;
@@ -104,4 +106,15 @@ function main() {
   return 0;
 }
 
-process.exit(main());
+if (require.main === module) {
+  process.exit(main());
+}
+
+module.exports = {
+  color,
+  combinedOutput,
+  main,
+  printHeader,
+  printStatus,
+  run,
+};

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+
+const bunCommand = process.env.BUN_EXE || 'bun';
+
+function color(code, text) {
+  return process.stdout.isTTY ? `\u001b[${code}m${text}\u001b[0m` : text;
+}
+
+function printHeader(title) {
+  const line = '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━';
+  console.log('');
+  console.log(color('0;34', line));
+  console.log(color('0;34', `▶ ${title}`));
+  console.log(color('0;34', line));
+}
+
+function printStatus(kind, message) {
+  const palette = {
+    error: ['0;31', '✗'],
+    success: ['0;32', '✓'],
+    warning: ['1;33', '⚠'],
+  };
+  const [code, prefix] = palette[kind];
+  console.log(color(code, `${prefix} ${message}`));
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: options.captureOutput ? ['inherit', 'pipe', 'pipe'] : 'inherit',
+    shell: false,
+    env: options.env || process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result;
+}
+
+function combinedOutput(result) {
+  return [result.stdout, result.stderr].filter(Boolean).join('');
+}
+
+function main() {
+  console.log('');
+  console.log(color('0;34', '╔═══════════════════════════════════════════╗'));
+  console.log(color('0;34', '║   Forge Quality Gate - Running Checks    ║'));
+  console.log(color('0;34', '╚═══════════════════════════════════════════╝'));
+
+  printHeader('1/4: Type Check');
+  const typecheck = run(bunCommand, ['run', 'typecheck']);
+  if ((typecheck.status ?? 1) !== 0) {
+    printStatus('error', 'Type check failed');
+    return 1;
+  }
+  printStatus('warning', 'SKIPPED (no TypeScript in project)');
+
+  printHeader('2/4: Lint');
+  const lint = run(bunCommand, ['run', 'lint']);
+  if ((lint.status ?? 1) !== 0) {
+    printStatus('error', 'Lint failed');
+    return 1;
+  }
+  printStatus('success', 'Lint passed');
+
+  printHeader('3/4: Security Audit');
+  const audit = run(bunCommand, ['audit'], { captureOutput: true });
+  const auditOutput = combinedOutput(audit);
+  if (auditOutput) {
+    process.stdout.write(auditOutput);
+    if (!auditOutput.endsWith('\n')) {
+      process.stdout.write('\n');
+    }
+  }
+  if (/critical|high/i.test(auditOutput)) {
+    printStatus('error', 'Security audit found critical/high vulnerabilities');
+    return 1;
+  }
+  if ((audit.status ?? 1) === 0) {
+    printStatus('success', 'Security audit passed');
+  } else {
+    printStatus('warning', 'Security audit found issues (moderate/low — non-blocking)');
+  }
+
+  printHeader('4/4: Tests');
+  const tests = run('node', ['scripts/test.js', '--validate']);
+  if ((tests.status ?? 1) !== 0) {
+    printStatus('error', 'Tests failed');
+    return 1;
+  }
+  printStatus('success', 'All tests passed');
+
+  console.log('');
+  console.log(color('0;32', '╔═══════════════════════════════════════════╗'));
+  console.log(color('0;32', '║     ✓ All Checks Passed Successfully     ║'));
+  console.log(color('0;32', '╚═══════════════════════════════════════════╝'));
+  console.log('');
+  return 0;
+}
+
+process.exit(main());

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -56,12 +56,23 @@ function main(options = {}) {
   console.log(color('0;34', '╚═══════════════════════════════════════════╝'));
 
   printHeader('1/4: Type Check');
-  const typecheck = runCommand(activeBunCommand, ['run', 'typecheck']);
+  const typecheck = runCommand(activeBunCommand, ['run', 'typecheck'], { captureOutput: true });
+  const typecheckOutput = combinedOutput(typecheck);
+  if (typecheckOutput) {
+    process.stdout.write(typecheckOutput);
+    if (!typecheckOutput.endsWith('\n')) {
+      process.stdout.write('\n');
+    }
+  }
   if ((typecheck.status ?? 1) !== 0) {
     printStatus('error', 'Type check failed');
     return 1;
   }
-  printStatus('warning', 'SKIPPED (no TypeScript in project)');
+  if (/no typescript in project|skipping type check/i.test(typecheckOutput)) {
+    printStatus('warning', 'SKIPPED (no TypeScript in project)');
+  } else {
+    printStatus('success', 'Type check passed');
+  }
 
   printHeader('2/4: Lint');
   const lint = runCommand(activeBunCommand, ['run', 'lint']);

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -44,6 +44,23 @@ print_warning() {
   echo -e "${YELLOW}⚠ $1${NC}"
 }
 
+run_validate_tests() {
+  if [[ "${OS:-}" == "Windows_NT" && ( -n "${MSYSTEM:-}" || "${OSTYPE:-}" == msys* || "${OSTYPE:-}" == cygwin* ) ]]; then
+    local bun_exe
+    bun_exe="$(where.exe bun 2>/dev/null | tr -d '\r' | grep -i 'bun\.exe$' | head -n 1)"
+
+    if [[ -n "$bun_exe" ]]; then
+      cmd.exe /d /c "set \"BUN_EXE=$bun_exe\" && node scripts\\test.js --validate"
+      return $?
+    fi
+
+    cmd.exe /d /c "node scripts\\test.js --validate"
+    return $?
+  fi
+
+  node scripts/test.js --validate
+}
+
 echo ""
 echo -e "${BLUE}╔═══════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║   Forge Quality Gate - Running Checks    ║${NC}"
@@ -78,7 +95,7 @@ fi
 
 # Step 4: Tests
 print_header "4/4: Tests"
-if node scripts/test.js --validate; then
+if run_validate_tests; then
   print_success "All tests passed"
 else
   print_error "Tests failed"

--- a/test-env/automation/setup-fixtures.test.js
+++ b/test-env/automation/setup-fixtures.test.js
@@ -8,13 +8,13 @@ const path = require('node:path');
 // SECURITY: Using execSync with HARDCODED script path only (no user input)
 const { execFileSync } = require('node:child_process');
 const { resolveBashCommand } = require('../../test/helpers/bash.js');
+const { ensureTestFixtures, FIXTURES_DIR } = require('../helpers/fixtures.js');
 
 // Import validation helpers from Phase 1
 const { checkGitState, isDetachedHead, hasUncommittedChanges, hasMergeConflict } = require('../validation/git-state-checker.js');
 const { validateFile: _validateFile } = require('../validation/file-checker.js');
 const { validateEnvFile: _validateEnvFile } = require('../validation/env-validator.js');
 
-const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
 const SETUP_SCRIPT = path.join(__dirname, 'setup-fixtures.sh');
 
 const EXPECTED_FIXTURES = [
@@ -24,19 +24,7 @@ const EXPECTED_FIXTURES = [
   'large-agents-md', 'missing-prerequisites'
 ];
 
-function ensureFixtures() {
-  try { fs.chmodSync(SETUP_SCRIPT, 0o755); } catch (_error) { }
-  try {
-    // SECURITY: Hardcoded command (no user input)
-    // Note: Don't use --force to avoid race conditions with other tests.
-    execFileSync(resolveBashCommand(), [SETUP_SCRIPT, '--no-validate'], {
-      cwd: __dirname,
-      stdio: 'pipe',
-    });
-  } catch (error) { console.error('Failed to run setup-fixtures.sh:', error.message); }
-}
-
-ensureFixtures();
+ensureTestFixtures();
 
 describe('setup-fixtures.sh', () => {
   test('should create all 15 fixtures', () => {

--- a/test-env/edge-cases/git-states.test.js
+++ b/test-env/edge-cases/git-states.test.js
@@ -4,6 +4,7 @@
 const { describe, test } = require('bun:test');
 const assert = require('node:assert/strict');
 const path = require('node:path');
+const { ensureTestFixtures, FIXTURES_DIR } = require('../helpers/fixtures.js');
 
 // Import validation helpers from Phase 1
 const {
@@ -13,8 +14,7 @@ const {
   hasMergeConflict
 } = require('../validation/git-state-checker.js');
 
-// Fixtures directory
-const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+ensureTestFixtures();
 
 describe('git-state-edge-cases', () => {
   describe('Detached HEAD (Warning)', () => {

--- a/test-env/edge-cases/permission-errors.test.js
+++ b/test-env/edge-cases/permission-errors.test.js
@@ -7,10 +7,11 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
 const { tmpdir } = require('node:os');
-
-const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+const { ensureTestFixtures, FIXTURES_DIR } = require('../helpers/fixtures.js');
 
 let testDir;
+
+ensureTestFixtures();
 
 before(() => {
   testDir = mkdtempSync(path.join(tmpdir(), 'forge-test-permissions-'));

--- a/test-env/edge-cases/rollback-user-sections.test.js
+++ b/test-env/edge-cases/rollback-user-sections.test.js
@@ -9,6 +9,10 @@ const path = require('path');
 const testDir = path.join(__dirname, 'temp-user-section-test');
 const _projectRoot = testDir;
 
+function ensureTestDir() {
+  fs.mkdirSync(testDir, { recursive: true });
+}
+
 // Test implementation of extractUserSections
 function extractUserSections(filePath) {
   if (!fs.existsSync(filePath)) return {};
@@ -78,6 +82,7 @@ describe('USER Section Extraction & Preservation Tests', () => {
 
   describe('Basic USER Section Extraction', () => {
     test('Extracts single USER section', () => {
+      ensureTestDir();
       const testFile = path.join(testDir, 'test1.md');
       const content = `# File
 <!-- USER:START -->
@@ -94,6 +99,7 @@ More content`;
     });
 
     test('Extracts multiple USER sections', () => {
+      ensureTestDir();
       const testFile = path.join(testDir, 'test2.md');
       const content = `# File
 <!-- USER:START -->
@@ -114,6 +120,7 @@ Second section
     });
 
     test('Returns empty object for non-existent file', () => {
+      ensureTestDir();
       const sections = extractUserSections(path.join(testDir, 'nonexistent.md'));
       assert.strictEqual(Object.keys(sections).length, 0);
     });
@@ -121,6 +128,7 @@ Second section
 
   describe('USER Section Preservation', () => {
     test('Preserves single USER section', () => {
+      ensureTestDir();
       const testFile = path.join(testDir, 'test6.md');
       const original = `# File
 <!-- USER:START -->

--- a/test-env/helpers/fixtures.js
+++ b/test-env/helpers/fixtures.js
@@ -7,7 +7,6 @@ const { resolveBashCommand } = require('../../test/helpers/bash.js');
 const TEST_ENV_DIR = path.join(__dirname, '..');
 const FIXTURES_DIR = path.join(TEST_ENV_DIR, 'fixtures');
 const SETUP_SCRIPT = path.join(TEST_ENV_DIR, 'automation', 'setup-fixtures.sh');
-const FIXTURE_LOCK_DIR = path.join(FIXTURES_DIR, '.setup-lock');
 
 function sleep(ms) {
 	const end = Date.now() + ms;
@@ -16,45 +15,51 @@ function sleep(ms) {
 	}
 }
 
-function fixturesNeedRepair() {
-	return !fs.existsSync(path.join(FIXTURES_DIR, 'fresh-project', '.git'))
-		|| !fs.existsSync(path.join(FIXTURES_DIR, 'dirty-git', 'uncommitted.txt'))
-		|| !fs.existsSync(path.join(FIXTURES_DIR, 'detached-head', '.git'))
-		|| !fs.existsSync(path.join(FIXTURES_DIR, 'merge-conflict', '.git', 'MERGE_HEAD'))
-		|| fs.existsSync(path.join(FIXTURES_DIR, 'no-git', '.git'))
-		|| !fs.existsSync(path.join(FIXTURES_DIR, 'read-only-dirs', '.claude'));
+function fixturesNeedRepair(fixturesDir) {
+	return !fs.existsSync(path.join(fixturesDir, 'fresh-project', '.git'))
+		|| !fs.existsSync(path.join(fixturesDir, 'dirty-git', 'uncommitted.txt'))
+		|| !fs.existsSync(path.join(fixturesDir, 'detached-head', '.git'))
+		|| !fs.existsSync(path.join(fixturesDir, 'merge-conflict', '.git', 'MERGE_HEAD'))
+		|| fs.existsSync(path.join(fixturesDir, 'no-git', '.git'))
+		|| !fs.existsSync(path.join(fixturesDir, 'read-only-dirs', '.claude'));
 }
 
-function repairFixtures() {
+function repairFixtures(setupScript) {
 	try {
-		fs.chmodSync(SETUP_SCRIPT, 0o755);
+		fs.chmodSync(setupScript, 0o755);
 	} catch (_error) {
 		// Best-effort on platforms that do not support chmod here.
 	}
 
-	execFileSync(resolveBashCommand(), [SETUP_SCRIPT, '--force', '--no-validate'], {
-		cwd: path.dirname(SETUP_SCRIPT),
+	execFileSync(resolveBashCommand(), [setupScript, '--force', '--no-validate'], {
+		cwd: path.dirname(setupScript),
 		stdio: 'pipe',
 	});
 }
 
-function ensureTestFixtures() {
-	if (!fixturesNeedRepair()) {
+function ensureTestFixtures(options = {}) {
+	const fixturesDir = options.fixturesDir ?? FIXTURES_DIR;
+	const setupScript = options.setupScript ?? SETUP_SCRIPT;
+	const lockDir = options.lockDir ?? path.join(fixturesDir, '.setup-lock');
+	const repair = options.repairFixtures ?? (() => repairFixtures(setupScript));
+	const needsRepair = () => fixturesNeedRepair(fixturesDir);
+
+	if (!needsRepair()) {
 		return;
 	}
 
-	fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+	fs.mkdirSync(fixturesDir, { recursive: true });
 	const deadline = Date.now() + 30000;
 
 	while (true) {
 		try {
-			fs.mkdirSync(FIXTURE_LOCK_DIR);
+			fs.mkdirSync(lockDir);
 			break;
 		} catch (error) {
 			if (error.code !== 'EEXIST') {
 				throw error;
 			}
-			if (!fixturesNeedRepair()) {
+			if (!needsRepair()) {
 				return;
 			}
 			if (Date.now() >= deadline) {
@@ -65,14 +70,14 @@ function ensureTestFixtures() {
 	}
 
 	try {
-		if (fixturesNeedRepair()) {
-			repairFixtures();
+		if (needsRepair()) {
+			repair();
 		}
-		if (fixturesNeedRepair()) {
+		if (needsRepair()) {
 			throw new Error('Fixture repair did not restore expected test fixture state');
 		}
 	} finally {
-		fs.rmSync(FIXTURE_LOCK_DIR, { recursive: true, force: true });
+		fs.rmSync(lockDir, { recursive: true, force: true });
 	}
 }
 

--- a/test-env/helpers/fixtures.js
+++ b/test-env/helpers/fixtures.js
@@ -1,0 +1,82 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { resolveBashCommand } = require('../../test/helpers/bash.js');
+
+const TEST_ENV_DIR = path.join(__dirname, '..');
+const FIXTURES_DIR = path.join(TEST_ENV_DIR, 'fixtures');
+const SETUP_SCRIPT = path.join(TEST_ENV_DIR, 'automation', 'setup-fixtures.sh');
+const FIXTURE_LOCK_DIR = path.join(FIXTURES_DIR, '.setup-lock');
+
+function sleep(ms) {
+	const end = Date.now() + ms;
+	while (Date.now() < end) {
+		// Busy-wait briefly while another worker repairs fixtures.
+	}
+}
+
+function fixturesNeedRepair() {
+	return !fs.existsSync(path.join(FIXTURES_DIR, 'fresh-project', '.git'))
+		|| !fs.existsSync(path.join(FIXTURES_DIR, 'dirty-git', 'uncommitted.txt'))
+		|| !fs.existsSync(path.join(FIXTURES_DIR, 'detached-head', '.git'))
+		|| !fs.existsSync(path.join(FIXTURES_DIR, 'merge-conflict', '.git', 'MERGE_HEAD'))
+		|| fs.existsSync(path.join(FIXTURES_DIR, 'no-git', '.git'))
+		|| !fs.existsSync(path.join(FIXTURES_DIR, 'read-only-dirs', '.claude'));
+}
+
+function repairFixtures() {
+	try {
+		fs.chmodSync(SETUP_SCRIPT, 0o755);
+	} catch (_error) {
+		// Best-effort on platforms that do not support chmod here.
+	}
+
+	execFileSync(resolveBashCommand(), [SETUP_SCRIPT, '--force', '--no-validate'], {
+		cwd: path.dirname(SETUP_SCRIPT),
+		stdio: 'pipe',
+	});
+}
+
+function ensureTestFixtures() {
+	if (!fixturesNeedRepair()) {
+		return;
+	}
+
+	fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+	const deadline = Date.now() + 30000;
+
+	while (true) {
+		try {
+			fs.mkdirSync(FIXTURE_LOCK_DIR);
+			break;
+		} catch (error) {
+			if (error.code !== 'EEXIST') {
+				throw error;
+			}
+			if (!fixturesNeedRepair()) {
+				return;
+			}
+			if (Date.now() >= deadline) {
+				throw new Error('Timed out waiting for fixture repair lock');
+			}
+			sleep(50);
+		}
+	}
+
+	try {
+		if (fixturesNeedRepair()) {
+			repairFixtures();
+		}
+		if (fixturesNeedRepair()) {
+			throw new Error('Fixture repair did not restore expected test fixture state');
+		}
+	} finally {
+		fs.rmSync(FIXTURE_LOCK_DIR, { recursive: true, force: true });
+	}
+}
+
+module.exports = {
+	ensureTestFixtures,
+	FIXTURES_DIR,
+};

--- a/test-env/helpers/fixtures.test.js
+++ b/test-env/helpers/fixtures.test.js
@@ -1,0 +1,70 @@
+const { afterEach, describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ensureTestFixtures } = require('./fixtures.js');
+
+const tempDirs = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function createTempFixturesDir() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-fixtures-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function materializeFixtureState(fixturesDir) {
+	fs.mkdirSync(path.join(fixturesDir, 'fresh-project', '.git'), { recursive: true });
+	fs.mkdirSync(path.join(fixturesDir, 'dirty-git'), { recursive: true });
+	fs.writeFileSync(path.join(fixturesDir, 'dirty-git', 'uncommitted.txt'), 'dirty', 'utf8');
+	fs.mkdirSync(path.join(fixturesDir, 'detached-head', '.git'), { recursive: true });
+	fs.mkdirSync(path.join(fixturesDir, 'merge-conflict', '.git'), { recursive: true });
+	fs.writeFileSync(path.join(fixturesDir, 'merge-conflict', '.git', 'MERGE_HEAD'), 'merge', 'utf8');
+	fs.mkdirSync(path.join(fixturesDir, 'no-git'), { recursive: true });
+	fs.mkdirSync(path.join(fixturesDir, 'read-only-dirs', '.claude'), { recursive: true });
+}
+
+describe('test-env/helpers/fixtures.js', () => {
+	test('repairs incomplete fixture directories before tests run', () => {
+		const fixturesDir = createTempFixturesDir();
+		const lockDir = path.join(fixturesDir, '.setup-lock');
+		let repairCount = 0;
+
+		ensureTestFixtures({
+			fixturesDir,
+			lockDir,
+			repairFixtures: () => {
+				repairCount += 1;
+				materializeFixtureState(fixturesDir);
+			},
+		});
+
+		expect(repairCount).toBe(1);
+		expect(fs.existsSync(path.join(fixturesDir, 'fresh-project', '.git'))).toBe(true);
+		expect(fs.existsSync(path.join(fixturesDir, 'merge-conflict', '.git', 'MERGE_HEAD'))).toBe(true);
+		expect(fs.existsSync(path.join(fixturesDir, 'no-git', '.git'))).toBe(false);
+	});
+
+	test('skips repair when fixture state is already complete', () => {
+		const fixturesDir = createTempFixturesDir();
+		const lockDir = path.join(fixturesDir, '.setup-lock');
+		let repairCount = 0;
+
+		materializeFixtureState(fixturesDir);
+		ensureTestFixtures({
+			fixturesDir,
+			lockDir,
+			repairFixtures: () => {
+				repairCount += 1;
+			},
+		});
+
+		expect(repairCount).toBe(0);
+	});
+});

--- a/test-env/validation/git-state-checker.test.js
+++ b/test-env/validation/git-state-checker.test.js
@@ -1,7 +1,7 @@
 // Test: Git State Checker Validation Helper
 // Tests for git repository state validation
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
+const { describe, test, beforeAll: before, afterAll: after, setDefaultTimeout } = require('bun:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -30,6 +30,8 @@ const gitExecOptions = {
     LEFTHOOK: '0',
   },
 };
+
+setDefaultTimeout(15000);
 
 before(() => {
   // Create temp directory for tests

--- a/test/beads-context-validate.test.js
+++ b/test/beads-context-validate.test.js
@@ -45,7 +45,7 @@ if [ "$1" = "show" ] && [ "$3" = "--json" ]; then
   cat ${shQuote(`./${path.basename(shimDir)}/show.json`)}
   exit 0
 fi
-if [ "$1" = "comments" ] && [ "$2" = "list" ]; then
+if [ "$1" = "comments" ] && [ "$2" = "${issueId}" ]; then
   cat ${shQuote(`./${path.basename(shimDir)}/comments.txt`)}
   exit 0
 fi

--- a/test/check-script.test.js
+++ b/test/check-script.test.js
@@ -1,44 +1,32 @@
 const fs = require('node:fs');
 const path = require('node:path');
-const { describe, test, expect } = require('bun:test');
+const { describe, test, expect } = require('bun:test');
 
-describe('scripts/validate.sh', () => {
-  const checkScriptPath = path.join(__dirname, '..', 'scripts', 'validate.sh');
+describe('scripts/validate.js', () => {
+  const checkScriptPath = path.join(__dirname, '..', 'scripts', 'validate.js');
 
-  describe('Script existence and permissions', () => {
+  describe('Script existence and entrypoint wiring', () => {
     test('should exist', () => {
       expect(fs.existsSync(checkScriptPath)).toBeTruthy();
     });
 
-    test('should be executable', () => {
-      // On Windows, we check if file exists (executable bit not applicable)
-      // On Unix, we check if executable bit is set
-      if (process.platform === 'win32') {
-        expect(fs.existsSync(checkScriptPath)).toBeTruthy();
-      } else {
-        const stats = fs.statSync(checkScriptPath);
-        const isExecutable = (stats.mode & 0o111) !== 0;
-        expect(isExecutable).toBeTruthy();
-      }
-    });
-
-    test('should have proper shebang for cross-platform compatibility', () => {
+    test('should have a node shebang for CLI execution', () => {
       const content = fs.readFileSync(checkScriptPath, 'utf-8');
       const firstLine = content.split('\n')[0];
-      // Should use #!/usr/bin/env bash or #!/bin/sh for portability
-      expect(firstLine.includes('#!/usr/bin/env bash') || firstLine.includes('#!/bin/sh')).toBeTruthy();
+      expect(firstLine.includes('#!/usr/bin/env node')).toBeTruthy();
+    });
+
+    test('should export main and guard direct execution', () => {
+      const content = fs.readFileSync(checkScriptPath, 'utf-8');
+      expect(content).toContain('if (require.main === module)');
+      expect(content).toContain('module.exports');
     });
   });
-
-  // Note: Exit code testing removed to avoid recursion
-  // (check.sh runs all tests including this test file)
-  // Manual verification: Run `bun run check` separately
 
   describe('Check orchestration', () => {
     test('should run checks in correct order', () => {
       const content = fs.readFileSync(checkScriptPath, 'utf-8');
 
-      // Check that step headers appear in order
       const typecheckIndex = content.indexOf('Type Check');
       const lintIndex = content.indexOf('Lint');
       const testIndex = content.indexOf('Tests');
@@ -50,39 +38,25 @@ describe('scripts/validate.sh', () => {
 
     test('should run security check', () => {
       const content = fs.readFileSync(checkScriptPath, 'utf-8');
-
-      // Should include security scan (npm audit or similar)
       expect(content.includes('audit') || content.includes('security')).toBeTruthy();
     });
 
     test('should stop on first failure', () => {
       const content = fs.readFileSync(checkScriptPath, 'utf-8');
-
-      // Should use 'set -e' to exit on first error
-      // OR explicitly check exit codes
-      expect(content.includes('set -e') || content.includes('exit 1') || content.includes('$?')).toBeTruthy();
+      expect(content.includes('return 1') || content.includes('throw')).toBeTruthy();
     });
   });
 
   describe('Output formatting', () => {
-    test('should provide clear progress indicators', () => {
+    test('should provide clear progress helpers', () => {
       const content = fs.readFileSync(checkScriptPath, 'utf-8');
-
-      // Should have echo statements showing progress
-      const echoCount = (content.match(/echo/g) || []).length;
-      expect(echoCount >= 4).toBeTruthy();
+      expect(content).toContain('printHeader');
+      expect(content).toContain('printStatus');
     });
 
     test('should use colors for better readability', () => {
-      // Skip color checks on CI environments that don't support it
-      if (process.env.CI) {
-        return; // Skip in CI
-      }
-
       const content = fs.readFileSync(checkScriptPath, 'utf-8');
-
-      // Should include ANSI color codes or tput commands
-      const hasColors = content.includes('\033[') || content.includes('tput');
+      const hasColors = content.includes('\\u001b[') || content.includes('process.stdout.isTTY');
       expect(hasColors).toBeTruthy();
     });
   });
@@ -90,7 +64,7 @@ describe('scripts/validate.sh', () => {
   describe('Integration with package.json', () => {
     test('package.json should have check script', () => {
       const packageJson = JSON.parse(
-        fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8')
+        fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'),
       );
 
       expect(packageJson.scripts.check).toBeTruthy();

--- a/test/check-script.test.js
+++ b/test/check-script.test.js
@@ -94,7 +94,7 @@ describe('scripts/validate.sh', () => {
       );
 
       expect(packageJson.scripts.check).toBeTruthy();
-      expect(packageJson.scripts.check.includes('scripts/validate.sh')).toBeTruthy();
+      expect(packageJson.scripts.check.includes('scripts/validate.js')).toBeTruthy();
     });
   });
 });

--- a/test/commands/_issue.test.js
+++ b/test/commands/_issue.test.js
@@ -2,7 +2,7 @@
 
 const { describe, test, expect } = require('bun:test');
 
-const { buildBdArgs } = require('../../lib/commands/_issue');
+const { buildBdArgs, makeAliasCommand } = require('../../lib/commands/_issue');
 
 describe('forge issue helpers', () => {
   test('buildBdArgs maps create to bd create passthrough', () => {
@@ -19,5 +19,27 @@ describe('forge issue helpers', () => {
     expect(buildBdArgs('claim', [])).toEqual({
       error: 'Missing issue id. Usage: forge claim <id> [bd-update-flags]',
     });
+  });
+
+  test('claim alias routes through the shared issue operation runner', async () => {
+    const calls = [];
+    const claim = makeAliasCommand('claim');
+
+    const result = await claim.handler(['forge-abc'], {}, '/repo', {
+      runIssueOperation: async (operation, args, projectRoot, deps) => {
+        calls.push({ operation, args, projectRoot, deps });
+        return { success: true, operation };
+      },
+    });
+
+    expect(result).toEqual({ success: true, operation: 'update' });
+    expect(calls).toEqual([{
+      operation: 'update',
+      args: ['forge-abc', '--claim'],
+      projectRoot: '/repo',
+      deps: {
+        runIssueOperation: expect.any(Function),
+      },
+    }]);
   });
 });

--- a/test/commands/issue.test.js
+++ b/test/commands/issue.test.js
@@ -29,33 +29,35 @@ describe('forge issue command surface', () => {
       {},
       '/fake/root',
       {
-        _exec: (command, args, opts) => {
-          calls.push({ command, args, opts });
+        runIssueOperation: async (operation, args, projectRoot) => {
+          calls.push({ operation, args, projectRoot });
+          return { success: true, subcommand: 'create' };
         },
       }
     );
 
     expect(result).toEqual({ success: true, subcommand: 'create' });
     expect(calls).toEqual([{
-      command: 'bd',
-      args: ['create', '--title', 'Test issue', '--type', 'feature'],
-      opts: { cwd: '/fake/root', stdio: 'inherit' },
+      operation: 'create',
+      args: ['--title', 'Test issue', '--type', 'feature'],
+      projectRoot: '/fake/root',
     }]);
   });
 
   test('claim alias dispatches to bd update --claim', async () => {
     const calls = [];
     const result = await claim.handler(['forge-abc'], {}, '/fake/root', {
-      _exec: (command, args, opts) => {
-        calls.push({ command, args, opts });
+      runIssueOperation: async (operation, args, projectRoot) => {
+        calls.push({ operation, args, projectRoot });
+        return { success: true, subcommand: 'claim' };
       },
     });
 
     expect(result).toEqual({ success: true, subcommand: 'claim' });
     expect(calls).toEqual([{
-      command: 'bd',
-      args: ['update', 'forge-abc', '--claim'],
-      opts: { cwd: '/fake/root', stdio: 'inherit' },
+      operation: 'update',
+      args: ['forge-abc', '--claim'],
+      projectRoot: '/fake/root',
     }]);
   });
 

--- a/test/commands/ship.test.js
+++ b/test/commands/ship.test.js
@@ -1,4 +1,4 @@
-const { describe, test, expect } = require('bun:test');
+const { describe, test, expect, setDefaultTimeout } = require('bun:test');
 const {
 	extractKeyDecisions,
 	extractTestScenarios,
@@ -10,6 +10,8 @@ const {
 	resolveBaseRemote,
 	resolveBaseBranch,
 } = require('../../lib/commands/ship.js');
+
+setDefaultTimeout(15000);
 
 describe('Ship Command - PR Creation', () => {
 	describe('Extract key decisions from research', () => {

--- a/test/dep-guard/analyzer.test.js
+++ b/test/dep-guard/analyzer.test.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { afterEach, describe, expect, test } = require('bun:test');
+const { afterEach, describe, expect, setDefaultTimeout, test } = require('bun:test');
 
 const {
 	analyzePhase3Dependencies,
@@ -10,6 +10,8 @@ const {
 } = require('../../lib/dep-guard/analyzer.js');
 
 const tempDirs = [];
+
+setDefaultTimeout(15000);
 
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {

--- a/test/forge-cli-registry.test.js
+++ b/test/forge-cli-registry.test.js
@@ -7,7 +7,7 @@
  * Uses subprocess spawning to test the actual CLI entry point.
  */
 
-const { describe, test, expect } = require('bun:test');
+const { describe, test, expect, setDefaultTimeout } = require('bun:test');
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -15,6 +15,8 @@ const os = require('node:os');
 const { loadCommands } = require('../lib/commands/_registry');
 
 const forgePath = path.join(__dirname, '..', 'bin', 'forge.js');
+
+setDefaultTimeout(15000);
 
 /**
  * Helper: run forge CLI with given args, return { stdout, stderr, status }.
@@ -175,7 +177,10 @@ describe('CLI Registry Integration', () => {
         workflowDecisions: { classification: 'critical' },
       });
 
-      const { stdout, stderr, status } = runForge(['verify', '--workflow-state', workflowState]);
+      const { stdout, stderr, status } = runForge(
+        ['verify', '--workflow-state', workflowState],
+        { PATH: '', Path: '' }
+      );
       const combined = stdout + stderr;
 
       expect(status).toBe(1);

--- a/test/forge-issues-sync.test.js
+++ b/test/forge-issues-sync.test.js
@@ -7,6 +7,7 @@ const { createGitHubProjectionPlan } = require('../lib/issue-sync/project-github
 describe('forge issue write sync', () => {
   test('creates a GitHub projection plan only for shared field writes', () => {
     expect(createGitHubProjectionPlan('update', ['forge-1', '--priority', '2'])).toBeNull();
+    expect(createGitHubProjectionPlan('close', ['--help'])).toBeNull();
 
     expect(createGitHubProjectionPlan('update', ['forge-1', '--title', 'Renamed'])).toEqual({
       operation: 'update',
@@ -74,6 +75,25 @@ describe('forge issue write sync', () => {
     });
 
     expect(result).toEqual({ success: true, output: 'local write ok' });
+    expect(queued).toEqual([]);
+  });
+
+  test('does not queue outbound projections for write help passthrough', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+    const queued = [];
+
+    const result = await runIssueOperation('close', ['--help'], '/repo', {
+      createService: () => ({
+        async run() {
+          return { success: true, output: 'bd close help output' };
+        },
+      }),
+      enqueueGitHubProjection: projection => {
+        queued.push(projection);
+      },
+    });
+
+    expect(result).toEqual({ success: true, output: 'bd close help output' });
     expect(queued).toEqual([]);
   });
 });

--- a/test/forge-issues-sync.test.js
+++ b/test/forge-issues-sync.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+
+const { createGitHubProjectionPlan } = require('../lib/issue-sync/project-github');
+
+describe('forge issue write sync', () => {
+  test('creates a GitHub projection plan only for shared field writes', () => {
+    expect(createGitHubProjectionPlan('update', ['forge-1', '--priority', '2'])).toBeNull();
+
+    expect(createGitHubProjectionPlan('update', ['forge-1', '--title', 'Renamed'])).toEqual({
+      operation: 'update',
+      args: ['forge-1', '--title', 'Renamed'],
+      fieldPaths: ['shared.title'],
+    });
+
+    expect(createGitHubProjectionPlan('update', ['forge-1', '--claim'])).toEqual({
+      operation: 'update',
+      args: ['forge-1', '--claim'],
+      fieldPaths: ['shared.assignees'],
+    });
+  });
+
+  test('queues outbound projections only after a successful local write', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+    const calls = [];
+    const queued = [];
+
+    const result = await runIssueOperation('update', ['forge-1', '--title', 'Renamed'], '/repo', {
+      createService: () => ({
+        async run(operation, args, context) {
+          calls.push({ phase: 'local', operation, args, context });
+          return { success: true, output: 'local write ok' };
+        },
+      }),
+      enqueueGitHubProjection: projection => {
+        queued.push(projection);
+      },
+    });
+
+    expect(result).toEqual({ success: true, output: 'local write ok' });
+    expect(calls).toEqual([{
+      phase: 'local',
+      operation: 'update',
+      args: ['forge-1', '--title', 'Renamed'],
+      context: {
+        projectRoot: '/repo',
+        deps: expect.objectContaining({
+          createService: expect.any(Function),
+          enqueueGitHubProjection: expect.any(Function),
+        }),
+      },
+    }]);
+    expect(queued).toEqual([{
+      operation: 'update',
+      args: ['forge-1', '--title', 'Renamed'],
+      fieldPaths: ['shared.title'],
+    }]);
+  });
+
+  test('does not queue outbound projections for local-only writes', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+    const queued = [];
+
+    const result = await runIssueOperation('update', ['forge-1', '--priority', '2'], '/repo', {
+      createService: () => ({
+        async run() {
+          return { success: true, output: 'local write ok' };
+        },
+      }),
+      enqueueGitHubProjection: projection => {
+        queued.push(projection);
+      },
+    });
+
+    expect(result).toEqual({ success: true, output: 'local write ok' });
+    expect(queued).toEqual([]);
+  });
+});

--- a/test/forge-issues-sync.test.js
+++ b/test/forge-issues-sync.test.js
@@ -15,6 +15,18 @@ describe('forge issue write sync', () => {
       fieldPaths: ['shared.title'],
     });
 
+    expect(createGitHubProjectionPlan('update', ['forge-1', '--title=Renamed'])).toEqual({
+      operation: 'update',
+      args: ['forge-1', '--title=Renamed'],
+      fieldPaths: ['shared.title'],
+    });
+
+    expect(createGitHubProjectionPlan('update', ['forge-1', '--labels=bug,triage'])).toEqual({
+      operation: 'update',
+      args: ['forge-1', '--labels=bug,triage'],
+      fieldPaths: ['shared.labels'],
+    });
+
     expect(createGitHubProjectionPlan('update', ['forge-1', '--claim'])).toEqual({
       operation: 'update',
       args: ['forge-1', '--claim'],

--- a/test/issue-sync/authority.test.js
+++ b/test/issue-sync/authority.test.js
@@ -1,0 +1,56 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+  getFieldAuthority,
+  isCacheField,
+  isForgeOwnedField,
+  isGitHubOwnedField,
+  isSharedField,
+} = require('../../lib/issue-sync/authority.js');
+
+describe('shared issue authority', () => {
+  test('maps shared identity and state fields to GitHub authority', () => {
+    expect(getFieldAuthority('github.number')).toBe('github');
+    expect(getFieldAuthority('github.nodeId')).toBe('github');
+    expect(getFieldAuthority('github.url')).toBe('github');
+    expect(getFieldAuthority('shared.title')).toBe('github');
+    expect(getFieldAuthority('shared.body')).toBe('github');
+    expect(getFieldAuthority('shared.state')).toBe('github');
+    expect(getFieldAuthority('shared.assignees')).toBe('github');
+    expect(getFieldAuthority('shared.labels')).toBe('github');
+    expect(getFieldAuthority('shared.milestone')).toBe('github');
+    expect(isGitHubOwnedField('shared.title')).toBe(true);
+    expect(isSharedField('shared.labels')).toBe(true);
+  });
+
+  test('maps workflow and bookkeeping fields to Forge authority', () => {
+    expect(getFieldAuthority('forge.issueId')).toBe('forge');
+    expect(getFieldAuthority('forge.dependencies')).toBe('forge');
+    expect(getFieldAuthority('forge.parentId')).toBe('forge');
+    expect(getFieldAuthority('forge.childIds')).toBe('forge');
+    expect(getFieldAuthority('forge.workflowStage')).toBe('forge');
+    expect(getFieldAuthority('forge.acceptanceCriteria')).toBe('forge');
+    expect(getFieldAuthority('forge.progressNotes')).toBe('forge');
+    expect(getFieldAuthority('forge.stageTransitions')).toBe('forge');
+    expect(getFieldAuthority('forge.decisions')).toBe('forge');
+    expect(getFieldAuthority('forge.memory')).toBe('forge');
+    expect(getFieldAuthority('sync.remoteUpdatedAt')).toBe('forge');
+    expect(getFieldAuthority('sync.pendingOutbound')).toBe('forge');
+    expect(getFieldAuthority('sync.drift')).toBe('forge');
+    expect(isForgeOwnedField('forge.dependencies')).toBe(true);
+    expect(isForgeOwnedField('sync.pendingOutbound')).toBe(true);
+  });
+
+  test('maps cache sections separately and returns null for unknown paths', () => {
+    expect(getFieldAuthority('cache.githubSnapshot')).toBe('cache');
+    expect(getFieldAuthority('cache.materializedIssue')).toBe('cache');
+    expect(getFieldAuthority('cache.legacyLinkHints.mapping')).toBe('cache');
+    expect(getFieldAuthority('cache.legacyLinkHints.githubIssue')).toBe('cache');
+    expect(getFieldAuthority('cache.legacyLinkHints.syncComments')).toBe('cache');
+    expect(getFieldAuthority('cache.legacyLinkHints.externalRef')).toBe('cache');
+    expect(getFieldAuthority('cache.legacyLinkHints.descriptionUrl')).toBe('cache');
+    expect(isCacheField('cache.legacyLinkHints.externalRef')).toBe(true);
+    expect(getFieldAuthority('shared.unknown')).toBeNull();
+    expect(getFieldAuthority('unknown.path')).toBeNull();
+  });
+});

--- a/test/issue-sync/authority.test.js
+++ b/test/issue-sync/authority.test.js
@@ -19,7 +19,9 @@ describe('shared issue authority', () => {
     expect(getFieldAuthority('shared.assignees')).toBe('github');
     expect(getFieldAuthority('shared.labels')).toBe('github');
     expect(getFieldAuthority('shared.milestone')).toBe('github');
+    expect(getFieldAuthority('sync.remoteUpdatedAt')).toBe('github');
     expect(isGitHubOwnedField('shared.title')).toBe(true);
+    expect(isGitHubOwnedField('sync.remoteUpdatedAt')).toBe(true);
     expect(isSharedField('shared.labels')).toBe(true);
   });
 
@@ -34,7 +36,6 @@ describe('shared issue authority', () => {
     expect(getFieldAuthority('forge.stageTransitions')).toBe('forge');
     expect(getFieldAuthority('forge.decisions')).toBe('forge');
     expect(getFieldAuthority('forge.memory')).toBe('forge');
-    expect(getFieldAuthority('sync.remoteUpdatedAt')).toBe('forge');
     expect(getFieldAuthority('sync.pendingOutbound')).toBe('forge');
     expect(getFieldAuthority('sync.drift')).toBe('forge');
     expect(isForgeOwnedField('forge.dependencies')).toBe(true);

--- a/test/issue-sync/github-pull.test.js
+++ b/test/issue-sync/github-pull.test.js
@@ -1,0 +1,51 @@
+const { describe, expect, test } = require('bun:test');
+
+const { normalizeRemoteIssue } = require('../../lib/issue-sync/github-pull.js');
+
+describe('github pull normalization', () => {
+  test('normalizes a GitHub issue payload into shared record inputs', () => {
+    const normalized = normalizeRemoteIssue({
+      number: 42,
+      node_id: 'I_kwDOForge42',
+      html_url: 'https://github.com/acme/forge/issues/42',
+      title: 'Canonical title',
+      body: 'Canonical body',
+      state: 'closed',
+      assignee: {
+        login: 'octocat',
+      },
+      assignees: [
+        { login: 'octocat' },
+        { login: 'hubot' },
+      ],
+      labels: [
+        { name: 'sync' },
+        { name: 'priority' },
+      ],
+      milestone: {
+        title: 'v2.0',
+      },
+      updated_at: '2026-04-24T10:00:00Z',
+      state_reason: 'completed',
+    });
+
+    expect(normalized).toEqual({
+      github: {
+        number: 42,
+        nodeId: 'I_kwDOForge42',
+        url: 'https://github.com/acme/forge/issues/42',
+      },
+      shared: {
+        title: 'Canonical title',
+        body: 'Canonical body',
+        state: 'closed',
+        assignees: ['octocat', 'hubot'],
+        labels: ['sync', 'priority'],
+        milestone: 'v2.0',
+      },
+      sync: {
+        remoteUpdatedAt: '2026-04-24T10:00:00Z',
+      },
+    });
+  });
+});

--- a/test/issue-sync/github-pull.test.js
+++ b/test/issue-sync/github-pull.test.js
@@ -79,4 +79,42 @@ describe('github pull normalization', () => {
       },
     });
   });
+
+  test('normalizes GraphQL connection-shaped assignees and labels', () => {
+    const normalized = normalizeRemoteIssue({
+      number: 77,
+      assignees: {
+        edges: [
+          { node: { login: 'octocat' } },
+          { node: { login: 'hubot' } },
+        ],
+      },
+      labels: {
+        nodes: [
+          { name: 'sync' },
+          { name: 'sync' },
+          { name: 'import' },
+        ],
+      },
+    });
+
+    expect(normalized).toEqual({
+      github: {
+        number: 77,
+        nodeId: null,
+        url: null,
+      },
+      shared: {
+        title: '',
+        body: '',
+        state: 'open',
+        assignees: ['octocat', 'hubot'],
+        labels: ['sync', 'import'],
+        milestone: null,
+      },
+      sync: {
+        remoteUpdatedAt: null,
+      },
+    });
+  });
 });

--- a/test/issue-sync/github-pull.test.js
+++ b/test/issue-sync/github-pull.test.js
@@ -48,4 +48,35 @@ describe('github pull normalization', () => {
       },
     });
   });
+
+  test('ignores API URLs and handles partial payloads gracefully', () => {
+    const normalized = normalizeRemoteIssue({
+      number: 42,
+      node_id: 'I_kwDOForge42',
+      url: 'https://api.github.com/repos/acme/forge/issues/42',
+      assignee: {
+        login: 'octocat',
+      },
+      labels: [],
+    });
+
+    expect(normalized).toEqual({
+      github: {
+        number: 42,
+        nodeId: 'I_kwDOForge42',
+        url: null,
+      },
+      shared: {
+        title: '',
+        body: '',
+        state: 'open',
+        assignees: ['octocat'],
+        labels: [],
+        milestone: null,
+      },
+      sync: {
+        remoteUpdatedAt: null,
+      },
+    });
+  });
 });

--- a/test/issue-sync/github-pull.test.js
+++ b/test/issue-sync/github-pull.test.js
@@ -80,9 +80,11 @@ describe('github pull normalization', () => {
     });
   });
 
-  test('normalizes GraphQL connection-shaped assignees and labels', () => {
+  test('normalizes GraphQL identity plus connection-shaped assignees and labels', () => {
     const normalized = normalizeRemoteIssue({
       number: 77,
+      id: 'I_kwDOForge77',
+      url: 'https://github.com/acme/forge/issues/77',
       assignees: {
         edges: [
           { node: { login: 'octocat' } },
@@ -101,8 +103,8 @@ describe('github pull normalization', () => {
     expect(normalized).toEqual({
       github: {
         number: 77,
-        nodeId: null,
-        url: null,
+        nodeId: 'I_kwDOForge77',
+        url: 'https://github.com/acme/forge/issues/77',
       },
       shared: {
         title: '',

--- a/test/issue-sync/import-primitives.test.js
+++ b/test/issue-sync/import-primitives.test.js
@@ -1,14 +1,14 @@
-import { describe, test, expect } from 'bun:test';
+const { describe, test, expect } = require('bun:test');
 
-import { buildSharedIssueRecord } from '../../lib/issue-sync/schema.js';
-import { createLinkStore } from '../../lib/issue-sync/link-store.js';
-import { reconcileSharedIssueRecord } from '../../lib/issue-sync/reconcile.js';
-import {
+const { buildSharedIssueRecord } = require('../../lib/issue-sync/schema.js');
+const { createLinkStore } = require('../../lib/issue-sync/link-store.js');
+const { reconcileSharedIssueRecord } = require('../../lib/issue-sync/reconcile.js');
+const {
   listRemoteIssues,
   normalizeRemoteIssue,
   resolveSharedLink,
   materializeLocalIssue,
-} from '../../lib/issue-sync/import-primitives.js';
+} = require('../../lib/issue-sync/import-primitives.js');
 
 describe('import primitives', () => {
   test('normalize and materialize a remote GitHub issue page through the steady-state reconciliation path', () => {

--- a/test/issue-sync/import-primitives.test.js
+++ b/test/issue-sync/import-primitives.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'bun:test';
+
+import { buildSharedIssueRecord } from '../../lib/issue-sync/schema.js';
+import { createLinkStore } from '../../lib/issue-sync/link-store.js';
+import { reconcileSharedIssueRecord } from '../../lib/issue-sync/reconcile.js';
+import {
+  listRemoteIssues,
+  normalizeRemoteIssue,
+  resolveSharedLink,
+  materializeLocalIssue,
+} from '../../lib/issue-sync/import-primitives.js';
+
+describe('import primitives', () => {
+  test('normalize and materialize a remote GitHub issue page through the steady-state reconciliation path', () => {
+    const remotePage = {
+      nodes: [
+        {
+          number: 42,
+          node_id: 'MDU6SXNzdWUxMjM0NTY=',
+          html_url: 'https://github.com/acme/repo/issues/42',
+          title: 'Import existing issue',
+          body: 'Imported from GitHub',
+          state: 'open',
+          assignees: [{ login: 'octocat' }],
+          labels: [{ name: 'bug' }, { name: 'triaged' }],
+          milestone: { title: 'v1' },
+          updated_at: '2026-04-24T10:00:00Z',
+        },
+      ],
+    };
+
+    const remoteIssues = listRemoteIssues(remotePage);
+    expect(remoteIssues).toHaveLength(1);
+    expect(remoteIssues[0].number).toBe(42);
+
+    const normalizedRemoteIssue = normalizeRemoteIssue(remoteIssues[0]);
+    expect(normalizedRemoteIssue.github.number).toBe(42);
+    expect(normalizedRemoteIssue.shared.title).toBe('Import existing issue');
+    expect(normalizedRemoteIssue.shared.assignees).toEqual(['octocat']);
+
+    const linkStore = createLinkStore([
+      {
+        forgeIssueId: 'forge-123',
+        github: {
+          nodeId: 'MDU6SXNzdWUxMjM0NTY=',
+          number: 42,
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+      },
+    ]);
+
+    const resolvedLink = resolveSharedLink(linkStore, normalizedRemoteIssue);
+    expect(resolvedLink?.forgeIssueId).toBe('forge-123');
+
+    const localRecord = buildSharedIssueRecord({
+      forge: {
+        issueId: 'forge-123',
+        workflowStage: 'in_progress',
+        progressNotes: ['keep me'],
+      },
+    });
+
+    const imported = materializeLocalIssue(localRecord, normalizedRemoteIssue, linkStore);
+    const steadyState = reconcileSharedIssueRecord(localRecord, normalizedRemoteIssue);
+
+    expect(imported.link?.forgeIssueId).toBe('forge-123');
+    expect(imported.diagnostics).toEqual(steadyState.diagnostics);
+    expect(imported.record).toEqual(steadyState.record);
+    expect(imported.record.cache.githubSnapshot).toEqual(normalizedRemoteIssue);
+    expect(imported.record.cache.materializedIssue).toEqual(steadyState.record.cache.materializedIssue);
+  });
+});

--- a/test/issue-sync/legacy-link-bridge.test.js
+++ b/test/issue-sync/legacy-link-bridge.test.js
@@ -16,12 +16,14 @@ describe('legacy link bridge', () => {
       mapping: {
         forgeIssueId: 'forge-nlgg',
         githubNumber: 42,
+        githubNodeId: 'I_kwDOForge42Primary',
       },
       githubIssue: 42,
       syncComments: [
         {
           beadsId: 'forge-nlgg',
           githubNumber: 42,
+          githubNodeId: 'I_kwDOForge42Stale',
           body: 'Synced as gh-42',
         },
         {
@@ -37,14 +39,24 @@ describe('legacy link bridge', () => {
     expect(result.link).toEqual({
       forgeIssueId: 'forge-nlgg',
       github: {
-        nodeId: null,
+        nodeId: 'I_kwDOForge42Primary',
         number: 42,
         url: 'https://github.com/acme/forge/issues/42',
       },
       sources: [
-        { source: 'mapping', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+        {
+          source: 'mapping',
+          githubNumber: 42,
+          githubNodeId: 'I_kwDOForge42Primary',
+          forgeIssueId: 'forge-nlgg',
+        },
         { source: 'githubIssue', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
-        { source: 'syncComment', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+        {
+          source: 'syncComment',
+          githubNumber: 42,
+          githubNodeId: 'I_kwDOForge42Stale',
+          forgeIssueId: 'forge-nlgg',
+        },
         { source: 'syncComment', githubNumber: 77, forgeIssueId: 'forge-nlgg' },
         { source: 'externalRef', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
         {
@@ -55,6 +67,14 @@ describe('legacy link bridge', () => {
         },
       ],
       diagnostics: [
+        {
+          type: 'legacy-link-drift',
+          field: 'github.nodeId',
+          selected: { source: 'mapping', value: 'I_kwDOForge42Primary' },
+          conflicts: [
+            { source: 'syncComment', value: 'I_kwDOForge42Stale' },
+          ],
+        },
         {
           type: 'legacy-link-drift',
           field: 'github.number',

--- a/test/issue-sync/legacy-link-bridge.test.js
+++ b/test/issue-sync/legacy-link-bridge.test.js
@@ -9,16 +9,29 @@ const { bridgeLegacyLinkHints } = require('../../lib/issue-sync/legacy-link-brid
 
 describe('legacy link bridge', () => {
   test('collapses conflicting legacy hints into one canonical record and drift diagnostic', () => {
-    const store = createLinkStore();
+    const store = createLinkStore([
+      {
+        forgeIssueId: 'forge-nlgg',
+        github: {
+          nodeId: 'I_kwDOForge41Existing',
+          number: 41,
+          url: 'https://github.com/acme/forge/issues/41',
+        },
+      },
+    ]);
 
     const result = bridgeLegacyLinkHints({
       forgeIssueId: 'forge-nlgg',
-      mapping: {
-        forgeIssueId: 'forge-nlgg',
-        githubNumber: 42,
-        githubNodeId: 'I_kwDOForge42Primary',
+      github: {
+        nodeId: 'I_kwDOForge42Primary',
+        number: 42,
+        url: 'https://github.com/acme/forge/issues/42',
       },
-      githubIssue: 42,
+      mapping: {
+        42: 'forge-nlgg',
+        7: 'forge-other',
+      },
+      github_issue: 42,
       syncComments: [
         {
           beadsId: 'forge-nlgg',
@@ -45,9 +58,15 @@ describe('legacy link bridge', () => {
       },
       sources: [
         {
-          source: 'mapping',
+          source: 'githubNodeId',
           githubNumber: 42,
           githubNodeId: 'I_kwDOForge42Primary',
+          forgeIssueId: 'forge-nlgg',
+          url: 'https://github.com/acme/forge/issues/42',
+        },
+        {
+          source: 'mapping',
+          githubNumber: 42,
           forgeIssueId: 'forge-nlgg',
         },
         { source: 'githubIssue', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
@@ -70,16 +89,18 @@ describe('legacy link bridge', () => {
         {
           type: 'legacy-link-drift',
           field: 'github.nodeId',
-          selected: { source: 'mapping', value: 'I_kwDOForge42Primary' },
+          selected: { source: 'githubNodeId', value: 'I_kwDOForge42Primary' },
           conflicts: [
+            { source: 'existing', value: 'I_kwDOForge41Existing' },
             { source: 'syncComment', value: 'I_kwDOForge42Stale' },
           ],
         },
         {
           type: 'legacy-link-drift',
           field: 'github.number',
-          selected: { source: 'externalRef', value: 42 },
+          selected: { source: 'githubNodeId', value: 42 },
           conflicts: [
+            { source: 'existing', value: 41 },
             { source: 'syncComment', value: 77 },
             { source: 'descriptionUrl', value: 99 },
           ],
@@ -89,6 +110,7 @@ describe('legacy link bridge', () => {
     expect(result.diagnostics).toEqual(result.link.diagnostics);
     expect(listCanonicalLinks(store)).toHaveLength(1);
     expect(resolveCanonicalLink(store, { forgeIssueId: 'forge-nlgg' })).toEqual(result.link);
+    expect(resolveCanonicalLink(store, { githubNodeId: 'I_kwDOForge42Primary' })).toEqual(result.link);
     expect(resolveCanonicalLink(store, { githubNumber: 42 })).toEqual(result.link);
   });
 });

--- a/test/issue-sync/legacy-link-bridge.test.js
+++ b/test/issue-sync/legacy-link-bridge.test.js
@@ -8,6 +8,52 @@ const {
 const { bridgeLegacyLinkHints } = require('../../lib/issue-sync/legacy-link-bridge.js');
 
 describe('legacy link bridge', () => {
+  test('hydrates one canonical record per legacy mapping entry when seeded from mapping only', () => {
+    const store = createLinkStore();
+
+    const result = bridgeLegacyLinkHints({
+      mapping: {
+        7: 'forge-seven',
+        42: 'forge-forty-two',
+      },
+    }, { store });
+
+    expect(result.links).toHaveLength(2);
+    expect(listCanonicalLinks(store)).toHaveLength(2);
+    expect(resolveCanonicalLink(store, { githubNumber: 7 })).toEqual({
+      forgeIssueId: 'forge-seven',
+      github: {
+        nodeId: null,
+        number: 7,
+        url: null,
+      },
+      sources: [
+        {
+          source: 'mapping',
+          forgeIssueId: 'forge-seven',
+          githubNumber: 7,
+        },
+      ],
+      diagnostics: [],
+    });
+    expect(resolveCanonicalLink(store, { forgeIssueId: 'forge-forty-two' })).toEqual({
+      forgeIssueId: 'forge-forty-two',
+      github: {
+        nodeId: null,
+        number: 42,
+        url: null,
+      },
+      sources: [
+        {
+          source: 'mapping',
+          forgeIssueId: 'forge-forty-two',
+          githubNumber: 42,
+        },
+      ],
+      diagnostics: [],
+    });
+  });
+
   test('collapses conflicting legacy hints into one canonical record and drift diagnostic', () => {
     const store = createLinkStore([
       {
@@ -112,5 +158,21 @@ describe('legacy link bridge', () => {
     expect(resolveCanonicalLink(store, { forgeIssueId: 'forge-nlgg' })).toEqual(result.link);
     expect(resolveCanonicalLink(store, { githubNodeId: 'I_kwDOForge42Primary' })).toEqual(result.link);
     expect(resolveCanonicalLink(store, { githubNumber: 42 })).toEqual(result.link);
+  });
+
+  test('does not synthesize a canonical url from an unrelated repository template', () => {
+    const store = createLinkStore();
+
+    const result = bridgeLegacyLinkHints({
+      forgeIssueId: 'forge-nlgg',
+      mapping: 42,
+      description: 'Linked issue: https://github.com/other/repo/issues/7',
+    }, { store });
+
+    expect(result.link.github).toEqual({
+      nodeId: null,
+      number: 42,
+      url: null,
+    });
   });
 });

--- a/test/issue-sync/legacy-link-bridge.test.js
+++ b/test/issue-sync/legacy-link-bridge.test.js
@@ -1,0 +1,74 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+  createLinkStore,
+  listCanonicalLinks,
+  resolveCanonicalLink,
+} = require('../../lib/issue-sync/link-store.js');
+const { bridgeLegacyLinkHints } = require('../../lib/issue-sync/legacy-link-bridge.js');
+
+describe('legacy link bridge', () => {
+  test('collapses conflicting legacy hints into one canonical record and drift diagnostic', () => {
+    const store = createLinkStore();
+
+    const result = bridgeLegacyLinkHints({
+      forgeIssueId: 'forge-nlgg',
+      mapping: {
+        forgeIssueId: 'forge-nlgg',
+        githubNumber: 42,
+      },
+      githubIssue: 42,
+      syncComments: [
+        {
+          beadsId: 'forge-nlgg',
+          githubNumber: 42,
+          body: 'Synced as gh-42',
+        },
+        {
+          beadsId: 'forge-nlgg',
+          githubNumber: 77,
+          body: 'Stale sync marker gh-77',
+        },
+      ],
+      externalRef: 'gh-42',
+      description: 'Linked issue: https://github.com/acme/forge/issues/99',
+    }, { store });
+
+    expect(result.link).toEqual({
+      forgeIssueId: 'forge-nlgg',
+      github: {
+        nodeId: null,
+        number: 42,
+        url: 'https://github.com/acme/forge/issues/42',
+      },
+      sources: [
+        { source: 'mapping', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+        { source: 'githubIssue', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+        { source: 'syncComment', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+        { source: 'syncComment', githubNumber: 77, forgeIssueId: 'forge-nlgg' },
+        { source: 'externalRef', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+        {
+          source: 'descriptionUrl',
+          githubNumber: 99,
+          forgeIssueId: 'forge-nlgg',
+          url: 'https://github.com/acme/forge/issues/99',
+        },
+      ],
+      diagnostics: [
+        {
+          type: 'legacy-link-drift',
+          field: 'github.number',
+          selected: { source: 'externalRef', value: 42 },
+          conflicts: [
+            { source: 'syncComment', value: 77 },
+            { source: 'descriptionUrl', value: 99 },
+          ],
+        },
+      ],
+    });
+    expect(result.diagnostics).toEqual(result.link.diagnostics);
+    expect(listCanonicalLinks(store)).toHaveLength(1);
+    expect(resolveCanonicalLink(store, { forgeIssueId: 'forge-nlgg' })).toEqual(result.link);
+    expect(resolveCanonicalLink(store, { githubNumber: 42 })).toEqual(result.link);
+  });
+});

--- a/test/issue-sync/link-store.test.js
+++ b/test/issue-sync/link-store.test.js
@@ -1,0 +1,27 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+  createLinkStore,
+  listCanonicalLinks,
+  resolveCanonicalLink,
+  upsertCanonicalLink,
+} = require('../../lib/issue-sync/link-store.js');
+
+describe('canonical link store', () => {
+  test('resolves one link by Forge issue ID, GitHub node ID, and GitHub number', () => {
+    const store = createLinkStore();
+    const link = upsertCanonicalLink(store, {
+      forgeIssueId: 'forge-nlgg',
+      github: {
+        nodeId: 'I_kwDOForge42',
+        number: 42,
+        url: 'https://github.com/acme/forge/issues/42',
+      },
+    });
+
+    expect(resolveCanonicalLink(store, { forgeIssueId: 'forge-nlgg' })).toEqual(link);
+    expect(resolveCanonicalLink(store, { githubNodeId: 'I_kwDOForge42' })).toEqual(link);
+    expect(resolveCanonicalLink(store, { githubNumber: 42 })).toEqual(link);
+    expect(listCanonicalLinks(store)).toEqual([link]);
+  });
+});

--- a/test/issue-sync/link-store.test.js
+++ b/test/issue-sync/link-store.test.js
@@ -24,4 +24,69 @@ describe('canonical link store', () => {
     expect(resolveCanonicalLink(store, { githubNumber: 42 })).toEqual(link);
     expect(listCanonicalLinks(store)).toEqual([link]);
   });
+
+  test('prefers the incoming canonical identity when collapsing duplicate records', () => {
+    const store = createLinkStore();
+    const forgeRecord = {
+      forgeIssueId: 'forge-nlgg',
+      github: {
+        nodeId: 'I_kwDOForge42Primary',
+        number: null,
+        url: 'https://github.com/acme/forge/issues/42',
+      },
+      sources: [
+        { source: 'mapping', githubNodeId: 'I_kwDOForge42Primary', forgeIssueId: 'forge-nlgg' },
+      ],
+      diagnostics: [],
+    };
+    const numberRecord = {
+      forgeIssueId: null,
+      github: {
+        nodeId: 'I_kwDOForge42Stale',
+        number: 42,
+        url: 'https://github.com/acme/forge/issues/42?stale=1',
+      },
+      sources: [
+        { source: 'syncComment', githubNodeId: 'I_kwDOForge42Stale', githubNumber: 42 },
+      ],
+      diagnostics: [],
+    };
+
+    store.records.push(forgeRecord, numberRecord);
+    store.byForgeIssueId.set('forge-nlgg', forgeRecord);
+    store.byGitHubNodeId.set('I_kwDOForge42Primary', forgeRecord);
+    store.byGitHubNodeId.set('I_kwDOForge42Stale', numberRecord);
+    store.byGitHubNumber.set(42, numberRecord);
+
+    const link = upsertCanonicalLink(store, {
+      forgeIssueId: 'forge-nlgg',
+      github: {
+        nodeId: 'I_kwDOForge42Incoming',
+        number: 42,
+        url: 'https://github.com/acme/forge/issues/42?incoming=1',
+      },
+      sources: [
+        { source: 'externalRef', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+      ],
+    });
+
+    expect(link).toEqual({
+      forgeIssueId: 'forge-nlgg',
+      github: {
+        nodeId: 'I_kwDOForge42Incoming',
+        number: 42,
+        url: 'https://github.com/acme/forge/issues/42?incoming=1',
+      },
+      sources: [
+        { source: 'externalRef', githubNumber: 42, forgeIssueId: 'forge-nlgg' },
+        { source: 'mapping', githubNodeId: 'I_kwDOForge42Primary', forgeIssueId: 'forge-nlgg' },
+        { source: 'syncComment', githubNodeId: 'I_kwDOForge42Stale', githubNumber: 42 },
+      ],
+      diagnostics: [],
+    });
+    expect(listCanonicalLinks(store)).toEqual([link]);
+    expect(resolveCanonicalLink(store, { forgeIssueId: 'forge-nlgg' })).toEqual(link);
+    expect(resolveCanonicalLink(store, { githubNodeId: 'I_kwDOForge42Incoming' })).toEqual(link);
+    expect(resolveCanonicalLink(store, { githubNumber: 42 })).toEqual(link);
+  });
 });

--- a/test/issue-sync/reconcile.test.js
+++ b/test/issue-sync/reconcile.test.js
@@ -1,51 +1,69 @@
 const { describe, expect, test } = require('bun:test');
 
 const { normalizeRemoteIssue } = require('../../lib/issue-sync/github-pull.js');
-const { reconcileSharedIssueRecord } = require('../../lib/issue-sync/reconcile.js');
+const {
+  buildMaterializedIssueSnapshot,
+  createDriftDiagnostic,
+  deepEqual,
+  reconcileSharedIssueRecord,
+  readField,
+  writeField,
+} = require('../../lib/issue-sync/reconcile.js');
 const { buildSharedIssueRecord } = require('../../lib/issue-sync/schema.js');
+
+function buildBaseRecord() {
+  return buildSharedIssueRecord({
+    github: {
+      number: 42,
+      nodeId: 'I_kwDOForge42',
+      url: 'https://github.com/acme/forge/issues/42',
+    },
+    shared: {
+      title: 'Local title',
+      body: 'Local body',
+      state: 'open',
+      assignees: ['octocat'],
+      labels: ['sync'],
+      milestone: 'v2.0',
+    },
+    forge: {
+      issueId: 'forge-nlgg',
+      workflowStage: 'dev',
+      decisions: ['keep local decision'],
+    },
+    cache: {
+      githubSnapshot: {
+        shared: {
+          title: 'Local title',
+        },
+      },
+      materializedIssue: {
+        cache: {
+          materializedIssue: 'stale',
+        },
+      },
+    },
+    sync: {
+      remoteUpdatedAt: '2026-04-24T10:00:00Z',
+      lastPulledAt: '2026-04-23T09:05:00Z',
+      lastPushedAt: '2026-04-23T09:10:00Z',
+      pendingOutbound: ['shared.title'],
+      drift: [],
+    },
+  });
+}
 
 describe('shared issue reconciliation', () => {
   test('updates GitHub-owned fields while preserving Forge-owned workflow state', () => {
     const localRecord = buildSharedIssueRecord({
-      github: {
-        number: 42,
-        nodeId: 'I_kwDOForge42',
-        url: 'https://github.com/acme/forge/issues/42',
-      },
+      ...buildBaseRecord(),
       shared: {
+        ...buildBaseRecord().shared,
         title: 'Stale local title',
-        body: 'Canonical body',
         state: 'closed',
-        assignees: ['octocat'],
-        labels: ['sync'],
-        milestone: 'v2.0',
-      },
-      forge: {
-        issueId: 'forge-nlgg',
-        workflowStage: 'dev',
-        dependencies: ['forge-alpha'],
-        progressNotes: ['keep me'],
-        stageTransitions: [{ stage: 'dev', at: '2026-04-23T09:00:00Z' }],
-        decisions: ['keep local decision'],
-        memory: ['local memory'],
-      },
-      cache: {
-        githubSnapshot: {
-          shared: {
-            title: 'Stale local title',
-          },
-        },
-        materializedIssue: {
-          forge: {
-            workflowStage: 'dev',
-          },
-        },
       },
       sync: {
-        remoteUpdatedAt: '2026-04-24T10:00:00Z',
-        lastPulledAt: '2026-04-23T09:05:00Z',
-        lastPushedAt: '2026-04-23T09:10:00Z',
-        pendingOutbound: ['shared.title'],
+        ...buildBaseRecord().sync,
         drift: [{ type: 'previous-drift' }],
       },
     });
@@ -55,7 +73,7 @@ describe('shared issue reconciliation', () => {
       node_id: 'I_kwDOForge42',
       html_url: 'https://github.com/acme/forge/issues/42',
       title: 'Canonical GitHub title',
-      body: 'Canonical body',
+      body: 'Local body',
       state: 'closed',
       assignees: [{ login: 'octocat' }],
       labels: [{ name: 'sync' }],
@@ -72,7 +90,7 @@ describe('shared issue reconciliation', () => {
     });
     expect(result.record.shared).toEqual({
       title: 'Canonical GitHub title',
-      body: 'Canonical body',
+      body: 'Local body',
       state: 'closed',
       assignees: ['octocat'],
       labels: ['sync'],
@@ -114,5 +132,173 @@ describe('shared issue reconciliation', () => {
       },
     });
     expect(result.record.cache.materializedIssue.cache.materializedIssue).toBeNull();
+  });
+
+  test('deepEqual compares nested arrays and objects', () => {
+    expect(deepEqual(
+      { shared: { labels: ['sync', { name: 'triage' }] } },
+      { shared: { labels: ['sync', { name: 'triage' }] } },
+    )).toBe(true);
+    expect(deepEqual(
+      { shared: { labels: ['sync', { name: 'triage' }] } },
+      { shared: { labels: ['sync', { name: 'bug' }] } },
+    )).toBe(false);
+    expect(deepEqual(['sync', 'triage'], ['sync', 'triage'])).toBe(true);
+    expect(deepEqual(['sync'], ['triage'])).toBe(false);
+    expect(deepEqual('forge', 'forge')).toBe(true);
+    expect(deepEqual('forge', 'sync')).toBe(false);
+  });
+
+  test('readField and writeField cover all GitHub-owned field paths', () => {
+    const cases = [
+      ['github.number', 42, 7],
+      ['github.nodeId', 'I_kwDOForge42', 'I_kwDOForge7'],
+      ['github.url', 'https://github.com/acme/forge/issues/42', 'https://github.com/acme/forge/issues/7'],
+      ['shared.title', 'Local title', 'Updated title'],
+      ['shared.body', 'Local body', 'Updated body'],
+      ['shared.state', 'open', 'closed'],
+      ['shared.assignees', ['octocat'], ['hubot']],
+      ['shared.labels', ['sync'], ['bug']],
+      ['shared.milestone', 'v2.0', 'v3.0'],
+      ['sync.remoteUpdatedAt', '2026-04-24T10:00:00Z', '2026-04-25T10:00:00Z'],
+    ];
+
+    for (const [fieldPath, initialValue, nextValue] of cases) {
+      const record = buildBaseRecord();
+      expect(readField(record, fieldPath)).toEqual(initialValue);
+      writeField(record, fieldPath, nextValue);
+      expect(readField(record, fieldPath)).toEqual(nextValue);
+    }
+
+    const record = buildBaseRecord();
+    expect(readField(record, 'unknown.field')).toBeUndefined();
+    writeField(record, 'unknown.field', 'ignored');
+    expect(record).toEqual(buildBaseRecord());
+  });
+
+  test('createDriftDiagnostic clones nested values', () => {
+    const localValue = { labels: ['sync'] };
+    const remoteValue = { labels: ['bug'] };
+
+    const diagnostic = createDriftDiagnostic('shared.labels', localValue, remoteValue);
+
+    localValue.labels.push('triage');
+    remoteValue.labels.push('priority');
+
+    expect(diagnostic).toEqual({
+      type: 'github-shared-drift',
+      field: 'shared.labels',
+      localValue: { labels: ['sync'] },
+      remoteValue: { labels: ['bug'] },
+    });
+  });
+
+  test('buildMaterializedIssueSnapshot clones the record and clears nested materializedIssue', () => {
+    const record = buildBaseRecord();
+
+    const snapshot = buildMaterializedIssueSnapshot(record);
+    snapshot.shared.title = 'Changed in snapshot';
+
+    expect(snapshot.cache.materializedIssue).toBeNull();
+    expect(record.cache.materializedIssue).toEqual({
+      cache: {
+        materializedIssue: 'stale',
+      },
+    });
+    expect(record.shared.title).toBe('Local title');
+  });
+
+  test('preserves the local remoteUpdatedAt watermark when requested', () => {
+    const result = reconcileSharedIssueRecord(
+      buildBaseRecord(),
+      normalizeRemoteIssue({
+        number: 42,
+        node_id: 'I_kwDOForge42',
+        html_url: 'https://github.com/acme/forge/issues/42',
+        title: 'Local title',
+        body: 'Local body',
+        labels: [{ name: 'sync' }],
+        assignees: [{ login: 'octocat' }],
+        milestone: { title: 'v2.0' },
+        updated_at: '2026-04-25T12:00:00Z',
+      }),
+      { preserveRemoteUpdatedAt: false },
+    );
+
+    expect(result.record.sync.remoteUpdatedAt).toBe('2026-04-24T10:00:00Z');
+  });
+
+  test('deduplicates repeated drift diagnostics', () => {
+    const duplicateDiagnostic = {
+      type: 'github-shared-drift',
+      field: 'shared.title',
+      localValue: 'Local title',
+      remoteValue: 'Canonical title',
+    };
+
+    const localRecord = buildSharedIssueRecord({
+      ...buildBaseRecord(),
+      sync: {
+        ...buildBaseRecord().sync,
+        drift: [duplicateDiagnostic],
+      },
+    });
+
+    const result = reconcileSharedIssueRecord(
+      localRecord,
+      normalizeRemoteIssue({
+        number: 42,
+        node_id: 'I_kwDOForge42',
+        html_url: 'https://github.com/acme/forge/issues/42',
+        title: 'Canonical title',
+        body: 'Local body',
+        labels: [{ name: 'sync' }],
+        assignees: [{ login: 'octocat' }],
+        milestone: { title: 'v2.0' },
+        updated_at: '2026-04-24T10:00:00Z',
+      }),
+    );
+
+    expect(result.record.sync.drift).toEqual([duplicateDiagnostic]);
+  });
+
+  test('caps drift history at the most recent 50 entries', () => {
+    const existingDrift = Array.from({ length: 60 }, (_, index) => ({
+      type: 'previous-drift',
+      field: `field-${index}`,
+    }));
+
+    const localRecord = buildSharedIssueRecord({
+      ...buildBaseRecord(),
+      sync: {
+        ...buildBaseRecord().sync,
+        drift: existingDrift,
+      },
+    });
+
+    const result = reconcileSharedIssueRecord(
+      localRecord,
+      normalizeRemoteIssue({
+        number: 42,
+        node_id: 'I_kwDOForge42',
+        html_url: 'https://github.com/acme/forge/issues/42',
+        title: 'Local title',
+        body: 'Local body',
+        labels: [{ name: 'sync' }],
+        assignees: [{ login: 'octocat' }],
+        milestone: { title: 'v2.0' },
+        updated_at: '2026-04-24T10:00:00Z',
+      }),
+    );
+
+    expect(result.record.sync.drift).toHaveLength(50);
+    expect(result.record.sync.drift[0]).toEqual({
+      type: 'previous-drift',
+      field: 'field-10',
+    });
+    expect(result.record.sync.drift.at(-1)).toEqual({
+      type: 'previous-drift',
+      field: 'field-59',
+    });
   });
 });

--- a/test/issue-sync/reconcile.test.js
+++ b/test/issue-sync/reconcile.test.js
@@ -1,0 +1,118 @@
+const { describe, expect, test } = require('bun:test');
+
+const { normalizeRemoteIssue } = require('../../lib/issue-sync/github-pull.js');
+const { reconcileSharedIssueRecord } = require('../../lib/issue-sync/reconcile.js');
+const { buildSharedIssueRecord } = require('../../lib/issue-sync/schema.js');
+
+describe('shared issue reconciliation', () => {
+  test('updates GitHub-owned fields while preserving Forge-owned workflow state', () => {
+    const localRecord = buildSharedIssueRecord({
+      github: {
+        number: 42,
+        nodeId: 'I_kwDOForge42',
+        url: 'https://github.com/acme/forge/issues/42',
+      },
+      shared: {
+        title: 'Stale local title',
+        body: 'Canonical body',
+        state: 'closed',
+        assignees: ['octocat'],
+        labels: ['sync'],
+        milestone: 'v2.0',
+      },
+      forge: {
+        issueId: 'forge-nlgg',
+        workflowStage: 'dev',
+        dependencies: ['forge-alpha'],
+        progressNotes: ['keep me'],
+        stageTransitions: [{ stage: 'dev', at: '2026-04-23T09:00:00Z' }],
+        decisions: ['keep local decision'],
+        memory: ['local memory'],
+      },
+      cache: {
+        githubSnapshot: {
+          shared: {
+            title: 'Stale local title',
+          },
+        },
+        materializedIssue: {
+          forge: {
+            workflowStage: 'dev',
+          },
+        },
+      },
+      sync: {
+        remoteUpdatedAt: '2026-04-24T10:00:00Z',
+        lastPulledAt: '2026-04-23T09:05:00Z',
+        lastPushedAt: '2026-04-23T09:10:00Z',
+        pendingOutbound: ['shared.title'],
+        drift: [{ type: 'previous-drift' }],
+      },
+    });
+
+    const remoteSnapshot = normalizeRemoteIssue({
+      number: 42,
+      node_id: 'I_kwDOForge42',
+      html_url: 'https://github.com/acme/forge/issues/42',
+      title: 'Canonical GitHub title',
+      body: 'Canonical body',
+      state: 'closed',
+      assignees: [{ login: 'octocat' }],
+      labels: [{ name: 'sync' }],
+      milestone: { title: 'v2.0' },
+      updated_at: '2026-04-24T10:00:00Z',
+    });
+
+    const result = reconcileSharedIssueRecord(localRecord, remoteSnapshot);
+
+    expect(result.record.github).toEqual({
+      number: 42,
+      nodeId: 'I_kwDOForge42',
+      url: 'https://github.com/acme/forge/issues/42',
+    });
+    expect(result.record.shared).toEqual({
+      title: 'Canonical GitHub title',
+      body: 'Canonical body',
+      state: 'closed',
+      assignees: ['octocat'],
+      labels: ['sync'],
+      milestone: 'v2.0',
+    });
+    expect(result.record.forge).toEqual(localRecord.forge);
+    expect(result.record.sync.remoteUpdatedAt).toBe('2026-04-24T10:00:00Z');
+    expect(result.record.sync.lastPulledAt).toBe('2026-04-23T09:05:00Z');
+    expect(result.record.sync.lastPushedAt).toBe('2026-04-23T09:10:00Z');
+    expect(result.record.sync.pendingOutbound).toEqual(['shared.title']);
+    expect(result.record.sync.drift).toEqual([
+      { type: 'previous-drift' },
+      {
+        type: 'github-shared-drift',
+        field: 'shared.title',
+        localValue: 'Stale local title',
+        remoteValue: 'Canonical GitHub title',
+      },
+    ]);
+    expect(result.diagnostics).toEqual([
+      {
+        type: 'github-shared-drift',
+        field: 'shared.title',
+        localValue: 'Stale local title',
+        remoteValue: 'Canonical GitHub title',
+      },
+    ]);
+    expect(result.record.cache.githubSnapshot).toEqual(remoteSnapshot);
+    expect(result.record.cache.materializedIssue).toMatchObject({
+      github: result.record.github,
+      shared: result.record.shared,
+      forge: localRecord.forge,
+      sync: {
+        remoteUpdatedAt: '2026-04-24T10:00:00Z',
+        lastPulledAt: '2026-04-23T09:05:00Z',
+        lastPushedAt: '2026-04-23T09:10:00Z',
+        pendingOutbound: ['shared.title'],
+        drift: result.record.sync.drift,
+      },
+    });
+    expect(result.record.cache.materializedIssue.cache.materializedIssue).toBeNull();
+  });
+});

--- a/test/issue-sync/schema.test.js
+++ b/test/issue-sync/schema.test.js
@@ -1,0 +1,94 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+  buildSharedIssueRecord,
+  createDefaultSharedIssueRecord,
+} = require('../../lib/issue-sync/schema.js');
+
+describe('shared issue schema', () => {
+  test('creates a normalized record with stable defaults', () => {
+    const record = createDefaultSharedIssueRecord();
+
+    expect(record).toEqual({
+      github: {
+        number: null,
+        nodeId: null,
+        url: null,
+      },
+      shared: {
+        title: '',
+        body: '',
+        state: 'open',
+        assignees: [],
+        labels: [],
+        milestone: null,
+      },
+      forge: {
+        issueId: null,
+        dependencies: [],
+        parentId: null,
+        childIds: [],
+        workflowStage: null,
+        acceptanceCriteria: [],
+        progressNotes: [],
+        stageTransitions: [],
+        decisions: [],
+        memory: [],
+      },
+      cache: {
+        githubSnapshot: null,
+        materializedIssue: null,
+        legacyLinkHints: {
+          mapping: null,
+          githubIssue: null,
+          syncComments: [],
+          externalRef: null,
+          descriptionUrl: null,
+        },
+      },
+      sync: {
+        remoteUpdatedAt: null,
+        lastPulledAt: null,
+        lastPushedAt: null,
+        pendingOutbound: [],
+        drift: [],
+      },
+    });
+  });
+
+  test('builds a normalized record while preserving section defaults', () => {
+    const record = buildSharedIssueRecord({
+      github: {
+        number: 42,
+        nodeId: 'I_kwDOG123',
+        url: 'https://github.com/acme/forge/issues/42',
+      },
+      shared: {
+        title: 'Shared title',
+        labels: ['sync'],
+      },
+      forge: {
+        issueId: 'forge-nlgg',
+        workflowStage: 'dev',
+      },
+      cache: {
+        legacyLinkHints: {
+          externalRef: 'gh-42',
+        },
+      },
+      sync: {
+        remoteUpdatedAt: '2026-04-24T10:00:00Z',
+      },
+    });
+
+    expect(record.github.number).toBe(42);
+    expect(record.shared.title).toBe('Shared title');
+    expect(record.shared.body).toBe('');
+    expect(record.forge.issueId).toBe('forge-nlgg');
+    expect(record.forge.dependencies).toEqual([]);
+    expect(record.cache.legacyLinkHints.externalRef).toBe('gh-42');
+    expect(record.cache.legacyLinkHints.mapping).toBeNull();
+    expect(record.sync.remoteUpdatedAt).toBe('2026-04-24T10:00:00Z');
+    expect(record.sync.pendingOutbound).toEqual([]);
+  });
+});

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { handleOpened, handleClosed } from '../../../scripts/github-beads-sync/index.mjs';
+import { readMapping } from '../../../scripts/github-beads-sync/mapping.mjs';
 
 function makeOpenedEvent(overrides = {}) {
   return {
@@ -73,11 +74,11 @@ function makeOptions(overrides = {}) {
     mappingPath: '/tmp/test-mapping.json',
     owner: 'testowner',
     repo: 'testrepo',
+    ...overrides,
     bd: makeMockBd(overrides.bd),
     github: makeMockGithub(overrides.github),
-    linkStore: makeMockLinkStore(overrides.linkStore),
+    linkStore: overrides.linkStore === null ? null : makeMockLinkStore(overrides.linkStore),
     mapping: makeMockMapping(overrides.mapping),
-    ...overrides,
   };
 }
 
@@ -199,6 +200,98 @@ describe('handleOpened', () => {
 
     try {
       expect(() => handleOpened(makeOpenedEvent(), options)).toThrow(`Failed to parse mapping file at ${mappingPath}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('persists canonical links into the legacy mapping file for default webhook runs', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'forge-nlgg-default-store-'));
+    const mappingPath = join(tempDir, 'beads-mapping.json');
+    const bdCloseCalls = [];
+
+    try {
+      const opened = await handleOpened(
+        makeOpenedEvent(),
+        {
+          ...makeOptions(),
+          mappingPath,
+          linkStore: null,
+          bd: makeMockBd({
+            bdCreate: () => 'forge-abc123',
+          }),
+          github: makeMockGithub({
+            createOrEditComment: () => {},
+          }),
+        },
+      );
+
+      expect(opened).toMatchObject({
+        success: true,
+        beadsId: 'forge-abc123',
+        issueNumber: 42,
+      });
+      expect(readMapping(mappingPath)).toEqual({
+        42: 'forge-abc123',
+      });
+
+      const closed = await handleClosed(
+        makeClosedEvent(),
+        {
+          ...makeOptions(),
+          mappingPath,
+          linkStore: null,
+          bd: makeMockBd({
+            bdShow: () => 'open',
+            bdClose: (id, reason) => {
+              bdCloseCalls.push({ id, reason });
+            },
+          }),
+        },
+      );
+
+      expect(closed).toMatchObject({
+        success: true,
+        beadsId: 'forge-abc123',
+        issueNumber: 42,
+      });
+      expect(bdCloseCalls).toEqual([
+        {
+          id: 'forge-abc123',
+          reason: 'Closed via GitHub issue #42',
+        },
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores partial injected link stores and falls back to the durable default store', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'forge-nlgg-partial-store-'));
+    const mappingPath = join(tempDir, 'beads-mapping.json');
+
+    try {
+      const result = await handleOpened(
+        makeOpenedEvent(),
+        {
+          ...makeOptions(),
+          mappingPath,
+          linkStore: {
+            resolveCanonicalLink: () => null,
+          },
+          bd: makeMockBd({
+            bdCreate: () => 'forge-abc123',
+          }),
+          github: makeMockGithub({
+            createOrEditComment: () => {},
+          }),
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(readMapping(mappingPath)).toEqual({
+        42: 'forge-abc123',
+      });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -234,7 +234,7 @@ describe('handleClosed', () => {
     expect(bdCloseCalls[0].reason).toContain('#42');
   });
 
-  it('fallback - no mapping, falls back to comment parsing', async () => {
+  it('skips when no canonical link exists even if a sync comment is present', async () => {
     const bdCloseCalls = [];
 
     const opts = makeOptions({
@@ -242,23 +242,21 @@ describe('handleClosed', () => {
         bdClose: (id, reason) => { bdCloseCalls.push({ id, reason }); },
         bdShow: () => 'open',
       },
-      mapping: {
-        getBeadsId: () => null,
-      },
       github: {
-        findSyncComment: () => ({
-          id: 999,
-          body: '<!-- beads-sync:42 -->\n**Beads:** `forge-fromcomment`',
-        }),
+        findSyncComment: () => {
+          throw new Error('sync comment lookup should not be consulted when canonical link is missing');
+        },
+      },
+      linkStore: {
+        resolveCanonicalLink: () => null,
       },
     });
 
     const result = await handleClosed(makeClosedEvent(), opts);
 
-    expect(result.success).toBe(true);
-    expect(result.beadsId).toBe('forge-fromcomment');
-    expect(bdCloseCalls).toHaveLength(1);
-    expect(bdCloseCalls[0].id).toBe('forge-fromcomment');
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no beads link found');
+    expect(bdCloseCalls).toHaveLength(0);
   });
 
   it('skips when no beads link found', async () => {

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { handleOpened, handleClosed } from '../../../scripts/github-beads-sync/index.mjs';
 
 function makeOpenedEvent(overrides = {}) {
@@ -182,6 +185,23 @@ describe('handleOpened', () => {
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('already synced (canonical link)');
     expect(result.beadsId).toBe('forge-existing');
+  });
+
+  it('throws when the legacy mapping file contains malformed JSON', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'forge-nlgg-'));
+    const mappingPath = join(tempDir, 'beads-mapping.json');
+    writeFileSync(mappingPath, '{"42":"forge-abc123"', 'utf8');
+    const options = {
+      ...makeOptions(),
+      mappingPath,
+      linkStore: null,
+    };
+
+    try {
+      expect(() => handleOpened(makeOpenedEvent(), options)).toThrow(`Failed to parse mapping file at ${mappingPath}`);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('skips unauthorized author with author_association gate', async () => {

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -467,6 +467,42 @@ describe('handleClosed', () => {
     ]);
   });
 
+  it('skips when the sync comment points at a different GitHub issue number', async () => {
+    const bdCloseCalls = [];
+    const upsertCanonicalLinkCalls = [];
+
+    const opts = makeOptions({
+      bd: {
+        bdClose: (id, reason) => { bdCloseCalls.push({ id, reason }); },
+        bdShow: () => 'open',
+      },
+      github: {
+        findSyncComment: () => ({
+          id: 7,
+          body: buildComment('forge-existing', 99, {
+            type: 'bug',
+            priority: 1,
+            externalRef: 'gh-99',
+          }),
+        }),
+      },
+      linkStore: {
+        resolveCanonicalLink: () => null,
+        upsertCanonicalLink: (record) => {
+          upsertCanonicalLinkCalls.push(record);
+          return record;
+        },
+      },
+    });
+
+    const result = await handleClosed(makeClosedEvent(), opts);
+
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no beads link found');
+    expect(upsertCanonicalLinkCalls).toHaveLength(0);
+    expect(bdCloseCalls).toHaveLength(0);
+  });
+
   it('skips when no beads link found', async () => {
     const result = await handleClosed(makeClosedEvent(), makeOptions({
       mapping: { getBeadsId: () => null },

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -156,7 +156,8 @@ describe('handleOpened', () => {
     expect(result.reason).toBe('no-beads in body');
   });
 
-  it('idempotent - canonical link store entry returns skip', async () => {
+  it('idempotent - canonical link store entry returns skip after repairing the sync comment', async () => {
+    const createOrEditCalls = [];
     const opts = makeOptions({
       linkStore: {
         resolveCanonicalLink: () => ({
@@ -173,8 +174,9 @@ describe('handleOpened', () => {
         setBeadsId: () => { throw new Error('legacy mapping should not be written when canonical link exists'); },
       },
       github: {
-        findSyncComment: () => { throw new Error('sync comment lookup should not be needed when canonical link exists'); },
-        createOrEditComment: () => { throw new Error('sync comment repair should not be needed when canonical link exists'); },
+        createOrEditComment: (owner, repo, num, body) => {
+          createOrEditCalls.push({ owner, repo, num, body });
+        },
       },
       bd: {
         bdCreate: () => { throw new Error('bdCreate should not be called for canonical duplicates'); },
@@ -186,6 +188,9 @@ describe('handleOpened', () => {
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('already synced (canonical link)');
     expect(result.beadsId).toBe('forge-existing');
+    expect(createOrEditCalls).toHaveLength(1);
+    expect(createOrEditCalls[0].num).toBe(42);
+    expect(createOrEditCalls[0].body).toContain('forge-existing');
   });
 
   it('throws when the legacy mapping file contains malformed JSON', () => {

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -414,8 +414,9 @@ describe('handleClosed', () => {
     expect(bdCloseCalls[0].reason).toContain('#42');
   });
 
-  it('skips when no canonical link exists even if a sync comment is present', async () => {
+  it('closes the beads issue when canonical link is missing but a sync comment is present', async () => {
     const bdCloseCalls = [];
+    const upsertCanonicalLinkCalls = [];
 
     const opts = makeOptions({
       bd: {
@@ -423,20 +424,47 @@ describe('handleClosed', () => {
         bdShow: () => 'open',
       },
       github: {
-        findSyncComment: () => {
-          throw new Error('sync comment lookup should not be consulted when canonical link is missing');
-        },
+        findSyncComment: () => ({
+          id: 7,
+          body: buildComment('forge-existing', 42, {
+            type: 'bug',
+            priority: 1,
+            externalRef: 'gh-42',
+          }),
+        }),
       },
       linkStore: {
         resolveCanonicalLink: () => null,
+        upsertCanonicalLink: (record) => {
+          upsertCanonicalLinkCalls.push(record);
+          return record;
+        },
       },
     });
 
     const result = await handleClosed(makeClosedEvent(), opts);
 
-    expect(result.skipped).toBe(true);
-    expect(result.reason).toBe('no beads link found');
-    expect(bdCloseCalls).toHaveLength(0);
+    expect(result).toMatchObject({
+      success: true,
+      beadsId: 'forge-existing',
+      issueNumber: 42,
+    });
+    expect(upsertCanonicalLinkCalls).toHaveLength(1);
+    expect(upsertCanonicalLinkCalls[0].forgeIssueId).toBe('forge-existing');
+    expect(upsertCanonicalLinkCalls[0].sources).toEqual([
+      {
+        source: 'syncComment',
+        forgeIssueId: 'forge-existing',
+        githubNumber: 42,
+        url: 'https://github.com/owner/repo/issues/42',
+      },
+    ]);
+    expect(bdCloseCalls).toEqual([
+      {
+        id: 'forge-existing',
+        reason: 'Closed via GitHub issue #42',
+      },
+    ]);
   });
 
   it('skips when no beads link found', async () => {

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -1,10 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import { handleOpened, handleClosed } from '../../../scripts/github-beads-sync/index.mjs';
 
-// ---------------------------------------------------------------------------
-// Helpers: fake event builders
-// ---------------------------------------------------------------------------
-
 function makeOpenedEvent(overrides = {}) {
   return {
     sender: { login: 'octocat' },
@@ -39,10 +35,6 @@ function makeClosedEvent(overrides = {}) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Helpers: mock dependency factories
-// ---------------------------------------------------------------------------
-
 function makeMockBd(overrides = {}) {
   return {
     bdCreate: overrides.bdCreate ?? (() => 'forge-abc123'),
@@ -65,6 +57,13 @@ function makeMockMapping(overrides = {}) {
   };
 }
 
+function makeMockLinkStore(overrides = {}) {
+  return {
+    resolveCanonicalLink: overrides.resolveCanonicalLink ?? (() => null),
+    upsertCanonicalLink: overrides.upsertCanonicalLink ?? (() => ({})),
+  };
+}
+
 function makeOptions(overrides = {}) {
   return {
     configPath: undefined,
@@ -73,18 +72,16 @@ function makeOptions(overrides = {}) {
     repo: 'testrepo',
     bd: makeMockBd(overrides.bd),
     github: makeMockGithub(overrides.github),
+    linkStore: makeMockLinkStore(overrides.linkStore),
     mapping: makeMockMapping(overrides.mapping),
     ...overrides,
   };
 }
 
-// ===========================================================================
-// handleOpened
-// ===========================================================================
 describe('handleOpened', () => {
-  it('happy path — creates beads issue, updates mapping, posts comment', async () => {
+  it('happy path - creates beads issue, upserts canonical link, posts comment', async () => {
     const bdCreateCalls = [];
-    const setBeadsIdCalls = [];
+    const upsertCanonicalLinkCalls = [];
     const createOrEditCalls = [];
 
     const opts = makeOptions({
@@ -95,168 +92,113 @@ describe('handleOpened', () => {
         findSyncComment: () => null,
         createOrEditComment: (ow, re, num, body) => { createOrEditCalls.push({ ow, re, num, body }); },
       },
+      linkStore: {
+        resolveCanonicalLink: () => null,
+        upsertCanonicalLink: (record) => { upsertCanonicalLinkCalls.push(record); return record; },
+      },
       mapping: {
-        getBeadsId: () => null,
-        setBeadsId: (p, num, id) => { setBeadsIdCalls.push({ p, num, id }); },
+        getBeadsId: () => { throw new Error('legacy mapping should not be consulted on canonical writes'); },
+        setBeadsId: () => { throw new Error('legacy mapping should not be written on canonical writes'); },
       },
     });
 
-    const event = makeOpenedEvent();
-    const result = await handleOpened(event, opts);
+    const result = await handleOpened(makeOpenedEvent(), opts);
 
     expect(result.success).toBe(true);
     expect(result.beadsId).toBe('forge-abc123');
     expect(result.issueNumber).toBe(42);
-
-    // bdCreate was called with sanitized title and mapped type/priority
-    expect(bdCreateCalls.length).toBe(1);
+    expect(bdCreateCalls).toHaveLength(1);
     expect(bdCreateCalls[0].title).toBe('Fix the thing');
     expect(bdCreateCalls[0].type).toBe('bug');
     expect(bdCreateCalls[0].priority).toBe(1);
     expect(bdCreateCalls[0].externalRef).toBe('gh-42');
-
-    // mapping updated
-    expect(setBeadsIdCalls.length).toBe(1);
-    expect(setBeadsIdCalls[0].num).toBe(42);
-    expect(setBeadsIdCalls[0].id).toBe('forge-abc123');
-
-    // comment posted
-    expect(createOrEditCalls.length).toBe(1);
+    expect(upsertCanonicalLinkCalls).toHaveLength(1);
+    expect(upsertCanonicalLinkCalls[0].forgeIssueId).toBe('forge-abc123');
+    expect(upsertCanonicalLinkCalls[0].github.number).toBe(42);
+    expect(createOrEditCalls).toHaveLength(1);
     expect(createOrEditCalls[0].num).toBe(42);
     expect(createOrEditCalls[0].body).toContain('forge-abc123');
   });
 
   it('skips bot actor (contains [bot])', async () => {
-    const event = makeOpenedEvent({ sender: { login: 'dependabot[bot]' } });
-    const result = await handleOpened(event, makeOptions());
+    const result = await handleOpened(makeOpenedEvent({ sender: { login: 'dependabot[bot]' } }), makeOptions());
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('bot actor');
   });
 
   it('skips bot actor (github-actions)', async () => {
-    const event = makeOpenedEvent({ sender: { login: 'github-actions' } });
-    const result = await handleOpened(event, makeOptions());
+    const result = await handleOpened(makeOpenedEvent({ sender: { login: 'github-actions' } }), makeOptions());
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('bot actor');
   });
 
   it('skips when issue has skip-beads-sync label', async () => {
-    const event = makeOpenedEvent({
+    const result = await handleOpened(makeOpenedEvent({
       issue: { labels: [{ name: 'bug' }, { name: 'skip-beads-sync' }] },
-    });
-    const result = await handleOpened(event, makeOptions());
+    }), makeOptions());
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('skip label');
   });
 
   it('skips when body contains no-beads', async () => {
-    const event = makeOpenedEvent({
+    const result = await handleOpened(makeOpenedEvent({
       issue: { body: 'This issue has no-beads tracking needed' },
-    });
-    const result = await handleOpened(event, makeOptions());
+    }), makeOptions());
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('no-beads in body');
   });
 
-  it('idempotent — mapping file entry returns skip', async () => {
+  it('idempotent - canonical link store entry returns skip', async () => {
     const opts = makeOptions({
-      mapping: {
-        getBeadsId: () => 'forge-existing',
-        setBeadsId: () => {},
-      },
-      github: {
-        findSyncComment: () => ({ id: 999, body: '<!-- beads-sync:42 -->' }),
-        createOrEditComment: () => {},
-      },
-    });
-
-    const event = makeOpenedEvent();
-    const result = await handleOpened(event, opts);
-
-    expect(result.skipped).toBe(true);
-    expect(result.reason).toBe('already synced (mapping file)');
-    expect(result.beadsId).toBe('forge-existing');
-  });
-
-  it('idempotent — sync comment repairs mapping when mapping is missing', async () => {
-    const setBeadsIdCalls = [];
-    const opts = makeOptions({
-      mapping: {
-        getBeadsId: () => null,
-        setBeadsId: (p, num, id) => { setBeadsIdCalls.push({ p, num, id }); },
-      },
-      github: {
-        findSyncComment: () => ({
-          id: 999,
-          body: '<!-- beads-sync:42 -->\n**Beads:** `forge-existing`',
+      linkStore: {
+        resolveCanonicalLink: () => ({
+          forgeIssueId: 'forge-existing',
+          github: {
+            nodeId: 'node-42',
+            number: 42,
+            url: 'https://github.com/testowner/testrepo/issues/42',
+          },
         }),
-        createOrEditComment: () => {},
       },
-    });
-
-    const event = makeOpenedEvent();
-    const result = await handleOpened(event, opts);
-
-    expect(result.skipped).toBe(true);
-    expect(result.reason).toBe('already synced (comment)');
-    expect(result.beadsId).toBe('forge-existing');
-    expect(setBeadsIdCalls.length).toBe(1);
-    expect(setBeadsIdCalls[0].id).toBe('forge-existing');
-  });
-
-  it('idempotent — mapping file repairs missing comment', async () => {
-    const createOrEditCalls = [];
-    const opts = makeOptions({
       mapping: {
-        getBeadsId: () => 'forge-existing',
-        setBeadsId: () => {},
+        getBeadsId: () => { throw new Error('legacy mapping should not be consulted when canonical link exists'); },
+        setBeadsId: () => { throw new Error('legacy mapping should not be written when canonical link exists'); },
       },
       github: {
-        findSyncComment: () => null,
-        createOrEditComment: (ow, re, num, body) => { createOrEditCalls.push({ ow, re, num, body }); },
+        findSyncComment: () => { throw new Error('sync comment lookup should not be needed when canonical link exists'); },
+        createOrEditComment: () => { throw new Error('sync comment repair should not be needed when canonical link exists'); },
+      },
+      bd: {
+        bdCreate: () => { throw new Error('bdCreate should not be called for canonical duplicates'); },
       },
     });
 
-    const event = makeOpenedEvent();
-    const result = await handleOpened(event, opts);
+    const result = await handleOpened(makeOpenedEvent(), opts);
 
     expect(result.skipped).toBe(true);
-    expect(result.reason).toBe('already synced (mapping file)');
-    expect(createOrEditCalls.length).toBe(1);
+    expect(result.reason).toBe('already synced (canonical link)');
+    expect(result.beadsId).toBe('forge-existing');
   });
 
   it('skips unauthorized author with author_association gate', async () => {
     const opts = makeOptions({
-      configPath: undefined,
+      configOverride: { publicRepoGate: 'author_association' },
     });
-    // We need a config that has publicRepoGate = 'author_association'
-    // Override by passing a custom configPath that doesn't exist (defaults) then override config
-    // Better approach: use a config override in options
-    const event = makeOpenedEvent({
+    const result = await handleOpened(makeOpenedEvent({
       issue: { author_association: 'NONE' },
-    });
-
-    // We need to set publicRepoGate on the config. Since loadConfig returns defaults
-    // with publicRepoGate: 'none', we need a config file or a config override.
-    // Let's use the configOverride option pattern.
-    opts.configOverride = { publicRepoGate: 'author_association' };
-
-    const result = await handleOpened(event, opts);
+    }), opts);
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('author not authorized');
   });
 });
 
-// ===========================================================================
-// handleClosed
-// ===========================================================================
 describe('handleClosed', () => {
-  it('happy path — reads mapping and closes beads issue', async () => {
+  it('happy path - reads canonical link store and closes beads issue', async () => {
     const bdCloseCalls = [];
 
     const opts = makeOptions({
@@ -264,24 +206,35 @@ describe('handleClosed', () => {
         bdClose: (id, reason) => { bdCloseCalls.push({ id, reason }); },
         bdShow: () => 'open',
       },
+      linkStore: {
+        resolveCanonicalLink: () => ({
+          forgeIssueId: 'forge-abc123',
+          github: {
+            nodeId: 'node-42',
+            number: 42,
+            url: 'https://github.com/testowner/testrepo/issues/42',
+          },
+        }),
+      },
       mapping: {
-        getBeadsId: () => 'forge-abc123',
+        getBeadsId: () => { throw new Error('legacy mapping should not be consulted when canonical link exists'); },
+      },
+      github: {
+        findSyncComment: () => { throw new Error('sync comment lookup should not be needed when canonical link exists'); },
       },
     });
 
-    const event = makeClosedEvent();
-    const result = await handleClosed(event, opts);
+    const result = await handleClosed(makeClosedEvent(), opts);
 
     expect(result.success).toBe(true);
     expect(result.beadsId).toBe('forge-abc123');
     expect(result.issueNumber).toBe(42);
-
-    expect(bdCloseCalls.length).toBe(1);
+    expect(bdCloseCalls).toHaveLength(1);
     expect(bdCloseCalls[0].id).toBe('forge-abc123');
     expect(bdCloseCalls[0].reason).toContain('#42');
   });
 
-  it('fallback — no mapping, falls back to comment parsing', async () => {
+  it('fallback - no mapping, falls back to comment parsing', async () => {
     const bdCloseCalls = [];
 
     const opts = makeOptions({
@@ -300,48 +253,48 @@ describe('handleClosed', () => {
       },
     });
 
-    const event = makeClosedEvent();
-    const result = await handleClosed(event, opts);
+    const result = await handleClosed(makeClosedEvent(), opts);
 
     expect(result.success).toBe(true);
     expect(result.beadsId).toBe('forge-fromcomment');
-
-    expect(bdCloseCalls.length).toBe(1);
+    expect(bdCloseCalls).toHaveLength(1);
     expect(bdCloseCalls[0].id).toBe('forge-fromcomment');
   });
 
   it('skips when no beads link found', async () => {
-    const opts = makeOptions({
+    const result = await handleClosed(makeClosedEvent(), makeOptions({
       mapping: { getBeadsId: () => null },
       github: { findSyncComment: () => null },
-    });
-
-    const event = makeClosedEvent();
-    const result = await handleClosed(event, opts);
+    }));
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('no beads link found');
   });
 
   it('skips when beads issue already closed', async () => {
-    const opts = makeOptions({
+    const result = await handleClosed(makeClosedEvent(), makeOptions({
+      linkStore: {
+        resolveCanonicalLink: () => ({
+          forgeIssueId: 'forge-abc123',
+          github: {
+            nodeId: 'node-42',
+            number: 42,
+            url: 'https://github.com/testowner/testrepo/issues/42',
+          },
+        }),
+      },
       bd: {
         bdShow: () => 'closed',
         bdClose: () => { throw new Error('should not be called'); },
       },
-      mapping: { getBeadsId: () => 'forge-abc123' },
-    });
-
-    const event = makeClosedEvent();
-    const result = await handleClosed(event, opts);
+    }));
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('already closed');
   });
 
   it('skips bot actor', async () => {
-    const event = makeClosedEvent({ sender: { login: 'renovate[bot]' } });
-    const result = await handleClosed(event, makeOptions());
+    const result = await handleClosed(makeClosedEvent({ sender: { login: 'renovate[bot]' } }), makeOptions());
 
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('bot actor');

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { buildComment } from '../../../scripts/github-beads-sync/comment.mjs';
 import { handleOpened, handleClosed } from '../../../scripts/github-beads-sync/index.mjs';
 import { readMapping } from '../../../scripts/github-beads-sync/mapping.mjs';
 
@@ -194,6 +195,61 @@ describe('handleOpened', () => {
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('already synced (canonical link)');
     expect(result.beadsId).toBe('forge-existing');
+    expect(createOrEditCalls).toHaveLength(1);
+    expect(createOrEditCalls[0].num).toBe(42);
+    expect(createOrEditCalls[0].body).toContain('forge-existing');
+  });
+
+  it('repairs canonical link from an existing sync comment before creating a duplicate beads issue', async () => {
+    const createOrEditCalls = [];
+    const upsertCanonicalLinkCalls = [];
+    const opts = makeOptions({
+      bd: {
+        bdCreate: () => { throw new Error('bdCreate should not be called when a sync comment already exists'); },
+      },
+      github: {
+        findSyncComment: () => ({
+          id: 7,
+          body: buildComment('forge-existing', 42, {
+            type: 'bug',
+            priority: 1,
+            externalRef: 'gh-42',
+          }),
+        }),
+        createOrEditComment: (owner, repo, num, body) => {
+          createOrEditCalls.push({ owner, repo, num, body });
+        },
+      },
+      linkStore: {
+        resolveCanonicalLink: () => null,
+        upsertCanonicalLink: (record) => {
+          upsertCanonicalLinkCalls.push(record);
+          return record;
+        },
+      },
+      mapping: {
+        getBeadsId: () => { throw new Error('legacy mapping should not be consulted when a sync comment already exists'); },
+        setBeadsId: () => { throw new Error('legacy mapping should not be written when a sync comment already exists'); },
+      },
+    });
+
+    const result = await handleOpened(makeOpenedEvent(), opts);
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: 'already synced (sync comment)',
+      beadsId: 'forge-existing',
+    });
+    expect(upsertCanonicalLinkCalls).toHaveLength(1);
+    expect(upsertCanonicalLinkCalls[0].forgeIssueId).toBe('forge-existing');
+    expect(upsertCanonicalLinkCalls[0].sources).toEqual([
+      {
+        source: 'syncComment',
+        forgeIssueId: 'forge-existing',
+        githubNumber: 42,
+        url: 'https://github.com/owner/repo/issues/42',
+      },
+    ]);
     expect(createOrEditCalls).toHaveLength(1);
     expect(createOrEditCalls[0].num).toBe(42);
     expect(createOrEditCalls[0].body).toContain('forge-existing');

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -69,6 +69,7 @@ function makeMockLinkStore(overrides = {}) {
 }
 
 function makeOptions(overrides = {}) {
+  const linkStoreOverride = overrides.linkStore;
   return {
     configPath: undefined,
     mappingPath: '/tmp/test-mapping.json',
@@ -77,7 +78,12 @@ function makeOptions(overrides = {}) {
     ...overrides,
     bd: makeMockBd(overrides.bd),
     github: makeMockGithub(overrides.github),
-    linkStore: overrides.linkStore === null ? null : makeMockLinkStore(overrides.linkStore),
+    linkStore:
+      linkStoreOverride === null
+        ? null
+        : linkStoreOverride === undefined
+          ? makeMockLinkStore()
+          : linkStoreOverride,
     mapping: makeMockMapping(overrides.mapping),
   };
 }
@@ -159,7 +165,7 @@ describe('handleOpened', () => {
   it('idempotent - canonical link store entry returns skip after repairing the sync comment', async () => {
     const createOrEditCalls = [];
     const opts = makeOptions({
-      linkStore: {
+      linkStore: makeMockLinkStore({
         resolveCanonicalLink: () => ({
           forgeIssueId: 'forge-existing',
           github: {
@@ -168,7 +174,7 @@ describe('handleOpened', () => {
             url: 'https://github.com/testowner/testrepo/issues/42',
           },
         }),
-      },
+      }),
       mapping: {
         getBeadsId: () => { throw new Error('legacy mapping should not be consulted when canonical link exists'); },
         setBeadsId: () => { throw new Error('legacy mapping should not be written when canonical link exists'); },
@@ -324,7 +330,7 @@ describe('handleClosed', () => {
         bdClose: (id, reason) => { bdCloseCalls.push({ id, reason }); },
         bdShow: () => 'open',
       },
-      linkStore: {
+      linkStore: makeMockLinkStore({
         resolveCanonicalLink: () => ({
           forgeIssueId: 'forge-abc123',
           github: {
@@ -333,7 +339,7 @@ describe('handleClosed', () => {
             url: 'https://github.com/testowner/testrepo/issues/42',
           },
         }),
-      },
+      }),
       mapping: {
         getBeadsId: () => { throw new Error('legacy mapping should not be consulted when canonical link exists'); },
       },
@@ -389,7 +395,7 @@ describe('handleClosed', () => {
 
   it('skips when beads issue already closed', async () => {
     const result = await handleClosed(makeClosedEvent(), makeOptions({
-      linkStore: {
+      linkStore: makeMockLinkStore({
         resolveCanonicalLink: () => ({
           forgeIssueId: 'forge-abc123',
           github: {
@@ -398,7 +404,7 @@ describe('handleClosed', () => {
             url: 'https://github.com/testowner/testrepo/issues/42',
           },
         }),
-      },
+      }),
       bd: {
         bdShow: () => 'closed',
         bdClose: () => { throw new Error('should not be called'); },

--- a/test/scripts/github-beads-sync/integration.test.js
+++ b/test/scripts/github-beads-sync/integration.test.js
@@ -196,8 +196,8 @@ describe('integration: full closed pipeline', () => {
 // Integration: Closed with missing canonical link
 // ===========================================================================
 describe('integration: closed without canonical link', () => {
-  it('skips when no canonical link exists, even if a sync comment is available', async () => {
-    const { options, bdCalls } = makeTrackedOptions({
+  it('closes when no canonical link exists but a matching sync comment is available', async () => {
+    const { options, bdCalls, linkStoreCalls } = makeTrackedOptions({
       linkStore: {
         resolveCanonicalLink: () => null,
       },
@@ -211,8 +211,39 @@ describe('integration: closed without canonical link', () => {
 
     const result = await handleClosed(issueClosedFixture, options);
 
+    expect(result).toMatchObject({
+      success: true,
+      beadsId: 'forge-fromcomment',
+      issueNumber: 42,
+    });
+    expect(linkStoreCalls.upsert).toHaveLength(1);
+    expect(linkStoreCalls.upsert[0].forgeIssueId).toBe('forge-fromcomment');
+    expect(bdCalls.close).toEqual([
+      {
+        id: 'forge-fromcomment',
+        reason: 'Closed via GitHub issue #42',
+      },
+    ]);
+  });
+
+  it('skips when a sync comment exists but its tagged issue number does not match the closed issue', async () => {
+    const { options, bdCalls, linkStoreCalls } = makeTrackedOptions({
+      linkStore: {
+        resolveCanonicalLink: () => null,
+      },
+      github: {
+        findSyncComment: () => ({
+          id: 12345,
+          body: '<!-- beads-sync:99 -->\n**Beads:** `forge-fromcomment`\n<details>\n<summary>Sync details</summary>\n\n- Type: feature\n- Priority: 1\n- External ref: gh-99\n- Synced: 2026-03-21T00:00:00.000Z\n\n</details>',
+        }),
+      },
+    });
+
+    const result = await handleClosed(issueClosedFixture, options);
+
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('no beads link found');
+    expect(linkStoreCalls.upsert).toHaveLength(0);
     expect(bdCalls.close).toHaveLength(0);
   });
 });

--- a/test/scripts/github-beads-sync/integration.test.js
+++ b/test/scripts/github-beads-sync/integration.test.js
@@ -1,7 +1,7 @@
 /**
  * Integration tests for GitHub-Beads sync pipeline.
  * Uses realistic webhook fixture data and tests the full pipeline
- * through dependency injection (sanitize -> map -> create -> mapping update -> comment).
+ * through dependency injection (sanitize -> map -> create -> canonical link -> comment).
  *
  * @module test/scripts/github-beads-sync/integration
  */
@@ -68,20 +68,21 @@ function makeMockGithubWithCalls(overrides = {}) {
 }
 
 /**
- * Create mock mapping functions with call recording.
+ * Create mock canonical link store functions with call recording.
  * @param {object} [overrides]
  * @returns {{ mocks: object, calls: object }}
  */
-function makeMockMappingWithCalls(overrides = {}) {
-  const calls = { get: [], set: [] };
+function makeMockLinkStoreWithCalls(overrides = {}) {
+  const calls = { resolve: [], upsert: [] };
   return {
     mocks: {
-      getBeadsId: overrides.getBeadsId ?? ((_path, num) => {
-        calls.get.push(num);
+      resolveCanonicalLink: overrides.resolveCanonicalLink ?? ((lookup) => {
+        calls.resolve.push(lookup);
         return null;
       }),
-      setBeadsId: overrides.setBeadsId ?? ((_path, num, id) => {
-        calls.set.push({ num, id });
+      upsertCanonicalLink: overrides.upsertCanonicalLink ?? ((link) => {
+        calls.upsert.push(link);
+        return link;
       }),
     },
     calls,
@@ -92,12 +93,12 @@ function makeMockMappingWithCalls(overrides = {}) {
  * Build full options object with call-recording mocks.
  * @param {object} [overrides] - Override individual mock functions
  * @param {object} [configOverride] - Config overrides for testing
- * @returns {{ options: object, bdCalls: object, githubCalls: object, mappingCalls: object }}
+ * @returns {{ options: object, bdCalls: object, githubCalls: object, linkStoreCalls: object }}
  */
 function makeTrackedOptions(overrides = {}, configOverride = undefined) {
   const { mocks: bdMocks, calls: bdCalls } = makeMockBdWithCalls(overrides.bd);
   const { mocks: githubMocks, calls: githubCalls } = makeMockGithubWithCalls(overrides.github);
-  const { mocks: mappingMocks, calls: mappingCalls } = makeMockMappingWithCalls(overrides.mapping);
+  const { mocks: linkStoreMocks, calls: linkStoreCalls } = makeMockLinkStoreWithCalls(overrides.linkStore);
 
   return {
     options: {
@@ -107,12 +108,12 @@ function makeTrackedOptions(overrides = {}, configOverride = undefined) {
       repo: 'test-repo',
       bd: bdMocks,
       github: githubMocks,
-      mapping: mappingMocks,
+      linkStore: linkStoreMocks,
       configOverride,
     },
     bdCalls,
     githubCalls,
-    mappingCalls,
+    linkStoreCalls,
   };
 }
 
@@ -120,8 +121,8 @@ function makeTrackedOptions(overrides = {}, configOverride = undefined) {
 // Integration: Full opened pipeline
 // ===========================================================================
 describe('integration: full opened pipeline', () => {
-  it('processes realistic webhook through sanitize -> map -> create -> mapping -> comment', async () => {
-    const { options, bdCalls, githubCalls, mappingCalls } = makeTrackedOptions();
+  it('processes realistic webhook through sanitize -> map -> create -> canonical link -> comment', async () => {
+    const { options, bdCalls, githubCalls, linkStoreCalls } = makeTrackedOptions();
 
     const result = await handleOpened(issueOpenedFixture, options);
 
@@ -140,10 +141,11 @@ describe('integration: full opened pipeline', () => {
     expect(createArgs.description).toBe('https://github.com/test-owner/test-repo/issues/42');
     expect(createArgs.externalRef).toBe('gh-42');
 
-    // Mapping was updated with issue number -> beads ID
-    expect(mappingCalls.set).toHaveLength(1);
-    expect(mappingCalls.set[0].num).toBe(42);
-    expect(mappingCalls.set[0].id).toBe('forge-integ001');
+    // Canonical link store was updated with the GitHub issue identity
+    expect(linkStoreCalls.upsert).toHaveLength(1);
+    expect(linkStoreCalls.upsert[0].forgeIssueId).toBe('forge-integ001');
+    expect(linkStoreCalls.upsert[0].github.number).toBe(42);
+    expect(linkStoreCalls.upsert[0].github.url).toBe('https://github.com/test-owner/test-repo/issues/42');
 
     // Sync comment was posted to GitHub
     expect(githubCalls.createOrEditComment).toHaveLength(1);
@@ -160,10 +162,16 @@ describe('integration: full opened pipeline', () => {
 // Integration: Full closed pipeline
 // ===========================================================================
 describe('integration: full closed pipeline', () => {
-  it('closes beads issue when mapping exists for the GitHub issue', async () => {
+  it('closes beads issue when a canonical link exists for the GitHub issue', async () => {
     const { options, bdCalls } = makeTrackedOptions({
-      mapping: {
-        getBeadsId: (_path, _num) => 'forge-integ001',
+      linkStore: {
+        resolveCanonicalLink: () => ({
+          forgeIssueId: 'forge-integ001',
+          github: {
+            number: 42,
+            url: 'https://github.com/test-owner/test-repo/issues/42',
+          },
+        }),
       },
     });
 
@@ -185,16 +193,14 @@ describe('integration: full closed pipeline', () => {
 });
 
 // ===========================================================================
-// Integration: Closed with missing mapping, fallback to sync comment
+// Integration: Closed with missing canonical link
 // ===========================================================================
-describe('integration: closed with comment fallback', () => {
-  it('falls back to sync comment when mapping has no entry', async () => {
+describe('integration: closed without canonical link', () => {
+  it('skips when no canonical link exists, even if a sync comment is available', async () => {
     const { options, bdCalls } = makeTrackedOptions({
-      // mapping returns null — no stored beads ID
-      mapping: {
-        getBeadsId: () => null,
+      linkStore: {
+        resolveCanonicalLink: () => null,
       },
-      // but findSyncComment returns a realistic comment
       github: {
         findSyncComment: () => ({
           id: 12345,
@@ -205,13 +211,9 @@ describe('integration: closed with comment fallback', () => {
 
     const result = await handleClosed(issueClosedFixture, options);
 
-    expect(result.success).toBe(true);
-    expect(result.beadsId).toBe('forge-fromcomment');
-
-    // bd.close was called using the ID extracted from the comment
-    expect(bdCalls.close).toHaveLength(1);
-    expect(bdCalls.close[0].id).toBe('forge-fromcomment');
-    expect(bdCalls.close[0].reason).toContain('#42');
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no beads link found');
+    expect(bdCalls.close).toHaveLength(0);
   });
 });
 

--- a/test/scripts/github-beads-sync/reverse-sync.test.js
+++ b/test/scripts/github-beads-sync/reverse-sync.test.js
@@ -144,12 +144,29 @@ describe('handleBeadsClosed', () => {
     expect(result.closed[0].beadsId).toBe('forge-x');
   });
 
-  test('skips issues without canonical GitHub link data even when description still has a legacy URL', () => {
+  test('falls back to the legacy description URL when canonical GitHub metadata is absent', () => {
     const closedCalls = [];
     const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
 
     const oldContent = '{"id":"forge-y","status":"open","github":{"number":null},"description":"https://github.com/legacy/repo/issues/77"}';
     const newContent = '{"id":"forge-y","status":"closed","github":{"number":null},"description":"https://github.com/legacy/repo/issues/77"}';
+
+    const result = handleBeadsClosed(oldContent, newContent, {
+      closeGitHubIssue: mockCloseGitHubIssue,
+    });
+
+    expect(closedCalls).toHaveLength(1);
+    expect(closedCalls[0]).toEqual({ owner: 'legacy', repo: 'repo', num: 77 });
+    expect(result.closed).toHaveLength(1);
+    expect(result.closed[0].beadsId).toBe('forge-y');
+  });
+
+  test('skips issues when neither canonical metadata nor legacy description URL is present', () => {
+    const closedCalls = [];
+    const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
+
+    const oldContent = '{"id":"forge-y","status":"open","github":{"number":null},"description":"No GitHub link here"}';
+    const newContent = '{"id":"forge-y","status":"closed","github":{"number":null},"description":"No GitHub link here"}';
 
     const result = handleBeadsClosed(oldContent, newContent, {
       closeGitHubIssue: mockCloseGitHubIssue,

--- a/test/scripts/github-beads-sync/reverse-sync.test.js
+++ b/test/scripts/github-beads-sync/reverse-sync.test.js
@@ -144,12 +144,12 @@ describe('handleBeadsClosed', () => {
     expect(result.closed[0].beadsId).toBe('forge-x');
   });
 
-  test('skips issues without canonical GitHub link data', () => {
+  test('skips issues without canonical GitHub link data even when description still has a legacy URL', () => {
     const closedCalls = [];
     const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
 
-    const oldContent = '{"id":"forge-y","status":"open","github":{"number":null}}';
-    const newContent = '{"id":"forge-y","status":"closed","github":{"number":null}}';
+    const oldContent = '{"id":"forge-y","status":"open","github":{"number":null},"description":"https://github.com/legacy/repo/issues/77"}';
+    const newContent = '{"id":"forge-y","status":"closed","github":{"number":null},"description":"https://github.com/legacy/repo/issues/77"}';
 
     const result = handleBeadsClosed(oldContent, newContent, {
       closeGitHubIssue: mockCloseGitHubIssue,

--- a/test/scripts/github-beads-sync/reverse-sync.test.js
+++ b/test/scripts/github-beads-sync/reverse-sync.test.js
@@ -127,12 +127,12 @@ describe('extractGitHubUrl', () => {
 // --- handleBeadsClosed ---
 
 describe('handleBeadsClosed', () => {
-  test('closes GitHub issue for each newly-closed beads issue', () => {
+  test('closes GitHub issue from canonical github metadata on newly closed beads issues', () => {
     const closedCalls = [];
     const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
 
-    const oldContent = '{"id":"forge-x","status":"open","description":"https://github.com/org/proj/issues/10"}';
-    const newContent = '{"id":"forge-x","status":"closed","description":"https://github.com/org/proj/issues/10"}';
+    const oldContent = '{"id":"forge-x","status":"open","github":{"number":10,"url":"https://github.com/org/proj/issues/10"}}';
+    const newContent = '{"id":"forge-x","status":"closed","github":{"number":10,"url":"https://github.com/org/proj/issues/10"}}';
 
     const result = handleBeadsClosed(oldContent, newContent, {
       closeGitHubIssue: mockCloseGitHubIssue,
@@ -144,12 +144,12 @@ describe('handleBeadsClosed', () => {
     expect(result.closed[0].beadsId).toBe('forge-x');
   });
 
-  test('skips issues without valid GitHub URL in description', () => {
+  test('skips issues without canonical GitHub link data', () => {
     const closedCalls = [];
     const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
 
-    const oldContent = '{"id":"forge-y","status":"open","description":"no-url-here"}';
-    const newContent = '{"id":"forge-y","status":"closed","description":"no-url-here"}';
+    const oldContent = '{"id":"forge-y","status":"open","github":{"number":null}}';
+    const newContent = '{"id":"forge-y","status":"closed","github":{"number":null}}';
 
     const result = handleBeadsClosed(oldContent, newContent, {
       closeGitHubIssue: mockCloseGitHubIssue,
@@ -164,7 +164,7 @@ describe('handleBeadsClosed', () => {
     const closedCalls = [];
     const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
 
-    const content = '{"id":"forge-z","status":"open","description":"https://github.com/o/r/issues/1"}';
+    const content = '{"id":"forge-z","status":"open","github":{"number":1,"url":"https://github.com/o/r/issues/1"}}';
 
     const result = handleBeadsClosed(content, content, {
       closeGitHubIssue: mockCloseGitHubIssue,
@@ -180,12 +180,12 @@ describe('handleBeadsClosed', () => {
     const mockCloseGitHubIssue = (owner, repo, num) => closedCalls.push({ owner, repo, num });
 
     const oldContent = [
-      '{"id":"forge-a","status":"open","description":"https://github.com/o/r/issues/1"}',
-      '{"id":"forge-b","status":"open","description":"https://github.com/o/r/issues/2"}',
+      '{"id":"forge-a","status":"open","github":{"number":1,"url":"https://github.com/o/r/issues/1"}}',
+      '{"id":"forge-b","status":"open","github":{"number":2,"url":"https://github.com/o/r/issues/2"}}',
     ].join('\n');
     const newContent = [
-      '{"id":"forge-a","status":"closed","description":"https://github.com/o/r/issues/1"}',
-      '{"id":"forge-b","status":"closed","description":"https://github.com/o/r/issues/2"}',
+      '{"id":"forge-a","status":"closed","github":{"number":1,"url":"https://github.com/o/r/issues/1"}}',
+      '{"id":"forge-b","status":"closed","github":{"number":2,"url":"https://github.com/o/r/issues/2"}}',
     ].join('\n');
 
     const result = handleBeadsClosed(oldContent, newContent, {
@@ -201,8 +201,8 @@ describe('handleBeadsClosed', () => {
       throw new Error('API failure');
     };
 
-    const oldContent = '{"id":"forge-e","status":"open","description":"https://github.com/o/r/issues/3"}';
-    const newContent = '{"id":"forge-e","status":"closed","description":"https://github.com/o/r/issues/3"}';
+    const oldContent = '{"id":"forge-e","status":"open","github":{"number":3,"url":"https://github.com/o/r/issues/3"}}';
+    const newContent = '{"id":"forge-e","status":"closed","github":{"number":3,"url":"https://github.com/o/r/issues/3"}}';
 
     const result = handleBeadsClosed(oldContent, newContent, {
       closeGitHubIssue: mockCloseGitHubIssue,

--- a/test/setup-lefthook-repair.test.js
+++ b/test/setup-lefthook-repair.test.js
@@ -8,8 +8,9 @@ const { checkLefthookStatus } = require('../lib/lefthook-check');
 const tempDirs = [];
 
 // This test shells through the full setup path and can take longer on
-// Windows/Node 22 runners than Bun's default 5s timeout.
-setDefaultTimeout(10000);
+// Windows runners when package-manager subprocesses contend with the rest
+// of the suite.
+setDefaultTimeout(30000);
 
 function makeTempDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-setup-lefthook-'));

--- a/test/status-command.test.js
+++ b/test/status-command.test.js
@@ -178,7 +178,8 @@ describe('status command authoritative workflow state', () => {
   });
 
   test('handler does not fall back to heuristic stage detection when state is missing', async () => {
-    const result = await statusCommand.handler([], {}, process.cwd());
+    const repoRoot = createTempBeadsRepo([]);
+    const result = await statusCommand.handler([], {}, repoRoot);
     expect(result.missingWorkflowState).toBe(true);
     expect(result.output).toContain('Context');
     expect(result.output).toContain('No active workflow state detected.');
@@ -198,6 +199,7 @@ describe('status command authoritative workflow state', () => {
   test('handler falls back gracefully when bd is unavailable', async () => {
     const originalPATH = process.env.PATH;
     const originalPath = process.env.Path;
+    const repoRoot = createTempBeadsRepo([]);
 
     process.env.PATH = '';
     process.env.Path = '';
@@ -206,7 +208,7 @@ describe('status command authoritative workflow state', () => {
       const result = await statusCommand.handler(
         ['--issue-id', 'forge-test'],
         {},
-        process.cwd()
+        repoRoot
       );
 
       expect(result.missingWorkflowState).toBe(true);

--- a/test/validate-script.test.js
+++ b/test/validate-script.test.js
@@ -110,6 +110,31 @@ describe('scripts/validate.js runtime', () => {
     ]);
   });
 
+  test('does not block when audit output only contains non-severity words like highlightjs', () => {
+    const calls = [];
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = main({
+      runCommand(command, args) {
+        calls.push([command, ...args]);
+        if (args[0] === 'audit') {
+          return makeResult(1, '1 moderate severity vulnerability found in highlightjs\n');
+        }
+        return makeResult(0);
+      },
+      bunCommand: 'bun-test',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([
+      ['bun-test', 'run', 'typecheck'],
+      ['bun-test', 'run', 'lint'],
+      ['bun-test', 'audit'],
+      ['node', 'scripts/test.js', '--validate'],
+    ]);
+  });
+
   test('reports a successful type check when the command actually ran', () => {
     const logs = [];
     logSpy = spyOn(console, 'log').mockImplementation((...args) => {

--- a/test/validate-script.test.js
+++ b/test/validate-script.test.js
@@ -118,7 +118,7 @@ describe('scripts/validate.js runtime', () => {
     writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
 
     const exitCode = main({
-      runCommand(command, args) {
+      runCommand(_command, args) {
         if (args[1] === 'typecheck') {
           return makeResult(0, 'Type check completed\n');
         }
@@ -140,7 +140,7 @@ describe('scripts/validate.js runtime', () => {
     writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
 
     const exitCode = main({
-      runCommand(command, args) {
+      runCommand(_command, args) {
         if (args[1] === 'typecheck') {
           return makeResult(0, 'No TypeScript in project - skipping type check\n');
         }

--- a/test/validate-script.test.js
+++ b/test/validate-script.test.js
@@ -109,4 +109,48 @@ describe('scripts/validate.js runtime', () => {
       ['node', 'scripts/test.js', '--validate'],
     ]);
   });
+
+  test('reports a successful type check when the command actually ran', () => {
+    const logs = [];
+    logSpy = spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+    writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = main({
+      runCommand(command, args) {
+        if (args[1] === 'typecheck') {
+          return makeResult(0, 'Type check completed\n');
+        }
+        return makeResult(0);
+      },
+      bunCommand: 'bun-test',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(logs.some(entry => entry.includes('Type check passed'))).toBe(true);
+    expect(logs.some(entry => entry.includes('SKIPPED (no TypeScript in project)'))).toBe(false);
+  });
+
+  test('reports skipped type check only when bun says the project has no TypeScript', () => {
+    const logs = [];
+    logSpy = spyOn(console, 'log').mockImplementation((...args) => {
+      logs.push(args.join(' '));
+    });
+    writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = main({
+      runCommand(command, args) {
+        if (args[1] === 'typecheck') {
+          return makeResult(0, 'No TypeScript in project - skipping type check\n');
+        }
+        return makeResult(0);
+      },
+      bunCommand: 'bun-test',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(logs.some(entry => entry.includes('SKIPPED (no TypeScript in project)'))).toBe(true);
+    expect(logs.some(entry => entry.includes('Type check passed'))).toBe(false);
+  });
 });

--- a/test/validate-script.test.js
+++ b/test/validate-script.test.js
@@ -1,0 +1,112 @@
+const { afterEach, describe, expect, spyOn, test } = require('bun:test');
+
+const { main } = require('../scripts/validate.js');
+
+function makeResult(status, stdout = '', stderr = '') {
+  return { status, stdout, stderr };
+}
+
+describe('scripts/validate.js runtime', () => {
+  let logSpy;
+  let writeSpy;
+
+  afterEach(() => {
+    logSpy?.mockRestore();
+    writeSpy?.mockRestore();
+    logSpy = undefined;
+    writeSpy = undefined;
+  });
+
+  test('runs the quality gates in order on success', () => {
+    const calls = [];
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = main({
+      runCommand(command, args) {
+        calls.push([command, ...args]);
+        return makeResult(0, args[0] === 'audit' ? 'No vulnerabilities found\n' : '');
+      },
+      bunCommand: 'bun-test',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([
+      ['bun-test', 'run', 'typecheck'],
+      ['bun-test', 'run', 'lint'],
+      ['bun-test', 'audit'],
+      ['node', 'scripts/test.js', '--validate'],
+    ]);
+  });
+
+  test('stops immediately when lint fails', () => {
+    const calls = [];
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+    const exitCode = main({
+      runCommand(command, args) {
+        calls.push([command, ...args]);
+        if (args[1] === 'lint') {
+          return makeResult(1);
+        }
+        return makeResult(0);
+      },
+      bunCommand: 'bun-test',
+    });
+
+    expect(exitCode).toBe(1);
+    expect(calls).toEqual([
+      ['bun-test', 'run', 'typecheck'],
+      ['bun-test', 'run', 'lint'],
+    ]);
+  });
+
+  test('blocks on critical or high audit findings', () => {
+    const calls = [];
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = main({
+      runCommand(command, args) {
+        calls.push([command, ...args]);
+        if (args[0] === 'audit') {
+          return makeResult(0, '1 high severity vulnerability\n');
+        }
+        return makeResult(0);
+      },
+      bunCommand: 'bun-test',
+    });
+
+    expect(exitCode).toBe(1);
+    expect(calls).toEqual([
+      ['bun-test', 'run', 'typecheck'],
+      ['bun-test', 'run', 'lint'],
+      ['bun-test', 'audit'],
+    ]);
+  });
+
+  test('continues to tests when audit finds only non-blocking issues', () => {
+    const calls = [];
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    writeSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = main({
+      runCommand(command, args) {
+        calls.push([command, ...args]);
+        if (args[0] === 'audit') {
+          return makeResult(1, '1 moderate severity vulnerability\n');
+        }
+        return makeResult(0);
+      },
+      bunCommand: 'bun-test',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(calls).toEqual([
+      ['bun-test', 'run', 'typecheck'],
+      ['bun-test', 'run', 'lint'],
+      ['bun-test', 'audit'],
+      ['node', 'scripts/test.js', '--validate'],
+    ]);
+  });
+});

--- a/test/workflow/enforce-stage.test.js
+++ b/test/workflow/enforce-stage.test.js
@@ -120,12 +120,17 @@ describe('workflow enforce-stage', () => {
   });
 
   test('enforceStageEntry requires workflow state for non-plan stages', async () => {
-    await expect(enforceStageEntry({
-      commandName: 'ship',
-      flags: {},
-      projectRoot: process.cwd(),
-      health: { healthy: true, hardStop: false, diagnostics: [] }
-    })).rejects.toThrow(/requires authoritative workflow state/i);
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-missing-state-'));
+    try {
+      await expect(enforceStageEntry({
+        commandName: 'ship',
+        flags: {},
+        projectRoot: tmpDir,
+        health: { healthy: true, hardStop: false, diagnostics: [] }
+      })).rejects.toThrow(/requires authoritative workflow state/i);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   test('enforceStageEntry reads workflow state from .forge-state.json when present', async () => {


### PR DESCRIPTION
## Problem
Forge?GitHub issue state was still split across mapping files, sync comments, Beads metadata, and description URL parsing. That left shared issue identity/state ambiguous and gave `forge-ij1` no stable pull/materialization primitives to build on.

## Root Cause
Forge had the command seam from `forge-ya9l`, but it still lacked a normalized shared issue record, a canonical link store, and field-level ownership rules across GitHub, Forge, and Beads. The local validate path also had Windows-specific wrapper and timeout brittleness that made shipping this work unreliable.

## Fix
This PR adds the normalized shared issue schema, canonical link reconciliation, inbound GitHub pull/reconcile/materialize primitives, and import-ready helpers used by `forge-ij1`. It also routes adapter behavior through the normalized core, documents the authority model and task plan, and hardens the local validate pipeline/tests so `bun run check` and pre-push validation pass in the `f3lx` worktree.

## Value
GitHub now serves as the shared identity/state surface while Forge keeps workflow authority and Beads remains the local cache/backend. That removes the sync-model ambiguity, gives `forge-ij1` a stable foundation, and makes the repo's validate/ship path reliable in this workflow.

## Beads
Closes forge-nlgg

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: `676 pass / 36 skip / 0 fail` via `node scripts/test.js --validate` and `bun run check`
- Scenarios covered: normalized schema/authority, canonical link reconciliation, inbound GitHub pull and local materialization, adapter projection through the shared core, import-ready pull primitives for `forge-ij1`, and Windows-safe validate/test harness flows

### Security Review
- OWASP Top 10: No new auth or secret surface was introduced; reviewed A03/A05 risk around command execution and config handling, and kept the branch on explicit CLI invocation paths rather than raw shell-built mutation flows
- Automated scan: `bun audit` ? `No vulnerabilities found`

### Design Doc
- `docs/plans/2026-04-24-forge-nlgg-design.md`
- `docs/research/forge-nlgg.md`

### Key Decisions
- GitHub owns shared issue identity/state, Forge owns workflow semantics, and Beads stays a local cache/backend
- Ongoing pull sync and `forge-ij1` import share the same normalize/reconcile/materialize primitives
- Legacy mappings/comments/description URLs are migration inputs only; one canonical link record becomes the source of truth
- Shared-field conflicts resolve by field ownership instead of system-level last-write-wins

### Documentation Updated
- `docs/BEADS_GITHUB_SYNC.md`
- `docs/research/forge-nlgg.md`
- `docs/plans/2026-04-24-forge-nlgg-design.md`
- `docs/plans/2026-04-24-forge-nlgg-tasks.md`
- `docs/plans/2026-04-24-forge-nlgg-decisions.md`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [ ] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun run check`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests
