### PR TITLE
test: migrate test-env to bun test imports

### DIFF
--- a/docs/plans/2026-04-26-vvhz-decisions.md
+++ b/docs/plans/2026-04-26-vvhz-decisions.md
@@ -1,0 +1,21 @@
+# Decisions: forge-vvhz test-env bun:test import migration
+
+## Decision 1
+
+**Date**: 2026-04-26
+**Task**: Planning catalog
+**Gap**: Prompt said 18 `test-env/` files use `node:test`, but the verified worktree has 19 `test-env/**/*.test.js` files, all already using CommonJS `require('bun:test')`.
+**Score**: 1/14
+**Route**: PROCEED
+**Choice made**: Treat the worktree as source of truth and migrate all 19 verified test files so `test-env/` stays internally consistent.
+**Status**: RESOLVED
+
+## Decision 2
+
+**Date**: 2026-04-26
+**Task**: Final consistency check
+**Gap**: Static `import { ... } from 'bun:test'` made migrated `test-env/**/*.test.js` files fail ESLint parsing because `eslint.config.js` classified `test-env/**/*.js` as CommonJS.
+**Score**: 3/14
+**Route**: PROCEED
+**Choice made**: Add only `test-env/**/*.test.js` to the existing ES module ESLint override and exclude those files from the CommonJS override. Leave non-test `test-env/**/*.js` files unchanged.
+**Status**: RESOLVED

--- a/docs/plans/2026-04-26-vvhz-design.md
+++ b/docs/plans/2026-04-26-vvhz-design.md
@@ -1,0 +1,56 @@
+# Feature: forge-vvhz test-env bun:test import migration
+
+**Date**: 2026-04-26
+**Status**: Planned
+**Issue**: forge-vvhz
+
+## Purpose
+
+Finish the `test-env/` test runner migration so the tests use `bun:test` APIs directly and consistently.
+
+## Verified Current State
+
+The requested `forge worktree create vvhz` command was run. It reported an existing path error while linking `.beads`, but Git already has a usable worktree at `.worktrees/vvhz` on branch `feat/vvhz`.
+
+The current source does not match the prompt exactly:
+
+- Verified branch: `feat/vvhz`
+- Verified `test-env/**/*.test.js` count: 19 files
+- Verified `node:test` imports in `test-env/**/*.test.js`: 0 files
+- Verified current test API style: CommonJS `require('bun:test')`
+- Verified assertion style: 18 files still use `node:assert/strict`; 1 file already uses `expect`
+
+## Success Criteria
+
+- All `test-env/**/*.test.js` files import test helpers from `bun:test`.
+- Node test lifecycle aliasing is removed where present:
+  - `beforeAll: before` becomes direct `beforeAll`
+  - `afterAll: after` becomes direct `afterAll`
+  - `before(...)` calls become `beforeAll(...)`
+  - `after(...)` calls become `afterAll(...)`
+- `node:assert/strict` imports are removed from migrated test files.
+- Assertion calls are migrated to `expect(...)` equivalents.
+- Each `test-env/**/*.test.js` file is verified with `bun test <file>`.
+
+## Out Of Scope
+
+- No production behavior changes.
+- No changes outside `test-env/**/*.test.js` and the plan artifacts unless verification proves a local test support bug is blocking the migration.
+- No broad cleanup of unrelated worktree, Beads, or Forge state.
+
+## Approach Selected
+
+Use a mechanical migration followed by per-file Bun test verification. The test files are independent enough to validate in waves, but the edits are consistent enough to apply mechanically:
+
+- Convert Bun test requires to Bun test imports.
+- Add `expect` to the Bun test import when assertions are migrated.
+- Convert known `assert` forms:
+  - `assert.strictEqual(actual, expected)` to `expect(actual).toBe(expected)`
+  - `assert.deepStrictEqual(actual, expected)` to `expect(actual).toEqual(expected)`
+  - `assert.ok(value)` to `expect(value).toBeTruthy()`
+  - `assert.match(value, pattern)` to `expect(value).toMatch(pattern)`
+  - `assert.fail(message)` to `throw new Error(message)`
+
+## Ambiguity Policy
+
+Use the `/dev` 7-dimension decision rubric for any spec gap. For this migration, the verified count mismatch is low risk because the actual source of truth is the worktree. Proceed with all 19 verified test files rather than leaving one `test-env` test file inconsistent.

--- a/docs/plans/2026-04-26-vvhz-tasks.md
+++ b/docs/plans/2026-04-26-vvhz-tasks.md
@@ -1,0 +1,73 @@
+# Tasks: forge-vvhz test-env bun:test import migration
+
+## Task 1: Automation and helper tests
+
+Files:
+
+- `test-env/automation/setup-fixtures.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`, `assert.match`
+- `test-env/helpers/fixtures.test.js`: `afterEach`, `describe`, `expect`, `test`; already uses `expect`
+
+TDD verification:
+
+- Run `bun test test-env/automation/setup-fixtures.test.js`
+- Run `bun test test-env/helpers/fixtures.test.js`
+
+## Task 2: Edge-case tests, wave A
+
+Files:
+
+- `test-env/edge-cases/auth-security.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/edge-cases/crypto-security.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/edge-cases/env-preservation.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/edge-cases/file-limits.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/edge-cases/git-states.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`
+
+TDD verification:
+
+- Run `bun test` for each file listed above.
+
+## Task 3: Edge-case tests, wave B
+
+Files:
+
+- `test-env/edge-cases/invalid-json.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/edge-cases/network-failures.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`, `assert.deepStrictEqual`
+- `test-env/edge-cases/permission-errors.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `test`; `assert.ok`, `assert.strictEqual`, `assert.fail`
+- `test-env/edge-cases/prerequisites.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`
+
+TDD verification:
+
+- Run `bun test` for each file listed above.
+
+## Task 4: Rollback and security edge-case tests
+
+Files:
+
+- `test-env/edge-cases/rollback-edge-cases.test.js`: `describe`, `test`; `assert.strictEqual`
+- `test-env/edge-cases/rollback-user-sections.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/edge-cases/rollback-validation.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/edge-cases/security.test.js`: `describe`, `test`; `assert.ok`, `assert.strictEqual`
+
+TDD verification:
+
+- Run `bun test` for each file listed above.
+
+## Task 5: Validation tests
+
+Files:
+
+- `test-env/validation/agent-validator.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `test`; `assert.ok`, `assert.strictEqual`
+- `test-env/validation/env-validator.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `test`; `assert.ok`, `assert.strictEqual`, `assert.match`
+- `test-env/validation/file-checker.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `test`; `assert.ok`, `assert.strictEqual`, `assert.match`
+- `test-env/validation/git-state-checker.test.js`: `describe`, `beforeAll` currently aliased as `before`, `afterAll` currently aliased as `after`, `setDefaultTimeout`, `test`; `assert.ok`, `assert.strictEqual`, `assert.match`
+
+TDD verification:
+
+- Run `bun test` for each file listed above.
+
+## Task 6: Final consistency check
+
+- Confirm no `node:test` imports remain under `test-env/`.
+- Confirm no `node:assert/strict` imports remain in `test-env/**/*.test.js`.
+- Confirm all `test-env/**/*.test.js` files use `import { ... } from 'bun:test'`.
+- Run `bun test test-env`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,9 +32,9 @@ export default [
       'no-undef': 'error',
     },
   },
-  // ES Modules (packages/skills, test/forge-uto, and eslint.config.js)
+  // ES Modules (packages/skills, migrated test-env tests, test/forge-uto, and eslint.config.js)
   {
-    files: ['packages/skills/**/*.js', 'test/forge-uto/**/*.js', 'test/scripts/github-beads-sync/**/*.js', 'eslint.config.js'],
+    files: ['packages/skills/**/*.js', 'test-env/**/*.test.js', 'test/forge-uto/**/*.js', 'test/scripts/github-beads-sync/**/*.js', 'eslint.config.js'],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'module',
@@ -55,7 +55,7 @@ export default [
   // CommonJS (everything else)
   {
     files: ['**/*.js'],
-    ignores: ['packages/skills/**/*.js', 'test/forge-uto/**/*.js', 'test/scripts/github-beads-sync/**/*.js', 'eslint.config.js'],
+    ignores: ['packages/skills/**/*.js', 'test-env/**/*.test.js', 'test/forge-uto/**/*.js', 'test/scripts/github-beads-sync/**/*.js', 'eslint.config.js'],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'commonjs',

--- a/test-env/automation/setup-fixtures.test.js
+++ b/test-env/automation/setup-fixtures.test.js
@@ -1,8 +1,7 @@
 // Test: setup-fixtures.sh
 // Validates that all 15 test fixtures are created correctly
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 // SECURITY: Using execSync with HARDCODED script path only (no user input)
@@ -30,24 +29,24 @@ describe('setup-fixtures.sh', () => {
   test('should create all 15 fixtures', () => {
     for (const fixture of EXPECTED_FIXTURES) {
       const fixturePath = path.join(FIXTURES_DIR, fixture);
-      assert.ok(fs.existsSync(fixturePath), `Fixture should exist: ${fixture}`);
+      expect(fs.existsSync(fixturePath)).toBeTruthy();
     }
   });
 
   describe('Fixture: fresh-project', () => {
     const fixturePath = path.join(FIXTURES_DIR, 'fresh-project');
     test('should have .git directory', () => {
-      assert.ok(fs.existsSync(path.join(fixturePath, '.git')));
+      expect(fs.existsSync(path.join(fixturePath, '.git'))).toBeTruthy();
     });
     test('should have clean git state', () => {
-      assert.strictEqual(checkGitState(fixturePath).passed, true);
+      expect(checkGitState(fixturePath).passed).toBe(true);
     });
   });
 
   describe('Fixture: no-git', () => {
     const fixturePath = path.join(FIXTURES_DIR, 'no-git');
     test('should NOT have .git directory', () => {
-      assert.strictEqual(fs.existsSync(path.join(fixturePath, '.git')), false);
+      expect(fs.existsSync(path.join(fixturePath, '.git'))).toBe(false);
     });
   });
 
@@ -55,7 +54,7 @@ describe('setup-fixtures.sh', () => {
     test('should have uncommitted changes', () => {
       const fixturePath = path.join(FIXTURES_DIR, 'dirty-git');
       const result = hasUncommittedChanges(fixturePath);
-      assert.strictEqual(result.hasChanges, true);
+      expect(result.hasChanges).toBe(true);
     });
   });
 
@@ -63,7 +62,7 @@ describe('setup-fixtures.sh', () => {
     test('should be in detached HEAD state', () => {
       const fixturePath = path.join(FIXTURES_DIR, 'detached-head');
       const result = isDetachedHead(fixturePath);
-      assert.strictEqual(result.detached, true);
+      expect(result.detached).toBe(true);
     });
   });
 
@@ -71,14 +70,14 @@ describe('setup-fixtures.sh', () => {
     test('should have active merge conflict', () => {
       const fixturePath = path.join(FIXTURES_DIR, 'merge-conflict');
       const result = hasMergeConflict(fixturePath);
-      assert.strictEqual(result.hasConflict, true);
+      expect(result.hasConflict).toBe(true);
     });
   });
 
   describe('Fixture: monorepo', () => {
     test('should have pnpm-workspace.yaml', () => {
       const fixturePath = path.join(FIXTURES_DIR, 'monorepo');
-      assert.ok(fs.existsSync(path.join(fixturePath, 'pnpm-workspace.yaml')));
+      expect(fs.existsSync(path.join(fixturePath, 'pnpm-workspace.yaml'))).toBeTruthy();
     });
   });
 
@@ -86,7 +85,7 @@ describe('setup-fixtures.sh', () => {
     test('should have AGENTS.md with >300 lines', () => {
       const fixturePath = path.join(FIXTURES_DIR, 'large-agents-md');
       const content = fs.readFileSync(path.join(fixturePath, 'AGENTS.md'), 'utf8');
-      assert.ok(content.split('\n').length > 300);
+      expect(content.split('\n').length > 300).toBeTruthy();
     });
   });
 
@@ -94,6 +93,6 @@ describe('setup-fixtures.sh', () => {
     const result = execFileSync(resolveBashCommand(), [SETUP_SCRIPT], {
       cwd: __dirname, stdio: 'pipe', encoding: 'utf8'
     });
-    assert.match(result, /Fixture already exists|Skipped/i);
+    expect(result).toMatch(/Fixture already exists|Skipped/i);
   });
 });

--- a/test-env/edge-cases/auth-security.test.js
+++ b/test-env/edge-cases/auth-security.test.js
@@ -3,8 +3,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 
 const rootDir = path.join(__dirname, '..', '..');
 
@@ -15,14 +14,8 @@ describe('OWASP A07: Identification & Authentication Failures', () => {
         path.join(rootDir, 'scripts', 'branch-protection.js'),
         'utf-8'
       );
-      assert.ok(
-        content.includes("'main'") || content.includes('"main"'),
-        'branch-protection.js should protect main branch'
-      );
-      assert.ok(
-        content.includes("'master'") || content.includes('"master"'),
-        'branch-protection.js should protect master branch'
-      );
+      expect(content.includes("'main'") || content.includes('"main"')).toBeTruthy();
+      expect(content.includes("'master'") || content.includes('"master"')).toBeTruthy();
     });
 
     test('branch-protection.js exits with code 1 for protected branches', () => {
@@ -30,10 +23,7 @@ describe('OWASP A07: Identification & Authentication Failures', () => {
         path.join(rootDir, 'scripts', 'branch-protection.js'),
         'utf-8'
       );
-      assert.ok(
-        content.includes('process.exit(1)'),
-        'should exit with code 1 to block push'
-      );
+      expect(content.includes('process.exit(1)')).toBeTruthy();
     });
   });
 
@@ -47,7 +37,7 @@ describe('OWASP A07: Identification & Authentication Failures', () => {
       const referencesGh = content.includes('gh ') ||
         content.includes("'gh'") ||
         content.includes('"gh"');
-      assert.ok(referencesGh, 'forge.js should reference gh CLI for GitHub operations');
+      expect(referencesGh).toBeTruthy();
     });
   });
 
