### PR TITLE
feat: add agent-agnostic project memory

### DIFF
--- a/docs/plans/2026-04-26-project-memory-design.md
+++ b/docs/plans/2026-04-26-project-memory-design.md
@@ -1,0 +1,170 @@
+# Design: Project Memory
+
+- **Slug**: project-memory
+- **Date**: 2026-04-26
+- **Status**: Implemented
+- **Issue**: forge-xdh7
+- **Parent epic**: forge-f3lx
+
+---
+
+## Purpose
+
+Forge needs one project-local memory format that every supported agent can read and write without depending on that agent's private memory system. The memory stores durable project context such as decisions, preferences, policies, and reusable notes.
+
+This complements Beads issue tracking. Beads remains the source of truth for issue lifecycle, workflow stages, ownership, dependencies, and task status. Project memory stores cross-session context that is useful even when it is not tied to one issue.
+
+The research conclusion is that current agent products mostly share instructions, not writable memory. `AGENTS.md`, `CLAUDE.md`, Cursor rules, Cline Memory Bank, and OpenCode rules are prompt/documentation surfaces. Claude auto memory and similar product-native stores are useful, but they are agent-specific and often machine-local. Forge should therefore own the canonical project memory and let agent-specific systems consume it through adapters.
+
+---
+
+## Success Criteria
+
+1. Store memory in a file-based, agent-agnostic location under `.forge/memory/`.
+2. Define a stable entry schema with `key`, `value`, `source-agent`, `timestamp`, and `tags`.
+3. Provide `lib/project-memory.js` with `read`, `write`, `search`, and `list` exports.
+4. Support Claude, Cursor, Codex, Cline, and OpenCode by avoiding agent-specific runtime assumptions.
+5. Keep the first implementation local and deterministic, with no MCP server dependency.
+
+---
+
+## Format Spec
+
+Project memory is stored as newline-delimited JSON at:
+
+```text
+.forge/memory/entries.jsonl
+```
+
+Each line is one entry:
+
+```json
+{"key":"policy.stage-order","value":"Run /plan before /dev for standard feature work.","source-agent":"Codex","timestamp":"2026-04-26T00:00:00.000Z","tags":["policy","workflow"],"scope":"project","confidence":0.95,"beads-refs":["forge-xdh7","forge-f3lx"]}
+```
+
+JSONL is used instead of one large JSON array because it is easier to inspect, diff, merge, and repair. Writes still upsert by `key`, so the canonical store does not accumulate duplicate current records for the same memory key.
+
+Entry fields:
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `key` | string | yes | Stable unique identifier. Writes upsert by key. |
+| `value` | JSON value | yes | String, number, boolean, object, array, or null. |
+| `source-agent` | string | yes | Agent that wrote the entry, such as `Claude`, `Cursor`, `Codex`, `Cline`, or `OpenCode`. |
+| `timestamp` | ISO-compatible string | yes | Caller-provided or generated at write time. |
+| `tags` | string array | yes | Search and grouping labels. |
+| `scope` | string | no | Suggested applicability, such as `repo`, `project`, `workflow`, `package:<name>`, or `path:<glob>`. |
+| `confidence` | number | no | Writer confidence from `0` to `1`; useful when surfacing inferred context. |
+| `supersedes` | string array | no | Older memory keys replaced by this entry. |
+| `beads-refs` | string array | no | Related Beads issue IDs. This is a reference only, not lifecycle state. |
+
+The JavaScript API accepts and returns `sourceAgent` while persisting `source-agent` on disk. This keeps the disk format language-neutral without making JavaScript callers use bracket notation.
+
+---
+
+## API
+
+`lib/project-memory.js` exports:
+
+- `read(projectRoot, key, options)` returns one entry or `null`.
+- `write(projectRoot, entry, options)` validates and upserts one entry by `key`.
+- `search(projectRoot, query, options)` performs case-insensitive search across key, JSON-serialized value, source agent, tags, and optional metadata.
+- `list(projectRoot, options)` returns all entries in file order.
+
+`options.filePath` can override the storage file for tests or future adapters.
+
+---
+
+## Coexistence With Beads
+
+Beads owns workflow state:
+
+- issue IDs, including `forge-xdh7`
+- parent/child relationships, including `forge-f3lx`
+- status, dependencies, priorities, claims, comments, and stage transitions
+- task progress and validation metadata
+
+Project memory owns reusable context:
+
+- durable decisions that apply across issues
+- coding or workflow preferences
+- project-local policies
+- repeated troubleshooting notes
+- agent-neutral context that should not live only in Claude, Cursor, Codex, Cline, or OpenCode private stores
+
+Memory entries may reference Beads IDs in `key`, `value`, or `tags`, but memory does not replace Beads records or duplicate issue lifecycle state.
+
+---
+
+## Coexistence With Agent-Specific Stores
+
+Agent-specific stores remain useful for private or product-native behavior. They should be treated as caches, views, or personal notes. Forge project memory is the shared baseline:
+
+- Claude can mirror selected context from its memory into `.forge/memory/entries.jsonl`.
+- Cursor rules can read or summarize project memory without making `.cursor/` the source of truth.
+- Codex skills can use project memory as project-local reusable context.
+- Cline and OpenCode can write the same format without needing Claude or Codex conventions.
+
+If agent-specific memory conflicts with project memory, the project memory entry should be treated as the portable project-level record until a new entry updates it.
+
+Adapter model:
+
+1. Canonical store: `.forge/memory/entries.jsonl`.
+2. Read-only prompt adapters: generated summaries for `AGENTS.md`, `CLAUDE.md`, Cursor `.mdc` rules, Cline Memory Bank, and OpenCode rules.
+3. Write adapters: Forge CLI or MCP tools that validate schema and write back to the canonical store.
+4. Agent-private stores: allowed to cache or summarize Forge memory, but not treated as authoritative.
+
+---
+
+## Technical Research
+
+Verified patterns:
+
+- `AGENTS.md` is an open, Markdown-based instruction format used across many coding agents. It is designed as a predictable place for agent instructions, not as a structured writable memory database. Source: https://agents.md/
+- Claude Code separates checked-in project instructions from auto memory. Claude auto memory is stored under `~/.claude/projects/<project>/memory/`, shared across worktrees for the same repo on one machine, and not shared across machines or cloud environments. Source: https://code.claude.com/docs/en/memory
+- Anthropic's memory tool is closer to the right abstraction for Forge: the model uses memory operations, but the client controls storage and can implement file, database, cloud, or encrypted backends. Source: https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool
+- Codex aggregates `AGENTS.md` and related instruction files into user instructions at session initialization. This is prompt/context loading, not an agent-neutral writeable memory store. Source: https://openai.com/index/unrolling-the-codex-agent-loop/
+- Cursor project rules live under `.cursor/rules` and act as persistent reusable prompt context. They can encode project knowledge, but they are Cursor-specific adapter files. Source: https://docs.cursor.com/ru/context/rules
+- Cline Memory Bank is a structured documentation method that preserves project knowledge in files and explicitly works with any AI that can read docs. This validates the file-backed direction, but Forge still needs a stricter schema for agent-neutral writes. Source: https://docs.cline.bot/features/memory-bank
+- OpenCode reads project `AGENTS.md` and can combine custom instruction files, again reinforcing instruction sharing rather than shared writable memory. Source: https://open-code.ai/en/docs/rules
+- MCP roots and tools provide the most plausible future shared API. Roots define filesystem boundaries; tools expose structured operations that agents can invoke. Sources: https://modelcontextprotocol.io/specification/2025-06-18/client/roots and https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+
+Conclusion: democratized Forge memory should be repo-owned, schema-validated, inspectable in Git, and adapter-driven. Agent-native memory should consume or mirror Forge memory, not own the canonical record.
+
+---
+
+## Future MCP Surfacing
+
+Future MCP support can expose the same file-backed data through tools such as:
+
+- `project_memory.list`
+- `project_memory.read`
+- `project_memory.write`
+- `project_memory.search`
+
+The MCP server should use `lib/project-memory.js` rather than introducing a second storage path. MCP responses should preserve the schema and include enough metadata for agents to cite the source entry.
+
+MCP should be the first-class shared write path because it gives all supporting agents the same tool contract. A future server should:
+
+- use MCP roots to locate the current project and prevent writes outside the workspace;
+- expose read/search/list tools as low-risk operations;
+- expose write as a validation-gated operation;
+- optionally return resource links or embedded resources for memory entries and generated summaries.
+
+---
+
+## Out of Scope
+
+- Replacing Beads issue tracking or workflow stage metadata.
+- Synchronizing memory to a remote service.
+- Conflict-free replicated editing across concurrent agents.
+- Storing secrets, credentials, tokens, or private user data.
+- Adding CLI commands or MCP tools in this change.
+- Migrating existing Claude, Cursor, Codex, Cline, or OpenCode memory stores.
+- Auto-generating agent-specific prompt/rule files in this change.
+
+---
+
+## Ambiguity Policy
+
+For schema additions, prefer additive optional fields under a future `version` bump. Do not change the meaning of existing fields without a migration plan and tests.

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -26,7 +26,9 @@ function nearestExistingPath(targetPath) {
 
 function assertRealPathInsideProjectRoot(root, targetPath) {
   const realRoot = fs.realpathSync.native(root);
-  const existingPath = nearestExistingPath(path.dirname(targetPath));
+  const existingPath = fs.existsSync(targetPath)
+    ? targetPath
+    : nearestExistingPath(path.dirname(targetPath));
   const realExistingPath = fs.realpathSync.native(existingPath);
 
   if (realExistingPath === realRoot) {
@@ -72,19 +74,34 @@ function isProcessAlive(pid) {
 function readLock(lockPath) {
   try {
     return JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  } catch (err) {
+    return {
+      pid: null,
+      createdAt: null,
+      invalid: true,
+      readError: err.message,
+    };
+  }
+}
+
+function invalidLockIsOld(lockPath, options = {}) {
+  const staleLockMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs >= staleLockMs;
   } catch (_err) {
-    return null;
+    return false;
   }
 }
 
 function removeStaleLock(lockPath, options = {}) {
   const lock = readLock(lockPath);
-  const staleLockMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
-  const createdAt = lock?.createdAt ? Date.parse(lock.createdAt) : NaN;
-  const isOld = Number.isNaN(createdAt) || Date.now() - createdAt >= staleLockMs;
+  if (lock.invalid && !invalidLockIsOld(lockPath, options)) {
+    return false;
+  }
+
   const ownerAlive = isProcessAlive(lock?.pid);
 
-  if (!ownerAlive && isOld) {
+  if (!ownerAlive) {
     fs.rmSync(lockPath, { force: true });
     return true;
   }
@@ -102,14 +119,12 @@ function acquireLock(filePath, options = {}) {
 
   while (true) {
     try {
-      const fd = fs.openSync(lockPath, 'wx');
-      fs.writeFileSync(fd, JSON.stringify({
+      fs.writeFileSync(lockPath, JSON.stringify({
         pid: process.pid,
         createdAt: new Date().toISOString(),
-      }));
+      }), { flag: 'wx' });
 
       return () => {
-        fs.closeSync(fd);
         fs.rmSync(lockPath, { force: true });
       };
     } catch (err) {

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -88,8 +88,9 @@ function invalidLockIsOld(lockPath, options = {}) {
   const staleLockMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
   try {
     return Date.now() - fs.statSync(lockPath).mtimeMs >= staleLockMs;
-  } catch (_err) {
-    return false;
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    throw err;
   }
 }
 
@@ -242,6 +243,12 @@ function validateEntry(entry) {
   validateOptionalArrays(entry);
 }
 
+function validateStoredEntry(entry) {
+  validateEntry(entry);
+  assertRequiredString(entry['source-agent'], 'source-agent');
+  assertStringArray(entry.tags, 'tags');
+}
+
 function readEntries(projectRoot, options = {}) {
   const filePath = memoryPath(projectRoot, options);
   if (!fs.existsSync(filePath)) {
@@ -252,11 +259,18 @@ function readEntries(projectRoot, options = {}) {
   if (content === '') return [];
 
   return content.split(/\r?\n/).map((line, index) => {
+    let parsed;
     try {
-      return JSON.parse(line);
+      parsed = JSON.parse(line);
     } catch (err) {
       throw new Error(`invalid project memory JSONL at line ${index + 1}: ${err.message}`);
     }
+    try {
+      validateStoredEntry(parsed);
+    } catch (err) {
+      throw new Error(`invalid project memory entry at line ${index + 1}: ${err.message}`);
+    }
+    return parsed;
   });
 }
 
@@ -278,8 +292,9 @@ function read(projectRoot, key, options = {}) {
   if (typeof key !== 'string' || key.trim() === '') {
     throw new Error('project memory read key is required');
   }
+  const normalizedKey = key.trim();
 
-  const entry = readEntries(projectRoot, options).find((candidate) => candidate.key === key);
+  const entry = readEntries(projectRoot, options).find((candidate) => candidate.key === normalizedKey);
   return entry ? toApiEntry(entry) : null;
 }
 

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -1,0 +1,191 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const DEFAULT_MEMORY_FILE = path.join('.forge', 'memory', 'entries.jsonl');
+
+function memoryPath(projectRoot, options = {}) {
+  return options.filePath || path.join(projectRoot, DEFAULT_MEMORY_FILE);
+}
+
+function toApiEntry(entry) {
+  const apiEntry = {
+    key: entry.key,
+    value: entry.value,
+    sourceAgent: entry['source-agent'],
+    timestamp: entry.timestamp,
+    tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
+  };
+
+  if (entry.scope !== undefined) apiEntry.scope = entry.scope;
+  if (entry.confidence !== undefined) apiEntry.confidence = entry.confidence;
+  if (entry.supersedes !== undefined) apiEntry.supersedes = [...entry.supersedes];
+  if (entry['beads-refs'] !== undefined) apiEntry.beadsRefs = [...entry['beads-refs']];
+
+  return apiEntry;
+}
+
+function toDiskEntry(entry) {
+  const diskEntry = {
+    key: entry.key,
+    value: entry.value,
+    'source-agent': entry.sourceAgent || entry['source-agent'],
+    timestamp: entry.timestamp || new Date().toISOString(),
+    tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
+  };
+
+  if (entry.scope !== undefined) diskEntry.scope = entry.scope;
+  if (entry.confidence !== undefined) diskEntry.confidence = entry.confidence;
+  if (entry.supersedes !== undefined) diskEntry.supersedes = [...entry.supersedes];
+  if (entry.beadsRefs !== undefined || entry['beads-refs'] !== undefined) {
+    diskEntry['beads-refs'] = [...(entry.beadsRefs || entry['beads-refs'])];
+  }
+
+  return diskEntry;
+}
+
+function validateEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error('project memory entry must be an object');
+  }
+  if (typeof entry.key !== 'string' || entry.key.trim() === '') {
+    throw new Error('project memory entry key is required');
+  }
+  if (!Object.prototype.hasOwnProperty.call(entry, 'value') || entry.value === undefined) {
+    throw new Error('project memory entry value is required');
+  }
+
+  const sourceAgent = entry.sourceAgent || entry['source-agent'];
+  if (typeof sourceAgent !== 'string' || sourceAgent.trim() === '') {
+    throw new Error('project memory entry sourceAgent is required');
+  }
+
+  if (entry.timestamp !== undefined) {
+    const parsed = Date.parse(entry.timestamp);
+    if (typeof entry.timestamp !== 'string' || Number.isNaN(parsed)) {
+      throw new Error('project memory entry timestamp must be an ISO-compatible string');
+    }
+  }
+
+  if (entry.tags !== undefined) {
+    if (!Array.isArray(entry.tags) || entry.tags.some((tag) => typeof tag !== 'string')) {
+      throw new Error('project memory entry tags must be an array of strings');
+    }
+  }
+
+  if (entry.scope !== undefined && (typeof entry.scope !== 'string' || entry.scope.trim() === '')) {
+    throw new Error('project memory entry scope must be a non-empty string');
+  }
+
+  if (entry.confidence !== undefined) {
+    if (typeof entry.confidence !== 'number' || entry.confidence < 0 || entry.confidence > 1) {
+      throw new Error('project memory entry confidence must be a number from 0 to 1');
+    }
+  }
+
+  if (entry.supersedes !== undefined) {
+    if (!Array.isArray(entry.supersedes) || entry.supersedes.some((key) => typeof key !== 'string')) {
+      throw new Error('project memory entry supersedes must be an array of strings');
+    }
+  }
+
+  const beadsRefs = entry.beadsRefs || entry['beads-refs'];
+  if (beadsRefs !== undefined) {
+    if (!Array.isArray(beadsRefs) || beadsRefs.some((ref) => typeof ref !== 'string')) {
+      throw new Error('project memory entry beadsRefs must be an array of strings');
+    }
+  }
+}
+
+function readEntries(projectRoot, options = {}) {
+  const filePath = memoryPath(projectRoot, options);
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8').trim();
+  if (content === '') return [];
+
+  return content.split(/\r?\n/).map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch (err) {
+      throw new Error(`invalid project memory JSONL at line ${index + 1}: ${err.message}`);
+    }
+  });
+}
+
+function writeEntries(projectRoot, entries, options = {}) {
+  const filePath = memoryPath(projectRoot, options);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  const content = entries.map((entry) => JSON.stringify(entry)).join('\n');
+  fs.writeFileSync(tempPath, content ? `${content}\n` : '', 'utf8');
+  fs.renameSync(tempPath, filePath);
+}
+
+function list(projectRoot, options = {}) {
+  return readEntries(projectRoot, options).map(toApiEntry);
+}
+
+function read(projectRoot, key, options = {}) {
+  if (typeof key !== 'string' || key.trim() === '') {
+    throw new Error('project memory read key is required');
+  }
+
+  const entry = readEntries(projectRoot, options).find((candidate) => candidate.key === key);
+  return entry ? toApiEntry(entry) : null;
+}
+
+function write(projectRoot, entry, options = {}) {
+  validateEntry(entry);
+
+  const entries = readEntries(projectRoot, options);
+  const normalized = toDiskEntry({
+    ...entry,
+    key: entry.key.trim(),
+    sourceAgent: (entry.sourceAgent || entry['source-agent']).trim(),
+    tags: entry.tags || [],
+  });
+
+  const existingIndex = entries.findIndex((candidate) => candidate.key === normalized.key);
+  if (existingIndex === -1) {
+    entries.push(normalized);
+  } else {
+    entries[existingIndex] = normalized;
+  }
+
+  writeEntries(projectRoot, entries, options);
+  return toApiEntry(normalized);
+}
+
+function searchableText(entry) {
+  return [
+    entry.key,
+    JSON.stringify(entry.value),
+    entry['source-agent'],
+    entry.scope,
+    String(entry.confidence ?? ''),
+    ...(Array.isArray(entry.tags) ? entry.tags : []),
+    ...(Array.isArray(entry.supersedes) ? entry.supersedes : []),
+    ...(Array.isArray(entry['beads-refs']) ? entry['beads-refs'] : []),
+  ].join('\n').toLowerCase();
+}
+
+function search(projectRoot, query, options = {}) {
+  if (typeof query !== 'string' || query.trim() === '') {
+    return [];
+  }
+
+  const needle = query.trim().toLowerCase();
+  return readEntries(projectRoot, options)
+    .filter((entry) => searchableText(entry).includes(needle))
+    .map(toApiEntry);
+}
+
+module.exports = {
+  read,
+  write,
+  search,
+  list,
+};

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -171,13 +171,14 @@ function write(projectRoot, entry, options = {}) {
   });
 
   const existingIndex = entries.findIndex((candidate) => candidate.key === normalized.key);
+  const nextEntries = entries.filter((candidate) => candidate.key !== normalized.key);
   if (existingIndex === -1) {
-    entries.push(normalized);
+    nextEntries.push(normalized);
   } else {
-    entries[existingIndex] = normalized;
+    nextEntries.splice(existingIndex, 0, normalized);
   }
 
-  writeEntries(projectRoot, entries, options);
+  writeEntries(projectRoot, nextEntries, options);
   return toApiEntry(normalized);
 }
 

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -2,15 +2,59 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const DEFAULT_MEMORY_FILE = path.join('.forge', 'memory', 'entries.jsonl');
+const DEFAULT_LOCK_TIMEOUT_MS = 5000;
+const DEFAULT_LOCK_RETRY_MS = 10;
 
 function memoryPath(projectRoot, options = {}) {
+  const root = path.resolve(projectRoot);
   if (!options.filePath) {
-    return path.join(projectRoot, DEFAULT_MEMORY_FILE);
+    return path.join(root, DEFAULT_MEMORY_FILE);
   }
 
-  return path.isAbsolute(options.filePath)
+  const candidate = path.isAbsolute(options.filePath)
     ? options.filePath
-    : path.join(projectRoot, options.filePath);
+    : path.join(root, options.filePath);
+  const resolved = path.resolve(candidate);
+  const relative = path.relative(root, resolved);
+
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('project memory filePath must stay within projectRoot');
+  }
+
+  return resolved;
+}
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function acquireLock(filePath, options = {}) {
+  const lockPath = `${filePath}.lock`;
+  const timeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const retryMs = options.lockRetryMs ?? DEFAULT_LOCK_RETRY_MS;
+  const startedAt = Date.now();
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  while (true) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      fs.writeFileSync(fd, JSON.stringify({
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+      }));
+
+      return () => {
+        fs.closeSync(fd);
+        fs.rmSync(lockPath, { force: true });
+      };
+    } catch (err) {
+      if (err.code !== 'EEXIST' || Date.now() - startedAt >= timeoutMs) {
+        throw err;
+      }
+      sleep(retryMs);
+    }
+  }
 }
 
 function toApiEntry(entry) {
@@ -161,25 +205,31 @@ function read(projectRoot, key, options = {}) {
 
 function write(projectRoot, entry, options = {}) {
   validateEntry(entry);
+  const filePath = memoryPath(projectRoot, options);
+  const releaseLock = acquireLock(filePath, options);
 
-  const entries = readEntries(projectRoot, options);
-  const normalized = toDiskEntry({
-    ...entry,
-    key: entry.key.trim(),
-    sourceAgent: (entry.sourceAgent || entry['source-agent']).trim(),
-    tags: entry.tags || [],
-  });
+  try {
+    const entries = readEntries(projectRoot, options);
+    const normalized = toDiskEntry({
+      ...entry,
+      key: entry.key.trim(),
+      sourceAgent: (entry.sourceAgent || entry['source-agent']).trim(),
+      tags: entry.tags || [],
+    });
 
-  const existingIndex = entries.findIndex((candidate) => candidate.key === normalized.key);
-  const nextEntries = entries.filter((candidate) => candidate.key !== normalized.key);
-  if (existingIndex === -1) {
-    nextEntries.push(normalized);
-  } else {
-    nextEntries.splice(existingIndex, 0, normalized);
+    const existingIndex = entries.findIndex((candidate) => candidate.key === normalized.key);
+    const nextEntries = entries.filter((candidate) => candidate.key !== normalized.key);
+    if (existingIndex === -1) {
+      nextEntries.push(normalized);
+    } else {
+      nextEntries.splice(existingIndex, 0, normalized);
+    }
+
+    writeEntries(projectRoot, nextEntries, options);
+    return toApiEntry(normalized);
+  } finally {
+    releaseLock();
   }
-
-  writeEntries(projectRoot, nextEntries, options);
-  return toApiEntry(normalized);
 }
 
 function searchableText(entry) {

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -4,28 +4,92 @@ const path = require('node:path');
 const DEFAULT_MEMORY_FILE = path.join('.forge', 'memory', 'entries.jsonl');
 const DEFAULT_LOCK_TIMEOUT_MS = 5000;
 const DEFAULT_LOCK_RETRY_MS = 10;
+const DEFAULT_STALE_LOCK_MS = 30000;
+
+function assertInsideProjectRoot(root, targetPath) {
+  const relative = path.relative(root, targetPath);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('project memory filePath must stay within projectRoot');
+  }
+}
+
+function nearestExistingPath(targetPath) {
+  let current = targetPath;
+  while (!fs.existsSync(current)) {
+    const next = path.dirname(current);
+    if (next === current) break;
+    current = next;
+  }
+
+  return current;
+}
+
+function assertRealPathInsideProjectRoot(root, targetPath) {
+  const realRoot = fs.realpathSync.native(root);
+  const existingPath = nearestExistingPath(path.dirname(targetPath));
+  const realExistingPath = fs.realpathSync.native(existingPath);
+
+  if (realExistingPath === realRoot) {
+    return;
+  }
+
+  assertInsideProjectRoot(realRoot, realExistingPath);
+}
 
 function memoryPath(projectRoot, options = {}) {
   const root = path.resolve(projectRoot);
   if (!options.filePath) {
-    return path.join(root, DEFAULT_MEMORY_FILE);
+    const defaultPath = path.join(root, DEFAULT_MEMORY_FILE);
+    assertRealPathInsideProjectRoot(root, defaultPath);
+    return defaultPath;
   }
 
   const candidate = path.isAbsolute(options.filePath)
     ? options.filePath
     : path.join(root, options.filePath);
   const resolved = path.resolve(candidate);
-  const relative = path.relative(root, resolved);
-
-  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error('project memory filePath must stay within projectRoot');
-  }
+  assertInsideProjectRoot(root, resolved);
+  assertRealPathInsideProjectRoot(root, resolved);
 
   return resolved;
 }
 
 function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === 'EPERM';
+  }
+}
+
+function readLock(lockPath) {
+  try {
+    return JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+  } catch (_err) {
+    return null;
+  }
+}
+
+function removeStaleLock(lockPath, options = {}) {
+  const lock = readLock(lockPath);
+  const staleLockMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
+  const createdAt = lock?.createdAt ? Date.parse(lock.createdAt) : NaN;
+  const isOld = Number.isNaN(createdAt) || Date.now() - createdAt >= staleLockMs;
+  const ownerAlive = isProcessAlive(lock?.pid);
+
+  if (!ownerAlive && isOld) {
+    fs.rmSync(lockPath, { force: true });
+    return true;
+  }
+
+  return false;
 }
 
 function acquireLock(filePath, options = {}) {
@@ -52,6 +116,7 @@ function acquireLock(filePath, options = {}) {
       if (err.code !== 'EEXIST' || Date.now() - startedAt >= timeoutMs) {
         throw err;
       }
+      removeStaleLock(lockPath, options);
       sleep(retryMs);
     }
   }

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -4,7 +4,13 @@ const path = require('node:path');
 const DEFAULT_MEMORY_FILE = path.join('.forge', 'memory', 'entries.jsonl');
 
 function memoryPath(projectRoot, options = {}) {
-  return options.filePath || path.join(projectRoot, DEFAULT_MEMORY_FILE);
+  if (!options.filePath) {
+    return path.join(projectRoot, DEFAULT_MEMORY_FILE);
+  }
+
+  return path.isAbsolute(options.filePath)
+    ? options.filePath
+    : path.join(projectRoot, options.filePath);
 }
 
 function toApiEntry(entry) {
@@ -43,57 +49,73 @@ function toDiskEntry(entry) {
   return diskEntry;
 }
 
-function validateEntry(entry) {
+function assertEntryObject(entry) {
   if (!entry || typeof entry !== 'object') {
-    throw new Error('project memory entry must be an object');
+    throw new TypeError('project memory entry must be an object');
   }
+}
+
+function assertRequiredString(value, fieldName) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`project memory entry ${fieldName} is required`);
+  }
+}
+
+function assertStringArray(value, fieldName) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new TypeError(`project memory entry ${fieldName} must be an array of strings`);
+  }
+}
+
+function validateRequiredFields(entry) {
   if (typeof entry.key !== 'string' || entry.key.trim() === '') {
-    throw new Error('project memory entry key is required');
+    throw new TypeError('project memory entry key is required');
   }
-  if (!Object.prototype.hasOwnProperty.call(entry, 'value') || entry.value === undefined) {
-    throw new Error('project memory entry value is required');
+  if (!Object.hasOwn(entry, 'value') || entry.value === undefined) {
+    throw new TypeError('project memory entry value is required');
   }
 
   const sourceAgent = entry.sourceAgent || entry['source-agent'];
-  if (typeof sourceAgent !== 'string' || sourceAgent.trim() === '') {
-    throw new Error('project memory entry sourceAgent is required');
-  }
+  assertRequiredString(sourceAgent, 'sourceAgent');
+}
 
+function validateTimestamp(entry) {
   if (entry.timestamp !== undefined) {
     const parsed = Date.parse(entry.timestamp);
     if (typeof entry.timestamp !== 'string' || Number.isNaN(parsed)) {
-      throw new Error('project memory entry timestamp must be an ISO-compatible string');
+      throw new TypeError('project memory entry timestamp must be an ISO-compatible string');
     }
   }
+}
 
-  if (entry.tags !== undefined) {
-    if (!Array.isArray(entry.tags) || entry.tags.some((tag) => typeof tag !== 'string')) {
-      throw new Error('project memory entry tags must be an array of strings');
-    }
-  }
-
+function validateScope(entry) {
   if (entry.scope !== undefined && (typeof entry.scope !== 'string' || entry.scope.trim() === '')) {
-    throw new Error('project memory entry scope must be a non-empty string');
+    throw new TypeError('project memory entry scope must be a non-empty string');
   }
+}
 
+function validateConfidence(entry) {
   if (entry.confidence !== undefined) {
     if (typeof entry.confidence !== 'number' || entry.confidence < 0 || entry.confidence > 1) {
-      throw new Error('project memory entry confidence must be a number from 0 to 1');
+      throw new TypeError('project memory entry confidence must be a number from 0 to 1');
     }
   }
+}
 
-  if (entry.supersedes !== undefined) {
-    if (!Array.isArray(entry.supersedes) || entry.supersedes.some((key) => typeof key !== 'string')) {
-      throw new Error('project memory entry supersedes must be an array of strings');
-    }
-  }
-
+function validateOptionalArrays(entry) {
+  if (entry.tags !== undefined) assertStringArray(entry.tags, 'tags');
+  if (entry.supersedes !== undefined) assertStringArray(entry.supersedes, 'supersedes');
   const beadsRefs = entry.beadsRefs || entry['beads-refs'];
-  if (beadsRefs !== undefined) {
-    if (!Array.isArray(beadsRefs) || beadsRefs.some((ref) => typeof ref !== 'string')) {
-      throw new Error('project memory entry beadsRefs must be an array of strings');
-    }
-  }
+  if (beadsRefs !== undefined) assertStringArray(beadsRefs, 'beadsRefs');
+}
+
+function validateEntry(entry) {
+  assertEntryObject(entry);
+  validateRequiredFields(entry);
+  validateTimestamp(entry);
+  validateScope(entry);
+  validateConfidence(entry);
+  validateOptionalArrays(entry);
 }
 
 function readEntries(projectRoot, options = {}) {

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -1,0 +1,163 @@
+const { describe, test, expect, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const projectMemory = require('../lib/project-memory');
+
+const tempRoots = [];
+
+function tempRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-project-memory-'));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('project memory', () => {
+  test('writes entries to the default .forge/memory JSONL file and reads them back', () => {
+    const root = tempRoot();
+
+    const entry = projectMemory.write(root, {
+      key: 'policy.stage-order',
+      value: 'Run /plan before /dev for standard feature work.',
+      sourceAgent: 'Codex',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      tags: ['policy', 'workflow'],
+      scope: 'project',
+      confidence: 0.95,
+      beadsRefs: ['forge-xdh7', 'forge-f3lx'],
+    });
+
+    expect(entry).toEqual({
+      key: 'policy.stage-order',
+      value: 'Run /plan before /dev for standard feature work.',
+      sourceAgent: 'Codex',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      tags: ['policy', 'workflow'],
+      scope: 'project',
+      confidence: 0.95,
+      beadsRefs: ['forge-xdh7', 'forge-f3lx'],
+    });
+
+    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
+    expect(fs.existsSync(memoryFile)).toBe(true);
+    const lines = fs.readFileSync(memoryFile, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0])).toMatchObject({
+      key: 'policy.stage-order',
+      'source-agent': 'Codex',
+      'beads-refs': ['forge-xdh7', 'forge-f3lx'],
+    });
+    expect(projectMemory.read(root, 'policy.stage-order')).toEqual(entry);
+    expect(projectMemory.list(root)).toEqual([entry]);
+  });
+
+  test('upserts entries by key without duplicating previous decisions', () => {
+    const root = tempRoot();
+
+    projectMemory.write(root, {
+      key: 'preference.agent-surface',
+      value: 'Support Claude and Codex first.',
+      sourceAgent: 'Claude',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      tags: ['preference'],
+    });
+    projectMemory.write(root, {
+      key: 'preference.agent-surface',
+      value: 'Support Claude, Cursor, Codex, Cline, and OpenCode.',
+      sourceAgent: 'Codex',
+      timestamp: '2026-04-26T00:01:00.000Z',
+      tags: ['preference', 'agents'],
+    });
+
+    expect(projectMemory.list(root)).toHaveLength(1);
+    expect(projectMemory.read(root, 'preference.agent-surface')).toMatchObject({
+      value: 'Support Claude, Cursor, Codex, Cline, and OpenCode.',
+      sourceAgent: 'Codex',
+      tags: ['preference', 'agents'],
+    });
+  });
+
+  test('searches keys, string values, source agents, and tags case-insensitively', () => {
+    const root = tempRoot();
+
+    projectMemory.write(root, {
+      key: 'decision.memory-format',
+      value: { format: 'json', directory: '.forge/memory' },
+      sourceAgent: 'Cursor',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      tags: ['decision', 'memory'],
+    });
+    projectMemory.write(root, {
+      key: 'policy.issue-tracking',
+      value: 'Memory complements Beads and does not replace issue lifecycle state.',
+      sourceAgent: 'Codex',
+      timestamp: '2026-04-26T00:01:00.000Z',
+      tags: ['policy', 'beads'],
+    });
+
+    expect(projectMemory.search(root, 'json')).toHaveLength(1);
+    expect(projectMemory.search(root, 'BEADS')[0].key).toBe('policy.issue-tracking');
+    expect(projectMemory.search(root, 'cursor')[0].key).toBe('decision.memory-format');
+    expect(projectMemory.search(root, 'memory')).toHaveLength(2);
+  });
+
+  test('searches optional shared-memory metadata fields', () => {
+    const root = tempRoot();
+
+    projectMemory.write(root, {
+      key: 'decision.canonical-store',
+      value: 'Forge memory is canonical; agent-native stores are caches or adapters.',
+      sourceAgent: 'Codex',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      tags: ['decision'],
+      scope: 'repo',
+      confidence: 1,
+      supersedes: ['decision.agent-private-memory'],
+      beadsRefs: ['forge-xdh7'],
+    });
+
+    expect(projectMemory.search(root, 'repo')[0].key).toBe('decision.canonical-store');
+    expect(projectMemory.search(root, 'forge-xdh7')[0].key).toBe('decision.canonical-store');
+    expect(projectMemory.search(root, 'agent-private')[0].key).toBe('decision.canonical-store');
+  });
+
+  test('validates required schema fields before writing', () => {
+    const root = tempRoot();
+
+    expect(() => projectMemory.write(root, {
+      key: '',
+      value: 'missing key',
+      sourceAgent: 'Codex',
+      tags: [],
+    })).toThrow('key');
+
+    expect(() => projectMemory.write(root, {
+      key: 'policy.invalid-tags',
+      value: 'tags must be an array',
+      sourceAgent: 'Codex',
+      tags: 'policy',
+    })).toThrow('tags');
+
+    expect(() => projectMemory.write(root, {
+      key: 'policy.invalid-agent',
+      value: 'source agent is required',
+      sourceAgent: '',
+      tags: [],
+    })).toThrow('sourceAgent');
+
+    expect(() => projectMemory.write(root, {
+      key: 'policy.invalid-confidence',
+      value: 'confidence is bounded',
+      sourceAgent: 'Codex',
+      confidence: 2,
+      tags: [],
+    })).toThrow('confidence');
+  });
+});

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -84,6 +84,54 @@ describe('project memory', () => {
     });
   });
 
