### PR TITLE
fix: stabilize behavioral judge Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,18 +204,28 @@ jobs:
           retention-days: 7
 
   followup-tests:
-    name: Targeted PR Tests
-    if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
-    runs-on: ubuntu-latest
+    name: Targeted PR Tests (${{ matrix.label }})
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node-version: 24
+            label: ubuntu-node24
+          - os: windows-latest
+            node-version: 22
+            label: windows-node22
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Setup Node.js 24
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -293,7 +303,7 @@ jobs:
         if: steps.affected.outputs.run_test_env == 'true'
         run: node --test test-env/**/*.test.js || true
       - name: Build followup profile
-        run: node scripts/test-profile.js --input-dir test-results --output test-results/followup.profile.json --label followup-tests --integration-skipped true
+        run: node scripts/test-profile.js --input-dir test-results --output test-results/followup-${{ matrix.label }}.profile.json --label followup-${{ matrix.label }} --integration-skipped true
       - name: Publish followup summary
         if: always()
         shell: bash
@@ -304,7 +314,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-artifacts-followup
+          name: test-artifacts-followup-${{ matrix.label }}
           path: test-results/
           retention-days: 7
 

--- a/scripts/behavioral-judge.sh
+++ b/scripts/behavioral-judge.sh
@@ -66,10 +66,25 @@ else
   INPUT="$(cat)"
 fi
 
-# Extract plan_output text if input is JSON, otherwise use raw input
-PLAN_TEXT="$INPUT"
-if command -v python3 >/dev/null 2>&1; then
-  EXTRACTED=$(echo "$INPUT" | python3 -c "
+extract_plan_text() {
+  if command -v node >/dev/null 2>&1; then
+    node -e "
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  try {
+    const parsed = JSON.parse(input);
+    const value = parsed && parsed.plan_output;
+    if (value) process.stdout.write(String(value));
+  } catch (_) {}
+});
+" 2>/dev/null
+    return $?
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -78,10 +93,16 @@ try:
         print(val)
 except:
     pass
-" 2>/dev/null) || true
-  if [ -n "$EXTRACTED" ]; then
-    PLAN_TEXT="$EXTRACTED"
+" 2>/dev/null
+    return $?
   fi
+}
+
+# Extract plan_output text if input is JSON, otherwise use raw input
+PLAN_TEXT="$INPUT"
+EXTRACTED=$(printf '%s' "$INPUT" | extract_plan_text) || true
+if [ -n "$EXTRACTED" ]; then
+  PLAN_TEXT="$EXTRACTED"
 fi
 
 # ─── Judge prompt ────────────────────────────────────────────────────────────