@@ -86,10 +76,7 @@ describe('OWASP A07: Identification & Authentication Failures', () => {
         }
       }
 
-      assert.strictEqual(
-        violations.length, 0,
-        `Found default credentials:\n${violations.join('\n')}`
-      );
+      expect(violations.length).toBe(0);
     });
   });
 
@@ -116,10 +103,7 @@ describe('OWASP A07: Identification & Authentication Failures', () => {
             content.includes('npx') ||
             content.includes('bunx') ||
             content.includes('node scripts/');
-          assert.ok(
-            usesEnvVar,
-            `${configFile} mentions auth but doesn't use env vars`
-          );
+          expect(usesEnvVar).toBeTruthy();
         }
       }
     });
@@ -138,10 +122,7 @@ describe('OWASP A07: Identification & Authentication Failures', () => {
           !line.includes('process.env');
       });
 
-      assert.strictEqual(
-        tokenAssignments.length, 0,
-        `forge.js has token assignments without process.env:\n${tokenAssignments.join('\n')}`
-      );
+      expect(tokenAssignments.length).toBe(0);
     });
   });
 });

--- a/test-env/edge-cases/crypto-security.test.js
+++ b/test-env/edge-cases/crypto-security.test.js
@@ -3,8 +3,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const { execFileSync } = require('node:child_process');
 
 const rootDir = path.join(__dirname, '..', '..');
@@ -14,18 +13,15 @@ describe('OWASP A02: Cryptographic Failures', () => {
     const gitignore = fs.readFileSync(path.join(rootDir, '.gitignore'), 'utf-8');
 
     test('.env.local pattern is in .gitignore', () => {
-      assert.ok(gitignore.includes('.env.local'), '.env.local should be in .gitignore');
+      expect(gitignore.includes('.env.local')).toBeTruthy();
     });
 
     test('.env pattern is in .gitignore', () => {
-      assert.ok(gitignore.includes('.env'), '.env should be in .gitignore');
+      expect(gitignore.includes('.env')).toBeTruthy();
     });
 
     test('.env.*.local pattern is in .gitignore', () => {
-      assert.ok(
-        gitignore.includes('.env.*.local'),
-        '.env.*.local should be in .gitignore'
-      );
+      expect(gitignore.includes('.env.*.local')).toBeTruthy();
     });
   });
 
@@ -65,19 +61,13 @@ describe('OWASP A02: Cryptographic Failures', () => {
     test('lib/ contains no hardcoded API keys or secrets', () => {
       const libDir = path.join(rootDir, 'lib');
       const violations = scanDirectory(libDir, secretPattern);
-      assert.strictEqual(
-        violations.length, 0,
-        `Found ${violations.length} hardcoded secrets in lib/:\n${violations.map(v => `  ${v.file}:${v.line}: ${v.content}`).join('\n')}`
-      );
+      expect(violations.length).toBe(0);
     });
 
     test('bin/ contains no hardcoded API keys or secrets', () => {
       const binDir = path.join(rootDir, 'bin');
       const violations = scanDirectory(binDir, secretPattern);
-      assert.strictEqual(
-        violations.length, 0,
-        `Found ${violations.length} hardcoded secrets in bin/:\n${violations.map(v => `  ${v.file}:${v.line}: ${v.content}`).join('\n')}`
-      );
+      expect(violations.length).toBe(0);
     });
   });
 
@@ -98,10 +88,7 @@ describe('OWASP A02: Cryptographic Failures', () => {
           violations.push(`  Line ${i + 1}: ${line.trim()}`);
         }
       }
-      assert.strictEqual(
-        violations.length, 0,
-        `agents-config.js contains hardcoded tokens:\n${violations.join('\n')}`
-      );
+      expect(violations.length).toBe(0);
     });
 
     test('MCP example config uses no inline secrets', () => {
@@ -110,10 +97,7 @@ describe('OWASP A02: Cryptographic Failures', () => {
         'utf-8'
       );
       const secretPattern = /(?:api[_-]?key|token|secret|password)\s*[:=]\s*['"][A-Za-z0-9+/=_-]{8,}['"]/i;
-      assert.ok(
-        !secretPattern.test(mcpExample),
-        '.mcp.json.example should not contain inline secrets'
-      );
+      expect(!secretPattern.test(mcpExample)).toBeTruthy();
     });
   });
 
@@ -134,10 +118,7 @@ describe('OWASP A02: Cryptographic Failures', () => {
         /^\.env($|\.)/.test(path.basename(f))
       );
 
-      assert.strictEqual(
-        envFiles.length, 0,
-        `Found tracked .env files: ${envFiles.join(', ')}`
-      );
+      expect(envFiles.length).toBe(0);
     });
   });
 });

--- a/test-env/edge-cases/env-preservation.test.js
+++ b/test-env/edge-cases/env-preservation.test.js
@@ -1,8 +1,7 @@
 // Test: .env.local Preservation Edge Cases
 // Validates .env.local preservation using env-validator.js
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
@@ -19,11 +18,11 @@ const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
 
 let testDir;
 
-before(() => {
+beforeAll(() => {
   testDir = mkdtempSync(path.join(tmpdir(), 'forge-test-env-preservation-'));
 });
 
-after(() => {
+afterAll(() => {
   rmSync(testDir, { recursive: true, force: true });
 });
 
@@ -43,8 +42,8 @@ NEW_VAR=added_value
 
       const result = checkPreservation(oldEnv, newEnv);
 
-      assert.strictEqual(result.passed, true, 'Should preserve all existing variables');
-      assert.strictEqual(result.failures.length, 0, 'Should have no preservation failures');
+      expect(result.passed).toBe(true);
+      expect(result.failures.length).toBe(0);
     });
 
     test('should add new variables without overwrite', () => {
@@ -58,12 +57,12 @@ ANOTHER_VAR=another
 
       const result = checkPreservation(oldEnv, newEnv);
 
-      assert.strictEqual(result.passed, true, 'Should allow adding new variables');
+      expect(result.passed).toBe(true);
 
       const newParsed = parseEnvFile(newEnv);
-      assert.strictEqual(newParsed.variables.API_KEY, 'old_key', 'Old key preserved');
-      assert.strictEqual(newParsed.variables.NEW_API, 'new_value', 'New var added');
-      assert.strictEqual(newParsed.variables.ANOTHER_VAR, 'another', 'Another var added');
+      expect(newParsed.variables.API_KEY).toBe('old_key');
+      expect(newParsed.variables.NEW_API).toBe('new_value');
+      expect(newParsed.variables.ANOTHER_VAR).toBe('another');
     });
 
     test('should not change existing values', () => {
@@ -77,11 +76,8 @@ SECRET=top_secret
 
       const result = checkPreservation(oldEnv, newEnv);
 
-      assert.strictEqual(result.passed, false, 'Should fail if values changed');
-      assert.ok(
-        result.failures.some(f => f.path === 'API_KEY'),
-        'Should report changed API_KEY'
-      );
+      expect(result.passed).toBe(false);
+      expect(result.failures.some(f => f.path === 'API_KEY')).toBeTruthy();
     });
 
     test('should never remove old variables', () => {
@@ -96,11 +92,8 @@ DATABASE_URL=url
 
       const result = checkPreservation(oldEnv, newEnv);
 
-      assert.strictEqual(result.passed, false, 'Should fail if variables removed');
-      assert.ok(
-        result.failures.some(f => f.path === 'SECRET'),
-        'Should report removed SECRET'
-      );
+      expect(result.passed).toBe(false);
+      expect(result.failures.some(f => f.path === 'SECRET')).toBeTruthy();
     });
   });
 
@@ -113,11 +106,8 @@ API_KEY=value
 
       const parsed = parseEnvFile(envContent);
 
-      assert.ok(parsed.comments.length >= 2, 'Should preserve multiple comment lines');
-      assert.ok(
-        parsed.comments.some(c => c.includes('header comment')),
-        'Should preserve header comment text'
-      );
+      expect(parsed.comments.length >= 2).toBeTruthy();
+      expect(parsed.comments.some(c => c.includes('header comment'))).toBeTruthy();
     });
 
     test('should handle inline comments', () => {
@@ -130,8 +120,8 @@ DATABASE_URL=url
 
       const parsed = parseEnvFile(envContent);
 
-      assert.ok(parsed.comments.length > 0, 'Should preserve comments');
-      assert.strictEqual(parsed.variables.API_KEY, 'value', 'Should parse value correctly');
+      expect(parsed.comments.length > 0).toBeTruthy();
+      expect(parsed.variables.API_KEY).toBe('value');
     });
   });
 
@@ -146,9 +136,9 @@ DATABASE_URL=url
 
       const parsed = parseEnvFile(envContent);
 
-      assert.strictEqual(parsed.variables.API_KEY, 'value', 'Should parse with spacing');
-      assert.strictEqual(parsed.variables.DATABASE_URL, 'url', 'Should parse after empty line');
-      assert.ok(parsed.raw.includes('\n\n'), 'Raw content should preserve empty lines');
+      expect(parsed.variables.API_KEY).toBe('value');
+      expect(parsed.variables.DATABASE_URL).toBe('url');
+      expect(parsed.raw.includes('\n\n')).toBeTruthy();
     });
 
     test('should preserve quoted values', () => {
@@ -160,9 +150,9 @@ PLAIN=unquoted
       const parsed = parseEnvFile(envContent);
 
       // parseEnvFile strips quotes, but values should be correct
-      assert.strictEqual(parsed.variables.API_KEY, 'quoted value', 'Double quoted value');
-      assert.strictEqual(parsed.variables.PATH, 'single quoted', 'Single quoted value');
-      assert.strictEqual(parsed.variables.PLAIN, 'unquoted', 'Unquoted value');
+      expect(parsed.variables.API_KEY).toBe('quoted value');
+      expect(parsed.variables.PATH).toBe('single quoted');
+      expect(parsed.variables.PLAIN).toBe('unquoted');
     });
 
     test('should preserve escaped values', () => {
@@ -173,8 +163,8 @@ REGEX="test\\nvalue"
       const parsed = parseEnvFile(envContent);
 
       // Should parse without errors
-      assert.ok(parsed.variables.PATH, 'Should parse path with backslashes');
-      assert.ok(parsed.variables.REGEX, 'Should parse regex with escapes');
+      expect(parsed.variables.PATH).toBeTruthy();
+      expect(parsed.variables.REGEX).toBeTruthy();
     });
   });
 