+  test('deduplicates all existing records for a key during upsert', () => {
+    const root = tempRoot();
+    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
+    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
+    fs.writeFileSync(memoryFile, [
+      JSON.stringify({
+        key: 'decision.duplicate',
+        value: 'stale manual merge copy',
+        'source-agent': 'Claude',
+        timestamp: '2026-04-26T00:00:00.000Z',
+        tags: ['stale'],
+      }),
+      JSON.stringify({
+        key: 'decision.keep',
+        value: 'unrelated entry',
+        'source-agent': 'Cursor',
+        timestamp: '2026-04-26T00:01:00.000Z',
+        tags: ['keep'],
+      }),
+      JSON.stringify({
+        key: 'decision.duplicate',
+        value: 'second stale manual merge copy',
+        'source-agent': 'Codex',
+        timestamp: '2026-04-26T00:02:00.000Z',
+        tags: ['stale'],
+      }),
+    ].join('\n') + '\n', 'utf8');
+
+    projectMemory.write(root, {
+      key: 'decision.duplicate',
+      value: 'current value',
+      sourceAgent: 'OpenCode',
+      timestamp: '2026-04-26T00:03:00.000Z',
+      tags: ['current'],
+    });
+
+    expect(projectMemory.list(root).map((entry) => entry.key)).toEqual([
+      'decision.duplicate',
+      'decision.keep',
+    ]);
+    expect(projectMemory.search(root, 'stale')).toEqual([]);
+    expect(projectMemory.read(root, 'decision.duplicate')).toMatchObject({
+      value: 'current value',
+      sourceAgent: 'OpenCode',
+      tags: ['current'],
+    });
+  });
+
   test('searches keys, string values, source agents, and tags case-insensitively', () => {
     const root = tempRoot();
 

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -247,6 +247,28 @@ describe('project memory', () => {
     })).toThrow('projectRoot');
   });
 
