### PR TITLE
fix: stabilize post-merge CI hotfix checks

### DIFF
--- a/.github/agentic-workflows/behavioral-test.lock.yml
+++ b/.github/agentic-workflows/behavioral-test.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96739abce2d49060d41da64b2204502efe4d05588061ae5a0d10fd3ab47ac8e1","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"32ac83ab90af84909d69ac5e68ed3326d8629687a948e5ff1c997f43f3fde149","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0","digest":"sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d","pinned_image":"ghcr.io/github/gh-aw-mcpg@sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2","digest":"sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba","pinned_image":"ghcr.io/github/github-mcp-server@sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -61,14 +61,6 @@ name: "Forge Workflow Behavioral Test"
         default: false
         description: Run 4-prompt calibration mode
         type: boolean
-  workflow_run:
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    branches:
-    - master
-    types:
-    - completed
-    workflows:
-    - detect-command-file-changes
 
 permissions: {}
 
@@ -80,11 +72,6 @@ run-name: "Forge Workflow Behavioral Test"
 
 jobs:
   activation:
-    needs: pre_activation
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
-      (!(github.event.workflow_run.repository.fork)))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -105,7 +92,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -195,19 +181,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           <system>
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -237,12 +223,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           </system>
           {{#runtime-import .github/workflows/behavioral-test.md}}
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -268,7 +254,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -287,8 +272,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
               }
             });
       - name: Validate prompt placeholders
@@ -428,9 +412,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5c7d74ae9b763579_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d9d96e4970ec6549_EOF'
           {"create_issue":{"labels":["behavioral-test"],"max":1,"title_prefix":"[behavioral-test]"},"create_report_incomplete_issue":{},"max_bot_mentions":2,"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5c7d74ae9b763579_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d9d96e4970ec6549_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -628,7 +612,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg@sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9f44dc6088150821_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_86e601dc8dd9f2f4_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -668,7 +652,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9f44dc6088150821_EOF
+          GH_AW_MCP_CONFIG_86e601dc8dd9f2f4_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -908,7 +892,6 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/sandbox/firewall/audit/
           if-no-files-found: ignore
-
   conclusion:
     needs:
       - activation
@@ -1212,32 +1195,6 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
             await main();
 
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@239aec45b78c8799417efdd5bc6d8cc036629ec1 # v0.71.1
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
-
   safe_outputs:
     needs:
       - activation
@@ -1323,4 +1280,3 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
-

--- a/.github/agentic-workflows/behavioral-test.md
+++ b/.github/agentic-workflows/behavioral-test.md
@@ -10,10 +10,6 @@ on:
         description: "Run 4-prompt calibration mode"
         type: boolean
         default: false
-  workflow_run:
-    workflows: ["detect-command-file-changes"]
-    types: [completed]
-    branches: [master]
 engine:
   id: claude
   model: claude-sonnet-4-6
@@ -51,10 +47,8 @@ Follow every step below exactly. Do not skip steps. Do not summarize — execute
 
 ## Step 0: Validate sync between .md and .lock.yml (Loophole Fix 14)
 
-> Note on trigger architecture (Loophole Fix 12): This workflow is triggered by `workflow_run`
-> from `detect-command-file-changes` (a standard GitHub Actions workflow that watches
-> `.claude/commands/**` on push to master). gh-aw does not support direct path-based push
-> triggers, so this two-workflow approach is required.
+> Note on trigger architecture: this behavioral judge is intentionally schedule/manual only.
+> It requires an Anthropic API key, so post-merge health must not depend on it.
 
 Before doing anything else, verify that the compiled `.lock.yml` matches this workflow's frontmatter
 version field. The `.lock.yml` is the auditable compiled form and must stay in sync.

--- a/.github/workflows/behavioral-test.lock.yml
+++ b/.github/workflows/behavioral-test.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96739abce2d49060d41da64b2204502efe4d05588061ae5a0d10fd3ab47ac8e1","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"32ac83ab90af84909d69ac5e68ed3326d8629687a948e5ff1c997f43f3fde149","compiler_version":"v0.71.1","strict":true,"agent_id":"claude","agent_model":"claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["ANTHROPIC_API_KEY","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0","digest":"sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d","pinned_image":"ghcr.io/github/gh-aw-mcpg@sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2","digest":"sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba","pinned_image":"ghcr.io/github/github-mcp-server@sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -61,14 +61,6 @@ name: "Forge Workflow Behavioral Test"
         default: false
         description: Run 4-prompt calibration mode
         type: boolean
-  workflow_run:
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    branches:
-    - master
-    types:
-    - completed
-    workflows:
-    - detect-command-file-changes
 
 permissions: {}
 
@@ -80,11 +72,6 @@ run-name: "Forge Workflow Behavioral Test"
 
 jobs:
   activation:
-    needs: pre_activation
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
-      (!(github.event.workflow_run.repository.fork)))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -105,7 +92,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
       - name: Generate agentic run info
         id: generate_aw_info
         env:
@@ -195,19 +181,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           <system>
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -237,12 +223,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_24d46cc07130db79_EOF'
+          cat << 'GH_AW_PROMPT_22323c221cb38c70_EOF'
           </system>
           {{#runtime-import .github/workflows/behavioral-test.md}}
-          GH_AW_PROMPT_24d46cc07130db79_EOF
+          GH_AW_PROMPT_22323c221cb38c70_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -268,7 +254,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -287,8 +272,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
-                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE
               }
             });
       - name: Validate prompt placeholders
@@ -428,9 +412,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5c7d74ae9b763579_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d9d96e4970ec6549_EOF'
           {"create_issue":{"labels":["behavioral-test"],"max":1,"title_prefix":"[behavioral-test]"},"create_report_incomplete_issue":{},"max_bot_mentions":2,"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5c7d74ae9b763579_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d9d96e4970ec6549_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -628,7 +612,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host --add-host host.docker.internal:127.0.0.1 --user '"${MCP_GATEWAY_UID}"':'"${MCP_GATEWAY_GID}"' --group-add '"${DOCKER_SOCK_GID}"' -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg@sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d'
           
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9f44dc6088150821_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_86e601dc8dd9f2f4_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -668,7 +652,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9f44dc6088150821_EOF
+          GH_AW_MCP_CONFIG_86e601dc8dd9f2f4_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -908,7 +892,6 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/logs/
             /tmp/gh-aw/sandbox/firewall/audit/
           if-no-files-found: ignore
-
   conclusion:
     needs:
       - activation
@@ -1212,32 +1195,6 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/parse_threat_detection_results.cjs');
             await main();
 
-  pre_activation:
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@239aec45b78c8799417efdd5bc6d8cc036629ec1 # v0.71.1
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
-
   safe_outputs:
     needs:
       - activation
@@ -1323,4 +1280,3 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
-

--- a/.github/workflows/behavioral-test.md
+++ b/.github/workflows/behavioral-test.md
@@ -10,10 +10,6 @@ on:
         description: "Run 4-prompt calibration mode"
         type: boolean
         default: false
-  workflow_run:
-    workflows: ["detect-command-file-changes"]
-    types: [completed]
-    branches: [master]
 engine:
   id: claude
   model: claude-sonnet-4-6
@@ -51,10 +47,8 @@ Follow every step below exactly. Do not skip steps. Do not summarize — execute
 
 ## Step 0: Validate sync between .md and .lock.yml (Loophole Fix 14)
 
-> Note on trigger architecture (Loophole Fix 12): This workflow is triggered by `workflow_run`
-> from `detect-command-file-changes` (a standard GitHub Actions workflow that watches
-> `.claude/commands/**` on push to master). gh-aw does not support direct path-based push
-> triggers, so this two-workflow approach is required.
+> Note on trigger architecture: this behavioral judge is intentionally schedule/manual only.
+> It requires an Anthropic API key, so post-merge health must not depend on it.
 
 Before doing anything else, verify that the compiled `.lock.yml` matches this workflow's frontmatter
 version field. The `.lock.yml` is the auditable compiled form and must stay in sync.

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,7 @@
+{
+  "name": ".opencode",
+  "dependencies": {
+    "@kilocode/plugin": "7.1.20",
+    "@opencode-ai/plugin": "1.14.24"
+  }
+}

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -90,17 +90,6 @@ function readLock(lockPath) {
   }
 }
 