@@ -189,13 +179,13 @@ REGEX="test\\nvalue"
       const gitignore = fs.readFileSync(gitignorePath, 'utf8');
       const shouldAdd = !gitignore.includes('.env.local');
 
-      assert.strictEqual(shouldAdd, true, '.env.local not in gitignore initially');
+      expect(shouldAdd).toBe(true);
 
       // Add it
       fs.writeFileSync(gitignorePath, gitignore + '.env.local\n');
 
       const updatedGitignore = fs.readFileSync(gitignorePath, 'utf8');
-      assert.ok(updatedGitignore.includes('.env.local'), 'Should add .env.local to gitignore');
+      expect(updatedGitignore.includes('.env.local')).toBeTruthy();
     });
 
     test('should not duplicate .env.local entry', () => {
@@ -208,11 +198,11 @@ REGEX="test\\nvalue"
       const gitignore = fs.readFileSync(gitignorePath, 'utf8');
       const shouldAdd = !gitignore.includes('.env.local');
 
-      assert.strictEqual(shouldAdd, false, '.env.local already in gitignore');
+      expect(shouldAdd).toBe(false);
 
       // Count occurrences
       const matches = gitignore.match(/\.env\.local/g);
-      assert.strictEqual(matches.length, 1, 'Should have exactly one .env.local entry');
+      expect(matches.length).toBe(1);
     });
   });
 
@@ -225,8 +215,8 @@ REGEX="test\\nvalue"
       if (fs.existsSync(envPath)) {
         const result = validateEnvFile(envPath);
 
-        assert.strictEqual(result.passed, true, 'Fixture .env.local should be valid');
-        assert.ok(result.coverage > 0, 'Should have coverage > 0');
+        expect(result.passed).toBe(true);
+        expect(result.coverage > 0).toBeTruthy();
       }
     });
   });

--- a/test-env/edge-cases/file-limits.test.js
+++ b/test-env/edge-cases/file-limits.test.js
@@ -1,8 +1,7 @@
 // Test: File Size Limit Edge Cases
 // Validates warnings for oversized files (non-blocking)
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
@@ -12,11 +11,11 @@ const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
 
 let testDir;
 
-before(() => {
+beforeAll(() => {
   testDir = mkdtempSync(path.join(__dirname, '.file-limits-test-'));
 });
 
-after(() => {
+afterAll(() => {
   rmSync(testDir, { recursive: true, force: true });
 });
 
@@ -65,10 +64,10 @@ describe('file-limits', () => {
       createAgentsMd(filePath, 199);
 
       const lines = countLines(filePath);
-      assert.ok(lines >= 199 && lines <= 200, `Should have ~199 lines, got ${lines}`);
+      expect(lines >= 199 && lines <= 200).toBeTruthy();
 
       const result = checkAgentsMdSize(filePath);
-      assert.strictEqual(result.warning, false, 'Should not warn at 199 lines');
+      expect(result.warning).toBe(false);
     });
 
     test('200 lines - no warning (boundary)', () => {
@@ -76,10 +75,10 @@ describe('file-limits', () => {
       createAgentsMd(filePath, 200);
 
       const lines = countLines(filePath);
-      assert.ok(lines >= 200 && lines <= 201, `Should have ~200 lines, got ${lines}`);
+      expect(lines >= 200 && lines <= 201).toBeTruthy();
 
       const result = checkAgentsMdSize(filePath);
-      assert.strictEqual(result.warning, false, 'Should not warn at exactly 200 lines');
+      expect(result.warning).toBe(false);
     });
 
     test('201 lines - warning appears', () => {
@@ -87,22 +86,22 @@ describe('file-limits', () => {
       createAgentsMd(filePath, 201);
 
       const lines = countLines(filePath);
-      assert.ok(lines >= 201, `Should have >=201 lines, got ${lines}`);
+      expect(lines >= 201).toBeTruthy();
 
       const result = checkAgentsMdSize(filePath);
-      assert.strictEqual(result.warning, true, 'Should warn at 201 lines');
-      assert.ok(result.message.includes('quite large'), 'Warning message should mention size');
+      expect(result.warning).toBe(true);
+      expect(result.message.includes('quite large')).toBeTruthy();
     });
 
     test('350 lines - warning with severity message', () => {
       const fixturePath = path.join(FIXTURES_DIR, 'large-agents-md', 'AGENTS.md');
 
       const lines = countLines(fixturePath);
-      assert.ok(lines > 300, `large-agents-md fixture should have >300 lines, got ${lines}`);
+      expect(lines > 300).toBeTruthy();
 
       const result = checkAgentsMdSize(fixturePath);
-      assert.strictEqual(result.warning, true, 'Should warn for large file');
-      assert.ok(result.lines > 300, `Should report >300 lines, got ${result.lines}`);
+      expect(result.warning).toBe(true);
+      expect(result.lines > 300).toBeTruthy();
     });
   });
 
@@ -113,10 +112,10 @@ describe('file-limits', () => {
 
       const result = checkAgentsMdSize(filePath);
 
-      assert.strictEqual(result.warning, true, 'Should warn');
+      expect(result.warning).toBe(true);
       // The actual implementation in bin/forge.js would console.log the suggestion
       // Here we just verify the warning is triggered
-      assert.ok(result.message, 'Should have warning message');
+      expect(result.message).toBeTruthy();
     });
 
     test('warning should not block operation', () => {
@@ -126,11 +125,11 @@ describe('file-limits', () => {
       const result = checkAgentsMdSize(filePath);
 
       // Warning exists but doesn't throw or block
-      assert.strictEqual(result.warning, true, 'Should warn');
-      assert.strictEqual(result.error, undefined, 'Should not have errors');
+      expect(result.warning).toBe(true);
+      expect(result.error).toBe(undefined);
 
       // The function completes successfully despite warning
-      assert.ok(result.lines > 0, 'Should complete and return line count');
+      expect(result.lines > 0).toBeTruthy();
     });
   });
 });

--- a/test-env/edge-cases/git-states.test.js
+++ b/test-env/edge-cases/git-states.test.js
@@ -1,8 +1,7 @@
 // Test: Git State Edge Cases
 // Validates git state warnings and blocking using git-state-checker.js
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const path = require('node:path');
 const { ensureTestFixtures, FIXTURES_DIR } = require('../helpers/fixtures.js');
 
@@ -23,8 +22,8 @@ describe('git-state-edge-cases', () => {
 
       const result = isDetachedHead(fixturePath);
 
-      assert.strictEqual(result.detached, true, 'Should detect detached HEAD');
-      assert.strictEqual(result.branch, null, 'Branch should be null when detached');
+      expect(result.detached).toBe(true);
+      expect(result.branch).toBe(null);
     });
 
     test('should allow detached HEAD to pass with warning', () => {
@@ -39,10 +38,7 @@ describe('git-state-edge-cases', () => {
       );
 
       // Either it passes with warning, or it "fails" but with low severity
-      assert.ok(
-        result.passed || hasDetachedWarning,
-        'Should either pass or have detached HEAD warning'
-      );
+      expect(result.passed || hasDetachedWarning).toBeTruthy();
     });
   });
 
@@ -52,12 +48,9 @@ describe('git-state-edge-cases', () => {
 
       const result = hasUncommittedChanges(fixturePath);
 
-      assert.strictEqual(result.hasChanges, true, 'Should detect uncommitted changes');
-      assert.ok(result.files.length > 0, 'Should list uncommitted files');
-      assert.ok(
-        result.files.some(f => f.includes('uncommitted.txt')),
-        'Should detect uncommitted.txt file'
-      );
+      expect(result.hasChanges).toBe(true);
+      expect(result.files.length > 0).toBeTruthy();
+      expect(result.files.some(f => f.includes('uncommitted.txt'))).toBeTruthy();
     });
 
     test('should allow uncommitted changes to pass with warning', () => {
@@ -70,10 +63,7 @@ describe('git-state-edge-cases', () => {
         /uncommitted changes/i.test(f.reason)
       );
 
-      assert.ok(
-        result.passed || hasUncommittedWarning,
-        'Should either pass or have uncommitted changes warning'
-      );
+      expect(result.passed || hasUncommittedWarning).toBeTruthy();
     });
   });
 
@@ -83,7 +73,7 @@ describe('git-state-edge-cases', () => {
 
       const result = hasMergeConflict(fixturePath);
 
-      assert.strictEqual(result.hasConflict, true, 'Should detect merge conflict');
+      expect(result.hasConflict).toBe(true);
     });
 
     test('should block installation on merge conflict', () => {
@@ -92,7 +82,7 @@ describe('git-state-edge-cases', () => {
       const result = checkGitState(fixturePath);
 
       // Merge conflicts should FAIL validation (blocking)
-      assert.strictEqual(result.passed, false, 'Should fail validation on merge conflict');
+      expect(result.passed).toBe(false);
     });
 
     test('should provide helpful error message for merge conflict', () => {
@@ -105,14 +95,11 @@ describe('git-state-edge-cases', () => {
         /merge conflict/i.test(f.reason)
       );
 
-      assert.ok(hasConflictError, 'Should have merge conflict error message');
+      expect(hasConflictError).toBeTruthy();
 
       // Error message should suggest resolution
       const conflictFailure = result.failures.find(f => /merge conflict/i.test(f.reason));
-      assert.ok(
-        conflictFailure && conflictFailure.reason.length > 10,
-        'Should provide detailed error message'
-      );
+      expect(conflictFailure && conflictFailure.reason.length > 10).toBeTruthy();
     });
   });
 
@@ -122,9 +109,9 @@ describe('git-state-edge-cases', () => {
 
       const result = checkGitState(fixturePath);
 
-      assert.strictEqual(result.passed, true, 'Clean repository should pass');
+      expect(result.passed).toBe(true);
       // Note: May have warnings (like detached HEAD) but should still pass overall
-      assert.ok(result.coverage > 0, 'Should have some coverage');
+      expect(result.coverage > 0).toBeTruthy();
     });
   });
 
@@ -134,11 +121,8 @@ describe('git-state-edge-cases', () => {
 
       const result = checkGitState(fixturePath);
 
-      assert.strictEqual(result.passed, false, 'Should fail without .git');
-      assert.ok(
-        result.failures.some(f => /not a git repository/i.test(f.reason)),
-        'Should have "not a git repository" error'
-      );
+      expect(result.passed).toBe(false);
+      expect(result.failures.some(f => /not a git repository/i.test(f.reason))).toBeTruthy();
     });
   });
 });

--- a/test-env/edge-cases/invalid-json.test.js
+++ b/test-env/edge-cases/invalid-json.test.js
@@ -1,8 +1,7 @@
 // Test: Invalid JSON and Schema Validation Edge Cases
 // Validates validatePluginSchema() handling of malformed and invalid plugin configs
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const { validatePluginSchema } = require('../../lib/plugin-manager');
 
 describe('invalid-json-edge-cases', () => {
@@ -10,29 +9,23 @@ describe('invalid-json-edge-cases', () => {
     test('should reject null plugin', () => {
       const result = validatePluginSchema(null);
 
-      assert.strictEqual(result.valid, false, 'Null plugin should be invalid');
-      assert.ok(result.errors.length > 0, 'Should have errors');
-      assert.ok(
-        result.errors.some(e => e.includes('non-null object')),
-        'Should error about non-null object'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.length > 0).toBeTruthy();
+      expect(result.errors.some(e => e.includes('non-null object'))).toBeTruthy();
     });
 
     test('should reject array as plugin', () => {
       const result = validatePluginSchema([]);
 
-      assert.strictEqual(result.valid, false, 'Array should be invalid');
-      assert.ok(
-        result.errors.some(e => e.includes('non-null object')),
-        'Should error about object type'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('non-null object'))).toBeTruthy();
     });
 
     test('should reject primitive types', () => {
       const result = validatePluginSchema('not an object');
 
-      assert.strictEqual(result.valid, false, 'String should be invalid');
-      assert.ok(result.errors.length > 0, 'Should have errors');
+      expect(result.valid).toBe(false);
+      expect(result.errors.length > 0).toBeTruthy();
     });
   });
 
@@ -46,11 +39,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail without id');
-      assert.ok(
-        result.errors.some(e => e.includes('id')),
-        'Should mention missing id'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('id'))).toBeTruthy();
     });
 
     test('should detect missing "name"', () => {
@@ -62,11 +52,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail without name');
-      assert.ok(
-        result.errors.some(e => e.includes('name')),
-        'Should mention missing name'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('name'))).toBeTruthy();
     });
 
     test('should detect missing "version"', () => {
@@ -78,11 +65,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail without version');
-      assert.ok(
-        result.errors.some(e => e.includes('version')),
-        'Should mention missing version'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('version'))).toBeTruthy();
     });
 
     test('should detect missing "directories"', () => {
@@ -94,11 +78,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail without directories');
-      assert.ok(
-        result.errors.some(e => e.includes('directories')),
-        'Should mention missing directories'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('directories'))).toBeTruthy();
     });
   });
 
