### PR TITLE
fix: allow stateless hotfix stage entry

### DIFF
--- a/lib/workflow/enforce-stage.js
+++ b/lib/workflow/enforce-stage.js
@@ -10,6 +10,8 @@ const {
 } = require('./state');
 const { loadState, WORKFLOW_STATE_FILENAME } = require('./state-manager');
 
+const STATELESS_ENTRY_STAGES = new Set(['plan', 'dev', 'validate', 'verify']);
+
 function getOverrideInput(flags = {}) {
   if (Object.hasOwn(flags, 'overrideStage')) {
     return flags.overrideStage;
@@ -131,7 +133,7 @@ async function enforceStageEntry({ commandName, args = [], flags = {}, projectRo
   const stateInput = resolveWorkflowStateInput(workflowState, flags, args, projectRoot);
   const currentState = readWorkflowStateInput(stateInput);
   if (!currentState) {
-    if (stageId === 'plan') {
+    if (STATELESS_ENTRY_STAGES.has(stageId)) {
       return { allowed: true, stage: stageId, workflowState: null };
     }
 

--- a/lib/workflow/enforce-stage.js
+++ b/lib/workflow/enforce-stage.js
@@ -10,7 +10,7 @@ const {
 } = require('./state');
 const { loadState, WORKFLOW_STATE_FILENAME } = require('./state-manager');
 
-const STATELESS_ENTRY_STAGES = new Set(['plan', 'dev', 'validate', 'verify']);
+const STATELESS_ENTRY_STAGES = new Set(['plan', 'dev', 'validate', 'review', 'verify']);
 
 function getOverrideInput(flags = {}) {
   if (Object.hasOwn(flags, 'overrideStage')) {

--- a/lib/workflow/enforce-stage.js
+++ b/lib/workflow/enforce-stage.js
@@ -10,7 +10,7 @@ const {
 } = require('./state');
 const { loadState, WORKFLOW_STATE_FILENAME } = require('./state-manager');
 
-const STATELESS_ENTRY_STAGES = new Set(['plan', 'dev', 'validate', 'review', 'verify']);
+const STATELESS_ENTRY_STAGES = new Set(['plan', 'dev', 'validate', 'verify']);
 
 function getOverrideInput(flags = {}) {
   if (Object.hasOwn(flags, 'overrideStage')) {

--- a/test/workflow/enforce-stage.test.js
+++ b/test/workflow/enforce-stage.test.js
@@ -133,6 +133,66 @@ describe('workflow enforce-stage', () => {
     }
   });
 
+  test('enforceStageEntry allows verify without workflow state for post-merge checks', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-verify-missing-state-'));
+    try {
+      const result = await enforceStageEntry({
+        commandName: 'verify',
+        flags: {},
+        projectRoot: tmpDir,
+        health: { healthy: true, hardStop: false, diagnostics: [] }
+      });
+
+      expect(result).toEqual({
+        allowed: true,
+        stage: 'verify',
+        workflowState: null
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('enforceStageEntry allows validate without workflow state for direct hotfix gates', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-validate-missing-state-'));
+    try {
+      const result = await enforceStageEntry({
+        commandName: 'validate',
+        flags: {},
+        projectRoot: tmpDir,
+        health: { healthy: true, hardStop: false, diagnostics: [] }
+      });
+
+      expect(result).toEqual({
+        allowed: true,
+        stage: 'validate',
+        workflowState: null
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('enforceStageEntry allows dev without workflow state for simple and hotfix starts', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-dev-missing-state-'));
+    try {
+      const result = await enforceStageEntry({
+        commandName: 'dev',
+        flags: {},
+        projectRoot: tmpDir,
+        health: { healthy: true, hardStop: false, diagnostics: [] }
+      });
+
+      expect(result).toEqual({
+        allowed: true,
+        stage: 'dev',
+        workflowState: null
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test('enforceStageEntry reads workflow state from .forge-state.json when present', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-workflow-state-'));
     try {

--- a/test/workflow/enforce-stage.test.js
+++ b/test/workflow/enforce-stage.test.js
@@ -173,21 +173,15 @@ describe('workflow enforce-stage', () => {
     }
   });
 
-  test('enforceStageEntry allows review without workflow state for direct PR feedback checks', async () => {
+  test('enforceStageEntry requires workflow state for review so ship-to-review transitions stay guarded', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-review-missing-state-'));
     try {
-      const result = await enforceStageEntry({
+      await expect(enforceStageEntry({
         commandName: 'review',
         flags: {},
         projectRoot: tmpDir,
         health: { healthy: true, hardStop: false, diagnostics: [] }
-      });
-
-      expect(result).toEqual({
-        allowed: true,
-        stage: 'review',
-        workflowState: null
-      });
+      })).rejects.toThrow(/requires authoritative workflow state/i);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/workflow/enforce-stage.test.js
+++ b/test/workflow/enforce-stage.test.js
@@ -173,6 +173,26 @@ describe('workflow enforce-stage', () => {
     }
   });
 
+  test('enforceStageEntry allows review without workflow state for direct PR feedback checks', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-review-missing-state-'));
+    try {
+      const result = await enforceStageEntry({
+        commandName: 'review',
+        flags: {},
+        projectRoot: tmpDir,
+        health: { healthy: true, hardStop: false, diagnostics: [] }
+      });
+
+      expect(result).toEqual({
+        allowed: true,
+        stage: 'review',
+        workflowState: null
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test('enforceStageEntry allows dev without workflow state for simple and hotfix starts', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-dev-missing-state-'));
     try {


### PR DESCRIPTION
## Problem
`forge dev`, `forge validate`, and `forge verify` can block before useful work when `.forge-state.json` is missing, even for hotfix/manual flows where the user intentionally did not run the full plan/dev state path.

## Root Cause
Stage enforcement treated every non-`plan` stage as requiring authoritative workflow state. That was too strict for resumable/direct stages: `dev` can be the first stage for simple/hotfix workflows, `validate` is often run directly as a safety gate, and `verify` is a post-merge health check that can rely on GitHub/Git state.

## Fix
Allow stateless entry for `plan`, `dev`, `validate`, and `verify` while keeping later PR/documentation stages such as `ship` guarded by authoritative workflow state.

## Value
Hotfix and manual recovery workflows no longer get blocked by missing local state before they can run validation or post-merge verification. The accountability gate remains in place before PR shipping.

## Beads
Closes forge-p41c

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 13 focused workflow-enforcement tests passing; full local validate ran 2986 passing, 58 skipped, 0 failed.
- Scenarios covered: stateless `dev`, stateless `validate`, stateless `verify`, and continued state requirement for `ship`.

### Security Review
- OWASP Top 10: No auth, secret, input parsing, or execution surface added. This only adjusts local stage-entry policy.
- Automated scan: `bun audit` reported no vulnerabilities.

### Design Doc
N/A - hotfix for observed workflow-state blocker.

### Key Decisions
- Keep `ship` strict because PR creation still needs an accountability gate.
- Permit `validate` without state because it is a direct safety gate and should not be blocked by missing local workflow metadata.
- Permit `verify` without state because post-merge health is sourced from GitHub/Git state, not local stage state.

### Documentation Updated
None - no doc-facing changes.

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff locally
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`node bin/forge.js validate`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests