### PR TITLE
0.0.12 runtime graph contract

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
 reviews:
   auto_review:
-    enabled: false
-    auto_incremental_review: false
+    enabled: true
+    auto_incremental_review: true

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
   "overrides": {
     "brace-expansion": "5.0.5",
     "eslint": "^10.0.2",
+    "fast-uri": "^3.1.2",
     "flatted": "3.4.2",
     "lodash": "4.18.1",
     "minimatch": "10.2.4",
@@ -367,7 +368,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
 

--- a/docs/work/2026-05-11-0.0.12-runtime-graph/design.md
+++ b/docs/work/2026-05-11-0.0.12-runtime-graph/design.md
@@ -1,0 +1,62 @@
+# Feature: 0.0.12 Runtime Graph Contract
+
+Date: 2026-05-11
+Status: in progress
+Issue: forge-besw.1
+
+## Purpose
+
+Publish the first runtime graph contract for Forge 0.0.12 so the current command workflow can be represented as composable runtime building blocks instead of a stage-only contract.
+
+## Success Criteria
+
+- Runtime graph primitives exist under `lib/core/`: Phase, Action, Artifact, EvaluatorRegion, Gate, and Evidence.
+- A versioned JSON schema/envelope is published for runtime graph artifacts.
+- The current command flow is represented as a resolved graph.
+- `forge migrate --dry-run` can print the resolved graph without writing files.
+- Tests prove the current command docs/flow can be represented by the graph.
+
+## Out of Scope
+
+- L1 rails.
+- Config loading.
+- Options API.
+- Protected paths.
+- Init behavior.
+- Install profiles.
+- Audit persistence.
+- Behavior rewrites of existing commands.
+
+## Approach Selected
+
+Add a small CommonJS runtime contract module under `lib/core/runtime-graph.js`, export a static schema envelope and a resolved graph for the existing command workflow, and include that graph in the existing migrate dry-run report. This keeps the PR as extraction and reporting only.
+
+## Constraints
+
+- Preserve existing migrate dry-run behavior and report status.
+- Keep graph data deterministic and side-effect free.
+- Reuse `.claude/commands/*.md` as the compatibility surface for current command docs.
+- Do not introduce runtime config loading or user-selectable options.
+
+## Edge Cases
+
+- Missing command docs should be surfaced by tests, not hidden by graph generation.
+- Dry-run rendering must keep the existing mutation guard.
+- The graph envelope must remain serializable as JSON.
+
+## Ambiguity Policy
+
+Use the 7-dimension `/dev` decision gate. Proceed only for local representation choices that do not alter public behavior. Stop for user input if a choice changes command behavior, adds config loading, or touches persistence.
+
+## Technical Research
+
+- Existing dry-run proof path is `lib/migrate-dry-run.js`, with `buildMigrationDryRunReport` and `renderMigrationDryRunReport`.
+- Existing migrate command is `lib/commands/migrate.js`, which only supports `forge migrate --dry-run`.
+- Current command docs are `.claude/commands/plan.md`, `.claude/commands/dev.md`, `.claude/commands/validate.md`, and `.claude/commands/ship.md`.
+- Existing validation scripts are `bun run typecheck`, `bun run lint`, `bun test`, and `node scripts/validate.js`.
+
+## TDD Scenarios
+
+- Happy path: the resolved graph exposes all six primitives and the plan/dev/validate/ship command flow.
+- Compatibility path: every command represented by the graph has a matching `.claude/commands/<command>.md` doc.
+- Dry-run path: migrate dry-run output prints the resolved runtime graph and still preserves the mutation guard.

--- a/docs/work/2026-05-11-0.0.12-runtime-graph/tasks.md
+++ b/docs/work/2026-05-11-0.0.12-runtime-graph/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: 0.0.12 Runtime Graph Contract
+
+Issue: forge-besw.1
+
+## Task 1: Runtime graph contract module
+
+OWNS: `lib/core/runtime-graph.js`, `test/runtime-graph.test.js`
+
+File(s): `lib/core/runtime-graph.js`, `test/runtime-graph.test.js`
+
+What to implement: Define Phase, Action, Artifact, EvaluatorRegion, Gate, and Evidence primitives; publish a versioned JSON schema/envelope; export a resolved graph for the current command flow.
+
+TDD steps:
+1. Write test: `test/runtime-graph.test.js` asserts the exported graph includes all six primitive collections and the plan/dev/validate/ship flow.
+2. Run test: confirm it fails because `lib/core/runtime-graph.js` does not exist.
+3. Implement: add `lib/core/runtime-graph.js`.
+4. Run test: confirm it passes.
+5. Commit: `feat: add runtime graph contract`
+
+Expected output: targeted runtime graph tests pass.
+
+## Task 2: Command-doc compatibility tests
+
+OWNS: `test/runtime-graph.test.js`
+
+File(s): `test/runtime-graph.test.js`
+
+What to implement: Prove every command node represented in the graph has a matching command doc in `.claude/commands/`.
+
+TDD steps:
+1. Write test: assert command action IDs map to existing `.claude/commands/<command>.md` files.
+2. Run test: confirm it fails before graph command actions exist.
+3. Implement: include command actions in the resolved graph.
+4. Run test: confirm it passes.
+5. Commit: `test: cover runtime graph command docs`
+
+Expected output: command-doc compatibility test passes.
+
+## Task 3: Migrate dry-run runtime graph proof
+
+OWNS: `lib/migrate-dry-run.js`, `test/migrate-dry-run.test.js`
+
+File(s): `lib/migrate-dry-run.js`, `test/migrate-dry-run.test.js`
+
+What to implement: Reuse the existing migrate dry-run report path to print the resolved runtime graph without side effects.
+
+TDD steps:
+1. Write test: assert `renderMigrationDryRunReport(buildMigrationDryRunReport(...))` contains runtime graph phases/actions/artifacts/evaluator regions/gates/evidence.
+2. Run test: confirm it fails before dry-run rendering includes the graph.
+3. Implement: attach the runtime graph envelope to the dry-run report and render a compact graph summary.
+4. Run test: confirm it passes and existing dry-run tests still pass.
+5. Commit: `feat: print runtime graph in migrate dry-run`
+
+Expected output: migrate dry-run tests pass and output includes the graph summary.

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -219,7 +219,7 @@ const RESOLVED_RUNTIME_GRAPH = {
       id: 'gate.ship-entry',
       phase: 'ship',
       label: '/ship entry',
-      requires: ['artifact.validation-output', 'artifact.pull-request'],
+      requires: ['artifact.validation-output'],
     }),
   ],
   evidence: [

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -1,0 +1,286 @@
+'use strict';
+
+const RUNTIME_GRAPH_SCHEMA_VERSION = '0.0.12';
+
+const RUNTIME_GRAPH_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://forge.local/schemas/runtime-graph-0.0.12.json',
+  title: 'Forge Runtime Graph Artifact',
+  type: 'object',
+  required: ['schemaVersion', 'kind', 'graph'],
+  properties: {
+    schemaVersion: { const: RUNTIME_GRAPH_SCHEMA_VERSION },
+    kind: { const: 'forge.runtimeGraph' },
+    graph: {
+      type: 'object',
+      required: [
+        'primitives',
+        'phases',
+        'actions',
+        'artifacts',
+        'evaluatorRegions',
+        'gates',
+        'evidence',
+        'edges',
+      ],
+    },
+  },
+};
+
+function Phase({ id, label, command, actions, artifacts, gates, evidence }) {
+  return { id, label, command, actions, artifacts, gates, evidence };
+}
+
+function Action({ id, kind, command, label, reads = [], writes = [], evidence = [] }) {
+  return { id, kind, command, label, reads, writes, evidence };
+}
+
+function Artifact({ id, kind, path, description }) {
+  return { id, kind, path, description };
+}
+
+function EvaluatorRegion({ id, label, phase, description }) {
+  return { id, label, phase, description };
+}
+
+function Gate({ id, phase, label, requires }) {
+  return { id, phase, label, requires };
+}
+
+function Evidence({ id, kind, source, description }) {
+  return { id, kind, source, description };
+}
+
+const RESOLVED_RUNTIME_GRAPH = {
+  id: 'forge.runtimeGraph.currentCommandFlow',
+  version: RUNTIME_GRAPH_SCHEMA_VERSION,
+  description: 'Resolved graph for the current /plan -> /dev -> /validate -> /ship command flow.',
+  primitives: {
+    Phase: 'phases',
+    Action: 'actions',
+    Artifact: 'artifacts',
+    EvaluatorRegion: 'evaluatorRegions',
+    Gate: 'gates',
+    Evidence: 'evidence',
+  },
+  phases: [
+    Phase({
+      id: 'plan',
+      label: '/plan',
+      command: 'plan',
+      actions: ['action.plan.command'],
+      artifacts: ['artifact.design-doc', 'artifact.task-list'],
+      gates: ['gate.plan-exit'],
+      evidence: ['evidence.command-docs'],
+    }),
+    Phase({
+      id: 'dev',
+      label: '/dev',
+      command: 'dev',
+      actions: ['action.dev.command'],
+      artifacts: ['artifact.changed-files'],
+      gates: ['gate.dev-exit'],
+      evidence: ['evidence.tdd-tests'],
+    }),
+    Phase({
+      id: 'validate',
+      label: '/validate',
+      command: 'validate',
+      actions: ['action.validate.command'],
+      artifacts: ['artifact.validation-output'],
+      gates: ['gate.validate-exit'],
+      evidence: ['evidence.validation-output'],
+    }),
+    Phase({
+      id: 'ship',
+      label: '/ship',
+      command: 'ship',
+      actions: ['action.ship.command'],
+      artifacts: ['artifact.pull-request'],
+      gates: ['gate.ship-entry'],
+      evidence: ['evidence.dry-run-report'],
+    }),
+  ],
+  actions: [
+    Action({
+      id: 'action.plan.command',
+      kind: 'command',
+      command: 'plan',
+      label: 'Capture design intent and task list',
+      writes: ['artifact.design-doc', 'artifact.task-list'],
+      evidence: ['evidence.command-docs'],
+    }),
+    Action({
+      id: 'action.dev.command',
+      kind: 'command',
+      command: 'dev',
+      label: 'Implement tasks with TDD evidence',
+      reads: ['artifact.design-doc', 'artifact.task-list'],
+      writes: ['artifact.changed-files'],
+      evidence: ['evidence.tdd-tests'],
+    }),
+    Action({
+      id: 'action.validate.command',
+      kind: 'command',
+      command: 'validate',
+      label: 'Run type, lint, test, and security checks',
+      reads: ['artifact.changed-files'],
+      writes: ['artifact.validation-output'],
+      evidence: ['evidence.validation-output'],
+    }),
+    Action({
+      id: 'action.ship.command',
+      kind: 'command',
+      command: 'ship',
+      label: 'Push branch and open a pull request',
+      reads: ['artifact.validation-output'],
+      writes: ['artifact.pull-request'],
+      evidence: ['evidence.dry-run-report'],
+    }),
+  ],
+  artifacts: [
+    Artifact({
+      id: 'artifact.design-doc',
+      kind: 'markdown',
+      path: 'docs/work/YYYY-MM-DD-<slug>/design.md',
+      description: 'Design intent, constraints, and research.',
+    }),
+    Artifact({
+      id: 'artifact.task-list',
+      kind: 'markdown',
+      path: 'docs/work/YYYY-MM-DD-<slug>/tasks.md',
+      description: 'TDD task list consumed by /dev.',
+    }),
+    Artifact({
+      id: 'artifact.changed-files',
+      kind: 'git-diff',
+      path: '<worktree>',
+      description: 'Source and test changes produced during /dev.',
+    }),
+    Artifact({
+      id: 'artifact.validation-output',
+      kind: 'terminal-output',
+      path: '<session>',
+      description: 'Fresh validation command output.',
+    }),
+    Artifact({
+      id: 'artifact.pull-request',
+      kind: 'github-pr',
+      path: '<pr-url>',
+      description: 'Pull request created by /ship.',
+    }),
+  ],
+  evaluatorRegions: [
+    EvaluatorRegion({
+      id: 'evaluator.plan-entry',
+      label: 'Plan entry and exit gates',
+      phase: 'plan',
+      description: 'Checks worktree isolation, design artifacts, and task handoff.',
+    }),
+    EvaluatorRegion({
+      id: 'evaluator.tdd-loop',
+      label: 'TDD implementation loop',
+      phase: 'dev',
+      description: 'Checks RED/GREEN/REFACTOR evidence and task completion.',
+    }),
+    EvaluatorRegion({
+      id: 'evaluator.validation-suite',
+      label: 'Validation suite',
+      phase: 'validate',
+      description: 'Checks type, lint, tests, and security scan evidence.',
+    }),
+    EvaluatorRegion({
+      id: 'evaluator.ship-readiness',
+      label: 'Ship readiness',
+      phase: 'ship',
+      description: 'Checks branch freshness, PR body, and issue linkage.',
+    }),
+  ],
+  gates: [
+    Gate({
+      id: 'gate.plan-exit',
+      phase: 'plan',
+      label: '/plan exit',
+      requires: ['artifact.design-doc', 'artifact.task-list', 'evidence.command-docs'],
+    }),
+    Gate({
+      id: 'gate.dev-exit',
+      phase: 'dev',
+      label: '/dev exit',
+      requires: ['artifact.changed-files', 'evidence.tdd-tests'],
+    }),
+    Gate({
+      id: 'gate.validate-exit',
+      phase: 'validate',
+      label: '/validate exit',
+      requires: ['artifact.validation-output', 'evidence.validation-output'],
+    }),
+    Gate({
+      id: 'gate.ship-entry',
+      phase: 'ship',
+      label: '/ship entry',
+      requires: ['artifact.validation-output', 'artifact.pull-request'],
+    }),
+  ],
+  evidence: [
+    Evidence({
+      id: 'evidence.command-docs',
+      kind: 'checked-in-doc',
+      source: '.claude/commands/*.md',
+      description: 'Command docs define the compatibility surface.',
+    }),
+    Evidence({
+      id: 'evidence.tdd-tests',
+      kind: 'test-output',
+      source: 'bun test',
+      description: 'Task-level failing then passing test output.',
+    }),
+    Evidence({
+      id: 'evidence.validation-output',
+      kind: 'validation-output',
+      source: 'bun run typecheck; bun run lint; bun test; npm audit',
+      description: 'Fresh validation evidence for the branch.',
+    }),
+    Evidence({
+      id: 'evidence.dry-run-report',
+      kind: 'dry-run-output',
+      source: 'forge migrate --dry-run',
+      description: 'Resolved graph can be printed without side effects.',
+    }),
+  ],
+  edges: [
+    { from: 'phase.plan', to: 'phase.dev', reason: 'design and task list feed implementation' },
+    { from: 'phase.dev', to: 'phase.validate', reason: 'implementation feeds validation' },
+    { from: 'phase.validate', to: 'phase.ship', reason: 'validated branch can be shipped' },
+  ],
+};
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function getResolvedRuntimeGraph() {
+  return cloneJson(RESOLVED_RUNTIME_GRAPH);
+}
+
+function buildRuntimeGraphEnvelope(graph = getResolvedRuntimeGraph()) {
+  return {
+    schemaVersion: RUNTIME_GRAPH_SCHEMA_VERSION,
+    kind: 'forge.runtimeGraph',
+    schema: cloneJson(RUNTIME_GRAPH_SCHEMA),
+    graph: cloneJson(graph),
+  };
+}
+
+module.exports = {
+  RUNTIME_GRAPH_SCHEMA_VERSION,
+  RUNTIME_GRAPH_SCHEMA,
+  Phase,
+  Action,
+  Artifact,
+  EvaluatorRegion,
+  Gate,
+  Evidence,
+  buildRuntimeGraphEnvelope,
+  getResolvedRuntimeGraph,
+};

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -7,10 +7,14 @@ const RUNTIME_GRAPH_SCHEMA = {
   $id: 'https://forge.local/schemas/runtime-graph-0.0.12.json',
   title: 'Forge Runtime Graph Artifact',
   type: 'object',
-  required: ['schemaVersion', 'kind', 'graph'],
+  required: ['schemaVersion', 'kind', 'schema', 'graph'],
   properties: {
     schemaVersion: { const: RUNTIME_GRAPH_SCHEMA_VERSION },
     kind: { const: 'forge.runtimeGraph' },
+    schema: {
+      type: 'object',
+      required: ['$schema', '$id'],
+    },
     graph: {
       type: 'object',
       required: [
@@ -238,7 +242,7 @@ const RESOLVED_RUNTIME_GRAPH = {
     Evidence({
       id: 'evidence.validation-output',
       kind: 'validation-output',
-      source: 'bun run typecheck; bun run lint; bun test; npm audit',
+      source: 'bun run typecheck; bun run lint; bun test; bun audit',
       description: 'Fresh validation evidence for the branch.',
     }),
     Evidence({

--- a/lib/migrate-dry-run.js
+++ b/lib/migrate-dry-run.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
+const { buildRuntimeGraphEnvelope } = require('./core/runtime-graph');
 const { WORKFLOW_STAGE_MATRIX } = require('./workflow/stages');
 
 const EXPECTED_CLASSIFICATIONS = Object.freeze([
@@ -361,6 +362,7 @@ function buildMigrationDryRunReport(projectRoot = process.cwd(), options = {}) {
     plannedFiles,
     fixtureCorpus: corpus,
     fixtureCorpusRun: corpusRun,
+    runtimeGraph: buildRuntimeGraphEnvelope(),
   };
 }
 
@@ -403,6 +405,8 @@ function renderMigrationDryRunReport(report) {
 
   lines.push(
     '',
+    ...renderRuntimeGraph(report.runtimeGraph),
+    '',
     'Dry-run guarantee',
     'No files were written outside controlled temp fixture materialization when --fixture-corpus is used.',
     '',
@@ -410,6 +414,24 @@ function renderMigrationDryRunReport(report) {
   );
 
   return `${lines.join('\n')}\n`;
+}
+
+function renderRuntimeGraph(envelope) {
+  if (!envelope?.graph) {
+    return ['Runtime graph', '(not available)'];
+  }
+
+  const graph = envelope.graph;
+  return [
+    'Runtime graph',
+    `Schema: ${envelope.kind}@${envelope.schemaVersion}`,
+    `Phases: ${graph.phases.map(phase => phase.id).join(' -> ')}`,
+    `Actions: ${graph.actions.map(action => action.id).join(', ')}`,
+    `Artifacts: ${graph.artifacts.map(artifact => artifact.id).join(', ')}`,
+    `Evaluator regions: ${graph.evaluatorRegions.map(region => region.id).join(', ')}`,
+    `Gates: ${graph.gates.map(gate => gate.id).join(', ')}`,
+    `Evidence: ${graph.evidence.map(evidence => evidence.id).join(', ')}`,
+  ];
 }
 
 function runV2FixtureCorpusDryRun() {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   },
   "overrides": {
     "eslint": "^10.0.2",
+    "fast-uri": "^3.1.2",
     "flatted": "3.4.2",
     "minimatch": "10.2.4",
     "brace-expansion": "5.0.5",

--- a/test/migrate-dry-run.test.js
+++ b/test/migrate-dry-run.test.js
@@ -143,6 +143,26 @@ describe('migrate dry-run', () => {
     expect(result.output).toContain('Fixture corpus: available');
   });
 
+  test('prints the resolved runtime graph in dry-run output without mutating the target repo', () => {
+    const { repoRoot } = materializeFixture('clean-v2-install');
+    const before = readGitStatus(repoRoot);
+
+    const report = buildMigrationDryRunReport(repoRoot);
+    const output = renderMigrationDryRunReport(report);
+
+    expect(report.runtimeGraph.kind).toBe('forge.runtimeGraph');
+    expect(output).toContain('Runtime graph');
+    expect(output).toContain('Phases: plan -> dev -> validate -> ship');
+    expect(output).toContain('Actions: action.plan.command, action.dev.command, action.validate.command, action.ship.command');
+    expect(output).toContain(
+      'Artifacts: artifact.design-doc, artifact.task-list, artifact.changed-files, artifact.validation-output, artifact.pull-request'
+    );
+    expect(output).toContain('Evaluator regions: evaluator.plan-entry, evaluator.tdd-loop, evaluator.validation-suite');
+    expect(output).toContain('Gates: gate.plan-exit, gate.dev-exit, gate.validate-exit, gate.ship-entry');
+    expect(output).toContain('Evidence: evidence.command-docs, evidence.tdd-tests, evidence.validation-output, evidence.dry-run-report');
+    expect(readGitStatus(repoRoot)).toBe(before);
+  });
+
   test('command preserves the rendered dry-run report when validation fails', async () => {
     const { repoRoot } = materializeFixture('broken-beads-state');
 

--- a/test/runtime-graph.test.js
+++ b/test/runtime-graph.test.js
@@ -68,4 +68,21 @@ describe('runtime graph contract', () => {
       expect(doc).toContain(`/${action.command}`);
     }
   });
+
+  test('does not make phase entry gates depend on artifacts produced by the same phase', () => {
+    const graph = getResolvedRuntimeGraph();
+
+    for (const gate of graph.gates.filter(candidate => candidate.label.includes('entry'))) {
+      const phase = graph.phases.find(candidate => candidate.id === gate.phase);
+      const phaseActions = graph.actions.filter(action => phase.actions.includes(action.id));
+      const samePhaseWrites = new Set(phaseActions.flatMap(action => action.writes));
+
+      for (const requirement of gate.requires) {
+        expect(
+          samePhaseWrites.has(requirement),
+          `${gate.id} should not require ${requirement} before ${phase.id} actions run`
+        ).toBe(false);
+      }
+    }
+  });
 });

--- a/test/runtime-graph.test.js
+++ b/test/runtime-graph.test.js
@@ -16,6 +16,8 @@ describe('runtime graph contract', () => {
     expect(envelope.schemaVersion).toBe(RUNTIME_GRAPH_SCHEMA_VERSION);
     expect(envelope.kind).toBe('forge.runtimeGraph');
     expect(envelope.schema).toEqual(RUNTIME_GRAPH_SCHEMA);
+    expect(envelope.schema.required).toContain('schema');
+    expect(envelope.schema.properties.schema.required).toEqual(['$schema', '$id']);
     expect(envelope.graph).toEqual(getResolvedRuntimeGraph());
     expect(JSON.parse(JSON.stringify(envelope))).toEqual(envelope);
   });
@@ -38,6 +40,8 @@ describe('runtime graph contract', () => {
       Gate: 'gates',
       Evidence: 'evidence',
     });
+    expect(graph.evidence.find(evidence => evidence.id === 'evidence.validation-output').source)
+      .toBe('bun run typecheck; bun run lint; bun test; bun audit');
   });
 
   test('represents the current plan to ship command flow as a resolved graph', () => {

--- a/test/runtime-graph.test.js
+++ b/test/runtime-graph.test.js
@@ -1,0 +1,71 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { describe, expect, test } = require('bun:test');
+
+const {
+  RUNTIME_GRAPH_SCHEMA_VERSION,
+  RUNTIME_GRAPH_SCHEMA,
+  buildRuntimeGraphEnvelope,
+  getResolvedRuntimeGraph,
+} = require('../lib/core/runtime-graph');
+
+describe('runtime graph contract', () => {
+  test('publishes a versioned JSON schema envelope for runtime graph artifacts', () => {
+    const envelope = buildRuntimeGraphEnvelope();
+
+    expect(envelope.schemaVersion).toBe(RUNTIME_GRAPH_SCHEMA_VERSION);
+    expect(envelope.kind).toBe('forge.runtimeGraph');
+    expect(envelope.schema).toEqual(RUNTIME_GRAPH_SCHEMA);
+    expect(envelope.graph).toEqual(getResolvedRuntimeGraph());
+    expect(JSON.parse(JSON.stringify(envelope))).toEqual(envelope);
+  });
+
+  test('defines the required runtime graph primitives', () => {
+    const graph = getResolvedRuntimeGraph();
+
+    expect(graph.phases.length).toBeGreaterThanOrEqual(4);
+    expect(graph.actions.length).toBeGreaterThanOrEqual(4);
+    expect(graph.artifacts.length).toBeGreaterThanOrEqual(3);
+    expect(graph.evaluatorRegions.length).toBeGreaterThanOrEqual(3);
+    expect(graph.gates.length).toBeGreaterThanOrEqual(4);
+    expect(graph.evidence.length).toBeGreaterThanOrEqual(4);
+
+    expect(graph.primitives).toEqual({
+      Phase: 'phases',
+      Action: 'actions',
+      Artifact: 'artifacts',
+      EvaluatorRegion: 'evaluatorRegions',
+      Gate: 'gates',
+      Evidence: 'evidence',
+    });
+  });
+
+  test('represents the current plan to ship command flow as a resolved graph', () => {
+    const graph = getResolvedRuntimeGraph();
+    const phaseIds = graph.phases.map(phase => phase.id);
+    const commandActionIds = graph.actions
+      .filter(action => action.kind === 'command')
+      .map(action => action.command);
+
+    expect(phaseIds).toEqual(['plan', 'dev', 'validate', 'ship']);
+    expect(commandActionIds).toEqual(['plan', 'dev', 'validate', 'ship']);
+    expect(graph.edges).toEqual([
+      { from: 'phase.plan', to: 'phase.dev', reason: 'design and task list feed implementation' },
+      { from: 'phase.dev', to: 'phase.validate', reason: 'implementation feeds validation' },
+      { from: 'phase.validate', to: 'phase.ship', reason: 'validated branch can be shipped' },
+    ]);
+  });
+
+  test('keeps graph command actions compatible with checked-in command docs', () => {
+    const repoRoot = path.resolve(__dirname, '..');
+    const graph = getResolvedRuntimeGraph();
+    const commandActions = graph.actions.filter(action => action.kind === 'command');
+
+    for (const action of commandActions) {
+      const docPath = path.join(repoRoot, '.claude', 'commands', `${action.command}.md`);
+      expect(fs.existsSync(docPath), `${action.id} should have ${docPath}`).toBe(true);
+      const doc = fs.readFileSync(docPath, 'utf8');
+      expect(doc).toContain(`/${action.command}`);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Forge 0.0.12 needs a runtime graph contract that replaces the old stage-only shape with explicit runtime primitives while preserving current command behavior.

## Root Cause

The current workflow is documented and executable, but there was no versioned graph artifact for Phase, Action, Artifact, EvaluatorRegion, Gate, and Evidence, and no dry-run proof that the resolved graph can be printed without side effects.

## Fix

- Added `lib/core/runtime-graph.js` with the 0.0.12 primitive constructors, JSON schema envelope, and resolved `/plan -> /dev -> /validate -> /ship` graph.
- Wired `lib/migrate-dry-run.js` to include and render the resolved runtime graph in `forge migrate --dry-run` output.
- Added tests for schema/envelope serialization, primitive coverage, command-doc compatibility, and dry-run no-mutation graph output.
- Added a `fast-uri` override so the repo security audit passes with the current toolchain lockfile.

## Value

0.0.12 now publishes the runtime graph contract and proves the current command flow can be represented and printed as a dry-run artifact without introducing config loading, options APIs, rails, init, install profiles, protected paths, or audit persistence.

## Beads

Closes forge-besw.1
Advances forge-besw

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: `bun test test/runtime-graph.test.js test/migrate-dry-run.test.js --timeout 15000` -> 16 passing
- Full suite: `bun test --timeout 15000` -> 3104 passing, 58 skipped
- Project gate: `bun run check` -> all checks passed

### Security Review
- OWASP Top 10: no new auth, persistence, network, config loading, or user-input execution surface.
- Automated audit: `bun audit` -> no vulnerabilities found.
- Dependency note: added `fast-uri` override to satisfy the existing audit path through dev tooling.

### Design Doc
- `docs/work/2026-05-11-0.0.12-runtime-graph/design.md`
- `docs/work/2026-05-11-0.0.12-runtime-graph/tasks.md`

### Key Decisions
- Keep graph resolution static for this PR; no config loading or options API.
- Reuse `forge migrate --dry-run` as the side-effect-free proof path.
- Keep command-doc compatibility tied to `.claude/commands/*.md`.

### Documentation Updated
- Added scoped workflow design and task docs under `docs/work/2026-05-11-0.0.12-runtime-graph/`.

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

Commands run:
- `bun run typecheck`
- `bun run lint`
- `bun test test/runtime-graph.test.js test/migrate-dry-run.test.js --timeout 15000`
- `bun test --timeout 15000`
- `bun audit`
- `bun run check`
- `node bin/forge.js migrate --dry-run`

Explicit non-scope:
- L1 rails
- Config loading
- Options API
- Protected paths
- Init
- Install profiles
- Audit persistence
- Command behavior rewrite

### Self-Review Checklist

- [x] I reviewed the full diff locally
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes
- [x] TDD compliance: All source files have corresponding tests

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime graph contract to visualize the command workflow (phases, actions, artifacts, gates, evidence)
  * Dry-run reports now include the resolved runtime graph

* **Documentation**
  * Added design and task documents describing the runtime graph contract and rollout plan

* **Tests**
  * Added tests validating the runtime graph contract and dry-run reporting

* **Chores**
  * Updated dependency override and enabled incremental auto-review configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/154)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->