### PR TITLE
Fix CodeRabbit after-tests trigger

### DIFF
--- a/.github/workflows/coderabbit-after-tests.yml
+++ b/.github/workflows/coderabbit-after-tests.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   trigger-coderabbit:
@@ -26,4 +26,6 @@ jobs:
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
           TEST_RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "Tests passed in ${TEST_RUN_URL}. @coderabbitai review"
+          if ! gh pr comment "$PR_NUMBER" --body "Tests passed in ${TEST_RUN_URL}. @coderabbitai review"; then
+            echo "::warning::Unable to trigger CodeRabbit review for PR #${PR_NUMBER}; continuing because tests passed."
+          fi


### PR DESCRIPTION
## Problem

`master` is failing on the `CodeRabbit After Tests` workflow after successful PR tests. The failing run is https://github.com/harshanandak/forge/actions/runs/25666002057.

## Root Cause

The workflow uses `gh pr comment` to trigger CodeRabbit after tests pass. For PR #156, GitHub rejected the comment mutation with `GraphQL: Resource not accessible by integration`, which turned a non-critical review trigger into a red `master` check.

## Fix

- Grant `pull-requests: write` to the workflow token.
- Treat a failed CodeRabbit trigger comment as a warning instead of a hard failure, since the tests already passed and review triggering should not break `master`.

## Validation

- `bun run lint`
- `bun test test/commands/worktree.test.js test/commands/clean.test.js --timeout 15000`
- `git diff --check -- .github/workflows/coderabbit-after-tests.yml`

## Notes

- `bunx actionlint .github/workflows/coderabbit-after-tests.yml` could not run because the npm package did not expose an executable in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow reliability by improving error handling for automated pull request operations. The workflow now gracefully handles failures in reporting steps without interrupting the overall process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->