### PR TITLE
docs: align v3 workflow boundaries

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -308,7 +308,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -304,14 +304,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -6,7 +6,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -20,13 +28,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -46,6 +54,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -237,7 +247,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -493,7 +503,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -504,6 +514,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -527,14 +541,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.claude/commands/premerge.md
+++ b/.claude/commands/premerge.md
@@ -99,7 +99,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -175,12 +175,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -2,14 +2,15 @@
 description: Deep research with parallel-deep-research, document findings
 ---
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.claude/commands/research.md
+++ b/.claude/commands/research.md
@@ -31,12 +31,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -314,8 +314,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -380,14 +380,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.claude/commands/rollback.md
+++ b/.claude/commands/rollback.md
@@ -168,7 +168,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -351,7 +351,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -363,7 +363,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -174,23 +174,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -179,7 +179,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -76,11 +76,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -193,14 +195,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Check current stage and context
 ---
 
@@ -42,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -50,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -58,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -42,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -50,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -58,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,4 +1,4 @@
-﻿---
+---
 description: Check current stage and context
 ---
 

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -3,7 +3,7 @@ description: Complete validation (type/lint/tests/security)
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -205,10 +205,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -269,14 +269,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -272,9 +272,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -183,28 +183,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -214,7 +214,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -258,12 +258,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.cline/workflows/dev.md
+++ b/.cline/workflows/dev.md
@@ -305,7 +305,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.cline/workflows/dev.md
+++ b/.cline/workflows/dev.md
@@ -301,14 +301,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.cline/workflows/plan.md
+++ b/.cline/workflows/plan.md
@@ -3,7 +3,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -17,13 +25,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -43,6 +51,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -234,7 +244,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -490,7 +500,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -501,6 +511,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -524,14 +538,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.cline/workflows/premerge.md
+++ b/.cline/workflows/premerge.md
@@ -96,7 +96,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -172,12 +172,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.cline/workflows/research.md
+++ b/.cline/workflows/research.md
@@ -1,12 +1,13 @@
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.cline/workflows/research.md
+++ b/.cline/workflows/research.md
@@ -28,12 +28,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.cline/workflows/review.md
+++ b/.cline/workflows/review.md
@@ -311,8 +311,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -377,14 +377,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.cline/workflows/rollback.md
+++ b/.cline/workflows/rollback.md
@@ -165,7 +165,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -348,7 +348,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -360,7 +360,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.cline/workflows/ship.md
+++ b/.cline/workflows/ship.md
@@ -176,7 +176,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.cline/workflows/ship.md
+++ b/.cline/workflows/ship.md
@@ -73,11 +73,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -190,14 +192,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.cline/workflows/ship.md
+++ b/.cline/workflows/ship.md
@@ -171,23 +171,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.cline/workflows/status.md
+++ b/.cline/workflows/status.md
@@ -1,3 +1,6 @@
+﻿---
+description: Check current stage and context
+---
 
 Check where you are in the project and what work is in progress.
 
@@ -39,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -47,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -55,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.cline/workflows/status.md
+++ b/.cline/workflows/status.md
@@ -39,7 +39,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -47,7 +47,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -55,7 +55,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.cline/workflows/status.md
+++ b/.cline/workflows/status.md
@@ -1,6 +1,3 @@
-﻿---
-description: Check current stage and context
----
 
 Check where you are in the project and what work is in progress.
 

--- a/.cline/workflows/validate.md
+++ b/.cline/workflows/validate.md
@@ -269,9 +269,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.cline/workflows/validate.md
+++ b/.cline/workflows/validate.md
@@ -1,6 +1,6 @@
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -202,10 +202,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -266,14 +266,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.cline/workflows/verify.md
+++ b/.cline/workflows/verify.md
@@ -180,28 +180,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -211,7 +211,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -255,12 +255,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -308,7 +308,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -304,14 +304,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -6,7 +6,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -20,13 +28,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -46,6 +54,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -237,7 +247,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -493,7 +503,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -504,6 +514,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -527,14 +541,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.codex/skills/premerge/SKILL.md
+++ b/.codex/skills/premerge/SKILL.md
@@ -99,7 +99,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -175,12 +175,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.codex/skills/research/SKILL.md
+++ b/.codex/skills/research/SKILL.md
@@ -2,14 +2,15 @@
 description: Deep research with parallel-deep-research, document findings
 ---
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.codex/skills/research/SKILL.md
+++ b/.codex/skills/research/SKILL.md
@@ -31,12 +31,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -314,8 +314,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -380,14 +380,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.codex/skills/rollback/SKILL.md
+++ b/.codex/skills/rollback/SKILL.md
@@ -168,7 +168,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -351,7 +351,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -363,7 +363,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -174,23 +174,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -179,7 +179,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -76,11 +76,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -193,14 +195,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Check current stage and context
 ---
 
@@ -42,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -50,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -58,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -42,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -50,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -58,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -1,4 +1,4 @@
-﻿---
+---
 description: Check current stage and context
 ---
 

--- a/.codex/skills/validate/SKILL.md
+++ b/.codex/skills/validate/SKILL.md
@@ -3,7 +3,7 @@ description: Complete validation (type/lint/tests/security)
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -205,10 +205,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -269,14 +269,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.codex/skills/validate/SKILL.md
+++ b/.codex/skills/validate/SKILL.md
@@ -272,9 +272,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.codex/skills/verify/SKILL.md
+++ b/.codex/skills/verify/SKILL.md
@@ -183,28 +183,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -214,7 +214,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -258,12 +258,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.cursor/commands/dev.md
+++ b/.cursor/commands/dev.md
@@ -305,7 +305,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.cursor/commands/dev.md
+++ b/.cursor/commands/dev.md
@@ -301,14 +301,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -3,7 +3,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -17,13 +25,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -43,6 +51,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -234,7 +244,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -490,7 +500,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -501,6 +511,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -524,14 +538,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.cursor/commands/premerge.md
+++ b/.cursor/commands/premerge.md
@@ -96,7 +96,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -172,12 +172,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.cursor/commands/research.md
+++ b/.cursor/commands/research.md
@@ -1,12 +1,13 @@
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.cursor/commands/research.md
+++ b/.cursor/commands/research.md
@@ -28,12 +28,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -311,8 +311,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -377,14 +377,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.cursor/commands/rollback.md
+++ b/.cursor/commands/rollback.md
@@ -165,7 +165,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -348,7 +348,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -360,7 +360,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -176,7 +176,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -73,11 +73,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -190,14 +192,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.cursor/commands/ship.md
+++ b/.cursor/commands/ship.md
@@ -171,23 +171,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.cursor/commands/status.md
+++ b/.cursor/commands/status.md
@@ -1,3 +1,6 @@
+﻿---
+description: Check current stage and context
+---
 
 Check where you are in the project and what work is in progress.
 
@@ -39,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -47,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -55,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.cursor/commands/status.md
+++ b/.cursor/commands/status.md
@@ -39,7 +39,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -47,7 +47,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -55,7 +55,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.cursor/commands/status.md
+++ b/.cursor/commands/status.md
@@ -1,6 +1,3 @@
-﻿---
-description: Check current stage and context
----
 
 Check where you are in the project and what work is in progress.
 

--- a/.cursor/commands/validate.md
+++ b/.cursor/commands/validate.md
@@ -269,9 +269,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.cursor/commands/validate.md
+++ b/.cursor/commands/validate.md
@@ -1,6 +1,6 @@
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -202,10 +202,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -266,14 +266,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.cursor/commands/verify.md
+++ b/.cursor/commands/verify.md
@@ -180,28 +180,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -211,7 +211,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -255,12 +255,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.github/prompts/dev.prompt.md
+++ b/.github/prompts/dev.prompt.md
@@ -306,14 +306,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.github/prompts/dev.prompt.md
+++ b/.github/prompts/dev.prompt.md
@@ -310,7 +310,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -8,7 +8,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -22,13 +30,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -48,6 +56,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -239,7 +249,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -495,7 +505,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -506,6 +516,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -529,14 +543,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.github/prompts/premerge.prompt.md
+++ b/.github/prompts/premerge.prompt.md
@@ -101,7 +101,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -177,12 +177,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.github/prompts/research.prompt.md
+++ b/.github/prompts/research.prompt.md
@@ -4,14 +4,15 @@ description: Deep research with parallel-deep-research, document findings
 tools: []
 ---
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.github/prompts/research.prompt.md
+++ b/.github/prompts/research.prompt.md
@@ -33,12 +33,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -316,8 +316,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -382,14 +382,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.github/prompts/rollback.prompt.md
+++ b/.github/prompts/rollback.prompt.md
@@ -170,7 +170,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -353,7 +353,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -365,7 +365,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.github/prompts/ship.prompt.md
+++ b/.github/prompts/ship.prompt.md
@@ -176,23 +176,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.github/prompts/ship.prompt.md
+++ b/.github/prompts/ship.prompt.md
@@ -78,11 +78,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -195,14 +197,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.github/prompts/ship.prompt.md
+++ b/.github/prompts/ship.prompt.md
@@ -181,7 +181,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -1,7 +1,9 @@
 ---
 name: status
-description: Check current stage and context
 tools: []
+---
+﻿---
+description: Check current stage and context
 ---
 
 Check where you are in the project and what work is in progress.
@@ -44,7 +46,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -52,7 +54,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -60,7 +62,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -44,7 +44,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -52,7 +52,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -60,7 +60,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -1,9 +1,7 @@
 ---
 name: status
-tools: []
----
-﻿---
 description: Check current stage and context
+tools: []
 ---
 
 Check where you are in the project and what work is in progress.

--- a/.github/prompts/validate.prompt.md
+++ b/.github/prompts/validate.prompt.md
@@ -274,9 +274,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.github/prompts/validate.prompt.md
+++ b/.github/prompts/validate.prompt.md
@@ -5,7 +5,7 @@ tools: []
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -207,10 +207,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -271,14 +271,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.github/prompts/verify.prompt.md
+++ b/.github/prompts/verify.prompt.md
@@ -185,28 +185,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -216,7 +216,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -260,12 +260,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.kilocode/workflows/dev.md
+++ b/.kilocode/workflows/dev.md
@@ -305,14 +305,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.kilocode/workflows/dev.md
+++ b/.kilocode/workflows/dev.md
@@ -309,7 +309,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.kilocode/workflows/plan.md
+++ b/.kilocode/workflows/plan.md
@@ -7,7 +7,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -21,13 +29,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -47,6 +55,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -238,7 +248,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -494,7 +504,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -505,6 +515,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -528,14 +542,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.kilocode/workflows/premerge.md
+++ b/.kilocode/workflows/premerge.md
@@ -100,7 +100,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -176,12 +176,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.kilocode/workflows/research.md
+++ b/.kilocode/workflows/research.md
@@ -3,14 +3,15 @@ description: Deep research with parallel-deep-research, document findings
 mode: code
 ---
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.kilocode/workflows/research.md
+++ b/.kilocode/workflows/research.md
@@ -32,12 +32,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.kilocode/workflows/review.md
+++ b/.kilocode/workflows/review.md
@@ -315,8 +315,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -381,14 +381,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.kilocode/workflows/rollback.md
+++ b/.kilocode/workflows/rollback.md
@@ -169,7 +169,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -352,7 +352,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -364,7 +364,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.kilocode/workflows/ship.md
+++ b/.kilocode/workflows/ship.md
@@ -180,7 +180,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.kilocode/workflows/ship.md
+++ b/.kilocode/workflows/ship.md
@@ -77,11 +77,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -194,14 +196,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.kilocode/workflows/ship.md
+++ b/.kilocode/workflows/ship.md
@@ -175,23 +175,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.kilocode/workflows/status.md
+++ b/.kilocode/workflows/status.md
@@ -1,8 +1,6 @@
 ---
-mode: code
----
-﻿---
 description: Check current stage and context
+mode: code
 ---
 
 Check where you are in the project and what work is in progress.

--- a/.kilocode/workflows/status.md
+++ b/.kilocode/workflows/status.md
@@ -1,6 +1,8 @@
 ---
-description: Check current stage and context
 mode: code
+---
+﻿---
+description: Check current stage and context
 ---
 
 Check where you are in the project and what work is in progress.
@@ -43,7 +45,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -51,7 +53,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -59,7 +61,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.kilocode/workflows/status.md
+++ b/.kilocode/workflows/status.md
@@ -43,7 +43,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -51,7 +51,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -59,7 +59,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.kilocode/workflows/validate.md
+++ b/.kilocode/workflows/validate.md
@@ -4,7 +4,7 @@ mode: code
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -206,10 +206,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -270,14 +270,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.kilocode/workflows/validate.md
+++ b/.kilocode/workflows/validate.md
@@ -273,9 +273,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.kilocode/workflows/verify.md
+++ b/.kilocode/workflows/verify.md
@@ -184,28 +184,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -215,7 +215,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -259,12 +259,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.opencode/commands/dev.md
+++ b/.opencode/commands/dev.md
@@ -308,7 +308,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.opencode/commands/dev.md
+++ b/.opencode/commands/dev.md
@@ -304,14 +304,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -6,7 +6,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -20,13 +28,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -46,6 +54,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -237,7 +247,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -493,7 +503,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -504,6 +514,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -527,14 +541,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.opencode/commands/premerge.md
+++ b/.opencode/commands/premerge.md
@@ -99,7 +99,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -175,12 +175,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.opencode/commands/research.md
+++ b/.opencode/commands/research.md
@@ -2,14 +2,15 @@
 description: Deep research with parallel-deep-research, document findings
 ---
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.opencode/commands/research.md
+++ b/.opencode/commands/research.md
@@ -31,12 +31,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -314,8 +314,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -380,14 +380,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.opencode/commands/rollback.md
+++ b/.opencode/commands/rollback.md
@@ -168,7 +168,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -351,7 +351,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -363,7 +363,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -174,23 +174,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -179,7 +179,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -76,11 +76,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -193,14 +195,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Check current stage and context
 ---
 
@@ -42,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -50,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -58,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -42,7 +42,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -50,7 +50,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -58,7 +58,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.opencode/commands/status.md
+++ b/.opencode/commands/status.md
@@ -1,4 +1,4 @@
-﻿---
+---
 description: Check current stage and context
 ---
 

--- a/.opencode/commands/validate.md
+++ b/.opencode/commands/validate.md
@@ -3,7 +3,7 @@ description: Complete validation (type/lint/tests/security)
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -205,10 +205,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -269,14 +269,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.opencode/commands/validate.md
+++ b/.opencode/commands/validate.md
@@ -272,9 +272,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.opencode/commands/verify.md
+++ b/.opencode/commands/verify.md
@@ -183,28 +183,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -214,7 +214,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -258,12 +258,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.roo/commands/dev.md
+++ b/.roo/commands/dev.md
@@ -305,14 +305,18 @@ The completion summary is generated from the live task list, decisions log, Bead
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD (you are here)
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.roo/commands/dev.md
+++ b/.roo/commands/dev.md
@@ -309,7 +309,6 @@ Utility: /status  -> Understand current context before starting
 
 Default template:
   /dev       -> Implement each task with subagent-driven TDD (you are here)
-  /dev       -> Implement each task with subagent-driven TDD
   /validate  -> Type check, lint, tests, security
   /ship      -> Push + create PR
   /review    -> Address PR feedback

--- a/.roo/commands/plan.md
+++ b/.roo/commands/plan.md
@@ -7,7 +7,15 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 # Plan
 
-This command runs in **3 phases**. Each phase ends with a HARD-GATE. Do not skip phases.
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
 ---
 
@@ -21,13 +29,13 @@ Before ANY planning work begins:
    - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
      Run: git checkout master — then re-run /plan."
 3. If on master, create the worktree NOW before asking any questions:
-   a. bd worktree create .worktrees/<slug> --branch feat/<slug>
+   a. forge worktree create <slug> --branch feat/<slug>
    b. cd .worktrees/<slug>
 4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
 5. Create the epic issue and record the stage transition:
    ```bash
-   bd create --title="<feature-name>" --type=epic
-   bd update <id> --status=in_progress
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
    bash scripts/beads-context.sh stage-transition <id> none plan
    ```
 6. ONLY THEN begin Phase 1.