+  test('rejects symlinked memory files outside the project root', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const root = tempRoot();
+    const outside = tempRoot();
+    const memoryDir = path.join(root, '.forge', 'memory');
+    const outsideFile = path.join(outside, 'entries.jsonl');
+    fs.mkdirSync(memoryDir, { recursive: true });
+    fs.writeFileSync(outsideFile, JSON.stringify({
+      key: 'policy.external',
+      value: 'external data',
+      'source-agent': 'Codex',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      tags: [],
+    }) + '\n', 'utf8');
+    fs.symlinkSync(outsideFile, path.join(memoryDir, 'entries.jsonl'), 'file');
+
+    expect(() => projectMemory.list(root)).toThrow('projectRoot');
+  });
+
   test('recovers stale lockfiles owned by dead processes', () => {
     const root = tempRoot();
     const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
@@ -267,6 +289,31 @@ describe('project memory', () => {
     });
 
     expect(projectMemory.read(root, 'policy.stale-lock')).toMatchObject({
+      value: 'recovered',
+    });
+    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
+  });
+
+  test('recovers fresh lockfiles owned by dead processes', () => {
+    const root = tempRoot();
+    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
+    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
+    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
+      pid: 99999999,
+      createdAt: new Date().toISOString(),
+    }), 'utf8');
+
+    projectMemory.write(root, {
+      key: 'policy.fresh-dead-lock',
+      value: 'recovered',
+      sourceAgent: 'Codex',
+      tags: [],
+    }, {
+      lockTimeoutMs: 250,
+      lockRetryMs: 5,
+    });
+
+    expect(projectMemory.read(root, 'policy.fresh-dead-lock')).toMatchObject({
       value: 'recovered',
     });
     expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -128,6 +128,36 @@ describe('project memory', () => {
     expect(projectMemory.search(root, 'agent-private')[0].key).toBe('decision.canonical-store');
   });
 