@@ -113,11 +94,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail with numeric id');
-      assert.ok(
-        result.errors.some(e => e.includes('id') && e.includes('string')),
-        'Should mention id must be string'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('id') && e.includes('string'))).toBeTruthy();
     });
 
     test('should detect non-string "name"', () => {
@@ -130,11 +108,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail with object name');
-      assert.ok(
-        result.errors.some(e => e.includes('name') && e.includes('string')),
-        'Should mention name must be string'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('name') && e.includes('string'))).toBeTruthy();
     });
 
     test('should detect non-string "version"', () => {
@@ -147,11 +122,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail with numeric version');
-      assert.ok(
-        result.errors.some(e => e.includes('version') && e.includes('string')),
-        'Should mention version must be string'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('version') && e.includes('string'))).toBeTruthy();
     });
 
     test('should detect non-object "directories"', () => {
@@ -164,11 +136,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail with string directories');
-      assert.ok(
-        result.errors.some(e => e.includes('directories') && e.includes('object')),
-        'Should mention directories must be object'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('directories') && e.includes('object'))).toBeTruthy();
     });
 
     test('should detect array "directories"', () => {
@@ -181,11 +150,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail with array directories');
-      assert.ok(
-        result.errors.some(e => e.includes('directories') && e.includes('object')),
-        'Should mention directories must be object'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('directories') && e.includes('object'))).toBeTruthy();
     });
   });
 
@@ -200,8 +166,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, true, 'Valid plugin should pass');
-      assert.strictEqual(result.errors.length, 0, 'Should have no errors');
+      expect(result.valid).toBe(true);
+      expect(result.errors.length).toBe(0);
     });
 
     test('should accept valid plugin with optional fields', () => {
@@ -216,8 +182,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, true, 'Valid plugin with optional fields should pass');
-      assert.strictEqual(result.errors.length, 0, 'Should have no errors');
+      expect(result.valid).toBe(true);
+      expect(result.errors.length).toBe(0);
     });
 
     test('should detect empty "directories" object', () => {
@@ -230,11 +196,8 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail with empty directories');
-      assert.ok(
-        result.errors.some(e => e.includes('directories') && e.includes('empty')),
-        'Should mention directories must not be empty'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('directories') && e.includes('empty'))).toBeTruthy();
     });
 
     test('should detect invalid optional field types', () => {
@@ -249,16 +212,10 @@ describe('invalid-json-edge-cases', () => {
 
       const result = validatePluginSchema(plugin);
 
-      assert.strictEqual(result.valid, false, 'Should fail with invalid optional fields');
-      assert.ok(result.errors.length >= 2, 'Should have at least 2 errors');
-      assert.ok(
-        result.errors.some(e => e.includes('description')),
-        'Should mention description error'
-      );
-      assert.ok(
-        result.errors.some(e => e.includes('homepage')),
-        'Should mention homepage error'
-      );
+      expect(result.valid).toBe(false);
+      expect(result.errors.length >= 2).toBeTruthy();
+      expect(result.errors.some(e => e.includes('description'))).toBeTruthy();
+      expect(result.errors.some(e => e.includes('homepage'))).toBeTruthy();
     });
   });
 });

--- a/test-env/edge-cases/network-failures.test.js
+++ b/test-env/edge-cases/network-failures.test.js
@@ -1,8 +1,7 @@
 // Test: Network Failures and Retry Logic Edge Cases
 // Validates safeExecWithRetry() handling of network failures and retry mechanisms
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const { execSync } = require('node:child_process');
 
 // Retry function implementation for testing
@@ -49,22 +48,22 @@ describe('network-failures-edge-cases', () => {
   describe('Retry Logic', () => {
     test('should succeed on first attempt with valid command', () => {
       const result = safeExecWithRetry('echo "test"', { maxRetries: 3 });
-      assert.strictEqual(result.success, true, 'Should succeed on first try');
-      assert.strictEqual(result.attempts, 1, 'Should only attempt once');
-      assert.ok(result.output, 'Should have output');
+      expect(result.success).toBe(true);
+      expect(result.attempts).toBe(1);
+      expect(result.output).toBeTruthy();
     });
 
     test('should retry on failed command', () => {
       const result = safeExecWithRetry('node -e "process.exit(1)"', { maxRetries: 2, initialDelay: 50 });
-      assert.strictEqual(result.success, false, 'Should fail after retries');
-      assert.strictEqual(result.attempts, 3, 'Should attempt 3 times (1 + 2 retries)');
-      assert.ok(result.error, 'Should have error message');
+      expect(result.success).toBe(false);
+      expect(result.attempts).toBe(3);
+      expect(result.error).toBeTruthy();
     });
 
     test('should respect maxRetries setting', () => {
       const result = safeExecWithRetry('node -e "process.exit(1)"', { maxRetries: 1, initialDelay: 50 });
-      assert.strictEqual(result.success, false, 'Should fail');
-      assert.strictEqual(result.attempts, 2, 'Should attempt 2 times (1 + 1 retry)');
+      expect(result.success).toBe(false);
+      expect(result.attempts).toBe(2);
     });
 
     test('should use exponential backoff', () => {
@@ -75,9 +74,9 @@ describe('network-failures-edge-cases', () => {
         maxDelay: 500
       });
       const duration = Date.now() - startTime;
-      assert.strictEqual(result.success, false, 'Should fail');
-      assert.strictEqual(result.attempts, 3, 'Should attempt 3 times');
-      assert.ok(duration >= 250, 'Should use exponential backoff delays');
+      expect(result.success).toBe(false);
+      expect(result.attempts).toBe(3);
+      expect(duration >= 250).toBeTruthy();
     });
   });
 
@@ -90,22 +89,22 @@ describe('network-failures-edge-cases', () => {
         maxDelay: 150,
         onDelay: delay => delays.push(delay)
       });
-      assert.strictEqual(result.attempts, 4, 'Should attempt 4 times (1 + 3 retries)');
-      assert.deepStrictEqual(delays, [100, 150, 150], 'Should cap exponential backoff at maxDelay');
+      expect(result.attempts).toBe(4);
+      expect(delays).toEqual([100, 150, 150]);
     });
 
     test('should handle zero retries', () => {
       const result = safeExecWithRetry('node -e "process.exit(1)"', { maxRetries: 0 });
-      assert.strictEqual(result.success, false, 'Should fail');
-      assert.strictEqual(result.attempts, 1, 'Should only attempt once with maxRetries=0');
+      expect(result.success).toBe(false);
+      expect(result.attempts).toBe(1);
     });
   });
 
   describe('Command Execution', () => {
     test('should capture command output on success', () => {
       const result = safeExecWithRetry('echo "hello world"', { maxRetries: 1 });
-      assert.strictEqual(result.success, true, 'Should succeed');
-      assert.ok(result.output.includes('hello'), 'Should capture output');
+      expect(result.success).toBe(true);
+      expect(result.output.includes('hello')).toBeTruthy();
     });
 
     test('should handle command timeout', () => {
@@ -113,7 +112,7 @@ describe('network-failures-edge-cases', () => {
         maxRetries: 1,
         timeout: 5000
       });
-      assert.strictEqual(result.success, true, 'Should succeed before timeout');
+      expect(result.success).toBe(true);
     });
 
     test('should provide error details on failure', () => {
@@ -121,9 +120,9 @@ describe('network-failures-edge-cases', () => {
         maxRetries: 1,
         initialDelay: 50
       });
-      assert.strictEqual(result.success, false, 'Should fail');
-      assert.ok(result.error, 'Should have error message');
-      assert.strictEqual(result.attempts, 2, 'Should retry once');
+      expect(result.success).toBe(false);
+      expect(result.error).toBeTruthy();
+      expect(result.attempts).toBe(2);
     });
   });
 });

--- a/test-env/edge-cases/permission-errors.test.js
+++ b/test-env/edge-cases/permission-errors.test.js
@@ -1,8 +1,7 @@
 // Test: Permission Error Edge Cases
 // Validates graceful handling of filesystem permission errors
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
@@ -13,11 +12,11 @@ let testDir;
 
 ensureTestFixtures();
 
-before(() => {
+beforeAll(() => {
   testDir = mkdtempSync(path.join(tmpdir(), 'forge-test-permissions-'));
 });
 
-after(() => {
+afterAll(() => {
   // Clean up - restore permissions before removing
   try {
     // Restore write permissions for cleanup
@@ -78,8 +77,8 @@ describe('permission-errors', () => {
 
       // On Unix, should detect no write permission
       if (process.platform !== 'win32') {
-        assert.strictEqual(result.writable, false, 'Should detect read-only directory');
-        assert.ok(result.error, 'Should have error message');
+        expect(result.writable).toBe(false);
+        expect(result.error).toBeTruthy();
       }
     });
 
@@ -94,7 +93,7 @@ describe('permission-errors', () => {
         // On Unix, check permissions
         if (process.platform !== 'win32') {
           const mode = stats.mode & 0o777;
-          assert.strictEqual(mode, 0o444, 'Fixture .claude should be read-only (444)');
+          expect(mode).toBe(0o444);
         }
       }
     });
@@ -115,8 +114,8 @@ describe('permission-errors', () => {
       const result = checkWritePermission(nestedDir);
 
       if (process.platform !== 'win32') {
-        assert.strictEqual(result.writable, false);
-        assert.ok(result.error.includes('permission'), 'Error should mention permission');
+        expect(result.writable).toBe(false);
+        expect(result.error.includes('permission')).toBeTruthy();
       }
     });
   });
@@ -138,11 +137,11 @@ describe('permission-errors', () => {
         fs.writeFileSync(filePath, 'new content');
         // If we get here on Unix, something is wrong
         if (process.platform !== 'win32') {
-          assert.fail('Should not be able to write to read-only file');
+          throw new Error('Should not be able to write to read-only file');
         }
       } catch (err) {
         if (process.platform !== 'win32') {
-          assert.ok(err.code === 'EACCES' || err.code === 'EPERM', 'Should get permission error');
+          expect(err.code === 'EACCES' || err.code === 'EPERM').toBeTruthy();
         }
       }
     });
@@ -155,16 +154,16 @@ describe('permission-errors', () => {
       const result = checkWritePermission(path.join(dir, 'nonexistent.txt'));
 
       // Should return a result (may vary by platform)
-      assert.ok(typeof result.writable === 'boolean', 'Should return writable status');
+      expect(typeof result.writable === 'boolean').toBeTruthy();
     });
 
     test('should handle permission errors gracefully', () => {
       const result = checkWritePermission('/root/protected.txt');
 
       // Should return error object, not throw
-      assert.ok(typeof result.writable === 'boolean', 'Should return result object');
+      expect(typeof result.writable === 'boolean').toBeTruthy();
       if (!result.writable) {
-        assert.ok(result.error, 'Should have error message');
+        expect(result.error).toBeTruthy();
       }
     });
   });
@@ -184,12 +183,12 @@ describe('permission-errors', () => {
       const result = checkWritePermission(readOnlyDir);
 
       if (process.platform !== 'win32') {
-        assert.strictEqual(result.writable, false);
+        expect(result.writable).toBe(false);
         // Should suggest fix based on platform
         if (process.platform === 'win32') {
-          assert.ok(result.error.includes('Administrator'), 'Should suggest Administrator on Windows');
+          expect(result.error.includes('Administrator')).toBeTruthy();
         } else {
-          assert.ok(result.error.includes('sudo'), 'Should suggest sudo on Unix');
+          expect(result.error.includes('sudo')).toBeTruthy();
         }
       }
     });
@@ -226,7 +225,7 @@ describe('permission-errors', () => {
 
       // No partial files should be created (Unix only)
       if (process.platform !== 'win32') {
-        assert.strictEqual(filesAfter.length, filesBefore.length, 'Should not create partial files');
+        expect(filesAfter.length).toBe(filesBefore.length);
       }
     });
   });