@@ -47,6 +55,8 @@ between parallel features or sessions.
 /plan <feature-slug>
 /plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
 /plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
 ```
 
 ---
@@ -238,7 +248,7 @@ After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
 ```
 <HARD-GATE: Phase 1 exit>
 Do NOT begin Phase 2 (web research) until:
-1. User has approved the design in this session
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
 2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/design.md
 3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
 4. Design doc is committed to git
@@ -494,7 +504,7 @@ Present the full task list. Allow the user to reorder, split, or remove tasks.
 
 ```
 <HARD-GATE: /plan exit>
-Do NOT proceed to /dev until ALL are confirmed:
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
 1. git branch --show-current output shows feat/<slug>
 2. git worktree list shows .worktrees/<slug>
 3. Baseline tests ran — either passing OR user confirmed to proceed past failures
@@ -505,6 +515,10 @@ Do NOT proceed to /dev until ALL are confirmed:
 8. `beads-context.sh set-acceptance` ran successfully (exit code 0)
 9. `dep-guard.sh store-contracts` ran successfully (exit code 0) — or skipped if no contracts found
 10. `dep-guard.sh check-ripple` ran successfully and any proposed dependency mutation was reviewed with the user before calling `apply-decision`
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
 </HARD-GATE>
 ```
 
@@ -528,14 +542,18 @@ Phase 3 output is generated from the live Beads issue, branch/worktree setup, ba
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list (you are here)
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+  /premerge  -> Merge-readiness checks move to PR-state hook in v3
 ```
 
 ## Tips

--- a/.roo/commands/premerge.md
+++ b/.roo/commands/premerge.md
@@ -100,7 +100,7 @@ git push
 ### Step 4: Sync Beads
 
 ```bash
-bd sync
+forge sync
 ```
 
 ### Step 5: Hand Off — STOP HERE
@@ -176,12 +176,16 @@ After you merge, run /verify
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user (you are here)
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.roo/commands/research.md
+++ b/.roo/commands/research.md
@@ -3,14 +3,15 @@ description: Deep research with parallel-deep-research, document findings
 mode: code
 ---
 
-> **Note**: `/research` is now Phase 2 of `/plan`.
+> **Note**: `/research` is legacy support for the research capability used by planning workflows.
 >
-> The research phase has been absorbed into the `/plan` command, which runs a full 3-phase workflow:
-> - **Phase 1**: Brainstorming — design intent, constraints, success criteria
-> - **Phase 2**: Technical research — web search, OWASP, codebase exploration, TDD scenarios
-> - **Phase 3**: Setup — branch, worktree, Beads issue, task list
+> Forge v3 treats `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify` as configurable building blocks over runtime skills, not a product-wide mandatory ladder.
+> `/plan` remains the default planner template and can include:
+> - Design intent: constraints, success criteria, and ambiguity policy
+> - Technical research: web search, OWASP, codebase exploration, TDD scenarios
+> - Setup: branch, worktree, Beads issue, task list
 >
-> Run `/plan <feature-slug>` to start the complete planning workflow.
+> Run `/plan <feature-slug>` when the active workflow needs the default planner template, or invoke the research skill fragment directly when the active plan permits it.
 
 # Research (Legacy Alias)
 

--- a/.roo/commands/research.md
+++ b/.roo/commands/research.md
@@ -32,12 +32,16 @@ Then continue with `/plan <slug> --continue` to run Phase 3 (setup + task list).
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry (research support)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/.roo/commands/review.md
+++ b/.roo/commands/review.md
@@ -315,8 +315,8 @@ gh pr checks <pr-number>
 ### Step 10: Update Beads
 
 ```bash
-bd update <id> --comment "PR review complete: all issues addressed, all checks passing"
-bd sync
+forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge sync
 ```
 
 ## Example Output
@@ -381,14 +381,18 @@ Do NOT declare /review complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud (you are here)
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Understanding the Tools

--- a/.roo/commands/rollback.md
+++ b/.roo/commands/rollback.md
@@ -169,7 +169,7 @@ Rollback complete!
 
 **Beads Integration**:
 - Parses commit message for issue number (`#123`)
-- If found, runs: `bd update <id> --status reverted --comment "PR reverted"`
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
 - Silently skips if Beads not installed
 - Updates issue tracking automatically
 
@@ -352,7 +352,7 @@ When rolling back a merged PR:
 1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
 2. If issue number found:
    ```bash
-   bd update <id> --status reverted --comment "PR reverted by rollback"
+   forge update <id> --status reverted --comment "PR reverted by rollback"
    ```
 3. Silently skip if:
    - Beads not installed
@@ -364,7 +364,7 @@ When rolling back a merged PR:
 If automatic detection doesn't work:
 ```bash
 # After rollback
-bd update 123 --status reverted --comment "Rolled back due to production issues"
+forge update 123 --status reverted --comment "Rolled back due to production issues"
 ```
 
 ## Troubleshooting

--- a/.roo/commands/ship.md
+++ b/.roo/commands/ship.md
@@ -180,7 +180,7 @@ forge team verify 2>&1 || true
 ```
 ✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
 ✓ Freshness: Branch is up-to-date with master
-✓ Beads: Marked done & synced (forge-xyz)
+✓ Beads: PR handoff recorded (forge-xyz)
 ✓ Pushed: feat/stripe-billing
 ✓ PR created: https://github.com/.../pull/123
   - PR body: Problem → Root Cause → Fix → Value (narrative format)

--- a/.roo/commands/ship.md
+++ b/.roo/commands/ship.md
@@ -77,11 +77,13 @@ bash scripts/pr-coordinator.sh auto-label <issue-id>
 bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 ```
 
-### Step 3: Update Beads
+### Step 3: Record PR Handoff
 ```bash
-bd update <id> --status done
-bd sync
+forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
 ```
+
+Do not mark the Beads issue done during `/ship`. Completion happens only after merge and post-merge verification.
 
 ### Step 4: Push Branch
 