-function isLockDirectory(lockPath) {
-  try {
-    return fs.statSync(lockPath).isDirectory();
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      throw err;
-    }
-    return false;
-  }
-}
-
 function lockPathAgeMs(lockPath) {
   try {
     return Date.now() - fs.statSync(lockPath).mtimeMs;
@@ -191,7 +180,7 @@ function isExistingLockError(err, lockPath) {
     return true;
   }
 
-  return err.code === 'EPERM' && isLockDirectory(lockPath);
+  return err.code === 'EPERM' && fs.existsSync(lockPath);
 }
 
 function cleanupCreatedLockFile(lockPath) {

--- a/test/dependabot-config.test.js
+++ b/test/dependabot-config.test.js
@@ -4,6 +4,8 @@ const { resolve } = require("path");
 const yaml = require("js-yaml");
 
 const configPath = resolve(__dirname, "../.github/dependabot.yml");
+const opencodePackagePath = resolve(__dirname, "../.opencode/package.json");
+const opencodeLockPath = resolve(__dirname, "../.opencode/package-lock.json");
 
 describe("dependabot.yml", () => {
   test("file exists", () => {
@@ -86,5 +88,15 @@ describe("dependabot.yml", () => {
     );
     expect(gha.labels).toContain("github-actions");
     expect(gha.labels).toContain("dependencies");
+  });
+
+  test("tracked OpenCode npm lockfile has a matching manifest", () => {
+    expect(existsSync(opencodePackagePath)).toBe(true);
+    expect(existsSync(opencodeLockPath)).toBe(true);
+
+    const manifest = JSON.parse(readFileSync(opencodePackagePath, "utf8"));
+    const lockfile = JSON.parse(readFileSync(opencodeLockPath, "utf8"));
+    expect(manifest.name).toBe(lockfile.name);
+    expect(manifest.dependencies).toEqual(lockfile.packages[""].dependencies);
   });
 });

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -331,6 +331,50 @@ describe('project memory', () => {
     expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
   });
 
+  test('treats Windows EPERM on existing lockfiles as lock contention', () => {
+    const root = tempRoot();
+    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
+    const lockPath = `${memoryFile}.lock`;
+    const originalOpenSync = fs.openSync;
+    let injected = false;
+
+    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify({
+      pid: 99999999,
+      createdAt: '2026-04-26T00:00:00.000Z',
+    }), 'utf8');
+
+    fs.openSync = function openSyncWithInjectedEperm(target, flags, ...args) {
+      if (!injected && target === lockPath && flags === 'wx') {
+        injected = true;
+        const err = new Error('operation not permitted');
+        err.code = 'EPERM';
+        throw err;
+      }
+      return originalOpenSync.call(this, target, flags, ...args);
+    };
+
+    try {
+      projectMemory.write(root, {
+        key: 'policy.eperm-lock-file',
+        value: 'recovered',
+        sourceAgent: 'Codex',
+        tags: [],
+      }, {
+        lockTimeoutMs: 250,
+        lockRetryMs: 5,
+      });
+    } finally {
+      fs.openSync = originalOpenSync;
+    }
+
+    expect(injected).toBe(true);
+    expect(projectMemory.read(root, 'policy.eperm-lock-file')).toMatchObject({
+      value: 'recovered',
+    });
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
   test('removes lockfiles when lock metadata initialization fails', () => {
     const root = tempRoot();
     const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
@@ -581,10 +625,11 @@ describe('project memory', () => {
 
   test('serializes concurrent writers without losing entries', async () => {
     const root = tempRoot();
+    const workerPath = path.join(root, 'project-memory-writer.cjs');
     const worker = `
 const projectMemory = require(${JSON.stringify(workerModulePath)});
-const root = process.argv[1];
-const index = Number(process.argv[2]);
+const root = process.argv.at(-2);
+const index = Number(process.argv.at(-1));
 projectMemory.write(root, {
   key: \`decision.concurrent.\${index}\`,
   value: \`writer-\${index}\`,
@@ -593,9 +638,10 @@ projectMemory.write(root, {
   tags: ['concurrent'],
 });
 `;
+    fs.writeFileSync(workerPath, worker);
 
     await Promise.all(Array.from({ length: 8 }, (_unused, index) => new Promise((resolve, reject) => {
-      const child = spawn(process.execPath, ['-e', worker, root, String(index)], {
+      const child = spawn(process.execPath, [workerPath, root, String(index)], {
         stdio: ['ignore', 'pipe', 'pipe'],
       });
       let stdout = '';

--- a/test/structural/agentic-workflow-sync.test.js
+++ b/test/structural/agentic-workflow-sync.test.js
@@ -52,6 +52,13 @@ describe('agentic-workflow sync checks', () => {
     expect(content).toMatch(/automatically generated|auto-generated/);
   });
 
+  test('behavioral-test.md stays schedule/manual only', () => {
+    const source = fs.readFileSync(mdPath, 'utf8');
+    const active = fs.readFileSync(activeMdPath, 'utf8');
+    expect(source).not.toContain('workflow_run:');
+    expect(active).not.toContain('workflow_run:');
+  });
+
   test('check-agentic-workflow-sync.yml contains "gh aw compile" in error message', () => {
     const content = fs.readFileSync(ciWorkflowPath, 'utf8');
     expect(content).toContain('gh aw compile');


### PR DESCRIPTION
## Summary
- treat Windows \EPERM\ on existing project-memory lock files as lock contention and cover it with a regression test
- make the project-memory concurrent writer test use a real temporary worker file instead of runtime-sensitive \-e\ argv positions
- remove the behavioral agentic workflow post-merge \workflow_run\ trigger so missing Anthropic credentials do not break master health
- track the OpenCode package manifest that matches the existing lockfile so Dependabot can process the directory

## Validation
- bun run typecheck
- bun run lint
- bun test test/project-memory.test.js test/dependabot-config.test.js test/structural/agentic-workflow-sync.test.js --timeout 30000
- bun test --timeout 30000
- js-yaml parses changed workflow/dependabot YAML
- node scripts/sync-agentic-workflow.js --check
- gh aw compile --validate --strict .github/workflows/behavioral-test.md

Closes forge-p3o7
Closes forge-bl71
Closes forge-lqps