--- a/test-env/edge-cases/prerequisites.test.js
+++ b/test-env/edge-cases/prerequisites.test.js
@@ -1,8 +1,7 @@
 // Test: Prerequisites Validation Edge Cases
 // Validates checkPrerequisites() detection of missing tools and version constraints
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const { execSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -88,7 +87,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.ok(result.errors.some(e => e.includes('git')), 'Should detect missing git');
+      expect(result.errors.some(e => e.includes('git'))).toBeTruthy();
     });
 
     test('should detect missing gh', () => {
@@ -100,7 +99,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.ok(result.errors.some(e => e.includes('gh')), 'Should detect missing gh');
+      expect(result.errors.some(e => e.includes('gh'))).toBeTruthy();
     });
 
     test('should detect old Node version', () => {
@@ -113,7 +112,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 19 });
-      assert.ok(result.errors.some(e => e.includes('Node.js 20+')), 'Should detect old Node version');
+      expect(result.errors.some(e => e.includes('Node.js 20+'))).toBeTruthy();
     });
 
     test('should detect missing package manager', () => {
@@ -125,7 +124,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.ok(result.errors.some(e => e.includes('package manager')), 'Should detect missing package manager');
+      expect(result.errors.some(e => e.includes('package manager'))).toBeTruthy();
     });
   });
 
@@ -140,7 +139,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.ok(!result.errors.some(e => e.includes('Node.js')), 'Node 20 should pass');
+      expect(!result.errors.some(e => e.includes('Node.js'))).toBeTruthy();
     });
 
     test('Node 22 - should pass', () => {
@@ -153,7 +152,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 22 });
-      assert.ok(!result.errors.some(e => e.includes('Node.js')), 'Node 22 should pass');
+      expect(!result.errors.some(e => e.includes('Node.js'))).toBeTruthy();
     });
 
     test('Node 19.9.9 - should fail', () => {
@@ -166,7 +165,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 19 });
-      assert.ok(result.errors.some(e => e.includes('Node.js 20+')), 'Node 19 should fail');
+      expect(result.errors.some(e => e.includes('Node.js 20+'))).toBeTruthy();
     });
   });
 
@@ -181,7 +180,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.ok(result.warnings.some(w => w.includes('not authenticated')), 'Should warn about unauthenticated gh');
+      expect(result.warnings.some(w => w.includes('not authenticated'))).toBeTruthy();
     });
 
     test('authenticated gh - should be OK', () => {
@@ -194,7 +193,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.ok(!result.warnings.some(w => w.includes('not authenticated')), 'Should not warn if authenticated');
+      expect(!result.warnings.some(w => w.includes('not authenticated'))).toBeTruthy();
     });
   });
 