@@ -194,14 +196,18 @@ Next: /review <pr-number> (when automated checks complete or new feedback appear
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR (you are here)
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.roo/commands/ship.md
+++ b/.roo/commands/ship.md
@@ -175,23 +175,11 @@ forge team sync 2>&1 || true
 forge team verify 2>&1 || true
 ```
 
-## Example Output
+## Output
 
-```
-✓ Validation: /validate passed (all 4 checks — fresh output confirmed)
-✓ Freshness: Branch is up-to-date with master
-✓ Beads: PR handoff recorded (forge-xyz)
-✓ Pushed: feat/stripe-billing
-✓ PR created: https://github.com/.../pull/123
-  - PR body: Problem → Root Cause → Fix → Value (narrative format)
-  - Beads linked: forge-xyz
-  - Implementation details in collapsible section
+`/ship` reports live validation status, branch freshness, Beads PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this command file.
 
-⏸️  PR created, checks started (Greptile, SonarCloud, GitHub Actions)
-   Poll for up to 60 seconds. If checks are still pending, stop here.
-
-Next: /review <pr-number> (when automated checks complete or new feedback appears)
-```
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
 
 ## Integration with Workflow
 

--- a/.roo/commands/status.md
+++ b/.roo/commands/status.md
@@ -1,8 +1,6 @@
 ---
-mode: code
----
-﻿---
 description: Check current stage and context
+mode: code
 ---
 
 Check where you are in the project and what work is in progress.

--- a/.roo/commands/status.md
+++ b/.roo/commands/status.md
@@ -1,6 +1,8 @@
 ---
-description: Check current stage and context
 mode: code
+---
+﻿---
+description: Check current stage and context
 ---
 
 Check where you are in the project and what work is in progress.
@@ -43,7 +45,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found — skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -51,7 +53,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id — found in git history, likely already merged"
+      echo "STALE: $id â€” found in git history, likely already merged"
     fi
   done
 fi
@@ -59,7 +61,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-bd close <id> --force --reason="Already merged — detected during status reconciliation"
+forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.roo/commands/status.md
+++ b/.roo/commands/status.md
@@ -43,7 +43,7 @@ DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|
 if [ -z "$DEFAULT_BRANCH" ]; then
   if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
   elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
-  else echo "ERROR: No main or master branch found â€” skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
 fi
 
 # For each in_progress issue, check if its PR was already merged
@@ -51,7 +51,7 @@ if [ -n "$DEFAULT_BRANCH" ]; then
   bd list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
     # Search git log for the issue ID in commit messages (fixed-strings for literal match)
     if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
-      echo "STALE: $id â€” found in git history, likely already merged"
+      echo "STALE: $id -- found in git history, likely already merged"
     fi
   done
 fi
@@ -59,7 +59,7 @@ fi
 
 If stale issues are found, close them:
 ```bash
-forge close <id> --force --reason="Already merged â€” detected during status reconciliation"
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
 ```
 
 ### Step 2: Review Recent Commits

--- a/.roo/commands/validate.md
+++ b/.roo/commands/validate.md
@@ -4,7 +4,7 @@ mode: code
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
-> - `/validate` (this command): Workflow Stage 3 — rebases onto the base branch, then runs type/lint/test/security checks
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
 > - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
@@ -206,10 +206,10 @@ If you have attempted 3+ fixes without resolution:
 If any check fails:
 ```bash
 # Create Beads issue for problems
-bd create "Fix <issue-description>"
+forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-bd update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```
@@ -270,14 +270,18 @@ Fix issues then re-run /validate
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output (you are here)
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /validate  -> Type check, lint, tests, security (you are here)
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```
 
 ## Tips

--- a/.roo/commands/validate.md
+++ b/.roo/commands/validate.md
@@ -273,9 +273,9 @@ Fix issues then re-run /validate
 Utility: /status  -> Understand current context before starting
 
 Default template:
-  /validate  -> Type check, lint, tests, security (you are here)
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
   /dev       -> Implement each task with subagent-driven TDD
-  /validate  -> Type check, lint, tests, security
+  /validate  -> Type check, lint, tests, security (you are here)
   /ship      -> Push + create PR
   /review    -> Address PR feedback
   /verify    -> Post-merge health check

--- a/.roo/commands/verify.md
+++ b/.roo/commands/verify.md
@@ -184,28 +184,28 @@ fi
 ```bash
 # Close issues found in PR body
 for id in $BEADS_IDS; do
-  bd close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
+  forge close "$id" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $id"
 done
 
 # If no issues found in body, try branch name match (skip if already closed above)
 if [ -z "$BEADS_IDS" ] && [ -n "$BRANCH_ID" ]; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 elif [ -n "$BRANCH_ID" ] && ! echo "$BEADS_IDS" | grep -qw "$BRANCH_ID"; then
-  bd close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" 2>&1 || echo "Warning: could not close $BRANCH_ID"
 fi
 ```
 
 **If no beads issues detected at all**, prompt the user:
 ```
 ⚠ No beads issue ID found in PR body or branch name.
-  If this PR closes a beads issue, run: bd close <id> --reason="Merged and verified on master (PR #<number>)"
+  If this PR closes a beads issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
 ```
 
 ```
 <HARD-GATE: /verify exit>
 Do NOT declare /verify complete until:
 1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
-2. If healthy: Beads issues extracted from PR body/branch and closed (bd close run and confirmed)
+2. If healthy: Beads issues extracted from PR body/branch and closed (`forge close` run and confirmed)
    - If no beads ID found: user was warned and given manual close command
 3. If issues found: Beads tracking issue created for every problem
 4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
@@ -215,7 +215,7 @@ Do NOT declare /verify complete until:
 
 ## Rules
 
-- **Never commits** — this command is read-only
+- **Never commits code** — this command may update Beads issue state after post-merge health is verified
 - **Never creates PRs** — if fixes are needed, that's a new /dev cycle
 - **Runs after user confirms merge** — not before
 - **Reports honestly** — if CI is broken on main, say so clearly
@@ -259,12 +259,16 @@ Do NOT declare /verify complete until:
 ## Integration with Workflow
 
 ```
-Utility: /status     → Understand current context before starting
-Stage 1: /plan       → Design intent → research → branch + worktree + task list
-Stage 2: /dev        → Implement each task with subagent-driven TDD
-Stage 3: /validate      → Type check, lint, tests, security — all fresh output
-Stage 4: /ship       → Push + create PR
-Stage 5: /review     → Address GitHub Actions, Greptile, SonarCloud
-Stage 6: /premerge   → Update docs, hand off PR to user
-Stage 7: /verify     → Post-merge CI check on main (you are here) ✓
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Manual/support surfaces:
+  /premerge  -> Merge-readiness checks when the active template requires them
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Project Workflow Instructions
 
-## 7-Stage TDD-First Workflow
+## Default TDD-First Workflow Template
 
-This project enforces a **strict TDD-first development workflow** with 7 stages:
+This project ships a **default TDD-first workflow template** with 7 named stage skills. In v3, these stages are one configurable composition over Forge runtime building blocks, not a product-wide mandatory ladder. Commands may be invoked as full stages or as smaller skill fragments when the active plan permits it.
 
 | Stage | Command     | Purpose                                                   | Required For |
 |-------|-------------|-----------------------------------------------------------|--------------|
@@ -20,12 +20,12 @@ This project enforces a **strict TDD-first development workflow** with 7 stages:
 
 When the user requests work, **you MUST automatically classify** the change type:
 
-### Critical (Full 7-stage workflow)
+### Critical (Full default workflow template)
 **Triggers:** Security, authentication, payments, breaking changes, new architecture, data migrations
 **Example:** "Add OAuth login", "Migrate database schema", "Implement payment gateway"
 **Workflow:** plan → dev → validate → ship → review → premerge → verify
 
-### Standard (6-stage workflow)
+### Standard (default workflow without post-merge verify)
 **Triggers:** Normal features, enhancements, new components
 **Example:** "Add user profile page", "Create notification system"
 **Workflow:** plan → dev → validate → ship → review → premerge
@@ -75,7 +75,7 @@ When the user requests work, **you MUST automatically classify** the change type
 
 Command files (`.claude/commands/*.md` and agent equivalents) must never hardcode example output when a script generates that output dynamically. Reference the script and describe what it does — don't duplicate its output with fake data that becomes stale.
 
-## TDD Development (Stage 2: /dev)
+## TDD Development (`/dev` Command)
 
 **Subagent-driven per-task implementation loop:**
 
@@ -114,7 +114,7 @@ Task 2: Validation logic
 
 > GitHub issue lifecycle may sync to Beads via CI -- see [docs/guides/BEADS_GITHUB_SYNC.md](docs/guides/BEADS_GITHUB_SYNC.md).
 
-**All workflow state stored in Beads metadata** (survives compaction):
+**Beads is the durable issue-state authority** (survives compaction). Forge may keep local adapter/cache files such as `.forge-state.json` for stage-entry recovery, but those files must not override current Beads issue state when Beads metadata is available.
 
 ```json
 {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Project Instructions
 
-Forge is a 7-stage TDD-first development workflow harness for AI coding agents (9 commands total, including utility stages).
+Forge is a TDD-first workflow harness for AI coding agents. The current default template has 7 named stage skills plus utility commands, and v3 treats those stages as configurable building blocks rather than a mandatory ladder for every task.
 
 **Package manager**: Bun (preferred for performance)
 
@@ -17,7 +17,7 @@ bun test         # Run tests
 
 ## Workflow
 
-> **IMPORTANT**: Read [AGENTS.md](AGENTS.md) using the Read tool at the start of every session to load the complete Forge 7-stage workflow, change classification, and detailed stage instructions. AGENTS.md is the single source of truth for the workflow.
+> **IMPORTANT**: Read [AGENTS.md](AGENTS.md) using the Read tool at the start of every session to load the current Forge workflow template, change classification, and detailed stage instructions. AGENTS.md is the single source of truth for the active workflow contract.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![CodeQL](https://github.com/harshanandak/forge/actions/workflows/codeql.yml/badge.svg)](https://github.com/harshanandak/forge/actions/workflows/codeql.yml)
 [![Security Policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/harshanandak/forge/blob/master/SECURITY.md)
 
-Ship features with confidence using a 7-stage TDD-first workflow for AI coding agents.
+Ship features with confidence using a composable TDD-first workflow framework for AI coding agents.
 
 ```
 /plan → /dev → /validate → /ship → /review → /premerge → /verify
@@ -87,9 +87,11 @@ bunx forge setup
 
 ---
 
-## The 7 Stages
+## Default Workflow Template
 
-| Stage | Command | Purpose |
+Forge ships these commands as a default template. In v3 planning, they are configurable building blocks: use the full flow when it fits, or invoke the individual command/skill surfaces when the project plan permits a smaller path.
+
+| Default Step | Command | Purpose |
 |-------|---------|---------|
 | **utility** | `/status` | Ranked issue dashboard with conflict detection |
 | **1. Plan** | `/plan` | Design Q&A → research → branch + task list |
@@ -191,7 +193,7 @@ forge-preflight ship      # Validate before /ship stage
 ```
 
 ### 5. Smart Tool Recommendations
-Curated plugin catalog across 7 workflow stages — plan, dev, validate, ship, review, and more:
+Curated plugin catalog across workflow commands — plan, dev, validate, ship, review, and more:
 - **Auto-detection**: Scans your project for frameworks, databases, auth, payments, and more
 - **Budget modes**: free, open-source, startup, professional, custom
 - **Portability-first**: MCPs included only when they add clear value over CLI alternatives
@@ -225,7 +227,7 @@ bunx forge setup --merge=smart    # Intelligent merge
 **Workflow Profiles** *(planned — not yet wired into setup)*
 - Will adapt workflow based on work type (3-8 stages):
   - `critical`: Full 8-stage workflow (auth, payments, security-sensitive)
-  - `standard`: 7-stage workflow (typical features)
+  - `standard`: default workflow template (typical features)
   - `refactor`: Behavior-preserving 5-stage workflow
   - `simple`: Streamlined 4-stage workflow
   - `hotfix`: Minimal 3-stage workflow (production fixes)

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -435,7 +435,7 @@ function checkPrerequisites() {
 // Universal SKILL.md content
 const SKILL_CONTENT = `---
 name: forge-workflow
-description: 7-stage TDD-first workflow for feature development. Use when building features, fixing bugs, or shipping PRs.
+description: Composable TDD-first workflow for feature development. Use when building features, fixing bugs, or shipping PRs.
 category: Development Workflow
 tags: [tdd, workflow, pr, git, testing]
 tools: [Bash, Read, Write, Edit, Grep, Glob]
@@ -453,9 +453,9 @@ Automatically invoke this skill when the user wants to:
 - Create a pull request
 - Run the development workflow
 
-## 7 Stages
+## Default Workflow Template
 
-| Stage | Command | Description |
+| Default Step | Command | Description |
 |-------|---------|-------------|
 | utility | \`/status\` | Check current context, active work, recent completions |
 | 1 | \`/plan\` | Design intent -> research -> branch + worktree + task list |
@@ -466,7 +466,9 @@ Automatically invoke this skill when the user wants to:
 | 6 | \`/premerge\` | Update docs, hand off PR to user |
 | 7 | \`/verify\` | Post-merge health check (CI on main, close Beads) |
 
-## Workflow Flow
+## Workflow Composition
+
+These commands are default building blocks. Use the whole flow when it fits, or invoke individual commands/skills when the active project plan permits a smaller path.
 
 \`\`\`
 /status -> /plan -> /dev -> /validate -> /ship -> /review -> /premerge -> /verify
@@ -482,22 +484,22 @@ Automatically invoke this skill when the user wants to:
 
 // Cursor MDC rule content
 const CURSOR_RULE = `---
-description: Forge 7-Stage TDD Workflow
+description: Forge TDD Workflow Template
 alwaysApply: true
 ---
 
 # Forge Workflow Commands
 
-Use these commands via \`/command-name\`:
+Use these default-template commands via \`/command-name\`:
 
 - \`/status\` (utility) - Check current context, active work, recent completions
-1. \`/plan\` - Design intent Q&A, research, branch + task list
-2. \`/dev\` - Subagent-driven TDD per task (spec + quality review)
-3. \`/validate\` - Type check, lint, security, tests (HARD-GATE)
-4. \`/ship\` - Push and create PR with design doc reference
-5. \`/review\` - Handle ALL PR issues (Actions, Greptile, SonarCloud)
-6. \`/premerge\` - Complete docs on feature branch, hand off PR to user
-7. \`/verify\` - Post-merge health check (CI on main, close Beads)
+- \`/plan\` - Design intent Q&A, research, branch + task list
+- \`/dev\` - Subagent-driven TDD per task (spec + quality review)
+- \`/validate\` - Type check, lint, security, tests (HARD-GATE)
+- \`/ship\` - Push and create PR with design doc reference
+- \`/review\` - Handle ALL PR issues (Actions, Greptile, SonarCloud)
+- \`/premerge\` - Complete docs on feature branch, hand off PR to user
+- \`/verify\` - Post-merge health check (CI on main, close Beads)
 
 See AGENTS.md for full workflow details.
 `;

--- a/docs/forge/VALIDATION.md
+++ b/docs/forge/VALIDATION.md
@@ -358,6 +358,6 @@ git push
 
 ## See Also
 
-- [Workflow Guide](../AGENTS.md) - Complete 7-stage workflow
+- [Workflow Guide](../AGENTS.md) - Complete default Forge workflow template
 - [TDD Guide](../CLAUDE.md) - TDD principles and practices
 - [Lefthook Docs](https://github.com/evilmartians/lefthook) - Full hook configuration

--- a/docs/guides/ENHANCED_ONBOARDING.md
+++ b/docs/guides/ENHANCED_ONBOARDING.md
@@ -35,7 +35,7 @@ bunx forge setup --merge=smart
 - Tech stack details
 
 **What gets updated:**
-- Workflow instructions (7-stage TDD process)
+- Workflow instructions (composable TDD process)
 - TDD principles
 - Git conventions
 
@@ -65,7 +65,7 @@ E-commerce platform for selling widgets.
 - 80% test coverage
 
 ## Workflow Configuration
-Use the 7-stage TDD workflow:
+Use the default TDD workflow template:
 1. /plan - Design intent, research, branch + worktree + task list
 2. /dev - Subagent-driven TDD per task
 ...
@@ -165,7 +165,7 @@ Forge adapts its workflow based on the type of work you're doing.
 
 ### Six Change Classifications
 
-#### 1. Critical (7 stages)
+#### 1. Critical (full default template)
 **Use for:** Security, auth, payments, breaking changes
 
 ```bash
@@ -178,7 +178,7 @@ bunx forge setup --type=critical
 /plan -> /dev -> /validate -> /ship -> /review -> /premerge -> /verify
 ```
 
-- Full 7-stage workflow with all gates
+- Full default Forge workflow template with all gates
 - OWASP analysis required
 - Design docs for strategic changes
 
@@ -354,7 +354,7 @@ git checkout -b feat/user-authentication
 bunx forge setup --type=critical
 
 # Uses Critical profile:
-# - Full 7-stage workflow
+# - Full default Forge workflow template
 # - OWASP analysis required
 # - Design docs for strategic changes
 ```
@@ -594,7 +594,7 @@ Share project knowledge with team.
 ## Related Documentation
 
 - [Main README](../README.md) - Overview and quick start
-- [Workflow Guide](../AGENTS.md) - Complete 7-stage workflow
+- [Workflow Guide](../AGENTS.md) - Complete default Forge workflow template
 - [Setup Guide](SETUP.md) - Agent-specific setup
 - [Agent Install Prompt](AGENT_INSTALL_PROMPT.md) - AI-assisted setup
 

--- a/docs/guides/SETUP.md
+++ b/docs/guides/SETUP.md
@@ -74,7 +74,7 @@ bunx forge setup
 
 **Files created**:
 - `CLAUDE.md` → Linked to `AGENTS.md`
-- `.claude/commands/` → 7 slash commands
+- `.claude/commands/` → default Forge slash commands
 - `.claude/rules/workflow.md` → Workflow rules
 - `.claude/skills/forge-workflow/` → Skill files
 
@@ -88,7 +88,7 @@ bunx forge setup
 ```
 
 **Skills available**:
-- `forge-workflow` - All 7 stages
+- `forge-workflow` - Default Forge workflow template
 - `parallel-deep-research` - Deep analysis and web research (if PARALLEL_API_KEY configured)
 - `sonarcloud-analysis` - Code quality (if SONARCLOUD_TOKEN configured)
 
@@ -102,7 +102,7 @@ bunx forge setup
 - `.cursor/skills/forge-workflow/` → Skill files
 
 **Usage**:
-Cursor reads `.cursorrules` and follows the 7-stage workflow.
+Cursor reads `.cursorrules` and follows the default Forge workflow template.
 
 **Commands**:
 Use Composer or Chat to reference stages:
@@ -279,7 +279,7 @@ bd init --stealth
 
 ### Beads GitHub Sync
 
-The `--sync` flag during setup scaffolds a GitHub Actions workflow that syncs Beads issues with GitHub Issues bidirectionally.
+The `--sync` flag during setup scaffolds GitHub Actions workflows that synchronize shared fields between GitHub Issues and Beads.
 
 ```bash
 # Enable Beads sync during setup
@@ -287,7 +287,7 @@ bunx forge setup --sync
 ```
 
 **What gets scaffolded**:
-- `.github/workflows/beads-sync.yml` - GitHub Actions workflow for bidirectional sync
+- GitHub Actions workflows for GitHub-to-Beads and Beads-to-GitHub shared-field sync
 - PAT (Personal Access Token) configuration via `gh secret set`
 
 **PAT requirements**:
@@ -303,9 +303,11 @@ gh secret set BEADS_SYNC_TOKEN --body "ghp_your_token_here"
 ```
 
 **How sync works**:
-- On push: Beads issues are synced to GitHub Issues
-- On issue change: GitHub Issues are synced back to Beads
-- Conflict resolution: last-write-wins with timestamps
+- GitHub Issues are the human/team/public interface.
+- Beads is Forge's local issue engine for `forge ready`, `forge close`, and workflow state.
+- Shared fields sync across the boundary: title, labels/type, priority, assignee, status, and canonical links.
+- Forge-owned workflow context stays local in Beads: stage, dependencies, progress notes, decisions, and evaluator metadata.
+- Conflict handling is field-scoped; do not use broad last-write-wins semantics for Forge-owned local context.
 
 ---
 

--- a/docs/reference/VALIDATION.md
+++ b/docs/reference/VALIDATION.md
@@ -358,6 +358,6 @@ git push
 
 ## See Also
 
-- [Workflow Guide](../AGENTS.md) - Complete 7-stage workflow
+- [Workflow Guide](../AGENTS.md) - Complete default Forge workflow template
 - [TDD Guide](../CLAUDE.md) - TDD principles and practices
 - [Lefthook Docs](https://github.com/evilmartians/lefthook) - Full hook configuration

--- a/docs/work/2026-04-28-skeleton-pivot/FINAL-THESIS.md
+++ b/docs/work/2026-04-28-skeleton-pivot/FINAL-THESIS.md
@@ -296,7 +296,7 @@ Without explicit kill criteria the iteration trap repeats forever.
 **Canonical (read in order)**:
 1. [FINAL-THESIS.md](./FINAL-THESIS.md) — this doc
 2. [release-plan.md](./release-plan.md) — active `0.0.x` runtime building-block roadmap
-3. [locked-decisions.md](./locked-decisions.md) — D1-D42 with supersedes
+3. [locked-decisions.md](./locked-decisions.md) — D1-D43 with supersedes
 4. [LEARNINGS.md](./LEARNINGS.md) — 15 takeaways from 6 iterations
 5. [iteration-driven-planning-skill.md](./iteration-driven-planning-skill.md) — the planning method itself, now framed as one configurable Forge `/plan` playbook template
 6. [v3-redesign-strategy.md](./v3-redesign-strategy.md) — full strategy reference

--- a/docs/work/2026-04-28-skeleton-pivot/README.md
+++ b/docs/work/2026-04-28-skeleton-pivot/README.md
@@ -1,6 +1,6 @@
 # Forge Runtime Building-Block Pivot
 
-**Status**: D1-D42 remain the historical decision baseline for this folder. The current active refinement is [runtime-building-blocks-refinement.md](./runtime-building-blocks-refinement.md). The old `v3` wording is a design-folder codename, not the package version plan. The active package roadmap is `0.0.x` based in [release-plan.md](./release-plan.md), starting from the verified package baseline `forge-workflow@0.0.10`.
+**Status**: D1-D43 remain the historical decision baseline for this folder. The current active refinement is [runtime-building-blocks-refinement.md](./runtime-building-blocks-refinement.md). The old `v3` wording is a design-folder codename, not the package version plan. The active package roadmap is `0.0.x` based in [release-plan.md](./release-plan.md), starting from the verified package baseline `forge-workflow@0.0.10`.
 
 ## Summary
 
@@ -9,6 +9,7 @@ Forge pivots from a fixed 7-stage opinionated workflow to configurable workflow/
 - **L1 locked rails**: TDD intent gate, secret scan, branch protection, signed commits, schema + integrity.
 - **Runtime primitives**: phases, actions, artifacts, evaluator regions, gates, evidence, skills, adapters, run ledger, review packets.
 - **Configurable graph**: project and user config compose primitives into a workflow.
+- **Composable skills**: stage-level super-skills can invoke callable sub-skills, so partial planning/review/evaluation work does not require running the whole workflow.
 - **Templates**: starter compositions for adoption, not the product itself.
 - **Adapters**: Beads/GitHub/Linear, agent harnesses, and external orchestrators consume the same runtime contract.
 
@@ -36,7 +37,7 @@ See [release-plan.md](./release-plan.md) for scope, evaluator regions, gates, an
 1. [runtime-building-blocks-refinement.md](./runtime-building-blocks-refinement.md) - current refinement and product hierarchy.
 2. [release-plan.md](./release-plan.md) - active `0.0.x` release roadmap.
 3. [FINAL-THESIS.md](./FINAL-THESIS.md) - historical 2026-04-29 baseline; keep for context.
-4. [locked-decisions.md](./locked-decisions.md) - D1-D42 decisions with rationale, tradeoffs, and anti-decisions.
+4. [locked-decisions.md](./locked-decisions.md) - D1-D43 decisions with rationale, tradeoffs, and anti-decisions.
 5. [LEARNINGS.md](./LEARNINGS.md) - takeaways from the iteration process.
 6. [iteration-driven-planning-skill.md](./iteration-driven-planning-skill.md) - planning method, now treated as one configurable planning template/skill.
 7. [v3-redesign-strategy.md](./v3-redesign-strategy.md) - reference strategy with superseded sections preserved.
@@ -59,3 +60,4 @@ When new clarity arrives:
 3. Keep package release plans in `0.0.x` terms.
 4. Keep external orchestrator compatibility explicit.
 5. Keep the strict current workflow expressible as one template.
+6. Keep super-skill/sub-skill invocation visible in the runtime graph and evaluator regions.

--- a/docs/work/2026-04-28-skeleton-pivot/iteration-driven-planning-skill.md
+++ b/docs/work/2026-04-28-skeleton-pivot/iteration-driven-planning-skill.md
@@ -10,9 +10,25 @@
 
 The 6-iteration planning method that produced this folder — parallel critics, research validation, anti-architect cuts, edge-case audits, quality-vs-speed tradeoffs, supersedes-tracked decisions — is a useful Forge `/plan` playbook template.
 
-It is not the product or the enforcement layer. The runtime building blocks are the product; this skill is one configurable composition over those primitives. This session is the proof-of-concept. ~30 design docs, 42 decisions, multiple supersedes, sharp final thesis from messy starting prompts. The method generalizes; the artifacts compound.
+It is not the product or the enforcement layer. The runtime building blocks are the product; this skill is one configurable composition over those primitives. This session is the proof-of-concept. ~30 design docs, 43 decisions, multiple supersedes, sharp final thesis from messy starting prompts. The method generalizes; the artifacts compound.
 
 > **Forge `/plan` is not "ask questions and write a doc." It is a structured iteration loop with parallel critics, research validation, and supersedes-tracked decisions that converges on a falsifiable thesis.**
+
+## Super-skill shape
+
+`/plan` is a super-skill. Its five phases are callable sub-skills, and each sub-skill maps to runtime primitives instead of being hard-coded prose inside one command:
+
+| Sub-skill | Runtime phase/action | Primary artifact | Evaluator region | Gate |
+|---|---|---|---|---|
+| `plan.intent_capture` | Capture design intent through one-question-at-a-time Q&A | intent statement | intent completeness | user sign-off or external-planner evidence |
+| `plan.parallel_research` | Fan out to source-backed research agents | research findings appended to design doc | source quality | all load-bearing claims cite primary sources |
+| `plan.parallel_critics` | Run anti-architect, gap-finder, sequencer, and configured critics | critic verdict packet | critic coverage | every required critic returns verdict + evidence + action |
+| `plan.synthesis` | Collapse findings into decisions and rerun only contested surfaces | decision delta | contradiction check | explicit converge / diverge / scope-shift result |
+| `plan.final_lock` | Emit final thesis, task list, and supersedes-tracked decisions | final thesis + locked decisions + task list | lock consistency | downstream `/dev` entry contract satisfied |
+
+The runtime can invoke all five as the default deep planning flow, or invoke only one when the user asks for a partial operation such as "run critics on this plan", "refresh research", or "lock this decision". Partial invocation must still write evidence and gate state, so a skipped phase is visible as skipped rather than silently absent.
+
+This mirrors the Hermes-style model captured by D35: description matching may select the super-skill, but graph state and user intent decide whether the whole composition or a sub-skill executes.
 
 ---
 
@@ -30,7 +46,7 @@ Phase 5: Final thesis lock     ──── exit gate
 
 Surface the design intent. **One question at a time** — no batching. Each question targets the highest-information-gain ambiguity remaining. The output is a structured intent statement: what we're building, why, who it's for, what success looks like, what's out of scope.
 
-- HARD-GATE: cannot proceed to Phase 2 without intent statement signed off by user.
+- HARD-GATE: cannot proceed to Phase 2 without either (a) intent statement signed off by the user, or (b) external-planner evidence that satisfies the `/dev` entry contract from D34.
 - Anti-pattern: "let me ask 8 questions at once and you can answer in any order" — produces shallow context and skipped questions.
 - Skill mechanic: maintain an open-question queue; ask the top one; integrate the answer; recompute the queue.
 
@@ -159,6 +175,7 @@ Auto-detection is a default. The user can always override with `--type=` or `--f
 - **Some under-invest** — agents skip research on a migration touching 15 files and three services, producing a plan that ships a regression on day 1. Cost: rollback + post-mortem.
 - **The iteration-driven method's power is configurable depth**, not maximum depth. Forge `/plan` ships with classification-aware defaults so the average case is right-sized and the user only adjusts at the edges.
 - **HARD-GATEs respect classification** — the gates that fire on `project-level` (full critic convergence required before lock) do NOT fire on `hotfix` (skip-to-lock with rollback plan is the gate). One skill, multiple gate profiles.
+- **Sub-skill dispatch preserves partial work** — if a task only needs `plan.parallel_critics`, Forge invokes that sub-skill, records its evidence, and leaves the other phase nodes unchanged.
 
 This is NOT an additional feature on top of `/plan` — it is **how `/plan` actually works**. Without classification-aware intensity, the iteration-driven method is unusable for anything smaller than `project-level`.
 
@@ -229,6 +246,7 @@ Forge already ships a skeletal `/plan` with three phases. The iteration-driven v
 1. **Self-evidence**: this session produced 38 sharp decisions from messy starting prompts using exactly this method. The method works.
 2. **Compounding artifacts**: every iteration produces durable docs (decisions, learnings, FINAL-THESIS). Future sessions read the prior thesis instead of re-deriving.
 3. **Fits the typed-memory model (D22)**: decisions/episodes/skills/preferences are exactly the seven categories the memory API already routes — `/plan` is the producer of the high-value entries.
+4. **Fits the runtime graph**: the planning phases are sub-skills with inputs, outputs, evaluator regions, gates, and evidence. This keeps `/plan` compatible with external planners and partial invocation instead of making it a monolithic ritual.
 
 ---
 
@@ -236,7 +254,7 @@ Forge already ships a skeletal `/plan` with three phases. The iteration-driven v
 
 > **Forge `/plan` skill: implement iteration-driven planning as a configurable playbook template (Phase 1–5 with HARD-GATEs and user-configurable depth).**
 >
-> Implements the meta-pattern documented in `docs/work/2026-04-28-skeleton-pivot/iteration-driven-planning-skill.md`. Scope: Phase 1 intent capture, Phase 2 parallel research with primary-source citation, Phase 3 parallel critics (anti-architect / gap-finder / sequencer), Phase 4 synthesis + iteration loop with explicit convergence criterion, Phase 5 final-thesis lock with supersedes tracking. Configurable per project (`plan.phases`, `plan.critics`, `plan.convergence-threshold`). Acceptance: re-runs this folder's iteration #1 → #6 trajectory and produces a substantively similar D1–D42 ledger from the original starting prompt.
+> Implements the meta-pattern documented in `docs/work/2026-04-28-skeleton-pivot/iteration-driven-planning-skill.md`. Scope: Phase 1 intent capture, Phase 2 parallel research with primary-source citation, Phase 3 parallel critics (anti-architect / gap-finder / sequencer), Phase 4 synthesis + iteration loop with explicit convergence criterion, Phase 5 final-thesis lock with supersedes tracking. Configurable per project (`plan.phases`, `plan.critics`, `plan.convergence-threshold`). Acceptance: re-runs this folder's iteration #1 → #6 trajectory and produces a substantively similar D1–D43 ledger from the original starting prompt.
 
 (Not yet created — left for the bd-update agent.)
 

--- a/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
+++ b/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
@@ -1,10 +1,10 @@
 # Forge v3 — Locked Decisions Log
 
-**Date**: 2026-04-28 (D1-D7) -> 2026-04-29 (D8-D42 added across iterations #3-#8)
-**Status**: Canonical decisions ledger for the v3 skeleton pivot — D1-D42 tracked, D41 reserved, supersedes annotated inline
+**Date**: 2026-04-28 (D1-D7) -> 2026-04-29 (D8-D42 added across iterations #3-#8) -> 2026-05-08 (D43 added)
+**Status**: Canonical decisions ledger for the v3 skeleton pivot — D1-D43 tracked, D41 reserved, supersedes annotated inline
 **Companion**: [release-plan.md](./release-plan.md), [v3-redesign-strategy.md](./v3-redesign-strategy.md), [FINAL-THESIS.md](./FINAL-THESIS.md), [LEARNINGS.md](./LEARNINGS.md)
 
-This is the single source of truth for which v3 questions are settled. Decisions D1-D7 came from the original critic loop (anti-architect / gap-finder / sequencer). D8-D14 came from the 2026-04-28 lock-in pass after the N1 moat deep dive, the v3 ecosystem audit, and the template-library design pass. D15-D20 came from the 2026-04-29 iteration #3/#4 work (Cursor capability spike, harness narrowing, agent action log, protected paths, ownership matrix). D21-D38 came from iterations #5 and #6 (memory architecture, Beads under-utilization research, efficiency audit, quality-vs-speed audit, /merge as continuous hook, /plan-as-optional, kill criteria). D39-D42 came from iteration #8 (versioned roadmap, hybrid semver/back-compat, reserved naming decision, staged launch).
+This is the single source of truth for which v3 questions are settled. Decisions D1-D7 came from the original critic loop (anti-architect / gap-finder / sequencer). D8-D14 came from the 2026-04-28 lock-in pass after the N1 moat deep dive, the v3 ecosystem audit, and the template-library design pass. D15-D20 came from the 2026-04-29 iteration #3/#4 work (Cursor capability spike, harness narrowing, agent action log, protected paths, ownership matrix). D21-D38 came from iterations #5 and #6 (memory architecture, Beads under-utilization research, efficiency audit, quality-vs-speed audit, /merge as continuous hook, /plan-as-optional, kill criteria). D39-D42 came from iteration #8 (versioned roadmap, hybrid semver/back-compat, reserved naming decision, staged launch). D43 records the super-skill/sub-skill runtime contract for planning and later skill surfaces.
 
 When a doc disagrees with this file, this file wins until a successor decisions log is dated and merged.
 
@@ -545,6 +545,18 @@ ACTIVE.
 **Tradeoff considered**: "Show HN at v3.0" was rejected — the positioning critic correctly flagged v3.0 as plumbing without a demo wedge, and a weak HN launch poisons the brand. "Show HN at v3.2" was rejected as too late — competitors may ship something similar in the 4–5 week gap, and the build-in-public thread starves without milestones.
 
 **Anti-decision**: We explicitly chose against an early HN launch at v3.0 (no wedge), against waiting until v3.2 (too slow, competitive risk), and against silent launches (no community pull, no learning loop from real users).
+
+---
+
+## D43 — Skills compose as super-skills with callable sub-skills
+
+**Decision**: Forge skills are hierarchical runtime nodes. A stage-level skill such as `/plan`, `/dev`, or `/review` may act as a super-skill that composes smaller callable sub-skills. The runtime can invoke the whole super-skill or a sub-skill only, based on the workflow graph, user intent, current evidence, and gate state. For `/plan`, the initial sub-skills are `plan.intent_capture`, `plan.parallel_research`, `plan.parallel_critics`, `plan.synthesis`, and `plan.final_lock`. ACTIVE — refines D35 by adding graph-level composition beneath description-match auto-invoke.
+
+**Rationale**: D35 solved discovery: accepted skills auto-invoke by description match. It did not solve granularity. A Hermes-style skill library is useful because it can call the right slice of behavior without forcing the whole ceremony every time. Forge needs the same property: "run critics on this plan" should not run intent capture, research, synthesis, and final lock unless the graph says those nodes are stale or required.
+
+**Tradeoff considered**: Keep one file per top-level stage skill only. That preserves the current command shape but keeps phases hidden inside prose and makes partial invocation ad hoc. Split every phase into unrelated top-level skills. That maximizes reuse but loses the coherent default workflow and makes `forge options why` harder to explain.
+
+**Anti-decision**: We explicitly chose against monolithic stage-only skills and against ungrouped free-floating skill fragments. Sub-skills must remain visible under a super-skill composition.
 
 ---
 

--- a/docs/work/2026-04-28-skeleton-pivot/release-plan.md
+++ b/docs/work/2026-04-28-skeleton-pivot/release-plan.md
@@ -212,17 +212,20 @@ Scope:
 - N13 and `forge-besw.24`.
 - Pattern detection proposes skills/evaluators from observed review failures.
 - Planning skill becomes one configurable template, not the canonical workflow.
+- Planning phases are exposed as callable sub-skills, so the runtime can invoke the full `/plan` super-skill or only `plan.intent_capture`, `plan.parallel_research`, `plan.parallel_critics`, `plan.synthesis`, or `plan.final_lock`.
 
 Evaluator regions:
 
 - Insight quality.
 - Skill proposal usefulness.
 - Accept/reject audit trail.
+- Super-skill stability: full-skill and sub-skill invocation produce consistent graph state, evidence, and gate outcomes.
 
 Release gate:
 
 - `forge insights --review-feedback` produces ranked proposals with evidence.
 - Accepted proposals can become skills or evaluator suggestions.
+- `forge options why <skill-id>` explains full `/plan` invocation, partial sub-skill invocation, skipped phases, and replacement by accepted local skills.
 
 ## 0.0.18 - Team Runtime Dashboard
 

--- a/docs/work/2026-04-28-skeleton-pivot/runtime-building-blocks-refinement.md
+++ b/docs/work/2026-04-28-skeleton-pivot/runtime-building-blocks-refinement.md
@@ -17,6 +17,7 @@ The product is not one workflow, one template library, one skill library, or one
 - what evidence is required,
 - what gates block or warn,
 - which skills implement behavior,
+- which skill fragments can be invoked independently,
 - which adapters expose the same contract to agents, trackers, and external orchestrators.
 
 Templates remain important, but only as adoption scaffolds. A template is a precomposed example of the primitives, not the primitive itself.
@@ -139,6 +140,32 @@ A skill can implement:
 
 The runtime decides whether the result passes. Skills provide behavior; evaluator regions and gates provide proof and policy.
 
+## Composable Skill Invocation
+
+Skills are hierarchical runtime nodes, not only top-level commands. A stage skill such as `plan` or `dev` can act as a super-skill that composes smaller callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+- `dev.implement_task`
+- `dev.spec_review`
+- `dev.quality_review`
+- `validate.reproduce`
+- `validate.root_cause`
+- `validate.verify`
+
+The runtime may invoke the whole super-skill, or only one sub-skill, depending on the workflow graph, current evidence, user request, and gate state. This is how Forge keeps the strict current workflow expressible as one template without forcing every run to execute every phase.
+
+Invocation rules:
+
+- Super-skills declare the full composition and default order.
+- Sub-skills declare their own inputs, outputs, evidence requirements, evaluator regions, and gates.
+- A skipped sub-skill remains addressable in the resolved graph; it is not deleted from the contract.
+- `forge options why <skill-id>` explains why a super-skill or sub-skill was invoked, skipped, blocked, or delegated.
+- Accepted local skills can replace a sub-skill without replacing the whole stage.
+
 ## Templates
 
 Templates are starter compositions of the runtime primitives.
@@ -187,4 +214,4 @@ Every future clarity pass should:
 3. Add or update a small release-numbered slice.
 4. Keep the current strict workflow expressible as one template.
 5. Keep external orchestrator compatibility explicit.
-
+6. Keep super-skill/sub-skill invocation visible in the runtime graph and evaluator regions.

--- a/lib/agents-config.js
+++ b/lib/agents-config.js
@@ -95,7 +95,7 @@ function createConditionalWriter(overwrite) {
 function generateAgentsMdContent(meta) {
   return `# Forge Workflow Framework
 
-This project uses the **Forge 7-Stage TDD Workflow** for development.
+This project uses the **Forge TDD Workflow Template** for development. The commands are composable building blocks, not a mandatory fixed ladder.
 
 ## Supported AI Agents
 
@@ -113,7 +113,7 @@ ${meta.testCommand}  # Run tests
 ${meta.buildCommand} # Build project
 \`\`\`
 
-## Forge 7-Stage TDD Workflow
+## Forge TDD Workflow Template
 
 ### Utility: /status
 Check current context and active work
@@ -121,14 +121,14 @@ Check current context and active work
 - Check Beads issues (if installed) for active work
 - Identify current workflow stage
 
-### Stage 1: /plan
+### /plan
 Create implementation plan
 - Research with web search (parallel-ai MCP recommended)
 - Document findings in \`docs/work/YYYY-MM-DD-<feature-slug>/design.md\`
 - Include decision rationale and security considerations
 - Generate plan, create Beads issue, break into TDD cycles
 
-### Stage 2: /dev
+### /dev
 TDD development (RED-GREEN-REFACTOR)
 - **RED**: Write failing test FIRST
 - **GREEN**: Implement minimal code to pass
@@ -136,7 +136,7 @@ TDD development (RED-GREEN-REFACTOR)
 - Commit after each cycle
 - Push regularly to remote
 
-### Stage 3: /validate
+### /validate
 Validation and quality gates
 - Type checking${meta.language === 'TypeScript' ? ' (TypeScript strict mode)' : ''}
 - Linting (ESLint)
@@ -144,14 +144,14 @@ Validation and quality gates
 - Test suite (all tests must pass)
 - Code coverage verification
 
-### Stage 4: /ship
+### /ship
 Create pull request
 - Generate PR body with context
 - Reference Beads issues
 - Include test coverage metrics
 - Link to research and plan documents
 
-### Stage 5: /review
+### /review
 Address ALL PR feedback
 - GitHub Actions failures
 - Code review comments
@@ -159,7 +159,7 @@ Address ALL PR feedback
 - Security scan results
 - Resolve all threads before merge
 
-### Stage 6: /premerge
+### /premerge
 Merge and cleanup
 - Update documentation
 - Merge pull request (squash commits)
@@ -167,7 +167,7 @@ Merge and cleanup
 - Archive completed work
 - Close Beads issues
 
-### Stage 7: /verify
+### /verify
 Final documentation cross-check
 - Verify all docs updated correctly
 - Check for broken links
@@ -335,7 +335,7 @@ function generateCopilotInstructionsContent(meta) {
 
   return `# Forge Workflow Framework
 
-This project uses the **Forge 7-Stage TDD Workflow** for development with GitHub Copilot.
+This project uses the **Forge TDD Workflow Template** for development with GitHub Copilot. The commands are composable building blocks, not a mandatory fixed ladder.
 
 ## Quick Start
 
@@ -353,7 +353,7 @@ ${meta.language ? `- **Language**: ${meta.language} (strict mode enabled)` : '- 
 - **Security**: OWASP Top 10 compliance required
 - **Version Control**: Git with conventional commits
 
-## Forge 7-Stage TDD Workflow
+## Forge TDD Workflow Template
 
 ### Utility: /status
 Check current context and active work
@@ -361,14 +361,14 @@ Check current context and active work
 - Check Beads issues (if installed) for active work
 - Identify current workflow stage
 
-### Stage 1: /plan
+### /plan
 Create implementation plan
 - Research with web search
 - Document findings in \`docs/work/YYYY-MM-DD-<feature-slug>/design.md\`
 - **Security**: Identify OWASP Top 10 considerations
 - Generate plan, create Beads issue, break into TDD cycles
 
-### Stage 2: /dev
+### /dev
 **TDD development (RED-GREEN-REFACTOR)**
 - **RED**: Write failing test FIRST
 - **GREEN**: Implement minimal code to pass
@@ -376,7 +376,7 @@ Create implementation plan
 - Commit after each cycle
 - Push regularly to remote
 
-### Stage 3: /validate
+### /validate
 Validation and quality gates
 - Type checking${meta.language === 'TypeScript' ? ' (TypeScript strict mode)' : ''}
 - Linting (ESLint - no errors allowed)
@@ -384,14 +384,14 @@ Validation and quality gates
 - Test suite (all tests must pass)
 - Code coverage verification (80%+ required)
 
-### Stage 4: /ship
+### /ship
 Create pull request
 - Generate PR body with context
 - Reference Beads issues
 - Include test coverage metrics
 - Link to research and plan documents
 
-### Stage 5: /review
+### /review
 Address ALL PR feedback
 - GitHub Actions failures
 - Code review comments
@@ -399,7 +399,7 @@ Address ALL PR feedback
 - Security scan results
 - **IMPORTANT**: Resolve all comment threads before merge
 
-### Stage 6: /premerge
+### /premerge
 Merge and cleanup
 - Update documentation
 - Merge pull request (squash commits only)
@@ -407,7 +407,7 @@ Merge and cleanup
 - Archive completed work
 - Close Beads issues
 
-### Stage 7: /verify
+### /verify
 Final documentation cross-check
 - Verify all docs updated correctly
 - Check for broken links
@@ -692,13 +692,13 @@ function generateCursorWorkflowContent(meta) {
   const packageManager = meta.testCommand?.includes('bun') ? 'bun' : 'npm';
 
   return `---
-description: "When working with Forge workflow stages"
+description: "When working with Forge workflow commands"
 alwaysApply: true
 ---
 
-# Forge 7-Stage TDD Workflow
+# Forge TDD Workflow Template
 
-Always follow these stages in order:
+Use these default commands as composable workflow building blocks:
 
 ## Utility: /status
 Check current context and active work
@@ -706,14 +706,14 @@ Check current context and active work
 - Check Beads issues (if installed) for active work
 - Identify current workflow stage
 
-## Stage 1: /plan
+## /plan
 Create implementation plan
 - Research with parallel-ai
 - Document findings in \`docs/work/YYYY-MM-DD-<feature-slug>/design.md\`
 - **Security**: OWASP Top 10 analysis
 - Generate plan, create Beads issue, break into TDD cycles
 
-## Stage 2: /dev
+## /dev
 **TDD development (RED-GREEN-REFACTOR)**
 - **RED**: Write failing test FIRST
 - **GREEN**: Implement minimal code to pass
@@ -721,7 +721,7 @@ Create implementation plan
 - Commit after each cycle
 - Push regularly to remote
 
-## Stage 3: /validate
+## /validate
 Validation (type/lint/tests/security)
 - Type checking${meta.language === 'TypeScript' ? ' (TypeScript strict mode)' : ''}
 - Linting (ESLint - no errors)
@@ -729,14 +729,14 @@ Validation (type/lint/tests/security)
 - Test suite (all tests must pass)
 - Code coverage (80%+ required)
 
-## Stage 4: /ship
+## /ship
 Create PR with documentation
 - Generate PR body with context
 - Reference Beads issues
 - Include test coverage metrics
 - Link to research and plan documents
 
-## Stage 5: /review
+## /review
 Address ALL PR feedback
 - GitHub Actions failures
 - Code review comments
@@ -744,7 +744,7 @@ Address ALL PR feedback
 - Security scan results
 - **IMPORTANT**: Resolve all comment threads
 
-## Stage 6: /premerge
+## /premerge
 Update docs, merge PR, cleanup
 - Update documentation
 - Merge pull request (squash commits only)
@@ -752,7 +752,7 @@ Update docs, merge PR, cleanup
 - Archive completed work
 - Close Beads issues
 
-## Stage 7: /verify
+## /verify
 Final documentation verification
 - Verify all docs updated correctly
 - Check for broken links
@@ -1073,7 +1073,7 @@ description: "Forge workflow for Kilo Code"
 
 # Forge Workflow Framework - Kilo Code
 
-This project uses the **Forge 7-Stage TDD Workflow** with Kilo Code native workflows.
+This project uses the **Forge TDD Workflow Template** with Kilo Code native workflows. The commands are composable building blocks, not a mandatory fixed ladder.
 
 ## Quick Start
 
@@ -1090,30 +1090,30 @@ Kilo Code uses native workflows, rules, and skills. Forge generates:
 - \`.kilocode/rules/workflow.md\`
 - \`.kilocode/skills/forge-workflow/SKILL.md\`
 
-These complement the Forge workflow stages below.
+These complement the Forge workflow commands below.
 
-## Forge 7-Stage TDD Workflow
+## Forge TDD Workflow Template
 
 ### Utility: /status
 Check current context and active work
 - Review git status and recent commits
 - Check Beads issues (if installed)
 
-### Stage 1: /plan
+### /plan
 Create implementation plan
 - Research with web search
 - Document findings in \`docs/work/YYYY-MM-DD-<feature-slug>/design.md\`
 - Security: OWASP Top 10 analysis
 - Generate plan, create Beads issue, break into TDD cycles
 
-### Stage 2: /dev
+### /dev
 **TDD development (RED-GREEN-REFACTOR)**
 - **RED**: Write failing test FIRST
 - **GREEN**: Implement minimal code to pass
 - **REFACTOR**: Clean up and optimize
 - Commit after each cycle
 
-### Stage 3: /validate
+### /validate
 Validation (type/lint/tests/security)
 - Type checking${meta.language === 'TypeScript' ? ' (TypeScript strict mode)' : ''}
 - Linting (ESLint)
@@ -1121,27 +1121,27 @@ Validation (type/lint/tests/security)
 - Test suite (all tests must pass)
 - Code coverage (80%+ required)
 
-### Stage 4: /ship
+### /ship
 Create pull request
 - Generate PR body with context
 - Reference Beads issues
 - Include test coverage metrics
 
-### Stage 5: /review
+### /review
 Address ALL PR feedback
 - GitHub Actions failures
 - Code review comments
 - AI review tools
 - Resolve all comment threads
 
-### Stage 6: /premerge
+### /premerge
 Merge and cleanup
 - Update documentation
 - Merge PR (squash commits)
 - Delete feature branch
 - Close Beads issues
 
-### Stage 7: /verify
+### /verify
 Final documentation verification
 - Verify all docs updated
 - Check for broken links
@@ -1307,7 +1307,7 @@ tools:
 
 # Planning & Review Agent
 
-You are in **planning mode** for the Forge 7-Stage TDD Workflow.
+You are in **planning mode** for the Forge TDD Workflow Template. Use only the planning pieces the current project plan calls for.
 
 ## Your Role
 
@@ -1319,9 +1319,9 @@ Focus on:
 - Analyzing OWASP Top 10 security considerations
 - **NO code changes allowed** - planning only
 
-## Forge Planning Stages
+## Forge Planning Commands
 
-### Stage 1: /plan
+### /plan
 - Research with web search for best practices
 - Document findings in \`docs/work/YYYY-MM-DD-<feature-slug>/design.md\`
 - Include security analysis (OWASP Top 10)
@@ -1360,7 +1360,7 @@ tools:
 
 # TDD Build Agent
 
-You are in **implementation mode** for the Forge 7-Stage TDD Workflow.
+You are in **implementation mode** for the Forge TDD Workflow Template. Use the TDD and validation pieces the current project plan calls for.
 
 ## MANDATORY TDD Process
 
@@ -1382,15 +1382,15 @@ You are in **implementation mode** for the Forge 7-Stage TDD Workflow.
 2. Extract helpers, remove duplication
 3. Commit: \`git commit -m "refactor: [description]"\`
 
-## Forge Development Stages
+## Forge Development Commands
 
-### Stage 2: /dev
+### /dev
 Implement features using TDD:
 - Follow RED-GREEN-REFACTOR for each feature
 - Commit after each GREEN cycle
 - Push regularly to remote
 
-### Stage 3: /validate
+### /validate
 Validate before creating PR:
 - Type checking (TypeScript strict mode)
 - Linting (ESLint - no errors)

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -415,7 +415,7 @@ function requiresGithubCliForSetup(selectedAgents, options = {}) {
 // Universal SKILL.md content
 const SKILL_CONTENT = `---
 name: forge-workflow
-description: 7-stage TDD-first workflow for feature development. Use when building features, fixing bugs, or shipping PRs.
+description: Composable TDD-first workflow for feature development. Use when building features, fixing bugs, or shipping PRs.
 category: Development Workflow
 tags: [tdd, workflow, pr, git, testing]
 tools: [Bash, Read, Write, Edit, Grep, Glob]
@@ -433,9 +433,9 @@ Automatically invoke this skill when the user wants to:
 - Create a pull request
 - Run the development workflow
 
-## 7 Stages
+## Default Workflow Template
 
-| Stage | Command | Description |
+| Default Step | Command | Description |
 |-------|---------|-------------|
 | utility | \`/status\` | Check current context, active work, recent completions |
 | 1 | \`/plan\` | Design intent -> research -> branch + worktree + task list |
@@ -446,7 +446,9 @@ Automatically invoke this skill when the user wants to:
 | 6 | \`/premerge\` | Update docs, hand off PR to user |
 | 7 | \`/verify\` | Post-merge health check (CI on main, close Beads) |
 
-## Workflow Flow
+## Workflow Composition
+
+These commands are default building blocks. Use the whole flow when it fits, or invoke individual commands/skills when the active project plan permits a smaller path.
 
 \`\`\`
 /status -> /plan -> /dev -> /validate -> /ship -> /review -> /premerge -> /verify

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -61,6 +61,10 @@ function hasExecutableHookCommand(content, commandPattern) {
     .some((line) => resolvesToExecutableHookCommand(line, commandPattern));
 }
 
+function escapeRegExp(value) {
+  return toText(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function createDiagnostic(code, subject, message, repair) {
   return {
     code,
@@ -153,7 +157,10 @@ function checkHookInstallation(projectRoot, options = {}) {
         content,
         /(?:^|[\s"'(;])(?:node\s+)?(?:[^\s"';&|]*[\\/])?\.forge[\\/]hooks[\\/]check-tdd\.js\b|(?:^|[\s"'(;])(?:node\s+)?check-tdd\.js\b/i
       );
-      const runsBeadsHook = new RegExp(`\\bbd\\s+hooks\\s+run\\s+${hookName}\\b`, 'i').test(content);
+      const runsBeadsHook = hasExecutableHookCommand(
+        content,
+        new RegExp(String.raw`\bbd\s+hooks\s+run\s+${escapeRegExp(hookName)}\b`, 'i')
+      );
 
       if (runsLefthook) return { active: true, provider: 'lefthook' };
       if (runsForgeHook) return { active: true, provider: 'forge' };

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -48,21 +48,54 @@ function isAbsoluteForPlatform(value, platform = process.platform) {
   return platform === 'win32' ? path.win32.isAbsolute(raw) : path.posix.isAbsolute(raw);
 }
 
-function resolvesToExecutableHookCommand(line, commandPattern) {
+function resolvesToExecutableHookCommand(line, matcher) {
   const trimmed = line.trim();
   if (!trimmed || trimmed.startsWith('#')) return false;
   if (/^(?:echo|printf)\b/i.test(trimmed)) return false;
-  return commandPattern.test(trimmed);
+  return matcher(trimmed);
 }
 
-function hasExecutableHookCommand(content, commandPattern) {
+function hasExecutableHookCommand(content, matcher) {
   return toText(content)
     .split(/\r?\n/)
-    .some((line) => resolvesToExecutableHookCommand(line, commandPattern));
+    .some((line) => resolvesToExecutableHookCommand(line, matcher));
 }
 
-function escapeRegExp(value) {
-  return toText(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function commandTokens(line) {
+  return line
+    .replace(/[;"'()]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function commandName(token) {
+  return toText(token)
+    .replaceAll('\\', '/')
+    .split('/')
+    .pop()
+    .toLowerCase()
+    .replace(/\.(?:exe|cmd)$/, '');
+}
+
+function invokesLefthook(line) {
+  return commandTokens(line).some((token) => commandName(token) === 'lefthook');
+}
+
+function invokesForgeHook(line) {
+  return commandTokens(line).some((token) => {
+    const normalized = token.replaceAll('\\', '/').toLowerCase();
+    return normalized.endsWith('.forge/hooks/check-tdd.js') || commandName(token) === 'check-tdd.js';
+  });
+}
+
+function invokesBeadsHook(line, hookName) {
+  const tokens = commandTokens(line);
+  return tokens.some((token, index) => (
+    commandName(token) === 'bd'
+    && toText(tokens[index + 1]).toLowerCase() === 'hooks'
+    && toText(tokens[index + 2]).toLowerCase() === 'run'
+    && toText(tokens[index + 3]).toLowerCase() === hookName
+  ));
 }
 
 function createDiagnostic(code, subject, message, repair) {
@@ -149,18 +182,9 @@ function checkHookInstallation(projectRoot, options = {}) {
       if (!stat.isFile() || stat.size === 0 || !executable) return { active: false, provider: 'missing' };
 
       const content = fs.readFileSync(filePath, 'utf8');
-      const runsLefthook = hasExecutableHookCommand(
-        content,
-        /\b(?:bunx\s+|bun\s+x\s+|npx\s+)?lefthook(?:\.exe|\.cmd)?\b/i
-      );
-      const runsForgeHook = hasExecutableHookCommand(
-        content,
-        /(?:^|[\s"'(;])(?:node\s+)?(?:[^\s"';&|]*[\\/])?\.forge[\\/]hooks[\\/]check-tdd\.js\b|(?:^|[\s"'(;])(?:node\s+)?check-tdd\.js\b/i
-      );
-      const runsBeadsHook = hasExecutableHookCommand(
-        content,
-        new RegExp(String.raw`\bbd\s+hooks\s+run\s+${escapeRegExp(hookName)}\b`, 'i')
-      );
+      const runsLefthook = hasExecutableHookCommand(content, invokesLefthook);
+      const runsForgeHook = hasExecutableHookCommand(content, invokesForgeHook);
+      const runsBeadsHook = hasExecutableHookCommand(content, (line) => invokesBeadsHook(line, hookName));
 
       if (runsLefthook) return { active: true, provider: 'lefthook' };
       if (runsForgeHook) return { active: true, provider: 'forge' };

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -43,6 +43,24 @@ function normalizeHooksPath(value, platform = process.platform) {
   return normalized;
 }
 
+function isAbsoluteForPlatform(value, platform = process.platform) {
+  const raw = toText(value).trim();
+  return platform === 'win32' ? path.win32.isAbsolute(raw) : path.posix.isAbsolute(raw);
+}
+
+function resolvesToExecutableHookCommand(line, commandPattern) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return false;
+  if (/^(?:echo|printf)\b/i.test(trimmed)) return false;
+  return commandPattern.test(trimmed);
+}
+
+function hasExecutableHookCommand(content, commandPattern) {
+  return toText(content)
+    .split(/\r?\n/)
+    .some((line) => resolvesToExecutableHookCommand(line, commandPattern));
+}
+
 function createDiagnostic(code, subject, message, repair) {
   return {
     code,
@@ -127,8 +145,14 @@ function checkHookInstallation(projectRoot, options = {}) {
       if (!stat.isFile() || stat.size === 0 || !executable) return { active: false, provider: 'missing' };
 
       const content = fs.readFileSync(filePath, 'utf8');
-      const runsLefthook = /\blefthook\b/i.test(content);
-      const runsForgeHook = /\.forge\/hooks\/check-tdd\.js|\.forge\\hooks\\check-tdd\.js|\bcheck-tdd\.js\b/i.test(content);
+      const runsLefthook = hasExecutableHookCommand(
+        content,
+        /\b(?:bunx\s+|bun\s+x\s+|npx\s+)?lefthook(?:\.exe|\.cmd)?\b/i
+      );
+      const runsForgeHook = hasExecutableHookCommand(
+        content,
+        /(?:^|[\s"'(;])(?:node\s+)?(?:[^\s"';&|]*[\\/])?\.forge[\\/]hooks[\\/]check-tdd\.js\b|(?:^|[\s"'(;])(?:node\s+)?check-tdd\.js\b/i
+      );
       const runsBeadsHook = new RegExp(`\\bbd\\s+hooks\\s+run\\s+${hookName}\\b`, 'i').test(content);
 
       if (runsLefthook) return { active: true, provider: 'lefthook' };
@@ -163,7 +187,7 @@ function checkHookInstallation(projectRoot, options = {}) {
     const active = expectedHooksPaths.has(hooksPath);
 
     if (active) {
-      const hooksDir = path.isAbsolute(toText(output).trim())
+      const hooksDir = isAbsoluteForPlatform(toText(output).trim(), platform)
         ? toText(output).trim()
         : path.resolve(gitRoot, toText(output).trim());
       const hookChecks = requiredHooks.map((hook) => ({

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -87,6 +87,7 @@ function invokesLefthook(line) {
 
 function invokesForgeHook(line) {
   const nonExecutingPreviousTokens = new Set(['-e', '-f', '-r', '-x', '[', 'test']);
+  const executingPreviousCommands = new Set(['bash', 'bun', 'env', 'exec', 'if', 'node', 'sh', 'then', '&&']);
   return commandTokens(line).some((token, index, tokens) => {
     const normalized = token.replaceAll('\\', '/').toLowerCase();
     if (!normalized.endsWith('.forge/hooks/check-tdd.js') && commandName(token) !== 'check-tdd.js') {
@@ -94,7 +95,8 @@ function invokesForgeHook(line) {
     }
 
     const previous = toText(tokens[index - 1]).toLowerCase();
-    return !nonExecutingPreviousTokens.has(previous);
+    if (nonExecutingPreviousTokens.has(previous)) return false;
+    return index === 0 || executingPreviousCommands.has(commandName(previous));
   });
 }
 

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -98,6 +98,26 @@ function isWhitespace(char) {
   return char === ' ' || char === '\t' || char === '\r' || char === '\n';
 }
 
+function isVariableNameStart(char) {
+  return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || char === '_';
+}
+
+function isVariableNameChar(char) {
+  return isVariableNameStart(char) || (char >= '0' && char <= '9');
+}
+
+function isAssignmentToken(token) {
+  const text = toText(token);
+  const equalsIndex = text.indexOf('=');
+  if (equalsIndex <= 0 || !isVariableNameStart(text[0])) return false;
+
+  for (let index = 1; index < equalsIndex; index += 1) {
+    if (!isVariableNameChar(text[index])) return false;
+  }
+
+  return true;
+}
+
 function heredocDelimiter(line) {
   const markerIndex = line.indexOf('<<');
   if (markerIndex === -1 || line[markerIndex + 2] === '<') return null;
@@ -121,9 +141,17 @@ function heredocDelimiter(line) {
 function isExecutingTokenPosition(tokens, index) {
   const nonExecutingPreviousTokens = new Set(['-e', '-f', '-r', '-x', '[', 'test']);
   const executingPreviousCommands = new Set(['bash', 'bun', 'env', 'exec', 'if', 'node', 'sh', 'then', '&&']);
-  const previous = toText(tokens[index - 1]).toLowerCase();
+
+  let previousIndex = index - 1;
+  while (previousIndex >= 0 && isAssignmentToken(tokens[previousIndex])) {
+    previousIndex -= 1;
+  }
+
+  if (previousIndex < 0) return true;
+
+  const previous = toText(tokens[previousIndex]).toLowerCase();
   if (nonExecutingPreviousTokens.has(previous)) return false;
-  return index === 0 || executingPreviousCommands.has(commandName(previous));
+  return executingPreviousCommands.has(commandName(previous));
 }
 
 function invokesLefthook(line) {

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -94,10 +94,28 @@ function commandName(token) {
     .replace(/\.(?:exe|cmd)$/, '');
 }
 
+function isWhitespace(char) {
+  return char === ' ' || char === '\t' || char === '\r' || char === '\n';
+}
+
 function heredocDelimiter(line) {
-  const token = commandTokens(line).find((part) => part.startsWith('<<'));
-  if (!token) return null;
-  return token.startsWith('<<-') ? token.slice(3) : token.slice(2);
+  const markerIndex = line.indexOf('<<');
+  if (markerIndex === -1 || line[markerIndex + 2] === '<') return null;
+
+  let cursor = markerIndex + 2;
+  if (line[cursor] === '-') cursor += 1;
+  while (cursor < line.length && isWhitespace(line[cursor])) cursor += 1;
+
+  const quote = line[cursor];
+  if (quote === '"' || quote === "'") {
+    cursor += 1;
+    const endQuote = line.indexOf(quote, cursor);
+    return endQuote === -1 ? line.slice(cursor).trim() || null : line.slice(cursor, endQuote) || null;
+  }
+
+  const start = cursor;
+  while (cursor < line.length && !isWhitespace(line[cursor])) cursor += 1;
+  return line.slice(start, cursor).trim() || null;
 }
 
 function isExecutingTokenPosition(tokens, index) {
@@ -114,6 +132,7 @@ function invokesLefthook(line) {
 
 function invokesForgeHook(line) {
   return commandTokens(line).some((token, index, tokens) => {
+    if (token.includes('=')) return false;
     const normalized = token.replaceAll('\\', '/').toLowerCase();
     if (!normalized.endsWith('.forge/hooks/check-tdd.js') && commandName(token) !== 'check-tdd.js') {
       return false;

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -51,7 +51,10 @@ function isAbsoluteForPlatform(value, platform = process.platform) {
 function resolvesToExecutableHookCommand(line, matcher) {
   const trimmed = line.trim();
   if (!trimmed || trimmed.startsWith('#')) return false;
-  if (/^(?:echo|printf)\b/i.test(trimmed)) return false;
+  if (/^(?:echo|printf)\b/i.test(trimmed)) {
+    const chainedCommand = trimmed.match(/&&\s*(.+)$/);
+    return chainedCommand ? matcher(chainedCommand[1]) : false;
+  }
   return matcher(trimmed);
 }
 
@@ -82,9 +85,15 @@ function invokesLefthook(line) {
 }
 
 function invokesForgeHook(line) {
-  return commandTokens(line).some((token) => {
+  const nonExecutingPreviousTokens = new Set(['-e', '-f', '-r', '-x', '[', 'test']);
+  return commandTokens(line).some((token, index, tokens) => {
     const normalized = token.replaceAll('\\', '/').toLowerCase();
-    return normalized.endsWith('.forge/hooks/check-tdd.js') || commandName(token) === 'check-tdd.js';
+    if (!normalized.endsWith('.forge/hooks/check-tdd.js') && commandName(token) !== 'check-tdd.js') {
+      return false;
+    }
+
+    const previous = toText(tokens[index - 1]).toLowerCase();
+    return !nonExecutingPreviousTokens.has(previous);
   });
 }
 

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -51,9 +51,10 @@ function isAbsoluteForPlatform(value, platform = process.platform) {
 function resolvesToExecutableHookCommand(line, matcher) {
   const trimmed = line.trim();
   if (!trimmed || trimmed.startsWith('#')) return false;
-  if (/^(?:echo|printf)\b/i.test(trimmed)) {
-    const chainedCommand = trimmed.match(/&&\s*(.+)$/);
-    return chainedCommand ? matcher(chainedCommand[1]) : false;
+  const firstCommand = commandName(commandTokens(trimmed)[0]);
+  if (firstCommand === 'echo' || firstCommand === 'printf') {
+    const chainIndex = trimmed.indexOf('&&');
+    return chainIndex === -1 ? false : matcher(trimmed.slice(chainIndex + 2).trim());
   }
   return matcher(trimmed);
 }

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -76,7 +76,7 @@ function isUsableWindowsShellCandidate(candidate, options = {}) {
 function checkHookInstallation(projectRoot, options = {}) {
   const exec = options._exec || defaultExecFileSync;
   const platform = options.platform || process.platform;
-  const expectedRelativeHooksPath = normalizeHooksPath('.lefthook/hooks', platform);
+  const expectedRelativeHooksPaths = ['.lefthook/hooks', '.beads/hooks'];
   const requiredHooks = ['pre-commit', 'pre-push'];
 
   function resolveGitRoot() {
@@ -92,7 +92,10 @@ function checkHookInstallation(projectRoot, options = {}) {
   }
 
   const gitRoot = resolveGitRoot();
-  const expectedAbsoluteHooksPath = normalizeHooksPath(`${gitRoot}/${expectedRelativeHooksPath}`, platform);
+  const expectedHooksPaths = new Set(expectedRelativeHooksPaths.flatMap((hooksPath) => [
+    normalizeHooksPath(hooksPath, platform),
+    normalizeHooksPath(`${gitRoot}/${normalizeHooksPath(hooksPath, platform)}`, platform)
+  ]));
 
   function resolveGitHooksDir() {
     try {
@@ -108,17 +111,44 @@ function checkHookInstallation(projectRoot, options = {}) {
     }
   }
 
-  function fileLooksLikeActiveHook(filePath) {
+  function classifyHookFile(filePath, hookName, visited = new Set()) {
     try {
+      const normalizedFilePath = path.resolve(filePath);
+      if (visited.has(normalizedFilePath)) {
+        return { active: false, provider: 'cycle' };
+      }
+      visited.add(normalizedFilePath);
+
       const stat = fs.statSync(filePath);
       const executable = platform === 'win32'
         || (typeof options._canExecuteHook === 'function'
           ? Boolean(options._canExecuteHook(filePath, stat))
           : (stat.mode & 0o111) !== 0);
-      if (!stat.isFile() || stat.size === 0 || !executable) return false;
-      return /\blefthook\b/i.test(fs.readFileSync(filePath, 'utf8'));
+      if (!stat.isFile() || stat.size === 0 || !executable) return { active: false, provider: 'missing' };
+
+      const content = fs.readFileSync(filePath, 'utf8');
+      const runsLefthook = /\blefthook\b/i.test(content);
+      const runsForgeHook = /\.forge\/hooks\/check-tdd\.js|\.forge\\hooks\\check-tdd\.js|\bcheck-tdd\.js\b/i.test(content);
+      const runsBeadsHook = new RegExp(`\\bbd\\s+hooks\\s+run\\s+${hookName}\\b`, 'i').test(content);
+
+      if (runsLefthook) return { active: true, provider: 'lefthook' };
+      if (runsForgeHook) return { active: true, provider: 'forge' };
+
+      if (runsBeadsHook) {
+        const chainedHookPath = path.join(gitRoot, '.beads', 'hooks', hookName);
+        if (path.resolve(chainedHookPath) !== normalizedFilePath && fs.existsSync(chainedHookPath)) {
+          const chained = classifyHookFile(chainedHookPath, hookName, visited);
+          if (chained.active) {
+            return { active: true, provider: `beads->${chained.provider}` };
+          }
+        }
+
+        return { active: false, provider: 'beads-unverified' };
+      }
+
+      return { active: false, provider: 'unknown' };
     } catch {
-      return false;
+      return { active: false, provider: 'missing' };
     }
   }
 
@@ -130,11 +160,17 @@ function checkHookInstallation(projectRoot, options = {}) {
     });
 
     hooksPath = normalizeHooksPath(output, platform);
-    const active = hooksPath === expectedRelativeHooksPath || hooksPath === expectedAbsoluteHooksPath;
+    const active = expectedHooksPaths.has(hooksPath);
 
     if (active) {
-      const hooksDir = path.join(gitRoot, '.lefthook', 'hooks');
-      const missingHooks = requiredHooks.filter(hook => !fileLooksLikeActiveHook(path.join(hooksDir, hook)));
+      const hooksDir = path.isAbsolute(toText(output).trim())
+        ? toText(output).trim()
+        : path.resolve(gitRoot, toText(output).trim());
+      const hookChecks = requiredHooks.map((hook) => ({
+        hook,
+        ...classifyHookFile(path.join(hooksDir, hook), hook)
+      }));
+      const missingHooks = hookChecks.filter(check => !check.active).map(check => check.hook);
       const verifiedActive = missingHooks.length === 0;
       return {
         active: verifiedActive,
@@ -142,6 +178,7 @@ function checkHookInstallation(projectRoot, options = {}) {
         verification: 'core.hooksPath',
         hooksPath: hooksPath || null,
         hooksDir,
+        providers: Object.fromEntries(hookChecks.map(check => [check.hook, check.provider])),
         missingHooks,
         message: verifiedActive
           ? ''
@@ -155,7 +192,7 @@ function checkHookInstallation(projectRoot, options = {}) {
         state: 'inactive',
         verification: 'core.hooksPath',
         hooksPath,
-        message: `Git core.hooksPath is set to "${hooksPath}", not ".lefthook/hooks".`
+        message: `Git core.hooksPath is set to "${hooksPath}", not ".lefthook/hooks" or ".beads/hooks".`
       };
     }
   } catch {
@@ -164,7 +201,11 @@ function checkHookInstallation(projectRoot, options = {}) {
 
   const hooksDir = resolveGitHooksDir();
   if (hooksDir) {
-    const missingHooks = requiredHooks.filter(hook => !fileLooksLikeActiveHook(path.join(hooksDir, hook)));
+    const hookChecks = requiredHooks.map((hook) => ({
+      hook,
+      ...classifyHookFile(path.join(hooksDir, hook), hook)
+    }));
+    const missingHooks = hookChecks.filter(check => !check.active).map(check => check.hook);
     const active = missingHooks.length === 0;
     return {
       active,
@@ -172,6 +213,7 @@ function checkHookInstallation(projectRoot, options = {}) {
       verification: 'git-path-hooks',
       hooksPath: hooksPath || null,
       hooksDir,
+      providers: Object.fromEntries(hookChecks.map(check => [check.hook, check.provider])),
       missingHooks,
       message: active
         ? ''

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -194,9 +194,10 @@ function checkHookInstallation(projectRoot, options = {}) {
     const active = expectedHooksPaths.has(hooksPath);
 
     if (active) {
-      const hooksDir = isAbsoluteForPlatform(toText(output).trim(), platform)
-        ? toText(output).trim()
-        : path.resolve(gitRoot, toText(output).trim());
+      const rawHooksPath = toText(output).trim();
+      const hooksDir = isAbsoluteForPlatform(rawHooksPath, platform)
+        ? rawHooksPath
+        : path.resolve(gitRoot, normalizeHooksPath(rawHooksPath, platform));
       const hookChecks = requiredHooks.map((hook) => ({
         hook,
         ...classifyHookFile(path.join(hooksDir, hook), hook)

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -60,9 +60,22 @@ function resolvesToExecutableHookCommand(line, matcher) {
 }
 
 function hasExecutableHookCommand(content, matcher) {
-  return toText(content)
-    .split(/\r?\n/)
-    .some((line) => resolvesToExecutableHookCommand(line, matcher));
+  let heredocEnd = null;
+
+  for (const line of toText(content).split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (heredocEnd) {
+      if (trimmed === heredocEnd) heredocEnd = null;
+      continue;
+    }
+
+    if (resolvesToExecutableHookCommand(line, matcher)) return true;
+
+    const delimiter = heredocDelimiter(line);
+    if (delimiter) heredocEnd = delimiter;
+  }
+
+  return false;
 }
 
 function commandTokens(line) {
@@ -81,22 +94,32 @@ function commandName(token) {
     .replace(/\.(?:exe|cmd)$/, '');
 }
 
+function heredocDelimiter(line) {
+  const token = commandTokens(line).find((part) => part.startsWith('<<'));
+  if (!token) return null;
+  return token.startsWith('<<-') ? token.slice(3) : token.slice(2);
+}
+
+function isExecutingTokenPosition(tokens, index) {
+  const nonExecutingPreviousTokens = new Set(['-e', '-f', '-r', '-x', '[', 'test']);
+  const executingPreviousCommands = new Set(['bash', 'bun', 'env', 'exec', 'if', 'node', 'sh', 'then', '&&']);
+  const previous = toText(tokens[index - 1]).toLowerCase();
+  if (nonExecutingPreviousTokens.has(previous)) return false;
+  return index === 0 || executingPreviousCommands.has(commandName(previous));
+}
+
 function invokesLefthook(line) {
   return commandTokens(line).some((token) => commandName(token) === 'lefthook');
 }
 
 function invokesForgeHook(line) {
-  const nonExecutingPreviousTokens = new Set(['-e', '-f', '-r', '-x', '[', 'test']);
-  const executingPreviousCommands = new Set(['bash', 'bun', 'env', 'exec', 'if', 'node', 'sh', 'then', '&&']);
   return commandTokens(line).some((token, index, tokens) => {
     const normalized = token.replaceAll('\\', '/').toLowerCase();
     if (!normalized.endsWith('.forge/hooks/check-tdd.js') && commandName(token) !== 'check-tdd.js') {
       return false;
     }
 
-    const previous = toText(tokens[index - 1]).toLowerCase();
-    if (nonExecutingPreviousTokens.has(previous)) return false;
-    return index === 0 || executingPreviousCommands.has(commandName(previous));
+    return isExecutingTokenPosition(tokens, index);
   });
 }
 
@@ -107,6 +130,7 @@ function invokesBeadsHook(line, hookName) {
     && toText(tokens[index + 1]).toLowerCase() === 'hooks'
     && toText(tokens[index + 2]).toLowerCase() === 'run'
     && toText(tokens[index + 3]).toLowerCase() === hookName
+    && isExecutingTokenPosition(tokens, index)
   ));
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "forge-workflow",
   "version": "0.0.10",
-  "description": "7-stage TDD workflow for ALL AI coding agents (Claude, Cursor, Cline, OpenCode, Copilot, Kilo Code, Roo Code, Codex)",
+  "description": "Composable TDD workflow framework for all AI coding agents (Claude, Cursor, Cline, OpenCode, Copilot, Kilo Code, Roo Code, Codex)",
   "bin": {
     "forge": "bin/forge.js",
     "forge-workflow": "bin/forge.js",

--- a/scripts/github-beads-sync/index.mjs
+++ b/scripts/github-beads-sync/index.mjs
@@ -157,7 +157,7 @@ export function handleOpened(event, options = {}) {
   }
 
   const existingSyncComment = parseComment(findSyncComment(owner, repo, issueNumber)?.body);
-  if (existingSyncComment?.beadsId) {
+  if (existingSyncComment?.beadsId && existingSyncComment.issueNumber === issueNumber) {
     canonicalLinkStore.upsertCanonicalLink({
       forgeIssueId: existingSyncComment.beadsId,
       github: getGitHubLink(issue),

--- a/scripts/sync-commands.js
+++ b/scripts/sync-commands.js
@@ -28,6 +28,8 @@ const { listCodexSkillEntries } = require('../lib/codex-skills');
  * @returns {{ frontmatter: Record<string, unknown>, body: string }}
  */
 function parseFrontmatter(content) {
+  content = content.replace(/^\uFEFF/, '');
+
   // Frontmatter must start at the very beginning with ---
   if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) {
     return { frontmatter: {}, body: content };
@@ -64,7 +66,7 @@ function parseFrontmatter(content) {
   // Parse the YAML string
   const trimmed = yamlStr.trim();
   if (trimmed === '') {
-    return { frontmatter: {}, body: content.slice(bodyStart) };
+    return { frontmatter: {}, body: content.slice(bodyStart).replace(/^\uFEFF/, '') };
   }
 
   /** @type {Record<string, unknown>} */
@@ -81,7 +83,7 @@ function parseFrontmatter(content) {
     return { frontmatter: {}, body: content };
   }
 
-  return { frontmatter, body: content.slice(bodyStart) };
+  return { frontmatter, body: content.slice(bodyStart).replace(/^\uFEFF/, '') };
 }
 
 /**

--- a/test/agents-md-generation.test.js
+++ b/test/agents-md-generation.test.js
@@ -35,8 +35,8 @@ describe('AGENTS.md generation', () => {
 
     const content = await fs.promises.readFile(agentsMdPath, 'utf-8');
 
-    // Verify it contains Forge 7-stage workflow
-    expect(content.includes('Forge 7-Stage TDD Workflow')).toBeTruthy();
+    // Verify it contains the Forge workflow template
+    expect(content.includes('Forge TDD Workflow Template')).toBeTruthy();
     expect(content.includes('/status')).toBeTruthy();
     expect(content.includes('/plan')).toBeTruthy();
     expect(content.includes('/dev')).toBeTruthy();

--- a/test/cleanup/dropped-agent-config.test.js
+++ b/test/cleanup/dropped-agent-config.test.js
@@ -8,8 +8,9 @@ describe('dropped-agent refs in config files', () => {
   describe('package.json', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
 
-    test('description contains "7-stage" (not "9-stage")', () => {
-      expect(pkg.description).toContain('7-stage');
+    test('description uses composable workflow language (not fixed stage count)', () => {
+      expect(pkg.description).toContain('Composable TDD workflow framework');
+      expect(pkg.description).not.toContain('7-stage');
       expect(pkg.description).not.toContain('9-stage');
     });
 

--- a/test/commands/plan-phase-tracking.test.js
+++ b/test/commands/plan-phase-tracking.test.js
@@ -6,21 +6,21 @@ const planPath = join(__dirname, '..', '..', '.claude', 'commands', 'plan.md');
 const planContent = readFileSync(planPath, 'utf-8');
 
 describe('/plan phase tracking', () => {
-  test('bd create appears BEFORE Phase 1 Q&A section (in Entry HARD-GATE area)', () => {
-    const bdCreateIndex = planContent.indexOf('bd create --title=');
+  test('forge create appears BEFORE Phase 1 Q&A section (in Entry HARD-GATE area)', () => {
+    const createIndex = planContent.indexOf('forge create --title=');
     const phase1HeadingIndex = planContent.indexOf('## Phase 1: Design Intent');
 
-    expect(bdCreateIndex).not.toBe(-1);
+    expect(createIndex).not.toBe(-1);
     expect(phase1HeadingIndex).not.toBe(-1);
-    expect(bdCreateIndex).toBeLessThan(phase1HeadingIndex);
+    expect(createIndex).toBeLessThan(phase1HeadingIndex);
   });
 
-  test('bd create uses --type=epic (not --type=feature)', () => {
+  test('forge create uses --type=epic (not --type=feature)', () => {
     // The early creation should be an epic
     const entryGateEnd = planContent.indexOf('## Phase 1: Design Intent');
     const entrySection = planContent.slice(0, entryGateEnd);
 
-    expect(entrySection).toMatch(/bd create\b.*--type=epic/);
+    expect(entrySection).toMatch(/forge create\b.*--type=epic/);
   });
 
   test('stage-transition with "none plan" appears at Phase 1 entry', () => {
@@ -52,11 +52,11 @@ describe('/plan phase tracking', () => {
     const step2Index = planContent.indexOf('### Step 2:', phase3Index);
     const step1Section = planContent.slice(phase3Index, step2Index);
 
-    // Should NOT have a standalone bd create for the main epic (without --parent)
-    expect(step1Section).not.toMatch(/bd create\b.*--type=epic/);
+    // Should NOT have a standalone forge create for the main epic (without --parent)
+    expect(step1Section).not.toMatch(/forge create\b.*--type=epic/);
 
-    // Any bd create in Step 1 should use --parent (child issue linking)
-    const step1Creates = step1Section.match(/bd create\b[^\n]*/g);
+    // Any forge create in Step 1 should use --parent (child issue linking)
+    const step1Creates = step1Section.match(/forge create\b[^\n]*/g);
     if (step1Creates) {
       for (const match of step1Creates) {
         expect(match).toContain('--parent');
@@ -67,17 +67,17 @@ describe('/plan phase tracking', () => {
     expect(step1Section).toMatch(/epic/i);
   });
 
-  test('bd create in Phase 3 is for child issues (--parent), not the main epic', () => {
+  test('forge create in Phase 3 is for child issues (--parent), not the main epic', () => {
     const phase3Index = planContent.indexOf('## Phase 3: Setup + Task List');
     const phase3Content = planContent.slice(phase3Index);
 
-    // Phase 3 should NOT have a standalone bd create --type=epic
-    expect(phase3Content).not.toMatch(/bd create\b.*--type=epic/);
+    // Phase 3 should NOT have a standalone forge create --type=epic
+    expect(phase3Content).not.toMatch(/forge create\b.*--type=epic/);
 
-    // Any bd create in Phase 3 should reference --parent (linking to epic)
-    const bdCreateMatches = phase3Content.match(/bd create\b[^\n]*/g);
-    if (bdCreateMatches) {
-      for (const match of bdCreateMatches) {
+    // Any forge create in Phase 3 should reference --parent (linking to epic)
+    const createMatches = phase3Content.match(/forge create\b[^\n]*/g);
+    if (createMatches) {
+      for (const match of createMatches) {
         expect(match).toContain('--parent');
       }
     }

--- a/test/copilot-config-generation.test.js
+++ b/test/copilot-config-generation.test.js
@@ -37,7 +37,7 @@ describe('GitHub Copilot config generation', () => {
 
     // Should include Forge workflow
     expect(content.includes('Forge')).toBeTruthy();
-    expect(content.includes('7-Stage') || content.includes('7 Stage')).toBeTruthy();
+    expect(content.includes('TDD Workflow Template')).toBeTruthy();
 
     // Should include all workflow stages
     expect(content.includes('/status')).toBeTruthy();

--- a/test/cursor-config-generation.test.js
+++ b/test/cursor-config-generation.test.js
@@ -38,9 +38,9 @@ describe('Cursor config generation', () => {
     expect(content.includes('alwaysApply:')).toBeTruthy();
     expect(content.includes('alwaysApply: true')).toBeTruthy();
 
-    // Should include 7-stage workflow
+    // Should include the Forge workflow template
     expect(content.includes('Forge')).toBeTruthy();
-    expect(content.includes('7-Stage') || content.includes('7 Stage')).toBeTruthy();
+    expect(content.includes('TDD Workflow Template')).toBeTruthy();
     expect(content.includes('/status')).toBeTruthy();
     expect(content.includes('/plan')).toBeTruthy();
     expect(content.includes('/dev')).toBeTruthy();
@@ -223,6 +223,6 @@ describe('Cursor config generation', () => {
     const workflowContent = await fs.promises.readFile(workflowPath, 'utf-8');
     expect(workflowContent).toContain('/plan');
     expect(workflowContent).toContain('/validate');
-    expect(workflowContent).toContain('Forge 7-Stage TDD Workflow');
+    expect(workflowContent).toContain('Forge TDD Workflow Template');
   });
 });

--- a/test/e2e/setup-workflow.test.js
+++ b/test/e2e/setup-workflow.test.js
@@ -276,7 +276,7 @@ describe('E2E: Full setup workflow', () => {
       );
 
       expect(content).not.toBe(existingContent);
-      expect(content.includes('Forge 7-Stage TDD Workflow')).toBeTruthy();
+      expect(content.includes('Forge TDD Workflow Template')).toBeTruthy();
     });
   });
 

--- a/test/forge-uto/task5-stage-count.test.js
+++ b/test/forge-uto/task5-stage-count.test.js
@@ -6,23 +6,24 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '../../');
 
-describe('Task 5: Stage count update', () => {
+describe('Task 5: workflow template language', () => {
   const src = fs.readFileSync(path.join(root, 'bin/forge.js'), 'utf8');
 
   test('bin/forge.js does not contain "9-stage"', () => {
     expect(src).not.toContain('9-stage');
   });
 
-  test('bin/forge.js contains "7-stage"', () => {
-    expect(src).toContain('7-stage');
+  test('bin/forge.js does not advertise a fixed 7-stage product identity', () => {
+    expect(src).not.toContain('7-stage TDD-first workflow');
   });
 
-  test('SKILL_CONTENT heading says ## 7 Stages not ## 9 Stages', () => {
+  test('SKILL_CONTENT heading says ## Default Workflow Template not fixed stages', () => {
     expect(src).not.toContain('## 9 Stages');
-    expect(src).toContain('## 7 Stages');
+    expect(src).not.toContain('## 7 Stages');
+    expect(src).toContain('## Default Workflow Template');
   });
 
-  test('SKILL_CONTENT workflow flow uses 7-stage commands', () => {
+  test('SKILL_CONTENT workflow composition keeps command order as default template', () => {
     expect(src).not.toContain('/status -> /research -> /plan');
     expect(src).toContain('/status -> /plan -> /dev');
   });
@@ -31,8 +32,9 @@ describe('Task 5: Stage count update', () => {
     expect(src).not.toContain('OpenSpec if strategic');
   });
 
-  test('CURSOR_RULE description says 7-Stage not 9-Stage', () => {
+  test('CURSOR_RULE description uses template language', () => {
     expect(src).not.toContain('Forge 9-Stage TDD Workflow');
-    expect(src).toContain('Forge 7-Stage TDD Workflow');
+    expect(src).not.toContain('Forge 7-Stage TDD Workflow');
+    expect(src).toContain('Forge TDD Workflow Template');
   });
 });

--- a/test/other-agents-config-generation.test.js
+++ b/test/other-agents-config-generation.test.js
@@ -33,7 +33,7 @@ describe('Kilo Code config generation', () => {
 
     const content = await fs.promises.readFile(workflowPath, 'utf-8');
     expect(content.includes('Forge')).toBeTruthy();
-    expect(content.includes('7-Stage') || content.includes('7 Stage')).toBeTruthy();
+    expect(content.includes('TDD Workflow Template')).toBeTruthy();
     expect(content.includes('/status')).toBeTruthy();
     expect(content.includes('/plan')).toBeTruthy();
     expect(content.includes('/dev')).toBeTruthy();

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -427,6 +427,28 @@ describe('runtime health checks', () => {
     });
   });
 
+  test('configured hooksPath rejects Forge hook paths stored in variable assignments', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'HOOK=.forge/hooks/check-tdd.js\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'HOOK=check-tdd.js\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
+  });
+
   test('configured hooksPath ignores comments and echo-only Beads hook mentions', () => {
     const projectRoot = createProjectRoot();
     const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
@@ -456,6 +478,28 @@ describe('runtime health checks', () => {
     fs.mkdirSync(hooksDir, { recursive: true });
     fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'cat <<EOF\nbd hooks run pre-commit\nEOF\n');
     fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'cat <<EOF\nbd hooks run pre-push\nEOF\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
+  });
+
+  test('configured hooksPath rejects hook mentions in quoted heredoc text', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), "cat <<'EOF'\nbd hooks run pre-commit\nEOF\n");
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'cat <<"EOF"\n.forge/hooks/check-tdd.js\nEOF\n');
 
     const result = checkRuntimeHealth(projectRoot, {
       _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -339,6 +339,28 @@ describe('runtime health checks', () => {
     });
   });
 
+  test('configured hooksPath ignores comments and echo-only Beads hook mentions', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '# bd hooks run pre-commit\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'echo bd hooks run pre-push\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
+  });
+
   test('configured hooksPath accepts Beads-managed hook entries that chain to Lefthook', () => {
     const projectRoot = createProjectRoot();
     const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -361,6 +361,28 @@ describe('runtime health checks', () => {
     });
   });
 
+  test('configured hooksPath accepts Forge hook execution commands', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'node .forge/hooks/check-tdd.js pre-commit "$@"\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), '.forge/hooks/check-tdd.js pre-push "$@"\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(false);
+    expect(result.checks.hooks.active).toBe(true);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'forge',
+      'pre-push': 'forge'
+    });
+  });
+
   test('configured hooksPath rejects Forge hook paths used only in file tests', () => {
     const projectRoot = createProjectRoot();
     const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
@@ -368,6 +390,28 @@ describe('runtime health checks', () => {
     fs.mkdirSync(hooksDir, { recursive: true });
     fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'if [ -f .forge/hooks/check-tdd.js ]; then echo present; fi\n');
     fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'test -x check-tdd.js && echo present\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
+  });
+
+  test('configured hooksPath rejects Forge hook paths passed to non-executing commands', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'cat .forge/hooks/check-tdd.js\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'ls .forge/hooks/check-tdd.js\n');
 
     const result = checkRuntimeHealth(projectRoot, {
       _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -317,6 +317,76 @@ describe('runtime health checks', () => {
     );
   });
 
+  test('configured hooksPath accepts Beads-managed hook entries that chain to Lefthook', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    const beadsHooksDir = path.join(projectRoot, '.beads', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.mkdirSync(beadsHooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '#!/usr/bin/env sh\nbd hooks run pre-commit "$@"\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), '#!/usr/bin/env sh\nbd hooks run pre-push "$@"\n');
+    fs.writeFileSync(path.join(beadsHooksDir, 'pre-commit'), '#!/usr/bin/env sh\nlefthook run pre-commit "$@"\n');
+    fs.writeFileSync(path.join(beadsHooksDir, 'pre-push'), '#!/usr/bin/env sh\nlefthook run pre-push "$@"\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(false);
+    expect(result.checks.hooks.active).toBe(true);
+    expect(result.checks.hooks.missingHooks).toEqual([]);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'beads->lefthook',
+      'pre-push': 'beads->lefthook'
+    });
+  });
+
+  test('configured hooksPath rejects pure Beads hook entries when Forge enforcement is unverified', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '#!/usr/bin/env sh\nbd hooks run pre-commit "$@"\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), '#!/usr/bin/env sh\nbd hooks run pre-push "$@"\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'beads-unverified',
+      'pre-push': 'beads-unverified'
+    });
+  });
+
+  test('configured Beads hooksPath is accepted when hook files chain to Lefthook', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.beads', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '#!/usr/bin/env sh\nlefthook run pre-commit "$@"\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), '#!/usr/bin/env sh\nlefthook run pre-push "$@"\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.beads/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(false);
+    expect(result.checks.hooks.active).toBe(true);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'lefthook',
+      'pre-push': 'lefthook'
+    });
+  });
+
   test('relative lefthook hooksPath is resolved from the git root', () => {
     const projectRoot = createProjectRoot();
     const nestedRoot = path.join(projectRoot, 'packages', 'api');

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -339,6 +339,50 @@ describe('runtime health checks', () => {
     });
   });
 
+  test('configured hooksPath accepts enforcement after echo preamble', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'echo "running" && lefthook run pre-commit "$@"\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'printf "running" && lefthook run pre-push "$@"\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(false);
+    expect(result.checks.hooks.active).toBe(true);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'lefthook',
+      'pre-push': 'lefthook'
+    });
+  });
+
+  test('configured hooksPath rejects Forge hook paths used only in file tests', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'if [ -f .forge/hooks/check-tdd.js ]; then echo present; fi\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'test -x check-tdd.js && echo present\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
+  });
+
   test('configured hooksPath ignores comments and echo-only Beads hook mentions', () => {
     const projectRoot = createProjectRoot();
     const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -282,8 +282,8 @@ describe('runtime health checks', () => {
 
   test('Windows hook-path comparisons are case-insensitive', () => {
     const projectRoot = createProjectRoot();
-    const windowsRoot = projectRoot.replace(/\//g, '\\').toUpperCase();
-    const hooksPath = `${windowsRoot}\\.LEFTHOOK\\HOOKS`;
+    const hooksPath = '.LEFTHOOK\\HOOKS';
+    writeLefthookEntries(projectRoot, path.join(projectRoot, '.LEFTHOOK', 'HOOKS'));
 
     const result = checkRuntimeHealth(projectRoot, {
       _exec: createExecStub({ hooksPath }),
@@ -315,6 +315,28 @@ describe('runtime health checks', () => {
         missingHooks: ['pre-commit', 'pre-push']
       })
     );
+  });
+
+  test('configured lefthook hooksPath ignores comments and echo-only mentions', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '# managed by lefthook\necho check-tdd.js missing\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), '# lefthook run pre-push\necho lefthook\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
   });
 
   test('configured hooksPath accepts Beads-managed hook entries that chain to Lefthook', () => {

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -449,6 +449,50 @@ describe('runtime health checks', () => {
     });
   });
 
+  test('configured hooksPath rejects Beads hook mentions in heredoc text', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'cat <<EOF\nbd hooks run pre-commit\nEOF\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'cat <<EOF\nbd hooks run pre-push\nEOF\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
+  });
+
+  test('configured hooksPath rejects Beads hook paths passed to non-executing commands', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'cat bd hooks run pre-commit\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'ls bd hooks run pre-push\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(true);
+    expect(result.checks.hooks.active).toBe(false);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'unknown',
+      'pre-push': 'unknown'
+    });
+  });
+
   test('configured hooksPath accepts Beads-managed hook entries that chain to Lefthook', () => {
     const projectRoot = createProjectRoot();
     const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -449,6 +449,31 @@ describe('runtime health checks', () => {
     });
   });
 
+  test('configured hooksPath accepts env-prefixed hook execution commands', () => {
+    const projectRoot = createProjectRoot();
+    const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');
+    const beadsHooksDir = path.join(projectRoot, '.beads', 'hooks');
+    fs.rmSync(hooksDir, { recursive: true, force: true });
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.mkdirSync(beadsHooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), 'FORGE_ENV=1 .forge/hooks/check-tdd.js\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), 'BEADS_ENV=1 bd hooks run pre-push "$@"\n');
+    fs.writeFileSync(path.join(beadsHooksDir, 'pre-push'), 'lefthook run pre-push "$@"\n');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.lefthook/hooks' }),
+      platform: 'win32',
+      shellRuntime: { available: true, command: 'C:\\Program Files\\Git\\bin\\bash.exe', policy: 'git-bash' }
+    });
+
+    expect(result.hardStop).toBe(false);
+    expect(result.checks.hooks.active).toBe(true);
+    expect(result.checks.hooks.providers).toEqual({
+      'pre-commit': 'forge',
+      'pre-push': 'beads->lefthook'
+    });
+  });
+
   test('configured hooksPath ignores comments and echo-only Beads hook mentions', () => {
     const projectRoot = createProjectRoot();
     const hooksDir = path.join(projectRoot, '.lefthook', 'hooks');

--- a/test/scripts/github-beads-sync/index.test.js
+++ b/test/scripts/github-beads-sync/index.test.js
@@ -255,6 +255,51 @@ describe('handleOpened', () => {
     expect(createOrEditCalls[0].body).toContain('forge-existing');
   });
 
+  it('ignores stale sync comments that reference a different GitHub issue number', async () => {
+    const bdCreateCalls = [];
+    const upsertCanonicalLinkCalls = [];
+    const createOrEditCalls = [];
+    const opts = makeOptions({
+      bd: {
+        bdCreate: (o) => {
+          bdCreateCalls.push(o);
+          return 'forge-new';
+        },
+      },
+      github: {
+        findSyncComment: () => ({
+          id: 7,
+          body: buildComment('forge-stale', 99, {
+            type: 'bug',
+            priority: 1,
+            externalRef: 'gh-99',
+          }),
+        }),
+        createOrEditComment: (owner, repo, num, body) => {
+          createOrEditCalls.push({ owner, repo, num, body });
+        },
+      },
+      linkStore: {
+        resolveCanonicalLink: () => null,
+        upsertCanonicalLink: (record) => {
+          upsertCanonicalLinkCalls.push(record);
+          return record;
+        },
+      },
+    });
+
+    const result = await handleOpened(makeOpenedEvent(), opts);
+
+    expect(result.success).toBe(true);
+    expect(result.beadsId).toBe('forge-new');
+    expect(bdCreateCalls).toHaveLength(1);
+    expect(upsertCanonicalLinkCalls).toHaveLength(1);
+    expect(upsertCanonicalLinkCalls[0].forgeIssueId).toBe('forge-new');
+    expect(createOrEditCalls).toHaveLength(1);
+    expect(createOrEditCalls[0].body).toContain('forge-new');
+    expect(createOrEditCalls[0].body).not.toContain('forge-stale');
+  });
+
   it('throws when the legacy mapping file contains malformed JSON', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'forge-nlgg-'));
     const mappingPath = join(tempDir, 'beads-mapping.json');

--- a/test/scripts/sync-commands.test.js
+++ b/test/scripts/sync-commands.test.js
@@ -25,6 +25,20 @@ describe('parseFrontmatter', () => {
     expect(result.body).toBe('Some body text');
   });
 
+  test('handles UTF-8 BOM before frontmatter', () => {
+    const input = '\uFEFF---\ndescription: Check current stage\n---\nSome body text';
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toEqual({ description: 'Check current stage' });
+    expect(result.body).toBe('Some body text');
+  });
+
+  test('strips UTF-8 BOM from body after frontmatter', () => {
+    const input = '---\ndescription: Check current stage\n---\n\uFEFFSome body text';
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toEqual({ description: 'Check current stage' });
+    expect(result.body).toBe('Some body text');
+  });
+
   test('handles multiple frontmatter keys', () => {
     const input = '---\ndescription: Plan a feature\nallowed_agents: claude\n---\nbody here';
     const result = parseFrontmatter(input);

--- a/test/structural/command-contracts.test.js
+++ b/test/structural/command-contracts.test.js
@@ -97,30 +97,21 @@ describe('Contract: /ship creates PR -> /review references PR', () => {
   });
 });
 
-// ─── Contract 5: All 7 workflow commands have correct stage numbers ─────────
+// Contract 5: workflow commands use configurable template language
 
-describe('Contract: all 7 workflow commands reference correct stage numbers', () => {
+describe('Contract: workflow commands use configurable template language', () => {
   /**
-   * Each workflow command file must contain an "Integration with Workflow"
-   * section that assigns the correct stage number to each command:
-   *   plan=1, dev=2, validate=3, ship=4, review=5, premerge=6, verify=7
+   * v3 treats the historical 7-stage ladder as one default template over
+   * runtime building blocks. Command docs must not reintroduce hardcoded
+   * Stage N gate language.
    */
-  const expectedStages = [
-    { command: 'plan', stage: 1 },
-    { command: 'dev', stage: 2 },
-    { command: 'validate', stage: 3 },
-    { command: 'ship', stage: 4 },
-    { command: 'review', stage: 5 },
-    { command: 'premerge', stage: 6 },
-    { command: 'verify', stage: 7 },
-  ];
+  const workflowCommands = ['plan', 'dev', 'validate', 'ship', 'review', 'premerge', 'verify'];
 
-  for (const { command, stage } of expectedStages) {
-    test(`${command}.md assigns Stage ${stage} to /${command}`, () => {
+  for (const command of workflowCommands) {
+    test(`${command}.md references the default template without Stage N numbering`, () => {
       const content = readCommand(`${command}.md`);
-      // Match pattern like "Stage 3: /validate" allowing flexible whitespace
-      const pattern = new RegExp(`Stage\\s+${stage}:\\s+/${command}\\b`);
-      expect(pattern.test(content)).toBeTruthy();
+      expect(content).toContain('Default template:');
+      expect(content).not.toMatch(/Stage\s+[1-7]:/);
     });
   }
 });

--- a/test/structural/command-contracts.test.js
+++ b/test/structural/command-contracts.test.js
@@ -111,7 +111,7 @@ describe('Contract: workflow commands use configurable template language', () =>
     test(`${command}.md references the default template without Stage N numbering`, () => {
       const content = readCommand(`${command}.md`);
       expect(content).toContain('Default template:');
-      expect(content).not.toMatch(/Stage\s+[1-7]:/);
+      expect(content).not.toMatch(/\bStage\s+[1-7]\b\s*(?::|-|--|->|—|–)?/);
     });
   }
 });

--- a/test/structural/command-files.test.js
+++ b/test/structural/command-files.test.js
@@ -198,7 +198,7 @@ describe('dead reference checks', () => {
     expect(hits).toEqual([]);
   });
 
-  test('no command file references "9-stage" or "nine stage" (now 7 stages)', () => {
+  test('no command file references "9-stage" or "nine stage"', () => {
     const hits = findMatches(/9-stage|nine.stage/i);
     expect(hits).toEqual([]);
   });

--- a/test/workflow-profiles.test.js
+++ b/test/workflow-profiles.test.js
@@ -29,7 +29,7 @@ describe('workflow-profiles', () => {
       expect(PROFILES.critical.tdd).toBe('strict');
     });
 
-    test('standard profile should have 7 stages', () => {
+    test('standard profile should include the default command template', () => {
       expect(PROFILES.standard.stages.length).toBe(7);
       expect(PROFILES.standard.stages.includes('/status')).toBeTruthy();
       expect(PROFILES.standard.stages.includes('/plan')).toBeTruthy();


### PR DESCRIPTION
## Problem
Forge v3 planning had conceptually moved to composable workflow building blocks, but active runtime docs, generated agent surfaces, setup templates, and tests still encoded the old mandatory fixed-stage model. `/validate` also failed on valid Beads-managed hook setups because runtime health could not distinguish Beads shims that chain into Forge/Lefthook enforcement from unverified pure Beads hooks.

## Root Cause
The boundary between Forge, Beads, and downstream projects was still mixed across three surfaces: Beads was treated as workflow authority in some docs, Forge wrapper commands were bypassed in agent instructions, and hook detection assumed only one Lefthook path. GitHub-to-Beads sync also trusted an existing sync comment without verifying it belonged to the current GitHub issue.

## Fix
This PR aligns the active docs, generated command/skill surfaces, setup templates, and test contracts around Forge as a composable TDD workflow template over runtime building blocks. It updates runtime hook classification to accept verified Beads-to-Lefthook chains while rejecting unverified Beads hook stubs, and it adds a stale sync-comment guard for GitHub-to-Beads issue creation.

## Value
Downstream Forge projects get clearer ownership boundaries: Beads remains durable issue state, Forge remains the workflow/runtime wrapper, and generated agent instructions no longer force the old mandatory `/plan`/fixed-stage ladder. The `/validate` false failure path is covered by tests so it should not regress.

## Beads
Closes forge-besw.24

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 3084 passing, 58 skipped, 0 failing
- Scenarios covered: Beads-managed hooks chaining into Lefthook, pure unverified Beads hooks rejected, configured `.beads/hooks` accepted when it chains, stale GitHub sync comments ignored, generated command docs use configurable template language, setup templates and agent configs avoid fixed-stage product identity.

### Security Review
- OWASP Top 10: No new externally exposed runtime surface; command execution paths remain existing CLI/GitHub/Beads wrappers. Hook classification avoids trusting unverified hook shims.
- Automated scan: `bun audit` passed with no vulnerabilities.

### Design Doc
See: `docs/work/2026-04-28-skeleton-pivot/runtime-building-blocks-refinement.md`

### Key Decisions
- Treat skills as composable super-skill/sub-skill building blocks rather than always-on mandatory stages.
- Keep Beads as durable issue-state authority and Forge as the workflow/runtime wrapper and local adapter.
- Accept Beads hook stubs only when they can be traced into real Forge/Lefthook enforcement.
- Keep generated agent surfaces synced from canonical command docs and enforce the new language through structural tests.

### Documentation Updated
`AGENTS.md`, `CLAUDE.md`, `README.md`, setup/validation guides, v3 planning docs, and generated command/skill surfaces for Claude, Codex, Cursor, Cline, GitHub Copilot, Kilo Code, OpenCode, and Roo.

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff locally
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun test --timeout 15000`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source/runtime changes have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for composable workflow templates with configurable command sequences instead of a fixed 7-stage pipeline.
  * Enabled partial planning invocations via new `--only=critics` and `--only=lock` flags for the `/plan` command.

* **Documentation**
  * Restructured workflow guides to emphasize template-based command flows with "Default template" and "Manual/support surfaces" sections.
  * Updated workflow commands to reflect current tooling and terminology across all documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->