+  test('resolves relative filePath overrides from the project root', () => {
+    const root = tempRoot();
+    const originalCwd = process.cwd();
+    const overridePath = path.join('.forge', 'memory', `${path.basename(root)}-custom.jsonl`);
+
+    try {
+      process.chdir(os.tmpdir());
+      projectMemory.write(root, {
+        key: 'decision.relative-override',
+        value: 'Relative override paths stay project-scoped.',
+        sourceAgent: 'Codex',
+        timestamp: '2026-04-26T00:00:00.000Z',
+        tags: ['paths'],
+      }, {
+        filePath: overridePath,
+      });
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    expect(fs.existsSync(path.join(root, overridePath))).toBe(true);
+    expect(fs.existsSync(path.join(os.tmpdir(), overridePath))).toBe(false);
+    expect(projectMemory.read(root, 'decision.relative-override', {
+      filePath: overridePath,
+    })).toMatchObject({
+      key: 'decision.relative-override',
+      sourceAgent: 'Codex',
+    });
+  });
+
   test('validates required schema fields before writing', () => {
     const root = tempRoot();
 

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -230,6 +230,48 @@ describe('project memory', () => {
     })).toThrow('projectRoot');
   });
 
+  test('rejects memory paths that traverse symlinks outside the project root', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const root = tempRoot();
+    const outside = tempRoot();
+    fs.symlinkSync(outside, path.join(root, '.forge'), 'dir');
+
+    expect(() => projectMemory.write(root, {
+      key: 'policy.symlink-escape',
+      value: 'must stay in repo',
+      sourceAgent: 'Codex',
+      tags: [],
+    })).toThrow('projectRoot');
+  });
+
+  test('recovers stale lockfiles owned by dead processes', () => {
+    const root = tempRoot();
+    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
+    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
+    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
+      pid: 99999999,
+      createdAt: '2026-04-26T00:00:00.000Z',
+    }), 'utf8');
+
+    projectMemory.write(root, {
+      key: 'policy.stale-lock',
+      value: 'recovered',
+      sourceAgent: 'Codex',
+      tags: [],
+    }, {
+      lockTimeoutMs: 250,
+      lockRetryMs: 5,
+    });
+
+    expect(projectMemory.read(root, 'policy.stale-lock')).toMatchObject({
+      value: 'recovered',
+    });
+    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
+  });
+
   test('serializes concurrent writers without losing entries', () => {
     const root = tempRoot();
     const worker = `

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -86,6 +86,23 @@ describe('project memory', () => {
     });
   });
 
+  test('normalizes read keys before lookup', () => {
+    const root = tempRoot();
+
+    projectMemory.write(root, {
+      key: ' preference.trimmed-read ',
+      value: 'read callers may pass padded keys',
+      sourceAgent: 'Codex',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      tags: ['preference'],
+    });
+
+    expect(projectMemory.read(root, ' preference.trimmed-read ')).toMatchObject({
+      key: 'preference.trimmed-read',
+      value: 'read callers may pass padded keys',
+    });
+  });
+
   test('deduplicates all existing records for a key during upsert', () => {
     const root = tempRoot();
     const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
@@ -334,7 +351,7 @@ projectMemory.write(root, {
 });
 `;
 
-    const results = await Promise.all(Array.from({ length: 8 }, (_unused, index) => new Promise((resolve) => {
+    await Promise.all(Array.from({ length: 8 }, (_unused, index) => new Promise((resolve, reject) => {
       const child = spawn(process.execPath, ['-e', worker, root, String(index)], {
         stdio: ['ignore', 'pipe', 'pipe'],
       });
@@ -343,13 +360,42 @@ projectMemory.write(root, {
 
       child.stdout.on('data', (chunk) => { stdout += chunk; });
       child.stderr.on('data', (chunk) => { stderr += chunk; });
-      child.on('close', (status) => resolve({ status, stdout, stderr }));
+      child.on('error', (err) => {
+        reject(new Error(`worker ${index} failed to spawn: ${err.message}`));
+      });
+      child.on('close', (status) => {
+        if (status === 0) {
+          resolve();
+          return;
+        }
+        reject(new Error(`worker ${index} exited with ${status}: ${stderr || stdout}`));
+      });
     })));
 
-    for (const result of results) {
-      expect(result.status).toBe(0);
-    }
     expect(projectMemory.search(root, 'concurrent')).toHaveLength(8);
+  });
+
+  test('rejects schema-invalid stored JSONL entries when reading', () => {
+    const root = tempRoot();
+    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
+    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
+    fs.writeFileSync(memoryFile, [
+      JSON.stringify({
+        key: 'policy.valid',
+        value: 'valid',
+        'source-agent': 'Codex',
+        timestamp: '2026-04-26T00:00:00.000Z',
+        tags: [],
+      }),
+      JSON.stringify({
+        key: 'policy.invalid',
+        value: 'missing disk source-agent',
+        sourceAgent: 'Codex',
+        tags: [],
+      }),
+    ].join('\n') + '\n', 'utf8');
+
+    expect(() => projectMemory.list(root)).toThrow('invalid project memory entry at line 2');
   });
 
   test('validates required schema fields before writing', () => {

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -1,5 +1,5 @@
 const { describe, test, expect, afterEach } = require('bun:test');
-const { spawnSync } = require('node:child_process');
+const { spawn } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -272,7 +272,7 @@ describe('project memory', () => {
     expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
   });
 
-  test('serializes concurrent writers without losing entries', () => {
+  test('serializes concurrent writers without losing entries', async () => {
     const root = tempRoot();
     const worker = `
 const projectMemory = require(${JSON.stringify(workerModulePath)});
@@ -287,11 +287,17 @@ projectMemory.write(root, {
 });
 `;
 
-    const results = Array.from({ length: 8 }, (_unused, index) => spawnSync(
-      process.execPath,
-      ['-e', worker, root, String(index)],
-      { encoding: 'utf8', timeout: 15000 }
-    ));
+    const results = await Promise.all(Array.from({ length: 8 }, (_unused, index) => new Promise((resolve) => {
+      const child = spawn(process.execPath, ['-e', worker, root, String(index)], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk) => { stdout += chunk; });
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+      child.on('close', (status) => resolve({ status, stdout, stderr }));
+    })));
 
     for (const result of results) {
       expect(result.status).toBe(0);

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -1,4 +1,5 @@
 const { describe, test, expect, afterEach } = require('bun:test');
+const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -6,6 +7,7 @@ const path = require('node:path');
 const projectMemory = require('../lib/project-memory');
 
 const tempRoots = [];
+const workerModulePath = path.resolve(__dirname, '..', 'lib', 'project-memory');
 
 function tempRoot() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-project-memory-'));
@@ -204,6 +206,55 @@ describe('project memory', () => {
       key: 'decision.relative-override',
       sourceAgent: 'Codex',
     });
+  });
+
+  test('rejects filePath overrides outside the project root', () => {
+    const root = tempRoot();
+
+    expect(() => projectMemory.write(root, {
+      key: 'policy.escape',
+      value: 'must stay in repo',
+      sourceAgent: 'Codex',
+      tags: [],
+    }, {
+      filePath: path.join('..', 'outside.jsonl'),
+    })).toThrow('projectRoot');
+
+    expect(() => projectMemory.write(root, {
+      key: 'policy.absolute-escape',
+      value: 'must stay in repo',
+      sourceAgent: 'Codex',
+      tags: [],
+    }, {
+      filePath: path.join(os.tmpdir(), `outside-${path.basename(root)}.jsonl`),
+    })).toThrow('projectRoot');
+  });
+
+  test('serializes concurrent writers without losing entries', () => {
+    const root = tempRoot();
+    const worker = `
+const projectMemory = require(${JSON.stringify(workerModulePath)});
+const root = process.argv[1];
+const index = Number(process.argv[2]);
+projectMemory.write(root, {
+  key: \`decision.concurrent.\${index}\`,
+  value: \`writer-\${index}\`,
+  sourceAgent: 'Codex',
+  timestamp: '2026-04-26T00:00:00.000Z',
+  tags: ['concurrent'],
+});
+`;
+
+    const results = Array.from({ length: 8 }, (_unused, index) => spawnSync(
+      process.execPath,
+      ['-e', worker, root, String(index)],
+      { encoding: 'utf8', timeout: 15000 }
+    ));
+
+    for (const result of results) {
+      expect(result.status).toBe(0);
+    }
+    expect(projectMemory.search(root, 'concurrent')).toHaveLength(8);
   });
 
   test('validates required schema fields before writing', () => {


### PR DESCRIPTION
## Problem
Forge does not have a shared, agent-agnostic project memory format. Claude, Cursor, Codex, Cline, and OpenCode each have their own instruction or memory surfaces, which creates drift and makes reusable project context hard to share across agents.

## Root Cause
Existing project context mechanisms are either prompt/instruction files or agent-private memory stores. They are useful adapters, but none is a Forge-owned canonical writable memory store that can coexist with Beads issue tracking.

## Fix
Adds a new file-backed project memory module plus TDD coverage and a design doc. The design uses a repo-owned JSONL store under .forge/memory as the canonical record, with future adapters and MCP tools layered on top.

## Value
Any supported agent can read and write the same durable project memory format. Beads remains authoritative for issue lifecycle, while Forge memory captures reusable decisions, preferences, policies, and context.

## Beads
Closes forge-xdh7
Parent epic: forge-f3lx

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 5 targeted tests passing
- Scenarios covered: JSONL write/read/list, upsert by key, search across entry fields, search across optional metadata, schema validation failures

### Security Review
- OWASP Top 10: local file write surface reviewed for scope; this change does not add network, auth, secrets handling, or command execution
- Automated scan: not run in full because the user requested direct ship after validation was taking too long

### Design Doc
See: docs/plans/2026-04-26-project-memory-design.md

### Key Decisions
- Use .forge/memory/entries.jsonl as the canonical repo-owned memory store.
- Treat agent-native memory systems as adapters, mirrors, or caches, not sources of truth.
- Keep Beads authoritative for issue lifecycle and workflow state.
- Preserve JavaScript ergonomics with sourceAgent while persisting source-agent on disk.
- Plan future MCP tools around the same lib/project-memory.js implementation.

### Documentation Updated
- docs/plans/2026-04-26-project-memory-design.md

### Validation
- [ ] Type check passing
- [x] Lint passing for changed JS files (0 errors, 0 warnings)
- [x] Targeted tests passing
- [ ] Security review completed by automated scan

</details>

---

### Self-Review Checklist

- [ ] I reviewed the full diff on GitHub
- [ ] No debug code (console.log, commented code, temporary changes)
- [ ] ESLint passes with zero warnings (bunx eslint .)
- [ ] All tests pass locally (bun test)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes
- [x] TDD compliance: source file has corresponding tests