@@ -158,7 +179,22 @@ parse_scores() {
   local response="$1"
   # Extract the JSON object from the LLM response content
   local content
-  content=$(echo "$response" | python3 -c "
+  if command -v node >/dev/null 2>&1; then
+    content=$(printf '%s' "$response" | node -e "
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+    const choice = (data.choices || [])[0] || {};
+    const message = choice.message || {};
+    process.stdout.write(String(message.content || ''));
+  } catch (_) {}
+});
+" 2>/dev/null) || true
+  elif command -v python3 >/dev/null 2>&1; then
+    content=$(printf '%s' "$response" | python3 -c "
 import sys, json
 try:
     data = json.load(sys.stdin)
@@ -170,6 +206,9 @@ try:
 except Exception as e:
     pass
 " 2>/dev/null) || true
+  else
+    content=""
+  fi
 
   if [ -z "$content" ]; then
     echo ""
@@ -178,7 +217,37 @@ except Exception as e:
 
   # Parse scores from content JSON
   local scores
-  scores=$(echo "$content" | python3 -c "
+  if command -v node >/dev/null 2>&1; then
+    scores=$(printf '%s' "$content" | node -e "
+let text = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { text += chunk; });
+process.stdin.on('end', () => {
+  function emit(value) {
+    const security = Number.parseInt(value.security, 10);
+    const tdd = Number.parseInt(value.tdd, 10);
+    const design = Number.parseInt(value.design, 10);
+    const structural = Number.parseInt(value.structural, 10);
+    if ([security, tdd, design, structural].every(score => Number.isInteger(score) && score >= 0 && score <= 5)) {
+      console.log([security, tdd, design, structural].join(' '));
+      return true;
+    }
+    return false;
+  }
+  try {
+    if (emit(JSON.parse(text.trim()))) return;
+  } catch (_) {}
+  const match = text.match(/\{[^}]+\}/s);
+  if (match) {
+    try {
+      if (emit(JSON.parse(match[0]))) return;
+    } catch (_) {}
+  }
+  process.exit(1);
+});
+" 2>/dev/null) || { echo ""; return 1; }
+  elif command -v python3 >/dev/null 2>&1; then
+    scores=$(printf '%s' "$content" | python3 -c "
 import sys, json, re
 text = sys.stdin.read().strip()
 # Try direct JSON parse first
@@ -209,6 +278,10 @@ if m:
         pass
 sys.exit(1)
 " 2>/dev/null) || { echo ""; return 1; }
+  else
+    echo ""
+    return 1
+  fi
 
   echo "$scores"
 }
@@ -221,10 +294,23 @@ call_openrouter() {
 
   # Escape prompt for JSON
   local escaped_prompt
-  escaped_prompt=$(echo "$prompt" | python3 -c "
+  if command -v node >/dev/null 2>&1; then
+    escaped_prompt=$(printf '%s' "$prompt" | node -e "
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  process.stdout.write(JSON.stringify(input));
+});
+" 2>/dev/null) || escaped_prompt='""'
+  elif command -v python3 >/dev/null 2>&1; then
+    escaped_prompt=$(printf '%s' "$prompt" | python3 -c "
 import sys, json
 print(json.dumps(sys.stdin.read()))
 " 2>/dev/null) || escaped_prompt='""'
+  else
+    escaped_prompt='""'
+  fi
 
   local body
   body=$(cat <<JSON
@@ -295,7 +381,22 @@ if [ "${BEHAVIORAL_JUDGE_TEST_MODE}" = "1" ]; then
   fi
 
   # Parse mock scores
-  scores=$(echo "$mock_scores" | python3 -c "
+  if command -v node >/dev/null 2>&1; then
+    scores=$(printf '%s' "$mock_scores" | node -e "
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', () => {
+  const scores = JSON.parse(input);
+  const security = Number.parseInt(scores.security ?? 3, 10);
+  const tdd = Number.parseInt(scores.tdd ?? 3, 10);
+  const design = Number.parseInt(scores.design ?? 3, 10);
+  const structural = Number.parseInt(scores.structural ?? 3, 10);
+  console.log([security, tdd, design, structural].join(' '));
+});
+" 2>/dev/null) || scores="3 3 3 3"
+  elif command -v python3 >/dev/null 2>&1; then
+    scores=$(printf '%s' "$mock_scores" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
 s = int(d.get('security', 3))
@@ -304,6 +405,9 @@ de = int(d.get('design', 3))
 st = int(d.get('structural', 3))
 print(f'{s} {t} {de} {st}')
 " 2>/dev/null) || scores="3 3 3 3"
+  else
+    scores="3 3 3 3"
+  fi
 
   read -r sec tdd_s des str <<< "$scores"
   compute_result "$sec" "$tdd_s" "$des" "$str" "$judge_model" "$judge_calls"

--- a/test/ci-workflow.test.js
+++ b/test/ci-workflow.test.js
@@ -20,9 +20,16 @@ describe('CI Workflow Configuration', () => {
   });
 
   describe('Follow-up PR Pushes', () => {
-    test('followup-tests job exists for synchronize events', () => {
+    test('followup-tests job exists for all pull request events', () => {
       expectSection('followup-tests');
-      expect(workflowContent.includes("if: github.event_name == 'pull_request' && github.event.action == 'synchronize'")).toBe(true);
+      expect(workflowContent.includes("if: github.event_name == 'pull_request'")).toBe(true);
+    });
+
+    test('followup-tests covers the Windows Node 22 lane before merge', () => {
+      expect(workflowContent.includes('name: Targeted PR Tests (${{ matrix.label }})')).toBe(true);
+      expect(workflowContent.includes('os: windows-latest')).toBe(true);
+      expect(workflowContent.includes('node-version: 22')).toBe(true);
+      expect(workflowContent.includes('label: windows-node22')).toBe(true);
     });
 
     test('followup-tests resolves affected targets through the shared execution planner', () => {

--- a/test/scripts/behavioral-judge.test.js
+++ b/test/scripts/behavioral-judge.test.js
@@ -1,4 +1,5 @@
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { describe, test, expect } = require('bun:test');
@@ -130,6 +131,27 @@ describe('scripts/behavioral-judge.sh', () => {
       expect(result.error).toBeUndefined();
       const parsed = parseOutput(result.stdout);
       expect(parsed).not.toBeNull();
+    }, 15000);
+
+    test('test mode prefers node JSON parsing when python3 is unavailable', () => {
+      const tempBin = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-python3-shim-'));
+      const marker = path.join(tempBin, 'python3-called');
+      const pythonShim = path.join(tempBin, 'python3');
+      fs.writeFileSync(pythonShim, `#!/usr/bin/env bash\necho called > ${JSON.stringify(marker)}\nexit 97\n`, 'utf8');
+      fs.chmodSync(pythonShim, 0o755);
+
+      try {
+        const result = runJudge(SAMPLE_PLAN_OUTPUT, {
+          BEHAVIORAL_JUDGE_TEST_MODE: '1',
+          PATH: `${tempBin}${path.delimiter}${process.env.PATH}`,
+        });
+        expect(result.error).toBeUndefined();
+        const parsed = parseOutput(result.stdout);
+        expect(parsed).not.toBeNull();
+        expect(fs.existsSync(marker)).toBe(false);
+      } finally {
+        fs.rmSync(tempBin, { recursive: true, force: true });
+      }
     }, 15000);
 
     test('output contains "result" field', () => {


### PR DESCRIPTION
## Summary
- stabilize `scripts/behavioral-judge.sh` test mode on Windows by preferring Node for JSON parsing and keeping Python only as fallback
- add regression coverage proving test mode does not call a failing `python3` shim
- close the CI coverage gap by running affected PR tests on Windows/Node 22 before merge, not only after merge on `master`

## Why
Post-merge Tests failed on `master` for PR #142 in `Full Matrix (windows-latest / Node 22)`:
https://github.com/harshanandak/forge/actions/runs/24989351678/job/73170705189

The failing test was `scripts/behavioral-judge.sh > test mode output (BEHAVIORAL_JUDGE_TEST_MODE=1) > outputs valid JSON when called with sample input`, timing out at 15000ms.

## Validation
- `bun test test/ci-workflow.test.js test/scripts/behavioral-judge.test.js --timeout 15000` passed: 58 tests
- `bunx eslint test/ci-workflow.test.js test/scripts/behavioral-judge.test.js --max-warnings 0` passed
- `bunx js-yaml .github/workflows/test.yml` passed
- `git diff --check` passed
- pre-push hook passed: lint plus affected tests and edge-case tests, 266 tests