@@ -209,7 +208,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.strictEqual(result.pkgManager, 'npm', 'Should detect npm');
+      expect(result.pkgManager).toBe('npm');
     });
 
     test('should detect yarn', () => {
@@ -222,7 +221,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.strictEqual(result.pkgManager, 'yarn', 'Should detect yarn');
+      expect(result.pkgManager).toBe('yarn');
     });
 
     test('should detect pnpm', () => {
@@ -235,7 +234,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.strictEqual(result.pkgManager, 'pnpm', 'Should detect pnpm');
+      expect(result.pkgManager).toBe('pnpm');
     });
 
     test('should detect bun', () => {
@@ -248,7 +247,7 @@ describe('prerequisites-edge-cases', () => {
       };
 
       const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20 });
-      assert.strictEqual(result.pkgManager, 'bun', 'Should detect bun');
+      expect(result.pkgManager).toBe('bun');
     });
 
     test('lockfile should override binary priority', () => {
@@ -268,7 +267,7 @@ describe('prerequisites-edge-cases', () => {
         };
 
         const result = checkPrerequisitesTest({ mockExec, nodeVersion: 20, projectRoot: tempDir });
-        assert.strictEqual(result.pkgManager, 'yarn', 'yarn.lock should override npm detection');
+        expect(result.pkgManager).toBe('yarn');
       } finally {
         rmSync(tempDir, { recursive: true, force: true });
       }

--- a/test-env/edge-cases/rollback-edge-cases.test.js
+++ b/test-env/edge-cases/rollback-edge-cases.test.js
@@ -1,8 +1,7 @@
 // Test: Rollback Edge Cases and Security
 // Comprehensive edge case testing for rollback system validation
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const path = require('node:path');
 
 const projectRoot = process.cwd();
@@ -69,306 +68,306 @@ describe('Rollback Edge Cases & Security Tests', () => {
   describe('Commit Hash Edge Cases', () => {
     test('Accepts 4-character hash (minimum)', () => {
       const result = validateRollbackInput('commit', 'abcd');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts 40-character hash (maximum)', () => {
       const result = validateRollbackInput('commit', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Rejects 3-character hash (too short)', () => {
       const result = validateRollbackInput('commit', 'abc');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects 41-character hash (too long)', () => {
       const result = validateRollbackInput('commit', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Accepts uppercase hex characters', () => {
       const result = validateRollbackInput('commit', 'ABCDEF123');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts mixed case hex', () => {
       const result = validateRollbackInput('commit', 'AbCdEf123');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Rejects hash with non-hex characters', () => {
       const result = validateRollbackInput('commit', 'g1h2i3j4');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects hash with special characters', () => {
       const result = validateRollbackInput('commit', 'abc-123');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects hash with spaces', () => {
       const result = validateRollbackInput('commit', 'abc 123');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('Shell Injection Prevention', () => {
     test('Rejects semicolon injection', () => {
       const result = validateRollbackInput('commit', 'abc123;rm -rf /');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects pipe injection', () => {
       const result = validateRollbackInput('commit', 'abc123|cat /etc/passwd');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects ampersand injection', () => {
       const result = validateRollbackInput('commit', 'abc123&whoami');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects dollar sign injection', () => {
       const result = validateRollbackInput('commit', 'abc123$(whoami)');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects backtick injection', () => {
       const result = validateRollbackInput('commit', 'abc123`whoami`');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects parenthesis injection', () => {
       const result = validateRollbackInput('commit', 'abc123(ls)');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects angle bracket injection', () => {
       const result = validateRollbackInput('commit', 'abc123<file.txt');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects newline injection', () => {
       const result = validateRollbackInput('commit', 'abc123\nrm -rf /');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects carriage return injection', () => {
       const result = validateRollbackInput('commit', 'abc123\rrm -rf /');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('Path Traversal Prevention', () => {
     test('Rejects simple path traversal', () => {
       const result = validateRollbackInput('partial', '../etc/passwd');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects multiple level traversal', () => {
       const result = validateRollbackInput('partial', '../../../etc/passwd');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects absolute path outside project', () => {
       const result = validateRollbackInput('partial', '/etc/passwd');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects Windows path traversal', () => {
       const result = validateRollbackInput('partial', '..\\..\\Windows\\System32');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects encoded path traversal', () => {
       const result = validateRollbackInput('partial', '..%2F..%2Fetc%2Fpasswd');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Accepts relative path within project', () => {
       const result = validateRollbackInput('partial', 'src/auth.js');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts nested path within project', () => {
       const result = validateRollbackInput('partial', 'src/components/ui/Button.tsx');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
   });
 
   describe('File Path Edge Cases', () => {
     test('Accepts multiple comma-separated files', () => {
       const result = validateRollbackInput('partial', 'file1.js,file2.js,file3.js');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Handles whitespace around commas', () => {
       const result = validateRollbackInput('partial', 'file1.js , file2.js , file3.js');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Rejects file with semicolon in name', () => {
       const result = validateRollbackInput('partial', 'file;rm.js');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects file with pipe in name', () => {
       const result = validateRollbackInput('partial', 'file|cat.js');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Accepts file with dots in name', () => {
       const result = validateRollbackInput('partial', 'config.test.js');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts file with dashes in name', () => {
       const result = validateRollbackInput('partial', 'my-component.js');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts file with underscores in name', () => {
       const result = validateRollbackInput('partial', 'my_component.js');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
   });
 
   describe('Branch Range Edge Cases', () => {
     test('Accepts valid branch range', () => {
       const result = validateRollbackInput('branch', 'abc123..def456');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Rejects range with single dot', () => {
       const result = validateRollbackInput('branch', 'abc123.def456');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects range with three dots', () => {
       const result = validateRollbackInput('branch', 'abc123...def456');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects range with no separator', () => {
       const result = validateRollbackInput('branch', 'abc123def456');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects range with invalid start hash', () => {
       const result = validateRollbackInput('branch', 'xyz..def456');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects range with invalid end hash', () => {
       const result = validateRollbackInput('branch', 'abc123..xyz');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects range with short start hash', () => {
       const result = validateRollbackInput('branch', 'abc..def456');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects range with short end hash', () => {
       const result = validateRollbackInput('branch', 'abc123..def');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Accepts range with mixed case hashes', () => {
       const result = validateRollbackInput('branch', 'AbC123..DeF456');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
   });
 
   describe('Method Validation', () => {
     test('Accepts "commit" method', () => {
       const result = validateRollbackInput('commit', 'HEAD');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts "pr" method', () => {
       const result = validateRollbackInput('pr', 'abc123');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts "partial" method', () => {
       const result = validateRollbackInput('partial', 'file.js');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Accepts "branch" method', () => {
       const result = validateRollbackInput('branch', 'abc123..def456');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Rejects invalid method', () => {
       const result = validateRollbackInput('invalid', 'HEAD');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects empty method', () => {
       const result = validateRollbackInput('', 'HEAD');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects null method', () => {
       const result = validateRollbackInput(null, 'HEAD');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects method with wrong case', () => {
       const result = validateRollbackInput('COMMIT', 'HEAD');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('Special Cases', () => {
     test('Accepts HEAD keyword', () => {
       const result = validateRollbackInput('commit', 'HEAD');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('Rejects head in lowercase (case sensitive)', () => {
       const result = validateRollbackInput('commit', 'head');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects HEAD~1 (not a valid format)', () => {
       const result = validateRollbackInput('commit', 'HEAD~1');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects HEAD^ (not a valid format)', () => {
       const result = validateRollbackInput('commit', 'HEAD^');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects empty target', () => {
       const result = validateRollbackInput('commit', '');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects whitespace-only target', () => {
       const result = validateRollbackInput('commit', '   ');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('Unicode and Encoding', () => {
     test('Rejects unicode characters in hash', () => {
       const result = validateRollbackInput('commit', 'abc123😀');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects unicode characters in file path', () => {
       const result = validateRollbackInput('partial', 'file😀.js');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('Rejects null bytes in target', () => {
       const result = validateRollbackInput('commit', 'abc\x00123');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
   });
 });

--- a/test-env/edge-cases/rollback-user-sections.test.js
+++ b/test-env/edge-cases/rollback-user-sections.test.js
@@ -1,8 +1,7 @@
 // Test: USER Section Extraction and Preservation
 // Tests for extractUserSections() and preserveUserSections()
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, expect } from 'bun:test';
 const fs = require('fs');
 const path = require('path');
 
@@ -66,13 +65,13 @@ function preserveUserSections(filePath, sections) {
 }
 
 describe('USER Section Extraction & Preservation Tests', () => {
-  before(() => {
+  beforeAll(() => {
     if (!fs.existsSync(testDir)) {
       fs.mkdirSync(testDir, { recursive: true });
     }
   });
 
-  after(() => {
+  afterAll(() => {
     try {
       fs.rmdirSync(testDir, { recursive: true });
     } catch (_err) {
@@ -92,8 +91,8 @@ More content`;
       fs.writeFileSync(testFile, content);
 
       const sections = extractUserSections(testFile);
-      assert.strictEqual(Object.keys(sections).length, 1);
-      assert.strictEqual(sections.user_0.trim(), 'Custom content here');
+      expect(Object.keys(sections).length).toBe(1);
+      expect(sections.user_0.trim()).toBe('Custom content here');
 
       fs.unlinkSync(testFile);
     });
@@ -112,9 +111,9 @@ Second section
       fs.writeFileSync(testFile, content);
 
       const sections = extractUserSections(testFile);
-      assert.strictEqual(Object.keys(sections).length, 2);
-      assert.strictEqual(sections.user_0.trim(), 'First section');
-      assert.strictEqual(sections.user_1.trim(), 'Second section');
+      expect(Object.keys(sections).length).toBe(2);
+      expect(sections.user_0.trim()).toBe('First section');
+      expect(sections.user_1.trim()).toBe('Second section');
 
       fs.unlinkSync(testFile);
     });
@@ -122,7 +121,7 @@ Second section
     test('Returns empty object for non-existent file', () => {
       ensureTestDir();
       const sections = extractUserSections(path.join(testDir, 'nonexistent.md'));
-      assert.strictEqual(Object.keys(sections).length, 0);
+      expect(Object.keys(sections).length).toBe(0);
     });
   });
 
@@ -146,7 +145,7 @@ Original content
       preserveUserSections(testFile, sections);
 
       const restored = fs.readFileSync(testFile, 'utf-8');
-      assert.ok(restored.includes('Original content'));
+      expect(restored.includes('Original content')).toBeTruthy();
 
       fs.unlinkSync(testFile);
     });

--- a/test-env/edge-cases/rollback-validation.test.js
+++ b/test-env/edge-cases/rollback-validation.test.js
@@ -1,8 +1,7 @@
 // Test: validateRollbackInput()
 // GREEN phase - Tests should pass with implementation
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const path = require('node:path');
 
 // Mock projectRoot for testing
@@ -77,37 +76,37 @@ function validateRollbackInput(method, target) {
 describe('GREEN Phase: Rollback Validation Tests', () => {
   test('Valid commit hash', () => {
     const result = validateRollbackInput('commit', 'a1b2c3d');
-    assert.strictEqual(result.valid, true, 'Should accept valid commit hash');
+    expect(result.valid).toBe(true);
   });
 
   test('HEAD is valid', () => {
     const result = validateRollbackInput('commit', 'HEAD');
-    assert.strictEqual(result.valid, true, 'Should accept HEAD');
+    expect(result.valid).toBe(true);
   });
 
   test('Invalid commit hash with semicolon', () => {
     const result = validateRollbackInput('commit', 'abc;rm -rf /');
-    assert.strictEqual(result.valid, false, 'Should reject shell metacharacters');
-    assert.ok(result.error.includes('Invalid'), 'Should have error message');
+    expect(result.valid).toBe(false);
+    expect(result.error.includes('Invalid')).toBeTruthy();
   });
 
   test('Invalid method', () => {
     const result = validateRollbackInput('invalid', 'HEAD');
-    assert.strictEqual(result.valid, false, 'Should reject invalid method');
+    expect(result.valid).toBe(false);
   });
 
   test('Path validation - reject path traversal', () => {
     const result = validateRollbackInput('partial', '../../../etc/passwd');
-    assert.strictEqual(result.valid, false, 'Should reject path traversal');
+    expect(result.valid).toBe(false);
   });
 
   test('Valid file paths', () => {
     const result = validateRollbackInput('partial', 'AGENTS.md,package.json');
-    assert.strictEqual(result.valid, true, 'Should accept valid file paths');
+    expect(result.valid).toBe(true);
   });
 
   test('Branch range validation', () => {
     const result = validateRollbackInput('branch', 'abc123..def456');
-    assert.strictEqual(result.valid, true, 'Should accept valid range');
+    expect(result.valid).toBe(true);
   });
 });

--- a/test-env/edge-cases/security.test.js
+++ b/test-env/edge-cases/security.test.js
@@ -2,8 +2,7 @@
 // Comprehensive security validation (shell injection, path traversal, unicode attacks)
 // Reuses patterns from test/rollback-edge-cases.test.js
 
-const { describe, test } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, expect } from 'bun:test';
 const path = require('node:path');
 
 // Security validation function (will be added to bin/forge.js)
@@ -66,248 +65,248 @@ describe('security-validation', () => {
   describe('Shell Injection Prevention', () => {
     test('should reject semicolon injection', () => {
       const result = validateUserInput('test;rm -rf /', 'path');
-      assert.strictEqual(result.valid, false);
-      assert.ok(result.error.includes('shell metacharacters'));
+      expect(result.valid).toBe(false);
+      expect(result.error.includes('shell metacharacters')).toBeTruthy();
     });
 
     test('should reject pipe injection', () => {
       const result = validateUserInput('test|cat /etc/passwd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject ampersand injection', () => {
       const result = validateUserInput('test&whoami', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject backtick injection', () => {
       const result = validateUserInput('test`whoami`', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject dollar sign command substitution', () => {
       const result = validateUserInput('test$(whoami)', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject newline injection', () => {
       const result = validateUserInput('test\nrm -rf /', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject carriage return injection', () => {
       const result = validateUserInput('test\rrm -rf /', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject output redirection', () => {
       const result = validateUserInput('test>/etc/passwd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject input redirection', () => {
       const result = validateUserInput('test</etc/passwd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject append operator', () => {
       const result = validateUserInput('test>>/etc/passwd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject AND operator', () => {
       const result = validateUserInput('test&&whoami', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject OR operator', () => {
       const result = validateUserInput('test||whoami', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject parentheses', () => {
       const result = validateUserInput('test(ls)', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject angle brackets', () => {
       const result = validateUserInput('<script>alert(1)</script>', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject multiple operators', () => {
       const result = validateUserInput('test;|&&&||', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('Path Traversal Prevention', () => {
     test('should reject parent directory traversal', () => {
       const result = validateUserInput('../../../etc/passwd', 'path');
-      assert.strictEqual(result.valid, false);
-      assert.ok(result.error.includes('outside project root'));
+      expect(result.valid).toBe(false);
+      expect(result.error.includes('outside project root')).toBeTruthy();
     });
 
     test('should reject absolute Unix paths', () => {
       const result = validateUserInput('/etc/passwd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject URL-encoded dot', () => {
       const result = validateUserInput('%2e%2e/passwd', 'path');
-      assert.strictEqual(result.valid, false);
-      assert.ok(result.error.includes('URL-encoded'));
+      expect(result.valid).toBe(false);
+      expect(result.error.includes('URL-encoded')).toBeTruthy();
     });
 
     test('should reject URL-encoded slash', () => {
       const result = validateUserInput('..%2fpasswd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject URL-encoded backslash', () => {
       const result = validateUserInput('..%5cpasswd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject mixed URL encoding', () => {
       const result = validateUserInput('..%2F..%2Fetc', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject Windows path traversal', () => {
       const result = validateUserInput('..\\..\\windows\\system32', 'path');
-      assert.strictEqual(result.valid, false);
-      assert.ok(result.error.includes('Backslash') || result.error.includes('ASCII') || result.error.includes('outside'));
+      expect(result.valid).toBe(false);
+      expect(result.error.includes('Backslash') || result.error.includes('ASCII') || result.error.includes('outside')).toBeTruthy();
     });
 
     test('should reject Windows drive letters', () => {
       const result = validateUserInput('C:\\Windows\\System32', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject UNC paths', () => {
       const result = validateUserInput('\\\\server\\share', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should allow safe relative paths', () => {
       const result = validateUserInput('docs/readme.md', 'path');
-      assert.strictEqual(result.valid, true, 'Safe relative paths should be allowed');
+      expect(result.valid).toBe(true);
     });
   });
 
   describe('Unicode Injection', () => {
     test('should reject zero-width space', () => {
       const result = validateUserInput('test\u200Bfile', 'path');
-      assert.strictEqual(result.valid, false);
-      assert.ok(result.error.includes('ASCII'));
+      expect(result.valid).toBe(false);
+      expect(result.error.includes('ASCII')).toBeTruthy();
     });
 
     test('should reject right-to-left override', () => {
       const result = validateUserInput('test\u202Efile', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject emoji in path', () => {
       const result = validateUserInput('📁folder/file.txt', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject Chinese characters', () => {
       const result = validateUserInput('路径/file.txt', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject Cyrillic lookalikes', () => {
       const result = validateUserInput('аdmin', 'path'); // First 'а' is Cyrillic
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject homoglyph attacks', () => {
       const result = validateUserInput('раypal', 'path'); // 'а' and 'р' are Cyrillic
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject non-printable ASCII', () => {
       const result = validateUserInput('test\x00file', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should reject high-bit characters', () => {
       const result = validateUserInput('test\xFFfile', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('Input Sanitization by Type', () => {
     test('agent name - should allow valid format', () => {
       const result = validateUserInput('claude-code', 'agent');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('agent name - should reject uppercase', () => {
       const result = validateUserInput('Claude-Code', 'agent');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('agent name - should reject underscores', () => {
       const result = validateUserInput('claude_code', 'agent');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('agent name - should reject special characters', () => {
       const result = validateUserInput('claude@code', 'agent');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('commit hash - should allow valid short hash', () => {
       const result = validateUserInput('abc123', 'hash');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('commit hash - should allow valid long hash', () => {
       const result = validateUserInput('abc123def456abc123def456abc123def456abcd', 'hash');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
 
     test('commit hash - should reject non-hex characters', () => {
       const result = validateUserInput('xyz123', 'hash');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('commit hash - should reject too short', () => {
       const result = validateUserInput('abc', 'hash');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('commit hash - should reject too long', () => {
       const result = validateUserInput('a'.repeat(41), 'hash');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('path - should allow alphanumeric with dash', () => {
       const result = validateUserInput('my-project-123', 'path');
-      assert.strictEqual(result.valid, true);
+      expect(result.valid).toBe(true);
     });
   });
 
   describe('Edge Case Combinations', () => {
     test('should reject multiple attack vectors combined', () => {
       const result = validateUserInput(';../../../etc\npässwd', 'path');
-      assert.strictEqual(result.valid, false);
+      expect(result.valid).toBe(false);
     });
 
     test('should handle empty string', () => {
       const result = validateUserInput('', 'path');
       // Empty string is technically valid ASCII, behavior may vary
       // Just verify it doesn't crash
-      assert.ok(typeof result.valid === 'boolean');
+      expect(typeof result.valid === 'boolean').toBeTruthy();
     });
 
     test('should handle very long input', () => {
       const result = validateUserInput('a'.repeat(10000), 'path');
       // Should not crash on long input
-      assert.ok(typeof result.valid === 'boolean');
+      expect(typeof result.valid === 'boolean').toBeTruthy();
     });
   });
 });

--- a/test-env/helpers/fixtures.test.js
+++ b/test-env/helpers/fixtures.test.js
@@ -1,4 +1,4 @@
-const { afterEach, describe, expect, test } = require('bun:test');
+import { afterEach, describe, expect, test } from 'bun:test';
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');

--- a/test-env/validation/agent-validator.test.js
+++ b/test-env/validation/agent-validator.test.js
@@ -1,8 +1,7 @@
 // Test: Agent Validator Helper
 // Tests for validating agent configurations
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
@@ -16,12 +15,12 @@ const {
 
 let testDir;
 
-before(() => {
+beforeAll(() => {
   // Create temp directory for tests
   testDir = mkdtempSync(path.join(tmpdir(), 'forge-test-agent-'));
 });
 
-after(() => {
+afterAll(() => {
   // Cleanup
   rmSync(testDir, { recursive: true, force: true });
 });
@@ -41,9 +40,9 @@ describe('agent-validator', () => {
 
       const result = validateAgent('claude', claudeDir);
 
-      assert.strictEqual(typeof result.passed, 'boolean');
-      assert.ok(Array.isArray(result.failures));
-      assert.strictEqual(typeof result.coverage, 'number');
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.failures)).toBeTruthy();
+      expect(typeof result.coverage).toBe('number');
     });
 
     test('should validate Cursor installation', () => {
@@ -59,8 +58,8 @@ describe('agent-validator', () => {
 
       const result = validateAgent('cursor', cursorDir);
 
-      assert.strictEqual(typeof result.passed, 'boolean');
-      assert.ok(Array.isArray(result.failures));
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.failures)).toBeTruthy();
     });
 
     test('should detect missing agent files', () => {
@@ -69,8 +68,8 @@ describe('agent-validator', () => {
 
       const result = validateAgent('claude', missingDir);
 
-      assert.strictEqual(result.passed, false);
-      assert.ok(result.failures.length > 0);
+      expect(result.passed).toBe(false);
+      expect(result.failures.length > 0).toBeTruthy();
     });
 
     test('should detect partial installation', () => {
@@ -83,8 +82,8 @@ describe('agent-validator', () => {
 
       const result = validateAgent('claude', partialDir);
 
-      assert.ok(result.failures.length > 0);
-      assert.ok(result.coverage < 1.0);
+      expect(result.failures.length > 0).toBeTruthy();
+      expect(result.coverage < 1.0).toBeTruthy();
     });
 
     test('should return unified interface format', () => {
@@ -94,14 +93,14 @@ describe('agent-validator', () => {
       const result = validateAgent('claude', formatDir);
 
       // Check interface structure
-      assert.ok('passed' in result);
-      assert.ok('failures' in result);
-      assert.ok('coverage' in result);
+      expect('passed' in result).toBeTruthy();
+      expect('failures' in result).toBeTruthy();
+      expect('coverage' in result).toBeTruthy();
 
-      assert.strictEqual(typeof result.passed, 'boolean');
-      assert.ok(Array.isArray(result.failures));
-      assert.strictEqual(typeof result.coverage, 'number');
-      assert.ok(result.coverage >= 0 && result.coverage <= 1);
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.failures)).toBeTruthy();
+      expect(typeof result.coverage).toBe('number');
+      expect(result.coverage >= 0 && result.coverage <= 1).toBeTruthy();
     });
   });
 
@@ -109,23 +108,23 @@ describe('agent-validator', () => {
     test('should return expected files for Claude Code', () => {
       const files = getExpectedFiles('claude');
 
-      assert.ok(Array.isArray(files));
-      assert.ok(files.length > 0);
+      expect(Array.isArray(files)).toBeTruthy();
+      expect(files.length > 0).toBeTruthy();
 
       // Should include at least CLAUDE.md
       const hasClaudeMd = files.some(f => f.path && f.path.includes('CLAUDE.md'));
-      assert.ok(hasClaudeMd);
+      expect(hasClaudeMd).toBeTruthy();
     });
 
     test('should return expected files for Cursor', () => {
       const files = getExpectedFiles('cursor');
 
-      assert.ok(Array.isArray(files));
-      assert.ok(files.length > 0);
+      expect(Array.isArray(files)).toBeTruthy();
+      expect(files.length > 0).toBeTruthy();
 
       // Should include .cursorrules (not CURSOR.md)
       const hasCursorRules = files.some(f => f.path && f.path.includes('.cursorrules'));
-      assert.ok(hasCursorRules);
+      expect(hasCursorRules).toBeTruthy();
     });
 
     test('should return expected files for all 8 agents', () => {
@@ -136,15 +135,15 @@ describe('agent-validator', () => {
 
       for (const agent of agents) {
         const files = getExpectedFiles(agent);
-        assert.ok(Array.isArray(files), `${agent} should return array`);
+        expect(Array.isArray(files)).toBeTruthy();
       }
     });
 
     test('should return empty array for unknown agent', () => {
       const files = getExpectedFiles('unknown-agent-xyz');
 
-      assert.ok(Array.isArray(files));
-      assert.strictEqual(files.length, 0);
+      expect(Array.isArray(files)).toBeTruthy();
+      expect(files.length).toBe(0);
     });
   });
 
@@ -163,7 +162,7 @@ describe('agent-validator', () => {
       const result = validateAgent('cursor', fullDir);
 
       // Coverage should be high (close to 1.0)
-      assert.ok(result.coverage > 0.5);
+      expect(result.coverage > 0.5).toBeTruthy();
     });
 
     test('should calculate partial coverage with some files missing', () => {
@@ -177,8 +176,8 @@ describe('agent-validator', () => {
       const result = validateAgent('claude', partialDir);
 
       // Coverage should be less than 1.0
-      assert.ok(result.coverage < 1.0);
-      assert.ok(result.coverage > 0);
+      expect(result.coverage < 1.0).toBeTruthy();
+      expect(result.coverage > 0).toBeTruthy();
     });
   });
 });

--- a/test-env/validation/env-validator.test.js
+++ b/test-env/validation/env-validator.test.js
@@ -1,8 +1,7 @@
 // Test: Env Validator Helper
 // Tests for .env.local file validation and preservation
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
@@ -17,12 +16,12 @@ const {
 
 let testDir;
 
-before(() => {
+beforeAll(() => {
   // Create temp directory for tests
   testDir = mkdtempSync(path.join(tmpdir(), 'forge-test-env-'));
 });
 
-after(() => {
+afterAll(() => {
   // Cleanup
   rmSync(testDir, { recursive: true, force: true });
 });
@@ -35,8 +34,8 @@ describe('env-validator', () => {
 
       const result = validateEnvFile(envPath);
 
-      assert.strictEqual(result.passed, true);
-      assert.strictEqual(result.failures.length, 0);
+      expect(result.passed).toBe(true);
+      expect(result.failures.length).toBe(0);
     });
 
     test('should detect malformed entries', () => {
@@ -45,8 +44,8 @@ describe('env-validator', () => {
 
       const result = validateEnvFile(envPath);
 
-      assert.strictEqual(result.passed, false);
-      assert.ok(result.failures.length > 0);
+      expect(result.passed).toBe(false);
+      expect(result.failures.length > 0).toBeTruthy();
     });
 
     test('should detect missing equals sign', () => {
@@ -55,8 +54,8 @@ describe('env-validator', () => {
 
       const result = validateEnvFile(envPath);
 
-      assert.strictEqual(result.passed, false);
-      assert.match(result.failures[0].reason, /invalid format/i);
+      expect(result.passed).toBe(false);
+      expect(result.failures[0].reason).toMatch(/invalid format/i);
     });
 
     test('should allow comments and empty lines', () => {
@@ -65,7 +64,7 @@ describe('env-validator', () => {
 
       const result = validateEnvFile(envPath);
 
-      assert.strictEqual(result.passed, true);
+      expect(result.passed).toBe(true);
     });
 
     test('should return unified interface format', () => {
@@ -75,14 +74,14 @@ describe('env-validator', () => {
       const result = validateEnvFile(envPath);
 
       // Check interface structure
-      assert.ok('passed' in result);
-      assert.ok('failures' in result);
-      assert.ok('coverage' in result);
+      expect('passed' in result).toBeTruthy();
+      expect('failures' in result).toBeTruthy();
+      expect('coverage' in result).toBeTruthy();
 
-      assert.strictEqual(typeof result.passed, 'boolean');
-      assert.ok(Array.isArray(result.failures));
-      assert.strictEqual(typeof result.coverage, 'number');
-      assert.ok(result.coverage >= 0 && result.coverage <= 1);
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.failures)).toBeTruthy();
+      expect(typeof result.coverage).toBe('number');
+      expect(result.coverage >= 0 && result.coverage <= 1).toBeTruthy();
     });
   });
 
@@ -92,9 +91,9 @@ describe('env-validator', () => {
 
       const result = parseEnvFile(content);
 
-      assert.ok(result.variables);
-      assert.strictEqual(result.variables.API_KEY, 'abc123');
-      assert.strictEqual(result.variables.DATABASE_URL, 'postgres://localhost');
+      expect(result.variables).toBeTruthy();
+      expect(result.variables.API_KEY).toBe('abc123');
+      expect(result.variables.DATABASE_URL).toBe('postgres://localhost');
     });
 
     test('should handle quoted values', () => {
@@ -102,8 +101,8 @@ describe('env-validator', () => {
 
       const result = parseEnvFile(content);
 
-      assert.strictEqual(result.variables.QUOTED, 'value with spaces');
-      assert.strictEqual(result.variables.SINGLE, 'single quoted');
+      expect(result.variables.QUOTED).toBe('value with spaces');
+      expect(result.variables.SINGLE).toBe('single quoted');
     });
 
     test('should preserve comments', () => {
@@ -111,8 +110,8 @@ describe('env-validator', () => {
 
       const result = parseEnvFile(content);
 
-      assert.ok(Array.isArray(result.comments));
-      assert.ok(result.comments.length >= 2);
+      expect(Array.isArray(result.comments)).toBeTruthy();
+      expect(result.comments.length >= 2).toBeTruthy();
     });
 
     test('should ignore empty lines', () => {
@@ -120,7 +119,7 @@ describe('env-validator', () => {
 
       const result = parseEnvFile(content);
 
-      assert.strictEqual(Object.keys(result.variables).length, 2);
+      expect(Object.keys(result.variables).length).toBe(2);
     });
 
     test('should handle multiline values', () => {
@@ -129,7 +128,7 @@ describe('env-validator', () => {
 
       const result = parseEnvFile(content);
 
-      assert.strictEqual(result.variables.SIMPLE, 'value');
+      expect(result.variables.SIMPLE).toBe('value');
     });
   });
 
@@ -140,8 +139,8 @@ describe('env-validator', () => {
 
       const result = checkPreservation(oldContent, newContent);
 
-      assert.strictEqual(result.passed, true);
-      assert.strictEqual(result.failures.length, 0);
+      expect(result.passed).toBe(true);
+      expect(result.failures.length).toBe(0);
     });
 
     test('should detect new variables added', () => {
@@ -150,7 +149,7 @@ describe('env-validator', () => {
 
       const result = checkPreservation(oldContent, newContent);
 
-      assert.strictEqual(result.passed, true);
+      expect(result.passed).toBe(true);
       // No failures because adding is allowed
     });
 
@@ -160,8 +159,8 @@ describe('env-validator', () => {
 
       const result = checkPreservation(oldContent, newContent);
 
-      assert.strictEqual(result.passed, false);
-      assert.ok(result.failures.some(f => /removed/i.test(f.reason)));
+      expect(result.passed).toBe(false);
+      expect(result.failures.some(f => /removed/i.test(f.reason))).toBeTruthy();
     });
 
     test('should detect changed values', () => {
@@ -170,8 +169,8 @@ describe('env-validator', () => {
 
       const result = checkPreservation(oldContent, newContent);
 
-      assert.strictEqual(result.passed, false);
-      assert.ok(result.failures.some(f => /changed/i.test(f.reason)));
+      expect(result.passed).toBe(false);
+      expect(result.failures.some(f => /changed/i.test(f.reason))).toBeTruthy();
     });
 
     test('should preserve comments', () => {
@@ -181,7 +180,7 @@ describe('env-validator', () => {
       const result = checkPreservation(oldContent, newContent);
 
       // Comments should be preserved
-      assert.strictEqual(result.passed, true);
+      expect(result.passed).toBe(true);
     });
   });
 });

--- a/test-env/validation/file-checker.test.js
+++ b/test-env/validation/file-checker.test.js
@@ -1,8 +1,7 @@
 // Test: File Checker Validation Helper
 // Tests for file existence, content, and symlink validation
 
-const { describe, test, beforeAll: before, afterAll: after } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
@@ -17,12 +16,12 @@ const {
 
 let testDir;
 
-before(() => {
+beforeAll(() => {
   // Create temp directory for tests
   testDir = mkdtempSync(path.join(tmpdir(), 'forge-test-file-checker-'));
 });
 
-after(() => {
+afterAll(() => {
   // Cleanup
   rmSync(testDir, { recursive: true, force: true });
 });
@@ -35,8 +34,8 @@ describe('file-checker', () => {
 
       const result = validateFile(filePath, { mustExist: true });
 
-      assert.strictEqual(result.passed, true);
-      assert.strictEqual(result.failures.length, 0);
+      expect(result.passed).toBe(true);
+      expect(result.failures.length).toBe(0);
     });
 
     test('should detect missing file', () => {
@@ -44,9 +43,9 @@ describe('file-checker', () => {
 
       const result = validateFile(filePath, { mustExist: true });
 
-      assert.strictEqual(result.passed, false);
-      assert.strictEqual(result.failures.length, 1);
-      assert.match(result.failures[0].reason, /does not exist/i);
+      expect(result.passed).toBe(false);
+      expect(result.failures.length).toBe(1);
+      expect(result.failures[0].reason).toMatch(/does not exist/i);
     });
 
     test('should validate file is not empty', () => {
@@ -55,7 +54,7 @@ describe('file-checker', () => {
 
       const result = validateFile(filePath, { mustExist: true, notEmpty: true });
 
-      assert.strictEqual(result.passed, true);
+      expect(result.passed).toBe(true);
     });
 
     test('should detect empty file', () => {
@@ -64,8 +63,8 @@ describe('file-checker', () => {
 
       const result = validateFile(filePath, { mustExist: true, notEmpty: true });
 
-      assert.strictEqual(result.passed, false);
-      assert.match(result.failures[0].reason, /is empty/i);
+      expect(result.passed).toBe(false);
+      expect(result.failures[0].reason).toMatch(/is empty/i);
     });
 
     test('should validate minimum file size', () => {
@@ -74,7 +73,7 @@ describe('file-checker', () => {
 
       const result = validateFile(filePath, { mustExist: true, minSize: 50 });
 
-      assert.strictEqual(result.passed, true);
+      expect(result.passed).toBe(true);
     });
 
     test('should detect file below minimum size', () => {
@@ -83,8 +82,8 @@ describe('file-checker', () => {
 
       const result = validateFile(filePath, { mustExist: true, minSize: 100 });
 
-      assert.strictEqual(result.passed, false);
-      assert.match(result.failures[0].reason, /smaller than minimum/i);
+      expect(result.passed).toBe(false);
+      expect(result.failures[0].reason).toMatch(/smaller than minimum/i);
     });
   });
 
@@ -107,8 +106,8 @@ describe('file-checker', () => {
 
       const result = checkSymlink(linkPath, targetPath);
 
-      assert.strictEqual(result.passed, true);
-      assert.strictEqual(result.failures.length, 0);
+      expect(result.passed).toBe(true);
+      expect(result.failures.length).toBe(0);
     });
 
     test('should detect missing symlink', () => {
@@ -117,8 +116,8 @@ describe('file-checker', () => {
 
       const result = checkSymlink(linkPath, targetPath);
 
-      assert.strictEqual(result.passed, false);
-      assert.match(result.failures[0].reason, /does not exist/i);
+      expect(result.passed).toBe(false);
+      expect(result.failures[0].reason).toMatch(/does not exist/i);
     });
 
     test('should detect incorrect symlink target', () => {
@@ -141,8 +140,8 @@ describe('file-checker', () => {
 
       const result = checkSymlink(linkPath, targetPath);
 
-      assert.strictEqual(result.passed, false);
-      assert.match(result.failures[0].reason, /points to wrong target/i);
+      expect(result.passed).toBe(false);
+      expect(result.failures[0].reason).toMatch(/points to wrong target/i);
     });
   });
 
@@ -160,23 +159,23 @@ describe('file-checker', () => {
 
       const result = validateInstallation('claude', testDir);
 
-      assert.strictEqual(typeof result.passed, 'boolean');
-      assert.ok(Array.isArray(result.failures));
-      assert.strictEqual(typeof result.coverage, 'number');
-      assert.ok(result.coverage >= 0 && result.coverage <= 1);
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.failures)).toBeTruthy();
+      expect(typeof result.coverage).toBe('number');
+      expect(result.coverage >= 0 && result.coverage <= 1).toBeTruthy();
     });
 
     test('should return unified interface format', () => {
       const result = validateInstallation('claude', testDir);
 
       // Check interface structure
-      assert.ok('passed' in result);
-      assert.ok('failures' in result);
-      assert.ok('coverage' in result);
+      expect('passed' in result).toBeTruthy();
+      expect('failures' in result).toBeTruthy();
+      expect('coverage' in result).toBeTruthy();
 
-      assert.strictEqual(typeof result.passed, 'boolean');
-      assert.ok(Array.isArray(result.failures));
-      assert.strictEqual(typeof result.coverage, 'number');
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.failures)).toBeTruthy();
+      expect(typeof result.coverage).toBe('number');
     });
 
     test('should calculate coverage correctly', () => {
@@ -188,12 +187,12 @@ describe('file-checker', () => {
       const result = validateInstallation('claude', testDir);
 
       // Coverage should be between 0 and 1
-      assert.ok(result.coverage >= 0);
-      assert.ok(result.coverage <= 1);
+      expect(result.coverage >= 0).toBeTruthy();
+      expect(result.coverage <= 1).toBeTruthy();
 
       // If not all files exist, coverage < 1
       if (result.failures.length > 0) {
-        assert.ok(result.coverage < 1);
+        expect(result.coverage < 1).toBeTruthy();
       }
     });
 
@@ -203,9 +202,9 @@ describe('file-checker', () => {
       if (result.failures.length > 0) {
         const failure = result.failures[0];
 
-        assert.ok('path' in failure || 'file' in failure);
-        assert.ok('reason' in failure);
-        assert.strictEqual(typeof failure.reason, 'string');
+        expect('path' in failure || 'file' in failure).toBeTruthy();
+        expect('reason' in failure).toBeTruthy();
+        expect(typeof failure.reason).toBe('string');
       }
     });
   });

--- a/test-env/validation/git-state-checker.test.js
+++ b/test-env/validation/git-state-checker.test.js
@@ -1,8 +1,7 @@
 // Test: Git State Checker Validation Helper
 // Tests for git repository state validation
 
-const { describe, test, beforeAll: before, afterAll: after, setDefaultTimeout } = require('bun:test');
-const assert = require('node:assert/strict');
+import { describe, test, beforeAll, afterAll, setDefaultTimeout, expect } from 'bun:test';
 const fs = require('node:fs');
 const path = require('node:path');
 const { mkdtempSync, rmSync } = require('node:fs');
@@ -33,12 +32,12 @@ const gitExecOptions = {
 
 setDefaultTimeout(15000);
 
-before(() => {
+beforeAll(() => {
   // Create temp directory for tests
   testDir = mkdtempSync(path.join(tmpdir(), 'forge-test-git-state-'));
 });
 
-after(() => {
+afterAll(() => {
   // Cleanup
   rmSync(testDir, { recursive: true, force: true });
 });
@@ -105,9 +104,9 @@ describe('git-state-checker', () => {
 
       const result = checkGitState(repoDir);
 
-      assert.strictEqual(result.passed, true);
-      assert.strictEqual(result.failures.length, 0);
-      assert.strictEqual(typeof result.coverage, 'number');
+      expect(result.passed).toBe(true);
+      expect(result.failures.length).toBe(0);
+      expect(typeof result.coverage).toBe('number');
     });
 
     test('should detect missing .git directory', () => {
@@ -116,9 +115,9 @@ describe('git-state-checker', () => {
 
       const result = checkGitState(nonGitDir);
 
-      assert.strictEqual(result.passed, false);
-      assert.ok(result.failures.length > 0);
-      assert.match(result.failures[0].reason, /not a git repository/i);
+      expect(result.passed).toBe(false);
+      expect(result.failures.length > 0).toBeTruthy();
+      expect(result.failures[0].reason).toMatch(/not a git repository/i);
     });
 
     test('should detect detached HEAD state', () => {
@@ -132,7 +131,7 @@ describe('git-state-checker', () => {
       const result = checkGitState(detachedDir);
 
       // Detached HEAD is a warning, not a failure (passed = true, but has findings)
-      assert.ok(result.failures.some(f => /detached HEAD/i.test(f.reason)));
+      expect(result.failures.some(f => /detached HEAD/i.test(f.reason))).toBeTruthy();
     });
 
     test('should detect uncommitted changes', () => {
@@ -146,7 +145,7 @@ describe('git-state-checker', () => {
 
       const result = checkGitState(dirtyDir);
 
-      assert.ok(result.failures.some(f => /uncommitted changes/i.test(f.reason)));
+      expect(result.failures.some(f => /uncommitted changes/i.test(f.reason))).toBeTruthy();
     });
 
     test('should detect merge conflicts', () => {
@@ -157,8 +156,8 @@ describe('git-state-checker', () => {
 
       const result = checkGitState(conflictDir);
 
-      assert.strictEqual(result.passed, false);
-      assert.ok(result.failures.some(f => /merge conflict/i.test(f.reason)));
+      expect(result.passed).toBe(false);
+      expect(result.failures.some(f => /merge conflict/i.test(f.reason))).toBeTruthy();
     });
 
     test('should return unified interface format', () => {
@@ -169,14 +168,14 @@ describe('git-state-checker', () => {
       const result = checkGitState(formatDir);
 
       // Check interface structure
-      assert.ok('passed' in result);
-      assert.ok('failures' in result);
-      assert.ok('coverage' in result);
+      expect('passed' in result).toBeTruthy();
+      expect('failures' in result).toBeTruthy();
+      expect('coverage' in result).toBeTruthy();
 
-      assert.strictEqual(typeof result.passed, 'boolean');
-      assert.ok(Array.isArray(result.failures));
-      assert.strictEqual(typeof result.coverage, 'number');
-      assert.ok(result.coverage >= 0 && result.coverage <= 1);
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.failures)).toBeTruthy();
+      expect(typeof result.coverage).toBe('number');
+      expect(result.coverage >= 0 && result.coverage <= 1).toBeTruthy();
     });
   });
 
@@ -188,7 +187,7 @@ describe('git-state-checker', () => {
 
       const result = isDetachedHead(normalDir);
 
-      assert.strictEqual(result.detached, false);
+      expect(result.detached).toBe(false);
     });
 
     test('should return true for detached HEAD', () => {
@@ -199,8 +198,8 @@ describe('git-state-checker', () => {
 
       const result = isDetachedHead(detachedDir);
 
-      assert.strictEqual(result.detached, true);
-      assert.strictEqual(result.branch, null);
+      expect(result.detached).toBe(true);
+      expect(result.branch).toBe(null);
     });
   });
 
@@ -212,8 +211,8 @@ describe('git-state-checker', () => {
 
       const result = hasUncommittedChanges(cleanDir);
 
-      assert.strictEqual(result.hasChanges, false);
-      assert.strictEqual(result.files.length, 0);
+      expect(result.hasChanges).toBe(false);
+      expect(result.files.length).toBe(0);
     });
 
     test('should return true with uncommitted changes', () => {
@@ -227,8 +226,8 @@ describe('git-state-checker', () => {
 
       const result = hasUncommittedChanges(dirtyDir);
 
-      assert.strictEqual(result.hasChanges, true);
-      assert.ok(result.files.length > 0);
+      expect(result.hasChanges).toBe(true);
+      expect(result.files.length > 0).toBeTruthy();
     });
   });
 
@@ -240,8 +239,8 @@ describe('git-state-checker', () => {
 
       const result = hasMergeConflict(normalDir);
 
-      assert.strictEqual(result.hasConflict, false);
-      assert.strictEqual(result.conflictedFiles.length, 0);
+      expect(result.hasConflict).toBe(false);
+      expect(result.conflictedFiles.length).toBe(0);
     });
 
     test('should return true for active merge conflict', () => {
@@ -252,7 +251,7 @@ describe('git-state-checker', () => {
 
       const result = hasMergeConflict(conflictDir);
 
-      assert.strictEqual(result.hasConflict, true);
+      expect(result.hasConflict).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
Migrate the verified test-env test suite to direct bun:test imports and Bun expect() assertions. The current branch contained 19 test-env/**/*.test.js files, not the 18 described in the issue, so all 19 were migrated for consistency.

## Changes
- Converted test-env/**/*.test.js from CommonJS bun:test requires to static import { ... } from 'bun:test'.
- Replaced node:assert/strict assertions with expect() equivalents.
- Replaced before/after lifecycle aliases with direct beforeAll/afterAll imports and calls.
- Updated eslint.config.js so migrated test-env test files parse as ES modules.
- Added /plan artifacts for forge-vvhz under docs/plans/.

## Testing
- bun run typecheck: pass (No TypeScript in project - skipping type check).
- bun run lint: pass.
- bun test test-env: pass, 266 pass / 0 fail across 19 files.
- bun test test-env/edge-cases/security.test.js: pass, 46 pass / 0 fail.
- Per-file bun test test-env/<file>: pass, 19/19 files.

## Beads
Closes forge-vvhz

Note: forge-vvhz is already marked CLOSED in Beads after local tracker repair.
