### PR TITLE
0.0.14 audit evidence persistence

### DIFF
--- a/docs/work/2026-05-12-0.0.14-audit-evidence/decisions.md
+++ b/docs/work/2026-05-12-0.0.14-audit-evidence/decisions.md
@@ -1,0 +1,11 @@
+# Decisions: 0.0.14 audit evidence persistence
+
+## Decision 1
+
+**Date**: 2026-05-12
+**Task**: Planning
+**Gap**: The installed `bd audit` command exposes `record` and `label`, but no `--meta-json` flag and no working `verify` subcommand in the current help output.
+**Score**: 2/14
+**Route**: PROCEED
+**Choice made**: Keep Beads as the source of truth with `bd audit record` and `bd audit label`; add only a minimal `.forge/log.jsonl` metadata fallback that references the Beads entry ID when richer upstream metadata is unavailable.
+**Status**: RESOLVED

--- a/docs/work/2026-05-12-0.0.14-audit-evidence/design.md
+++ b/docs/work/2026-05-12-0.0.14-audit-evidence/design.md
@@ -1,0 +1,91 @@
+# Feature: 0.0.14 audit evidence persistence
+
+Date: 2026-05-12
+Status: Planned
+Issue: forge-besw.20
+Related design-only issue: forge-besw.27
+
+## Purpose
+
+Persist evidence for `/dev` and future `/build` subagent calls through Beads audit entries so implementer, spec reviewer, and quality reviewer activity is visible to audit, evaluation, and downstream mining flows.
+
+## Verified Context
+
+- `origin/HEAD` is `master`, and the worktree was created at `origin/master` commit `cda53e886bd52b34c63e52fe64d804153161c648`.
+- `lib/commands/dev.js` currently owns the executable `/dev` helper surface and exports `executeDev`, decision routing, and task completion helpers.
+- No executable `/build` command exists in `lib/commands` on this branch; `/build` support will therefore be a reusable audit helper plus documented event shape rather than a new command.
+- `bd audit record --help` supports `--kind`, `--issue-id`, `--model`, `--prompt`, `--response`, `--tool-name`, `--exit-code`, `--error`, and `--stdin`.
+- `bd audit label --help` supports `bd audit label <entry-id> --label <value> --reason <reason>`.
+- Current `bd audit --help` does not expose `verify` or `--meta-json`; `bd audit verify --json` prints audit help instead of verifying a hash chain in this environment.
+
+## Success Criteria
+
+1. Forge has a reusable audit evidence module for subagent invocation events.
+2. `/dev` can emit implementer, spec reviewer, and quality reviewer audit events without leaking raw secrets.
+3. Reviewer PASS/FAIL verdicts map to `bd audit label <entry-id> --label good|bad` when the label command is available.
+4. Tests cover event shape, redaction, label command behavior, and `.forge/log.jsonl` fallback metadata.
+5. The PR body states the fallback decision and the exact validation commands run.
+
+## Out of Scope
+
+- No 0.0.13 config, L1 rails, protected paths, or options API changes.
+- No new `/build` command unless a command already exists to wire.
+- No replacement for Beads as source of truth.
+- No separate hash-chain implementation to compete with `.beads/interactions.jsonl`.
+
+## Approach Selected
+
+Add `lib/audit-evidence.js` as a narrow adapter around `bd audit record` and `bd audit label`. The adapter will build a redaction-safe `llm_call` payload from a normalized subagent event, record it through Beads, and optionally append minimal metadata to `.forge/log.jsonl` only when richer upstream metadata support such as `--meta-json` is unavailable.
+
+`/dev` will call the adapter through exported helper functions so the current command remains testable and the same event contract can be reused by a future `/build` command without adding rails or options.
+
+## Event Shape
+
+Normalized event input:
+
+```json
+{
+  "command": "dev",
+  "issueId": "forge-besw.20",
+  "role": "implementer|spec_reviewer|quality_reviewer",
+  "phase": "RED|GREEN|REFACTOR|SPEC|QUALITY",
+  "taskId": "task-1",
+  "taskTitle": "Audit evidence helper",
+  "model": "unknown",
+  "prompt": "redacted prompt summary",
+  "response": "redacted response summary",
+  "verdict": "PASS|FAIL|UNKNOWN",
+  "metadata": {}
+}
+```
+
+Beads record command:
+
+```bash
+bd audit record --json --kind llm_call --issue-id <issue> --model <model> --prompt <redacted-json> --response <redacted-json>
+```
+
+Reviewer labeling:
+
+```bash
+bd audit label <entry-id> --label good|bad --reason "<role> verdict: PASS|FAIL"
+```
+
+Fallback metadata line:
+
+```json
+{"kind":"forge.auditEvidence","beadsEntryId":"int-...","sourceOfTruth":"beads","metadata":{}}
+```
+
+## Fallback Decision
+
+Current upstream `bd audit` does not expose `--meta-json`. This PR will implement a minimal `.forge/log.jsonl` metadata fallback that references the Beads audit entry ID. The fallback is supplemental only; Beads remains the source of truth for interaction records and labels.
+
+## Validation Plan
+
+- `bun test test/audit-evidence.test.js`
+- `bun test test/commands/dev.test.js test/audit-evidence.test.js`
+- `bun run typecheck`
+- `bun run lint`
+- `bun run check`
+- Manual audit CLI checks for `bd audit record`, `bd audit label`, and current `bd audit verify` availability.

--- a/docs/work/2026-05-12-0.0.14-audit-evidence/tasks.md
+++ b/docs/work/2026-05-12-0.0.14-audit-evidence/tasks.md
@@ -1,0 +1,49 @@
+# Tasks: 0.0.14 audit evidence persistence
+
+## Task 1: Add audit evidence adapter
+
+Ownership:
+- `lib/audit-evidence.js`
+- `test/audit-evidence.test.js`
+
+TDD:
+1. RED: Add tests for normalized implementer/spec/quality event shape, redaction of secret-like values, Beads record command invocation, and fallback metadata writing when upstream `--meta-json` is unavailable.
+2. GREEN: Implement the adapter with injectable command runner and filesystem dependencies.
+3. REFACTOR: Keep the adapter small, command-safe, and reusable by `/dev` and future `/build`.
+
+Acceptance:
+- No raw token/password/secret values are persisted in prompt, response, or fallback metadata.
+- Beads record output is parsed for `id`.
+- `.forge/log.jsonl` lines include `sourceOfTruth: "beads"` and `beadsEntryId`.
+
+## Task 2: Wire `/dev` subagent evidence helpers
+
+Ownership:
+- `lib/commands/dev.js`
+- `test/commands/dev.test.js`
+
+TDD:
+1. RED: Add tests for implementer, spec reviewer, and quality reviewer evidence emission through `/dev` helpers.
+2. GREEN: Export `/dev` helper functions that call the audit adapter with the defined event roles.
+3. REFACTOR: Preserve existing `/dev` behavior and avoid config/options/API rail changes.
+
+Acceptance:
+- Implementer events call `bd audit record`.
+- Spec reviewer PASS/FAIL labels become `good`/`bad`.
+- Quality reviewer PASS/FAIL labels become `good`/`bad`.
+- Unknown verdicts do not label.
+
+## Task 3: Document CLI behavior and fallback decision
+
+Ownership:
+- `docs/work/2026-05-12-0.0.14-audit-evidence/design.md`
+- PR body
+
+TDD:
+1. RED: Add or update tests that lock the fallback decision where practical.
+2. GREEN: Document that `bd audit --meta-json` and `bd audit verify` are unavailable in the current CLI surface, and that `.forge/log.jsonl` is supplemental metadata only.
+3. REFACTOR: Keep documentation concise and tied to validated commands.
+
+Acceptance:
+- PR body includes issues covered, validation commands, and fallback decision.
+- No claim that `bd audit verify` passes unless the current command actually verifies.

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -8,7 +8,7 @@ const VERDICT_LABELS = {
 };
 
 const REVIEWER_ROLES = new Set(['spec_reviewer', 'quality_reviewer']);
-const SECRET_KEY_PATTERN = /(api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)/i;
+const SECRET_KEY_PATTERN = /(api(?:[_-]|\s)?key|authorization|credential|password|private(?:[_-]|\s)?key|secret|token)/i;
 const SECRET_TEXT_KEY_PATTERN = String.raw`(?:api(?:[_-]|\s)?key|authorization|credential|password|private(?:[_-]|\s)?key|secret|token)`;
 const SECRET_TEXT_PATTERNS = [
 	{
@@ -20,7 +20,7 @@ const SECRET_TEXT_PATTERNS = [
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{
-		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+is\\s+)([^\\s&,]+)`, 'gi'),
+		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+is\\s+)([^&,\r\n]+)`, 'gi'),
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{
@@ -157,17 +157,21 @@ function writeFallbackMetadata(payload, entryId, options) {
 		kind: 'forge.auditEvidence',
 		sourceOfTruth: 'beads',
 		beadsEntryId: entryId,
-		command: payload.command,
-		role: payload.role,
-		phase: payload.phase,
-		taskId: payload.taskId,
-		taskTitle: payload.taskTitle,
-		metadata: payload.metadata,
+		command: redact(payload.command),
+		role: redact(payload.role),
+		phase: redact(payload.phase),
+		taskId: redact(payload.taskId),
+		taskTitle: redact(payload.taskTitle),
+		metadata: redact(payload.metadata),
 	};
 
-	fsImpl.mkdirSync(forgeDir, { recursive: true });
-	fsImpl.appendFileSync(logPath, `${JSON.stringify(line)}\n`);
-	return { path: logPath, line };
+	try {
+		fsImpl.mkdirSync(forgeDir, { recursive: true });
+		fsImpl.appendFileSync(logPath, `${JSON.stringify(line)}\n`);
+		return { path: logPath, line };
+	} catch (error) {
+		return { path: logPath, line, skipped: true, error: error.message };
+	}
 }
 
 function recordSubagentAuditEvent(event, options = {}) {

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -9,7 +9,7 @@ const VERDICT_LABELS = {
 
 const REVIEWER_ROLES = new Set(['spec_reviewer', 'quality_reviewer']);
 const SECRET_KEY_PATTERN = /(api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)/i;
-const SECRET_TEXT_KEY_PATTERN = String.raw`(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)`;
+const SECRET_TEXT_KEY_PATTERN = String.raw`(?:api(?:[_-]|\s)?key|authorization|credential|password|private(?:[_-]|\s)?key|secret|token)`;
 const SECRET_TEXT_PATTERNS = [
 	{
 		pattern: /\bBearer\s+\S+/gi,
@@ -20,7 +20,11 @@ const SECRET_TEXT_PATTERNS = [
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{
-		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+)([^\\s]+)`, 'gi'),
+		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+is\\s+)([^\\s&,]+)`, 'gi'),
+		replace: (_match, prefix) => `${prefix}[REDACTED]`,
+	},
+	{
+		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+)(?!is\\b)([^\\s]+)`, 'gi'),
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -230,20 +230,32 @@ function labelSubagentAuditEvent(entryId, event, options = {}) {
 
 	const runCommand = options.runCommand || defaultRunCommand;
 	const reason = `${role} verdict: ${verdict}`;
-	const output = runCommand('bd', [
-		'audit',
-		'label',
-		entryId,
-		'--json',
-		'--label',
-		label,
-		'--reason',
-		reason,
-	], { cwd: options.cwd || process.cwd() });
+	let output;
+	try {
+		output = runCommand('bd', [
+			'audit',
+			'label',
+			entryId,
+			'--json',
+			'--label',
+			label,
+			'--reason',
+			reason,
+		], { cwd: options.cwd || process.cwd() });
+	} catch (error) {
+		return {
+			success: false,
+			label,
+			error: error.message,
+		};
+	}
+
+	const labeledEntryId = parseRecordId(output);
 
 	return {
-		success: true,
+		success: labeledEntryId === entryId,
 		label,
+		entryId: labeledEntryId,
 		output,
 	};
 }

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -29,7 +29,7 @@ const SECRET_TEXT_PATTERNS = [
 	},
 	{
 		pattern: new RegExp(
-			`((?:"|')?${SECRET_TEXT_KEY_PATTERN}(?:"|')?\\s*:\\s*)(?:"[^"]*"|'[^']*'|[^\\s,}\\]]+)`,
+			`((?:"|')?${SECRET_TEXT_KEY_PATTERN}(?:"|')?\\s*:\\s*)(?:"[^"]*"|'[^']*'|[^,}\\]\r\n]+)`,
 			'gi'
 		),
 		replace: (_match, prefix) => `${prefix}"[REDACTED]"`,

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -168,6 +168,10 @@ function writeFallbackMetadata(payload, entryId, options) {
 function recordSubagentAuditEvent(event, options = {}) {
 	const payload = buildSubagentAuditPayload(event);
 	const runCommand = options.runCommand || defaultRunCommand;
+	const metaJsonSupported =
+		typeof options.metaJsonSupported === 'boolean'
+			? options.metaJsonSupported
+			: hasAuditMetaJsonSupport(runCommand, { cwd: options.cwd || process.cwd() });
 	const args = [
 		'audit',
 		'record',
@@ -189,13 +193,12 @@ function recordSubagentAuditEvent(event, options = {}) {
 		payload.response,
 	);
 
+	if (metaJsonSupported && Object.keys(payload.metadata).length > 0) {
+		args.push('--meta-json', JSON.stringify(payload.metadata));
+	}
+
 	const output = runCommand('bd', args, { cwd: options.cwd || process.cwd() });
 	const entryId = parseRecordId(output);
-	const metaJsonSupported =
-		typeof options.metaJsonSupported === 'boolean'
-			? options.metaJsonSupported
-			: hasAuditMetaJsonSupport(runCommand, { cwd: options.cwd || process.cwd() });
-
 	const fallback = metaJsonSupported ? null : writeFallbackMetadata(payload, entryId, options);
 
 	return {

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -96,6 +96,11 @@ function buildSubagentAuditPayload(event) {
 		throw new TypeError('Audit event role is required');
 	}
 
+	const metadata =
+		event.metadata && typeof event.metadata === 'object' && !Array.isArray(event.metadata)
+			? event.metadata
+			: {};
+
 	return {
 		kind: 'llm_call',
 		command: event.command,
@@ -119,7 +124,7 @@ function buildSubagentAuditPayload(event) {
 			verdict: event.verdict || 'UNKNOWN',
 			content: event.response || '',
 		}),
-		metadata: redact(event.metadata || {}),
+		metadata: redact(metadata),
 		verdict: event.verdict,
 	};
 }

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -24,7 +24,10 @@ const SECRET_TEXT_PATTERNS = [
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{
-		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+)(?!is\\b)([^\\s]+)`, 'gi'),
+		pattern: new RegExp(
+			`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+)(?!is\\b)([^&,\r\n]*?)(?=\\s+\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+|[&,\r\n]|$)`,
+			'gi'
+		),
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -10,9 +10,22 @@ const VERDICT_LABELS = {
 const REVIEWER_ROLES = new Set(['spec_reviewer', 'quality_reviewer']);
 const SECRET_KEY_PATTERN = /(api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)/i;
 const SECRET_TEXT_PATTERNS = [
-	/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi,
-	/\b(token|password|secret|api[_-]?key)=([^&\s]+)/gi,
-	/\b(token|password|secret|api[_-]?key)\s+([^\s]+)/gi,
+	{
+		pattern: /\bBearer\s+\S+/gi,
+		replace: () => 'Bearer [REDACTED]',
+	},
+	{
+		pattern: /(\b(?:token|password|secret|api[_-]?key)\b\s*=\s*)([^\s&,]+)/gi,
+		replace: (_match, prefix) => `${prefix}[REDACTED]`,
+	},
+	{
+		pattern: /(\b(?:token|password|secret|api[_-]?key)\b\s+)([^\s]+)/gi,
+		replace: (_match, prefix) => `${prefix}[REDACTED]`,
+	},
+	{
+		pattern: /((?:"|')?(?:token|password|secret|api[_-]?key)(?:"|')?\s*:\s*)(?:"[^"]*"|'[^']*'|[^\s,}\]]+)/gi,
+		replace: (_match, prefix) => `${prefix}"[REDACTED]"`,
+	},
 	/\bsk-[A-Za-z0-9_-]{8,}\b/g,
 ];
 
@@ -27,10 +40,15 @@ function defaultRunCommand(command, args, options = {}) {
 
 function redactString(value) {
 	return SECRET_TEXT_PATTERNS.reduce(
-		(current, pattern) => current.replace(pattern, (match, key) => {
-			if (key) return `${key}=[REDACTED]`;
-			return '[REDACTED]';
-		}),
+		(current, entry) => {
+			if (entry && typeof entry === 'object') {
+				return current.replace(entry.pattern, entry.replace);
+			}
+			return current.replace(entry, (match, key) => {
+				if (key) return `${key}=[REDACTED]`;
+				return '[REDACTED]';
+			});
+		},
 		value,
 	);
 }

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -124,24 +124,21 @@ function buildSubagentAuditPayload(event) {
 	};
 }
 
-function parseRecordId(output) {
+function parseRecordId(output, { requireJson = false } = {}) {
 	if (!output) return null;
 	try {
 		const parsed = JSON.parse(output);
-		return parsed.id || null;
+		return typeof parsed.id === 'string' ? parsed.id : null;
 	} catch (_error) {
+		if (requireJson) return null;
 		const match = /\bint-[A-Za-z0-9_-]+\b/.exec(String(output));
 		return match ? match[0] : null;
 	}
 }
 
 function hasAuditMetaJsonSupport(runCommand = defaultRunCommand, options = {}) {
-	try {
-		const output = runCommand('bd', ['audit', 'record', '--help'], options);
-		return String(output).includes('--meta-json');
-	} catch (_error) {
-		return false;
-	}
+	const output = runCommand('bd', ['audit', 'record', '--help'], options);
+	return String(output).includes('--meta-json');
 }
 
 function writeFallbackMetadata(payload, entryId, options) {
@@ -207,7 +204,7 @@ function recordSubagentAuditEvent(event, options = {}) {
 	}
 
 	const output = runCommand('bd', args, { cwd: options.cwd || process.cwd() });
-	const entryId = parseRecordId(output);
+	const entryId = parseRecordId(output, { requireJson: true });
 	const fallback = metaJsonSupported ? null : writeFallbackMetadata(payload, entryId, options);
 
 	return {
@@ -250,7 +247,7 @@ function labelSubagentAuditEvent(entryId, event, options = {}) {
 		};
 	}
 
-	const labeledEntryId = parseRecordId(output);
+	const labeledEntryId = parseRecordId(output, { requireJson: true });
 
 	return {
 		success: labeledEntryId === entryId,

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -9,21 +9,25 @@ const VERDICT_LABELS = {
 
 const REVIEWER_ROLES = new Set(['spec_reviewer', 'quality_reviewer']);
 const SECRET_KEY_PATTERN = /(api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)/i;
+const SECRET_TEXT_KEY_PATTERN = String.raw`(?:api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)`;
 const SECRET_TEXT_PATTERNS = [
 	{
 		pattern: /\bBearer\s+\S+/gi,
 		replace: () => 'Bearer [REDACTED]',
 	},
 	{
-		pattern: /(\b(?:token|password|secret|api[_-]?key)\b\s*=\s*)([^\s&,]+)/gi,
+		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s*=\\s*)([^\\s&,]+)`, 'gi'),
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{
-		pattern: /(\b(?:token|password|secret|api[_-]?key)\b\s+)([^\s]+)/gi,
+		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s+)([^\\s]+)`, 'gi'),
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{
-		pattern: /((?:"|')?(?:token|password|secret|api[_-]?key)(?:"|')?\s*:\s*)(?:"[^"]*"|'[^']*'|[^\s,}\]]+)/gi,
+		pattern: new RegExp(
+			`((?:"|')?${SECRET_TEXT_KEY_PATTERN}(?:"|')?\\s*:\\s*)(?:"[^"]*"|'[^']*'|[^\\s,}\\]]+)`,
+			'gi'
+		),
 		replace: (_match, prefix) => `${prefix}"[REDACTED]"`,
 	},
 	/\bsk-[A-Za-z0-9_-]{8,}\b/g,

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -16,7 +16,7 @@ const SECRET_TEXT_PATTERNS = [
 		replace: () => 'Bearer [REDACTED]',
 	},
 	{
-		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s*=\\s*)([^\\s&,]+)`, 'gi'),
+		pattern: new RegExp(`(\\b${SECRET_TEXT_KEY_PATTERN}\\b\\s*=\\s*)([^&,\r\n]+)`, 'gi'),
 		replace: (_match, prefix) => `${prefix}[REDACTED]`,
 	},
 	{

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -1,0 +1,235 @@
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const VERDICT_LABELS = {
+	PASS: 'good',
+	FAIL: 'bad',
+};
+
+const REVIEWER_ROLES = new Set(['spec_reviewer', 'quality_reviewer']);
+const SECRET_KEY_PATTERN = /(api[_-]?key|authorization|credential|password|private[_-]?key|secret|token)/i;
+const SECRET_TEXT_PATTERNS = [
+	/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi,
+	/\b(token|password|secret|api[_-]?key)=([^&\s]+)/gi,
+	/\b(token|password|secret|api[_-]?key)\s+([^\s]+)/gi,
+	/\bsk-[A-Za-z0-9_-]{8,}\b/g,
+];
+
+function defaultRunCommand(command, args, options = {}) {
+	return execFileSync(command, args, {
+		cwd: options.cwd || process.cwd(),
+		encoding: 'utf8',
+		input: options.input,
+		timeout: options.timeout || 120000,
+	});
+}
+
+function redactString(value) {
+	return SECRET_TEXT_PATTERNS.reduce(
+		(current, pattern) => current.replace(pattern, (match, key) => {
+			if (key) return `${key}=[REDACTED]`;
+			return '[REDACTED]';
+		}),
+		value,
+	);
+}
+
+function redact(value, key = '') {
+	if (SECRET_KEY_PATTERN.test(key)) {
+		return '[REDACTED]';
+	}
+
+	if (typeof value === 'string') {
+		return redactString(value);
+	}
+
+	if (Array.isArray(value)) {
+		return value.map(item => redact(item));
+	}
+
+	if (value && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value).map(([entryKey, entryValue]) => [entryKey, redact(entryValue, entryKey)]),
+		);
+	}
+
+	return value;
+}
+
+function asJsonString(value) {
+	if (typeof value === 'string') return redactString(value);
+	return JSON.stringify(redact(value));
+}
+
+function buildSubagentAuditPayload(event) {
+	if (!event || typeof event !== 'object') {
+		throw new TypeError('Audit event must be an object');
+	}
+	if (!event.command) {
+		throw new TypeError('Audit event command is required');
+	}
+	if (!event.role) {
+		throw new TypeError('Audit event role is required');
+	}
+
+	return {
+		kind: 'llm_call',
+		command: event.command,
+		issueId: event.issueId,
+		role: event.role,
+		phase: event.phase,
+		taskId: event.taskId,
+		taskTitle: event.taskTitle,
+		model: event.model || 'unknown',
+		prompt: asJsonString({
+			command: event.command,
+			role: event.role,
+			phase: event.phase,
+			taskId: event.taskId,
+			taskTitle: event.taskTitle,
+			content: event.prompt || '',
+		}),
+		response: asJsonString({
+			command: event.command,
+			role: event.role,
+			verdict: event.verdict || 'UNKNOWN',
+			content: event.response || '',
+		}),
+		metadata: redact(event.metadata || {}),
+		verdict: event.verdict,
+	};
+}
+
+function parseRecordId(output) {
+	if (!output) return null;
+	try {
+		const parsed = JSON.parse(output);
+		return parsed.id || null;
+	} catch (_error) {
+		const match = /\bint-[A-Za-z0-9_-]+\b/.exec(String(output));
+		return match ? match[0] : null;
+	}
+}
+
+function hasAuditMetaJsonSupport(runCommand = defaultRunCommand, options = {}) {
+	try {
+		const output = runCommand('bd', ['audit', 'record', '--help'], options);
+		return String(output).includes('--meta-json');
+	} catch (_error) {
+		return false;
+	}
+}
+
+function writeFallbackMetadata(payload, entryId, options) {
+	if (!entryId || !payload.metadata || Object.keys(payload.metadata).length === 0) {
+		return null;
+	}
+
+	const cwd = options.cwd || process.cwd();
+	const fsImpl = options.fs || fs;
+	const forgeDir = path.join(cwd, '.forge').replace(/\\/g, '/');
+	const logPath = path.join(forgeDir, 'log.jsonl').replace(/\\/g, '/');
+	const line = {
+		kind: 'forge.auditEvidence',
+		sourceOfTruth: 'beads',
+		beadsEntryId: entryId,
+		command: payload.command,
+		role: payload.role,
+		phase: payload.phase,
+		taskId: payload.taskId,
+		taskTitle: payload.taskTitle,
+		metadata: payload.metadata,
+	};
+
+	fsImpl.mkdirSync(forgeDir, { recursive: true });
+	fsImpl.appendFileSync(logPath, `${JSON.stringify(line)}\n`);
+	return { path: logPath, line };
+}
+
+function recordSubagentAuditEvent(event, options = {}) {
+	const payload = buildSubagentAuditPayload(event);
+	const runCommand = options.runCommand || defaultRunCommand;
+	const args = [
+		'audit',
+		'record',
+		'--json',
+		'--kind',
+		'llm_call',
+	];
+
+	if (payload.issueId) {
+		args.push('--issue-id', payload.issueId);
+	}
+
+	args.push(
+		'--model',
+		payload.model,
+		'--prompt',
+		payload.prompt,
+		'--response',
+		payload.response,
+	);
+
+	const output = runCommand('bd', args, { cwd: options.cwd || process.cwd() });
+	const entryId = parseRecordId(output);
+	const metaJsonSupported =
+		typeof options.metaJsonSupported === 'boolean'
+			? options.metaJsonSupported
+			: hasAuditMetaJsonSupport(runCommand, { cwd: options.cwd || process.cwd() });
+
+	const fallback = metaJsonSupported ? null : writeFallbackMetadata(payload, entryId, options);
+
+	return {
+		success: Boolean(entryId),
+		entryId,
+		output,
+		payload,
+		fallback,
+	};
+}
+
+function labelSubagentAuditEvent(entryId, event, options = {}) {
+	const verdict = String(event?.verdict || '').toUpperCase();
+	const role = event?.role;
+	const label = VERDICT_LABELS[verdict];
+
+	if (!entryId || !REVIEWER_ROLES.has(role) || !label) {
+		return { skipped: true };
+	}
+
+	const runCommand = options.runCommand || defaultRunCommand;
+	const reason = `${role} verdict: ${verdict}`;
+	const output = runCommand('bd', [
+		'audit',
+		'label',
+		entryId,
+		'--json',
+		'--label',
+		label,
+		'--reason',
+		reason,
+	], { cwd: options.cwd || process.cwd() });
+
+	return {
+		success: true,
+		label,
+		output,
+	};
+}
+
+function recordAndLabelSubagentAuditEvent(event, options = {}) {
+	const record = recordSubagentAuditEvent(event, options);
+	const label = labelSubagentAuditEvent(record.entryId, event, options);
+	return { record, label };
+}
+
+module.exports = {
+	VERDICT_LABELS,
+	buildSubagentAuditPayload,
+	recordSubagentAuditEvent,
+	labelSubagentAuditEvent,
+	recordAndLabelSubagentAuditEvent,
+	hasAuditMetaJsonSupport,
+	redact,
+};

--- a/lib/audit-evidence.js
+++ b/lib/audit-evidence.js
@@ -45,13 +45,10 @@ function defaultRunCommand(command, args, options = {}) {
 function redactString(value) {
 	return SECRET_TEXT_PATTERNS.reduce(
 		(current, entry) => {
-			if (entry && typeof entry === 'object') {
+			if (entry && typeof entry === 'object' && !(entry instanceof RegExp)) {
 				return current.replace(entry.pattern, entry.replace);
 			}
-			return current.replace(entry, (match, key) => {
-				if (key) return `${key}=[REDACTED]`;
-				return '[REDACTED]';
-			});
+			return current.replace(entry, () => '[REDACTED]');
 		},
 		value,
 	);

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -394,10 +394,11 @@ async function executeDev(featureName, options = {}) {
 
 		// Validate REFACTOR requires passing tests
 		if (phase === 'REFACTOR' && testsPassing === false) {
-			return {
+			const result = {
 				success: false,
 				error: 'Cannot proceed to REFACTOR phase: tests are failing. Complete GREEN phase first.',
 			};
+			return withDevAuditEvidence(featureName, currentPhase, result, options);
 		}
 
 		// Execute based on phase

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -412,7 +412,8 @@ async function executeDev(featureName, options = {}) {
 			result.summary = 'Write failing tests for the feature';
 		} else if (currentPhase === 'GREEN') {
 			// Run tests to check status
-			const testResults = await runTests();
+			const runPhaseTests = options.runTests || runTests;
+			const testResults = await runPhaseTests();
 			result.testResults = testResults;
 			result.success = testResults.success; // Reflect actual test outcome
 			if (!testResults.success) {
@@ -444,7 +445,9 @@ function withDevAuditEvidence(featureName, phase, result, options = {}) {
 		phase,
 		taskTitle: `forge dev ${featureName}`,
 		prompt: `forge dev ${featureName} ${phase}`,
-		response: result.summary || result.error || result.guidance || '',
+		response: result.success === false
+			? result.error || result.summary || result.guidance || ''
+			: result.summary || result.error || result.guidance || '',
 		verdict: result.success === false ? 'FAIL' : 'PASS',
 		metadata: {
 			featureName,
@@ -599,11 +602,12 @@ function verifyTaskCompletion(taskTitle, ownedFiles, opts = {}) {
 }
 
 function emitDevSubagentAuditEvidence(role, phase, event = {}, options = {}) {
+	const safeEvent = event && typeof event === 'object' ? event : {};
 	return recordAndLabelSubagentAuditEvent({
-		...event,
+		...safeEvent,
 		command: 'dev',
 		role,
-		phase: event.phase || phase,
+		phase: safeEvent.phase || phase,
 	}, options);
 }
 
@@ -619,12 +623,41 @@ function emitQualityReviewerAuditEvidence(event, options = {}) {
 	return emitDevSubagentAuditEvidence('quality_reviewer', 'QUALITY', event, options);
 }
 
+function parseDevHandlerInput(rawArgs = [], rawFlags = {}) {
+	const parsedArgs = [];
+	const flags = { ...rawFlags };
+	if (flags['issue-id'] && !flags.issueId) {
+		flags.issueId = flags['issue-id'];
+	}
+
+	for (let i = 0; i < rawArgs.length; i++) {
+		const arg = rawArgs[i];
+
+		if (arg === '--issue-id' && i + 1 < rawArgs.length) {
+			flags.issueId = rawArgs[i + 1];
+			i++;
+		} else if (typeof arg === 'string' && arg.startsWith('--issue-id=')) {
+			flags.issueId = arg.slice('--issue-id='.length);
+		} else if (arg === '--phase' && i + 1 < rawArgs.length) {
+			flags.phase = rawArgs[i + 1];
+			i++;
+		} else if (typeof arg === 'string' && arg.startsWith('--phase=')) {
+			flags.phase = arg.slice('--phase='.length);
+		} else {
+			parsedArgs.push(arg);
+		}
+	}
+
+	return { args: parsedArgs, flags };
+}
+
 module.exports = {
 	name: 'dev',
 	description: 'Run the TDD development stage with phase guidance',
 	handler: async (args, flags = {}) => {
-		const featureName = args[0] || 'feature';
-		const phaseInput = flags.phase || args[1];
+		const parsed = parseDevHandlerInput(args, flags);
+		const featureName = parsed.args[0] || 'feature';
+		const phaseInput = parsed.flags.phase || parsed.args[1];
 		const phase = typeof phaseInput === 'string' ? phaseInput.toUpperCase() : undefined;
 		if (phase && !['RED', 'GREEN', 'REFACTOR'].includes(phase)) {
 			return {
@@ -636,8 +669,8 @@ module.exports = {
 		const result = await executeDev(featureName, {
 			...(phase ? { phase } : {}),
 			audit: true,
-			issueId: flags.issueId,
-			auditOptions: flags.auditOptions,
+			issueId: parsed.flags.issueId,
+			auditOptions: parsed.flags.auditOptions,
 		});
 		if (!result.success) {
 			return result;

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -477,6 +477,17 @@ function withDevAuditEvidence(featureName, phase, result, options = {}) {
 			auditEvidence,
 		};
 	} catch (error) {
+		if (isAuditCommandUnavailableError(error)) {
+			return {
+				...result,
+				auditEvidence: {
+					success: false,
+					skipped: true,
+					error: error.message,
+				},
+			};
+		}
+
 		return {
 			...result,
 			success: false,
@@ -487,6 +498,10 @@ function withDevAuditEvidence(featureName, phase, result, options = {}) {
 			},
 		};
 	}
+}
+
+function isAuditCommandUnavailableError(error) {
+	return error?.code === 'ENOENT' || /\bbd\b.*not found/i.test(error?.message || '');
 }
 
 /**

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -11,6 +11,7 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { recordAndLabelSubagentAuditEvent } = require('../audit-evidence');
 
 function getExecOptions() {
 	return { encoding: 'utf8', cwd: process.cwd(), timeout: 120000 };
@@ -557,6 +558,27 @@ function verifyTaskCompletion(taskTitle, ownedFiles, opts = {}) {
 	return { committed: true, autoCommitted: true, commitSha, hasChanges: true };
 }
 
+function emitDevSubagentAuditEvidence(role, phase, event, options = {}) {
+	return recordAndLabelSubagentAuditEvent({
+		...event,
+		command: 'dev',
+		role,
+		phase: event.phase || phase,
+	}, options);
+}
+
+function emitImplementerAuditEvidence(event, options = {}) {
+	return emitDevSubagentAuditEvidence('implementer', event?.phase || 'GREEN', event, options);
+}
+
+function emitSpecReviewerAuditEvidence(event, options = {}) {
+	return emitDevSubagentAuditEvidence('spec_reviewer', 'SPEC', event, options);
+}
+
+function emitQualityReviewerAuditEvidence(event, options = {}) {
+	return emitDevSubagentAuditEvidence('quality_reviewer', 'QUALITY', event, options);
+}
+
 module.exports = {
 	name: 'dev',
 	description: 'Run the TDD development stage with phase guidance',
@@ -591,6 +613,9 @@ module.exports = {
 	generateCommitMessage,
 	identifyParallelWork,
 	executeDev,
+	emitImplementerAuditEvidence,
+	emitSpecReviewerAuditEvidence,
+	emitQualityReviewerAuditEvidence,
 	calculateDecisionRoute,
 	DECISION_ROUTES,
 	verifyTaskCompletion,

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -558,7 +558,7 @@ function verifyTaskCompletion(taskTitle, ownedFiles, opts = {}) {
 	return { committed: true, autoCommitted: true, commitSha, hasChanges: true };
 }
 
-function emitDevSubagentAuditEvidence(role, phase, event, options = {}) {
+function emitDevSubagentAuditEvidence(role, phase, event = {}, options = {}) {
 	return recordAndLabelSubagentAuditEvent({
 		...event,
 		command: 'dev',

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -381,13 +381,15 @@ async function executeDev(featureName, options = {}) {
 			// Use --phase flag to explicitly specify GREEN or REFACTOR.
 			currentPhase = detectTDDPhase({ sourceFiles, testFiles, testsPassing });
 
-			return {
+			const result = {
 				success: true,
 				detectedPhase: currentPhase,
 				autoDetected: true,
 				guidance: getTDDGuidance(currentPhase),
 				summary: `Default ${currentPhase} phase (use --phase flag for explicit phase control)`,
 			};
+
+			return withDevAuditEvidence(featureName, currentPhase, result, options);
 		}
 
 		// Validate REFACTOR requires passing tests
@@ -423,11 +425,49 @@ async function executeDev(featureName, options = {}) {
 			result.summary = 'Improve code quality while keeping tests green';
 		}
 
-		return result;
+		return withDevAuditEvidence(featureName, currentPhase, result, options);
 	} catch (error) {
 		return {
 			success: false,
 			error: `Failed to execute dev command: ${error.message}`,
+		};
+	}
+}
+
+function withDevAuditEvidence(featureName, phase, result, options = {}) {
+	if (!options.audit) {
+		return result;
+	}
+
+	const auditEvent = {
+		issueId: options.issueId,
+		phase,
+		taskTitle: `forge dev ${featureName}`,
+		prompt: `forge dev ${featureName} ${phase}`,
+		response: result.summary || result.error || result.guidance || '',
+		verdict: result.success === false ? 'FAIL' : 'PASS',
+		metadata: {
+			featureName,
+			phase,
+			detectedPhase: result.detectedPhase,
+			nextPhase: result.nextPhase,
+			autoDetected: Boolean(result.autoDetected),
+			success: result.success !== false,
+		},
+	};
+
+	try {
+		return {
+			...result,
+			auditEvidence: emitImplementerAuditEvidence(auditEvent, options.auditOptions || {}),
+		};
+	} catch (error) {
+		return {
+			...result,
+			auditEvidence: {
+				success: false,
+				error: error.message,
+			},
 		};
 	}
 }
@@ -593,7 +633,12 @@ module.exports = {
 			};
 		}
 
-		const result = await executeDev(featureName, phase ? { phase } : {});
+		const result = await executeDev(featureName, {
+			...(phase ? { phase } : {}),
+			audit: true,
+			issueId: flags.issueId,
+			auditOptions: flags.auditOptions,
+		});
 		if (!result.success) {
 			return result;
 		}

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -607,7 +607,7 @@ function emitDevSubagentAuditEvidence(role, phase, event = {}, options = {}) {
 		...safeEvent,
 		command: 'dev',
 		role,
-		phase: safeEvent.phase || phase,
+		phase: phase || safeEvent.phase,
 	}, options);
 }
 

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -627,6 +627,9 @@ function emitQualityReviewerAuditEvidence(event, options = {}) {
 function parseDevHandlerInput(rawArgs = [], rawFlags = {}) {
 	const parsedArgs = [];
 	const flags = { ...rawFlags };
+	const missingValue = (name) => ({ args: parsedArgs, flags, error: `${name} requires a value` });
+	const isMissingValue = (value) => value === undefined || value === '' ||
+		(typeof value === 'string' && value.startsWith('--'));
 	if (flags['issue-id'] && !flags.issueId) {
 		flags.issueId = flags['issue-id'];
 	}
@@ -634,15 +637,27 @@ function parseDevHandlerInput(rawArgs = [], rawFlags = {}) {
 	for (let i = 0; i < rawArgs.length; i++) {
 		const arg = rawArgs[i];
 
-		if (arg === '--issue-id' && i + 1 < rawArgs.length) {
+		if (arg === '--issue-id') {
+			if (isMissingValue(rawArgs[i + 1])) {
+				return missingValue('--issue-id');
+			}
 			flags.issueId = rawArgs[i + 1];
 			i++;
 		} else if (typeof arg === 'string' && arg.startsWith('--issue-id=')) {
+			if (arg.slice('--issue-id='.length) === '') {
+				return missingValue('--issue-id');
+			}
 			flags.issueId = arg.slice('--issue-id='.length);
-		} else if (arg === '--phase' && i + 1 < rawArgs.length) {
+		} else if (arg === '--phase') {
+			if (isMissingValue(rawArgs[i + 1])) {
+				return missingValue('--phase');
+			}
 			flags.phase = rawArgs[i + 1];
 			i++;
 		} else if (typeof arg === 'string' && arg.startsWith('--phase=')) {
+			if (arg.slice('--phase='.length) === '') {
+				return missingValue('--phase');
+			}
 			flags.phase = arg.slice('--phase='.length);
 		} else {
 			parsedArgs.push(arg);
@@ -657,6 +672,12 @@ module.exports = {
 	description: 'Run the TDD development stage with phase guidance',
 	handler: async (args, flags = {}) => {
 		const parsed = parseDevHandlerInput(args, flags);
+		if (parsed.error) {
+			return {
+				success: false,
+				error: parsed.error,
+			};
+		}
 		const featureName = parsed.args[0] || 'feature';
 		const phaseInput = parsed.flags.phase || parsed.args[1];
 		const phase = typeof phaseInput === 'string' ? phaseInput.toUpperCase() : undefined;

--- a/lib/commands/dev.js
+++ b/lib/commands/dev.js
@@ -461,13 +461,26 @@ function withDevAuditEvidence(featureName, phase, result, options = {}) {
 	};
 
 	try {
+		const auditEvidence = emitImplementerAuditEvidence(auditEvent, options.auditOptions || {});
+		if (auditEvidence.record?.success === false) {
+			const auditError = auditEvidence.record.error || 'bd audit record failed';
+			return {
+				...result,
+				success: false,
+				error: result.success === false ? result.error : `Audit evidence persistence failed: ${auditError}`,
+				auditEvidence,
+			};
+		}
+
 		return {
 			...result,
-			auditEvidence: emitImplementerAuditEvidence(auditEvent, options.auditOptions || {}),
+			auditEvidence,
 		};
 	} catch (error) {
 		return {
 			...result,
+			success: false,
+			error: result.success === false ? result.error : `Audit evidence persistence failed: ${error.message}`,
 			auditEvidence: {
 				success: false,
 				error: error.message,
@@ -624,44 +637,69 @@ function emitQualityReviewerAuditEvidence(event, options = {}) {
 	return emitDevSubagentAuditEvidence('quality_reviewer', 'QUALITY', event, options);
 }
 
+function isMissingDevFlagValue(value) {
+	return value === undefined || value === '' || (typeof value === 'string' && value.startsWith('--'));
+}
+
+function missingDevFlagValue(name, parsedArgs, flags) {
+	return { args: parsedArgs, flags, error: `${name} requires a value` };
+}
+
+function consumeSeparatedDevFlag(name, key, rawArgs, index, parsedArgs, flags) {
+	const value = rawArgs[index + 1];
+	if (isMissingDevFlagValue(value)) {
+		return missingDevFlagValue(name, parsedArgs, flags);
+	}
+
+	flags[key] = value;
+	return { consumed: 2 };
+}
+
+function consumeEqualsDevFlag(prefix, name, key, arg, parsedArgs, flags) {
+	const value = arg.slice(prefix.length);
+	if (value === '') {
+		return missingDevFlagValue(name, parsedArgs, flags);
+	}
+
+	flags[key] = value;
+	return { consumed: 1 };
+}
+
+function consumeDevFlag(rawArgs, index, parsedArgs, flags) {
+	const arg = rawArgs[index];
+	if (arg === '--issue-id') {
+		return consumeSeparatedDevFlag('--issue-id', 'issueId', rawArgs, index, parsedArgs, flags);
+	}
+	if (typeof arg === 'string' && arg.startsWith('--issue-id=')) {
+		return consumeEqualsDevFlag('--issue-id=', '--issue-id', 'issueId', arg, parsedArgs, flags);
+	}
+	if (arg === '--phase') {
+		return consumeSeparatedDevFlag('--phase', 'phase', rawArgs, index, parsedArgs, flags);
+	}
+	if (typeof arg === 'string' && arg.startsWith('--phase=')) {
+		return consumeEqualsDevFlag('--phase=', '--phase', 'phase', arg, parsedArgs, flags);
+	}
+
+	return { consumed: 0 };
+}
+
 function parseDevHandlerInput(rawArgs = [], rawFlags = {}) {
 	const parsedArgs = [];
 	const flags = { ...rawFlags };
-	const missingValue = (name) => ({ args: parsedArgs, flags, error: `${name} requires a value` });
-	const isMissingValue = (value) => value === undefined || value === '' ||
-		(typeof value === 'string' && value.startsWith('--'));
 	if (flags['issue-id'] && !flags.issueId) {
 		flags.issueId = flags['issue-id'];
 	}
 
 	for (let i = 0; i < rawArgs.length; i++) {
-		const arg = rawArgs[i];
-
-		if (arg === '--issue-id') {
-			if (isMissingValue(rawArgs[i + 1])) {
-				return missingValue('--issue-id');
-			}
-			flags.issueId = rawArgs[i + 1];
-			i++;
-		} else if (typeof arg === 'string' && arg.startsWith('--issue-id=')) {
-			if (arg.slice('--issue-id='.length) === '') {
-				return missingValue('--issue-id');
-			}
-			flags.issueId = arg.slice('--issue-id='.length);
-		} else if (arg === '--phase') {
-			if (isMissingValue(rawArgs[i + 1])) {
-				return missingValue('--phase');
-			}
-			flags.phase = rawArgs[i + 1];
-			i++;
-		} else if (typeof arg === 'string' && arg.startsWith('--phase=')) {
-			if (arg.slice('--phase='.length) === '') {
-				return missingValue('--phase');
-			}
-			flags.phase = arg.slice('--phase='.length);
-		} else {
-			parsedArgs.push(arg);
+		const consumed = consumeDevFlag(rawArgs, i, parsedArgs, flags);
+		if (consumed.error) {
+			return consumed;
 		}
+		if (consumed.consumed > 0) {
+			i += consumed.consumed - 1;
+			continue;
+		}
+		parsedArgs.push(rawArgs[i]);
 	}
 
 	return { args: parsedArgs, flags };

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -56,7 +56,7 @@ describe('audit evidence adapter', () => {
 			command: 'dev',
 			role: 'implementer',
 			prompt:
-				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz api key: spaced-api-123 private key spaced-private-123',
+				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz, api key: spaced-api-123 private key spaced-private-123, password=correct horse battery staple',
 			response:
 				"Result: {'secret':'value-123'} private-key sk-private authorization bearer-token token is phrase-token-123, password is correct horse battery staple, credential: multi word credential, standalone sk-12345678",
 		});
@@ -77,12 +77,12 @@ describe('audit evidence adapter', () => {
 		expect(serialized).not.toContain('xyz');
 		expect(serialized).not.toContain('spaced-api-123');
 		expect(serialized).not.toContain('spaced-private-123');
+		expect(serialized).not.toContain('correct horse battery staple');
 		expect(serialized).not.toContain('value-123');
 		expect(serialized).not.toContain('sk-private');
 		expect(serialized).not.toContain('sk-12345678');
 		expect(serialized).not.toContain('bearer-token');
 		expect(serialized).not.toContain('phrase-token-123');
-		expect(serialized).not.toContain('correct horse battery staple');
 		expect(serialized).not.toContain('multi word credential');
 		expect(serialized).toContain('token is [REDACTED]');
 		expect(serialized).toContain('password is [REDACTED]');

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -56,8 +56,9 @@ describe('audit evidence adapter', () => {
 			command: 'dev',
 			role: 'implementer',
 			prompt:
-				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz',
-			response: "Result: {'secret':'value-123'} private-key sk-private authorization bearer-token standalone sk-12345678",
+				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz api key: spaced-api-123 private key spaced-private-123',
+			response:
+				"Result: {'secret':'value-123'} private-key sk-private authorization bearer-token token is phrase-token-123 standalone sk-12345678",
 		});
 
 		const serialized = JSON.stringify(payload);
@@ -74,10 +75,14 @@ describe('audit evidence adapter', () => {
 		expect(serialized).not.toContain('pk-123');
 		expect(serialized).not.toContain('abc');
 		expect(serialized).not.toContain('xyz');
+		expect(serialized).not.toContain('spaced-api-123');
+		expect(serialized).not.toContain('spaced-private-123');
 		expect(serialized).not.toContain('value-123');
 		expect(serialized).not.toContain('sk-private');
 		expect(serialized).not.toContain('sk-12345678');
 		expect(serialized).not.toContain('bearer-token');
+		expect(serialized).not.toContain('phrase-token-123');
+		expect(serialized).toContain('token is [REDACTED]');
 		expect(serialized).not.toMatch(/\d+=\[REDACTED\]/);
 	});
 

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -58,7 +58,7 @@ describe('audit evidence adapter', () => {
 			prompt:
 				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz api key: spaced-api-123 private key spaced-private-123',
 			response:
-				"Result: {'secret':'value-123'} private-key sk-private authorization bearer-token token is phrase-token-123, password is correct horse battery staple standalone sk-12345678",
+				"Result: {'secret':'value-123'} private-key sk-private authorization bearer-token token is phrase-token-123, password is correct horse battery staple, credential: multi word credential, standalone sk-12345678",
 		});
 
 		const serialized = JSON.stringify(payload);
@@ -83,8 +83,10 @@ describe('audit evidence adapter', () => {
 		expect(serialized).not.toContain('bearer-token');
 		expect(serialized).not.toContain('phrase-token-123');
 		expect(serialized).not.toContain('correct horse battery staple');
+		expect(serialized).not.toContain('multi word credential');
 		expect(serialized).toContain('token is [REDACTED]');
 		expect(serialized).toContain('password is [REDACTED]');
+		expect(serialized).toMatch(/credential.*REDACTED/);
 		expect(serialized).not.toMatch(/\d+=\[REDACTED\]/);
 	});
 

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -206,7 +206,7 @@ describe('audit evidence adapter', () => {
 		const commands = [];
 		const runCommand = (cmd, args) => {
 			commands.push({ cmd, args });
-			return JSON.stringify({ id: 'int-label' });
+			return JSON.stringify({ id: args[2] });
 		};
 
 		const pass = labelSubagentAuditEvent('int-pass', {
@@ -219,7 +219,11 @@ describe('audit evidence adapter', () => {
 		}, { runCommand });
 
 		expect(pass.label).toBe('good');
+		expect(pass.success).toBe(true);
+		expect(pass.entryId).toBe('int-pass');
 		expect(fail.label).toBe('bad');
+		expect(fail.success).toBe(true);
+		expect(fail.entryId).toBe('int-fail');
 		expect(commands[0].args).toEqual([
 			'audit',
 			'label',
@@ -231,6 +235,28 @@ describe('audit evidence adapter', () => {
 			'spec_reviewer verdict: PASS',
 		]);
 		expect(commands[1].args).toContain('bad');
+	});
+
+	test('reports label failures when bd output is invalid or the command fails', () => {
+		const invalid = labelSubagentAuditEvent('int-pass', {
+			role: 'spec_reviewer',
+			verdict: 'PASS',
+		}, {
+			runCommand: () => JSON.stringify({ ok: true }),
+		});
+		const thrown = labelSubagentAuditEvent('int-fail', {
+			role: 'quality_reviewer',
+			verdict: 'FAIL',
+		}, {
+			runCommand: () => {
+				throw new Error('bd label failed');
+			},
+		});
+
+		expect(invalid.success).toBe(false);
+		expect(invalid.entryId).toBe(null);
+		expect(thrown.success).toBe(false);
+		expect(thrown.error).toBe('bd label failed');
 	});
 
 	test('does not label implementer or unknown verdict events', () => {
@@ -267,13 +293,14 @@ describe('audit evidence adapter', () => {
 		}, {
 			runCommand: (cmd, args) => {
 				commands.push({ cmd, args });
-				return JSON.stringify({ id: commands.length === 1 ? 'int-record' : 'int-label' });
+				return JSON.stringify({ id: 'int-record' });
 			},
 			metaJsonSupported: true,
 		});
 
 		expect(result.record.entryId).toBe('int-record');
 		expect(result.label.label).toBe('good');
+		expect(result.label.success).toBe(true);
 		expect(commands.length).toBe(2);
 	});
 

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -123,6 +123,7 @@ describe('audit evidence adapter', () => {
 	});
 
 	test('skips fallback metadata when upstream meta-json support is present', () => {
+		const commands = [];
 		const fsDouble = createFsDouble();
 		const result = recordSubagentAuditEvent({
 			command: 'dev',
@@ -134,11 +135,19 @@ describe('audit evidence adapter', () => {
 			metadata: { files: ['test/audit-evidence.test.js'] },
 		}, {
 			fs: fsDouble,
-			runCommand: () => JSON.stringify({ id: 'int-meta' }),
+			runCommand: (cmd, args) => {
+				commands.push({ cmd, args });
+				return JSON.stringify({ id: 'int-meta' });
+			},
 			metaJsonSupported: true,
 		});
 
 		expect(result.entryId).toBe('int-meta');
+		expect(commands[0].args).toContain('--meta-json');
+		const metaIndex = commands[0].args.indexOf('--meta-json');
+		expect(JSON.parse(commands[0].args[metaIndex + 1])).toEqual({
+			files: ['test/audit-evidence.test.js'],
+		});
 		expect(fsDouble.writes.length).toBe(0);
 	});
 

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -55,8 +55,9 @@ describe('audit evidence adapter', () => {
 		const payload = buildSubagentAuditPayload({
 			command: 'dev',
 			role: 'implementer',
-			prompt: 'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123"}',
-			response: "Result: {'secret':'value-123'}",
+			prompt:
+				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz',
+			response: "Result: {'secret':'value-123'} private-key sk-private authorization bearer-token",
 		});
 
 		const serialized = JSON.stringify(payload);
@@ -64,10 +65,18 @@ describe('audit evidence adapter', () => {
 		expect(serialized).toContain('token');
 		expect(serialized).toContain('password');
 		expect(serialized).toContain('api_key');
+		expect(serialized).toContain('private_key');
+		expect(serialized).toContain('authorization');
+		expect(serialized).toContain('credential');
 		expect(serialized).not.toContain('abc123');
 		expect(serialized).not.toContain('hunter2');
 		expect(serialized).not.toContain('key-123');
+		expect(serialized).not.toContain('pk-123');
+		expect(serialized).not.toContain('abc');
+		expect(serialized).not.toContain('xyz');
 		expect(serialized).not.toContain('value-123');
+		expect(serialized).not.toContain('sk-private');
+		expect(serialized).not.toContain('bearer-token');
 	});
 
 	test('records subagent calls through bd audit record and writes fallback metadata without replacing Beads', () => {

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -1,0 +1,211 @@
+const { describe, test, expect } = require('bun:test');
+const {
+	buildSubagentAuditPayload,
+	recordSubagentAuditEvent,
+	labelSubagentAuditEvent,
+	recordAndLabelSubagentAuditEvent,
+	hasAuditMetaJsonSupport,
+	VERDICT_LABELS,
+} = require('../lib/audit-evidence');
+
+function createFsDouble() {
+	const writes = [];
+	const dirs = [];
+	return {
+		writes,
+		dirs,
+		mkdirSync: (dir, options) => {
+			dirs.push({ dir, options });
+		},
+		appendFileSync: (file, data) => {
+			writes.push({ file, data });
+		},
+	};
+}
+
+describe('audit evidence adapter', () => {
+	test('builds redaction-safe implementer event payloads', () => {
+		const payload = buildSubagentAuditPayload({
+			command: 'dev',
+			issueId: 'forge-besw.20',
+			role: 'implementer',
+			phase: 'GREEN',
+			taskId: 'task-1',
+			taskTitle: 'Wire audit evidence',
+			model: 'gpt-test',
+			prompt: 'Use token=abc123 and password hunter2',
+			response: { status: 'ok', apiKey: 'secret-key', nested: { note: 'done' } },
+			metadata: { authorization: 'Bearer secret-token', files: ['lib/audit-evidence.js'] },
+		});
+
+		const serialized = JSON.stringify(payload);
+		expect(payload.kind).toBe('llm_call');
+		expect(payload.command).toBe('dev');
+		expect(payload.role).toBe('implementer');
+		expect(payload.phase).toBe('GREEN');
+		expect(payload.model).toBe('gpt-test');
+		expect(serialized).toContain('[REDACTED]');
+		expect(serialized).not.toContain('abc123');
+		expect(serialized).not.toContain('hunter2');
+		expect(serialized).not.toContain('secret-key');
+		expect(serialized).not.toContain('secret-token');
+	});
+
+	test('records subagent calls through bd audit record and writes fallback metadata without replacing Beads', () => {
+		const commands = [];
+		const fsDouble = createFsDouble();
+		const runCommand = (cmd, args) => {
+			commands.push({ cmd, args });
+			return JSON.stringify({ id: 'int-test123', kind: 'llm_call', schema_version: 1 });
+		};
+
+		const result = recordSubagentAuditEvent({
+			command: 'dev',
+			issueId: 'forge-besw.20',
+			role: 'quality_reviewer',
+			phase: 'QUALITY',
+			taskId: 'task-2',
+			taskTitle: 'Quality review',
+			prompt: 'review prompt',
+			response: 'review response',
+			metadata: { rubric: 'quality', token: 'hide-me' },
+		}, {
+			cwd: 'C:/repo',
+			fs: fsDouble,
+			runCommand,
+			metaJsonSupported: false,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.entryId).toBe('int-test123');
+		expect(commands[0].cmd).toBe('bd');
+		expect(commands[0].args).toEqual([
+			'audit',
+			'record',
+			'--json',
+			'--kind',
+			'llm_call',
+			'--issue-id',
+			'forge-besw.20',
+			'--model',
+			'unknown',
+			'--prompt',
+			expect.any(String),
+			'--response',
+			expect.any(String),
+		]);
+		expect(fsDouble.dirs[0].dir).toBe('C:/repo/.forge');
+		expect(fsDouble.writes[0].file).toBe('C:/repo/.forge/log.jsonl');
+		const fallback = JSON.parse(fsDouble.writes[0].data);
+		expect(fallback.kind).toBe('forge.auditEvidence');
+		expect(fallback.sourceOfTruth).toBe('beads');
+		expect(fallback.beadsEntryId).toBe('int-test123');
+		expect(JSON.stringify(fallback)).not.toContain('hide-me');
+	});
+
+	test('skips fallback metadata when upstream meta-json support is present', () => {
+		const fsDouble = createFsDouble();
+		const result = recordSubagentAuditEvent({
+			command: 'dev',
+			issueId: 'forge-besw.20',
+			role: 'implementer',
+			phase: 'RED',
+			prompt: 'prompt',
+			response: 'response',
+			metadata: { files: ['test/audit-evidence.test.js'] },
+		}, {
+			fs: fsDouble,
+			runCommand: () => JSON.stringify({ id: 'int-meta' }),
+			metaJsonSupported: true,
+		});
+
+		expect(result.entryId).toBe('int-meta');
+		expect(fsDouble.writes.length).toBe(0);
+	});
+
+	test('labels reviewer PASS and FAIL verdicts as good and bad', () => {
+		const commands = [];
+		const runCommand = (cmd, args) => {
+			commands.push({ cmd, args });
+			return JSON.stringify({ id: 'int-label' });
+		};
+
+		const pass = labelSubagentAuditEvent('int-pass', {
+			role: 'spec_reviewer',
+			verdict: 'PASS',
+		}, { runCommand });
+		const fail = labelSubagentAuditEvent('int-fail', {
+			role: 'quality_reviewer',
+			verdict: 'FAIL',
+		}, { runCommand });
+
+		expect(pass.label).toBe('good');
+		expect(fail.label).toBe('bad');
+		expect(commands[0].args).toEqual([
+			'audit',
+			'label',
+			'int-pass',
+			'--json',
+			'--label',
+			'good',
+			'--reason',
+			'spec_reviewer verdict: PASS',
+		]);
+		expect(commands[1].args).toContain('bad');
+	});
+
+	test('does not label implementer or unknown verdict events', () => {
+		const commands = [];
+		const runCommand = (cmd, args) => {
+			commands.push({ cmd, args });
+			return '{}';
+		};
+
+		const implementer = labelSubagentAuditEvent('int-impl', {
+			role: 'implementer',
+			verdict: 'PASS',
+		}, { runCommand });
+		const unknown = labelSubagentAuditEvent('int-unknown', {
+			role: 'quality_reviewer',
+			verdict: 'UNKNOWN',
+		}, { runCommand });
+
+		expect(implementer.skipped).toBe(true);
+		expect(unknown.skipped).toBe(true);
+		expect(commands.length).toBe(0);
+	});
+
+	test('records then labels reviewer events', () => {
+		const commands = [];
+		const result = recordAndLabelSubagentAuditEvent({
+			command: 'dev',
+			issueId: 'forge-besw.20',
+			role: 'spec_reviewer',
+			phase: 'SPEC',
+			prompt: 'prompt',
+			response: 'response',
+			verdict: 'PASS',
+		}, {
+			runCommand: (cmd, args) => {
+				commands.push({ cmd, args });
+				return JSON.stringify({ id: commands.length === 1 ? 'int-record' : 'int-label' });
+			},
+			metaJsonSupported: true,
+		});
+
+		expect(result.record.entryId).toBe('int-record');
+		expect(result.label.label).toBe('good');
+		expect(commands.length).toBe(2);
+	});
+
+	test('detects whether bd audit record exposes meta-json support', () => {
+		expect(hasAuditMetaJsonSupport(() => 'Usage: bd audit record --meta-json string')).toBe(true);
+		expect(hasAuditMetaJsonSupport(() => 'Usage: bd audit record --prompt string')).toBe(false);
+		expect(hasAuditMetaJsonSupport(() => { throw new Error('missing bd'); })).toBe(false);
+	});
+
+	test('exports verdict label map', () => {
+		expect(VERDICT_LABELS.PASS).toBe('good');
+		expect(VERDICT_LABELS.FAIL).toBe('bad');
+	});
+});

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -56,7 +56,7 @@ describe('audit evidence adapter', () => {
 			command: 'dev',
 			role: 'implementer',
 			prompt:
-				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz, api key: spaced-api-123 private key spaced-private-123, password=correct horse battery staple',
+				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz, api key: spaced-api-123 private key spaced-private-123, password correct horse battery staple, password=another correct horse battery staple',
 			response:
 				"Result: {'secret':'value-123'} private-key sk-private authorization bearer-token token is phrase-token-123, password is correct horse battery staple, credential: multi word credential, standalone sk-12345678",
 		});
@@ -78,6 +78,7 @@ describe('audit evidence adapter', () => {
 		expect(serialized).not.toContain('spaced-api-123');
 		expect(serialized).not.toContain('spaced-private-123');
 		expect(serialized).not.toContain('correct horse battery staple');
+		expect(serialized).not.toContain('another correct horse battery staple');
 		expect(serialized).not.toContain('value-123');
 		expect(serialized).not.toContain('sk-private');
 		expect(serialized).not.toContain('sk-12345678');

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -173,6 +173,22 @@ describe('audit evidence adapter', () => {
 		expect(result.fallback.error).toBe('disk unavailable');
 	});
 
+	test('requires JSON ids from bd audit record output', () => {
+		const result = recordSubagentAuditEvent({
+			command: 'dev',
+			role: 'implementer',
+			prompt: 'prompt',
+			response: 'response',
+		}, {
+			runCommand: () => 'help text with int-fallback',
+			metaJsonSupported: true,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.entryId).toBe(null);
+		expect(result.fallback).toBe(null);
+	});
+
 	test('skips fallback metadata when upstream meta-json support is present', () => {
 		const commands = [];
 		const fsDouble = createFsDouble();
@@ -242,7 +258,7 @@ describe('audit evidence adapter', () => {
 			role: 'spec_reviewer',
 			verdict: 'PASS',
 		}, {
-			runCommand: () => JSON.stringify({ ok: true }),
+			runCommand: () => 'help text with int-pass',
 		});
 		const thrown = labelSubagentAuditEvent('int-fail', {
 			role: 'quality_reviewer',
@@ -307,7 +323,7 @@ describe('audit evidence adapter', () => {
 	test('detects whether bd audit record exposes meta-json support', () => {
 		expect(hasAuditMetaJsonSupport(() => 'Usage: bd audit record --meta-json string')).toBe(true);
 		expect(hasAuditMetaJsonSupport(() => 'Usage: bd audit record --prompt string')).toBe(false);
-		expect(hasAuditMetaJsonSupport(() => { throw new Error('missing bd'); })).toBe(false);
+		expect(() => hasAuditMetaJsonSupport(() => { throw new Error('missing bd'); })).toThrow('missing bd');
 	});
 
 	test('exports verdict label map', () => {

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -57,7 +57,7 @@ describe('audit evidence adapter', () => {
 			role: 'implementer',
 			prompt:
 				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz',
-			response: "Result: {'secret':'value-123'} private-key sk-private authorization bearer-token",
+			response: "Result: {'secret':'value-123'} private-key sk-private authorization bearer-token standalone sk-12345678",
 		});
 
 		const serialized = JSON.stringify(payload);
@@ -76,7 +76,9 @@ describe('audit evidence adapter', () => {
 		expect(serialized).not.toContain('xyz');
 		expect(serialized).not.toContain('value-123');
 		expect(serialized).not.toContain('sk-private');
+		expect(serialized).not.toContain('sk-12345678');
 		expect(serialized).not.toContain('bearer-token');
+		expect(serialized).not.toMatch(/\d+=\[REDACTED\]/);
 	});
 
 	test('records subagent calls through bd audit record and writes fallback metadata without replacing Beads', () => {

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -58,7 +58,7 @@ describe('audit evidence adapter', () => {
 			prompt:
 				'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123","private_key":"pk-123"} authorization: abc credential=xyz api key: spaced-api-123 private key spaced-private-123',
 			response:
-				"Result: {'secret':'value-123'} private-key sk-private authorization bearer-token token is phrase-token-123 standalone sk-12345678",
+				"Result: {'secret':'value-123'} private-key sk-private authorization bearer-token token is phrase-token-123, password is correct horse battery staple standalone sk-12345678",
 		});
 
 		const serialized = JSON.stringify(payload);
@@ -82,7 +82,9 @@ describe('audit evidence adapter', () => {
 		expect(serialized).not.toContain('sk-12345678');
 		expect(serialized).not.toContain('bearer-token');
 		expect(serialized).not.toContain('phrase-token-123');
+		expect(serialized).not.toContain('correct horse battery staple');
 		expect(serialized).toContain('token is [REDACTED]');
+		expect(serialized).toContain('password is [REDACTED]');
 		expect(serialized).not.toMatch(/\d+=\[REDACTED\]/);
 	});
 
@@ -100,10 +102,10 @@ describe('audit evidence adapter', () => {
 			role: 'quality_reviewer',
 			phase: 'QUALITY',
 			taskId: 'task-2',
-			taskTitle: 'Quality review',
+			taskTitle: 'Quality review password is correct horse battery staple',
 			prompt: 'review prompt',
 			response: 'review response',
-			metadata: { rubric: 'quality', token: 'hide-me' },
+			metadata: { rubric: 'quality', token: 'hide-me', 'api key': 'spaced-meta-key' },
 		}, {
 			cwd: 'C:/repo',
 			fs: fsDouble,
@@ -136,6 +138,37 @@ describe('audit evidence adapter', () => {
 		expect(fallback.sourceOfTruth).toBe('beads');
 		expect(fallback.beadsEntryId).toBe('int-test123');
 		expect(JSON.stringify(fallback)).not.toContain('hide-me');
+		expect(JSON.stringify(fallback)).not.toContain('spaced-meta-key');
+		expect(JSON.stringify(fallback)).not.toContain('correct horse battery staple');
+		expect(fallback.taskTitle).toContain('password is [REDACTED]');
+	});
+
+	test('keeps fallback metadata best-effort after Beads recording succeeds', () => {
+		const result = recordSubagentAuditEvent({
+			command: 'dev',
+			role: 'quality_reviewer',
+			phase: 'QUALITY',
+			prompt: 'review prompt',
+			response: 'review response',
+			metadata: { files: ['test/audit-evidence.test.js'] },
+		}, {
+			cwd: 'C:/repo',
+			fs: {
+				mkdirSync: () => {
+					throw new Error('disk unavailable');
+				},
+				appendFileSync: () => {
+					throw new Error('should not write');
+				},
+			},
+			runCommand: () => JSON.stringify({ id: 'int-test123', kind: 'llm_call', schema_version: 1 }),
+			metaJsonSupported: false,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.entryId).toBe('int-test123');
+		expect(result.fallback.skipped).toBe(true);
+		expect(result.fallback.error).toBe('disk unavailable');
 	});
 
 	test('skips fallback metadata when upstream meta-json support is present', () => {

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -189,6 +189,27 @@ describe('audit evidence adapter', () => {
 		expect(result.fallback).toBe(null);
 	});
 
+	test('normalizes malformed metadata before audit recording', () => {
+		const commands = [];
+		const result = recordSubagentAuditEvent({
+			command: 'dev',
+			role: 'implementer',
+			prompt: 'prompt',
+			response: 'response',
+			metadata: 'token=should-not-be-meta-json',
+		}, {
+			runCommand: (cmd, args) => {
+				commands.push({ cmd, args });
+				return JSON.stringify({ id: 'int-record' });
+			},
+			metaJsonSupported: true,
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.payload.metadata).toEqual({});
+		expect(commands[0].args).not.toContain('--meta-json');
+	});
+
 	test('skips fallback metadata when upstream meta-json support is present', () => {
 		const commands = [];
 		const fsDouble = createFsDouble();

--- a/test/audit-evidence.test.js
+++ b/test/audit-evidence.test.js
@@ -51,6 +51,25 @@ describe('audit evidence adapter', () => {
 		expect(serialized).not.toContain('secret-token');
 	});
 
+	test('redacts JSON-style secret assignments in free-form strings', () => {
+		const payload = buildSubagentAuditPayload({
+			command: 'dev',
+			role: 'implementer',
+			prompt: 'Payload: {"token":"abc123","password": "hunter2","api_key": "key-123"}',
+			response: "Result: {'secret':'value-123'}",
+		});
+
+		const serialized = JSON.stringify(payload);
+		expect(serialized).toContain('[REDACTED]');
+		expect(serialized).toContain('token');
+		expect(serialized).toContain('password');
+		expect(serialized).toContain('api_key');
+		expect(serialized).not.toContain('abc123');
+		expect(serialized).not.toContain('hunter2');
+		expect(serialized).not.toContain('key-123');
+		expect(serialized).not.toContain('value-123');
+	});
+
 	test('records subagent calls through bd audit record and writes fallback metadata without replacing Beads', () => {
 		const commands = [];
 		const fsDouble = createFsDouble();

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -412,6 +412,19 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(runner.commands[0].args.join(' ')).toContain('llm_call');
 		});
 
+		test('emits implementer evidence with a default event object', () => {
+			const runner = createRunner();
+			const result = emitImplementerAuditEvidence(undefined, {
+				runCommand: runner.runCommand,
+				metaJsonSupported: true,
+			});
+
+			expect(result.record.entryId).toBe('int-record');
+			expect(result.label.skipped).toBe(true);
+			expect(runner.commands.length).toBe(1);
+			expect(runner.commands[0].args).toContain('record');
+		});
+
 		test('emits spec reviewer PASS evidence and labels it good', () => {
 			const runner = createRunner();
 			const result = emitSpecReviewerAuditEvidence({

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -281,6 +281,28 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(JSON.parse(commands[0].args[promptIndex + 1]).content).toBe('forge dev audit-feature RED');
 		});
 
+		test('handler parses issue-id equals flags before emitting audit evidence', async () => {
+			const commands = [];
+			const runCommand = (cmd, args) => {
+				commands.push({ cmd, args });
+				return JSON.stringify({ id: 'int-record' });
+			};
+
+			const result = await handler(['audit-feature', '--issue-id=forge-besw.20', 'RED'], {
+				auditOptions: {
+					runCommand,
+					metaJsonSupported: true,
+				},
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.phase).toBe('RED');
+			expect(commands[0].args).toContain('--issue-id');
+			expect(commands[0].args).toContain('forge-besw.20');
+			const promptIndex = commands[0].args.indexOf('--prompt');
+			expect(JSON.parse(commands[0].args[promptIndex + 1]).content).toBe('forge dev audit-feature RED');
+		});
+
 		test('should validate tests pass before allowing REFACTOR', async () => {
 			const result = await executeDev('feature', { phase: 'REFACTOR', testsPassing: false });
 			expect(result.success).toBe(false);

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -7,6 +7,9 @@ const {
 	generateCommitMessage,
 	identifyParallelWork,
 	executeDev,
+	emitImplementerAuditEvidence,
+	emitSpecReviewerAuditEvidence,
+	emitQualityReviewerAuditEvidence,
 	calculateDecisionRoute,
 	DECISION_ROUTES,
 } = require('../../lib/commands/dev.js');
@@ -372,6 +375,108 @@ describe('Dev Command - TDD Cycle Management', () => {
 				expect(result.route).toBe('BLOCKED');
 				expect(result.mandatoryOverride).toBe(true);
 			});
+		});
+	});
+
+	describe('/dev audit evidence helpers', () => {
+		function createRunner() {
+			const commands = [];
+			return {
+				commands,
+				runCommand: (cmd, args) => {
+					commands.push({ cmd, args });
+					return JSON.stringify({ id: commands.length === 1 ? 'int-record' : 'int-label' });
+				},
+			};
+		}
+
+		test('emits implementer evidence through bd audit record', () => {
+			const runner = createRunner();
+			const result = emitImplementerAuditEvidence({
+				issueId: 'forge-besw.20',
+				phase: 'GREEN',
+				taskId: 'task-1',
+				taskTitle: 'Implement audit helper',
+				prompt: 'implement prompt',
+				response: 'implementation complete',
+			}, {
+				runCommand: runner.runCommand,
+				metaJsonSupported: true,
+			});
+
+			expect(result.record.entryId).toBe('int-record');
+			expect(result.label.skipped).toBe(true);
+			expect(runner.commands.length).toBe(1);
+			expect(runner.commands[0].args).toContain('record');
+			expect(runner.commands[0].args).toContain('forge-besw.20');
+			expect(runner.commands[0].args.join(' ')).toContain('llm_call');
+		});
+
+		test('emits spec reviewer PASS evidence and labels it good', () => {
+			const runner = createRunner();
+			const result = emitSpecReviewerAuditEvidence({
+				issueId: 'forge-besw.20',
+				taskId: 'task-1',
+				taskTitle: 'Spec review',
+				prompt: 'spec prompt',
+				response: 'PASS',
+				verdict: 'PASS',
+			}, {
+				runCommand: runner.runCommand,
+				metaJsonSupported: true,
+			});
+
+			expect(result.record.entryId).toBe('int-record');
+			expect(result.label.label).toBe('good');
+			expect(runner.commands[1].args).toEqual([
+				'audit',
+				'label',
+				'int-record',
+				'--json',
+				'--label',
+				'good',
+				'--reason',
+				'spec_reviewer verdict: PASS',
+			]);
+		});
+
+		test('emits quality reviewer FAIL evidence and labels it bad', () => {
+			const runner = createRunner();
+			const result = emitQualityReviewerAuditEvidence({
+				issueId: 'forge-besw.20',
+				taskId: 'task-2',
+				taskTitle: 'Quality review',
+				prompt: 'quality prompt',
+				response: 'FAIL',
+				verdict: 'FAIL',
+			}, {
+				runCommand: runner.runCommand,
+				metaJsonSupported: true,
+			});
+
+			expect(result.record.entryId).toBe('int-record');
+			expect(result.label.label).toBe('bad');
+			expect(runner.commands[1].args).toContain('bad');
+			expect(runner.commands[1].args).toContain('quality_reviewer verdict: FAIL');
+		});
+
+		test('does not label reviewer events with unknown verdicts', () => {
+			const runner = createRunner();
+			const result = emitQualityReviewerAuditEvidence({
+				issueId: 'forge-besw.20',
+				taskId: 'task-3',
+				taskTitle: 'Quality review pending',
+				prompt: 'quality prompt',
+				response: 'needs more data',
+				verdict: 'UNKNOWN',
+			}, {
+				runCommand: runner.runCommand,
+				metaJsonSupported: true,
+			});
+
+			expect(result.record.entryId).toBe('int-record');
+			expect(result.label.skipped).toBe(true);
+			expect(runner.commands.length).toBe(1);
 		});
 	});
 });

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -211,6 +211,30 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(['RED', 'GREEN', 'REFACTOR'].includes(result.detectedPhase)).toBeTruthy();
 		});
 
+		test('records audit evidence when enabled during dev execution', async () => {
+			const commands = [];
+			const runCommand = (cmd, args) => {
+				commands.push({ cmd, args });
+				return JSON.stringify({ id: 'int-record' });
+			};
+
+			const result = await executeDev('audit-feature', {
+				phase: 'RED',
+				audit: true,
+				auditOptions: {
+					runCommand,
+					metaJsonSupported: true,
+				},
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.auditEvidence.record.entryId).toBe('int-record');
+			expect(commands.length).toBe(1);
+			expect(commands[0].cmd).toBe('bd');
+			expect(commands[0].args).toContain('record');
+			expect(commands[0].args).toContain('llm_call');
+		});
+
 		test('should validate tests pass before allowing REFACTOR', async () => {
 			const result = await executeDev('feature', { phase: 'REFACTOR', testsPassing: false });
 			expect(result.success).toBe(false);

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -236,6 +236,22 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(commands[0].args).toContain('llm_call');
 		});
 
+		test('fails dev execution when audit evidence persistence fails', async () => {
+			const result = await executeDev('audit-feature', {
+				phase: 'RED',
+				audit: true,
+				auditOptions: {
+					runCommand: () => 'missing-json-id',
+					metaJsonSupported: true,
+				},
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toMatch(/Audit evidence persistence failed/);
+			expect(result.auditEvidence.record.success).toBe(false);
+			expect(result.auditEvidence.record.entryId).toBe(null);
+		});
+
 		test('records failed GREEN audit evidence with the concrete error response', async () => {
 			const commands = [];
 			const runCommand = (cmd, args) => {

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -308,6 +308,31 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toMatch(/tests.*fail/i);
 		});
+
+		test('records audit evidence when REFACTOR is blocked by failing tests', async () => {
+			const commands = [];
+			const result = await executeDev('feature', {
+				phase: 'REFACTOR',
+				testsPassing: false,
+				audit: true,
+				auditOptions: {
+					runCommand: (cmd, args) => {
+						commands.push({ cmd, args });
+						return JSON.stringify({ id: 'int-record' });
+					},
+					metaJsonSupported: true,
+				},
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.auditEvidence.record.entryId).toBe('int-record');
+			expect(commands.length).toBe(1);
+			expect(commands[0].args).toContain('record');
+			const responseIndex = commands[0].args.indexOf('--response');
+			const response = JSON.parse(commands[0].args[responseIndex + 1]);
+			expect(response.verdict).toBe('FAIL');
+			expect(response.content).toMatch(/Cannot proceed to REFACTOR phase/);
+		});
 	});
 
 	describe('Parallel development support', () => {

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -1,5 +1,6 @@
 const { describe, test, expect } = require('bun:test');
 const {
+	handler,
 	detectTDDPhase,
 	identifyFilePairs,
 	runTests,
@@ -235,6 +236,51 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(commands[0].args).toContain('llm_call');
 		});
 
+		test('records failed GREEN audit evidence with the concrete error response', async () => {
+			const commands = [];
+			const runCommand = (cmd, args) => {
+				commands.push({ cmd, args });
+				return JSON.stringify({ id: 'int-record' });
+			};
+
+			const result = await executeDev('audit-feature', {
+				phase: 'GREEN',
+				audit: true,
+				runTests: async () => ({ success: false, error: 'unit tests failed hard' }),
+				auditOptions: {
+					runCommand,
+					metaJsonSupported: true,
+				},
+			});
+
+			const responseIndex = commands[0].args.indexOf('--response');
+			const response = JSON.parse(commands[0].args[responseIndex + 1]);
+			expect(result.success).toBe(false);
+			expect(response.content).toBe('unit tests failed hard');
+		});
+
+		test('handler parses issue-id flags before emitting audit evidence', async () => {
+			const commands = [];
+			const runCommand = (cmd, args) => {
+				commands.push({ cmd, args });
+				return JSON.stringify({ id: 'int-record' });
+			};
+
+			const result = await handler(['audit-feature', '--issue-id', 'forge-besw.20', 'RED'], {
+				auditOptions: {
+					runCommand,
+					metaJsonSupported: true,
+				},
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.phase).toBe('RED');
+			expect(commands[0].args).toContain('--issue-id');
+			expect(commands[0].args).toContain('forge-besw.20');
+			const promptIndex = commands[0].args.indexOf('--prompt');
+			expect(JSON.parse(commands[0].args[promptIndex + 1]).content).toBe('forge dev audit-feature RED');
+		});
+
 		test('should validate tests pass before allowing REFACTOR', async () => {
 			const result = await executeDev('feature', { phase: 'REFACTOR', testsPassing: false });
 			expect(result.success).toBe(false);
@@ -439,6 +485,19 @@ describe('Dev Command - TDD Cycle Management', () => {
 		test('emits implementer evidence with a default event object', () => {
 			const runner = createRunner();
 			const result = emitImplementerAuditEvidence(undefined, {
+				runCommand: runner.runCommand,
+				metaJsonSupported: true,
+			});
+
+			expect(result.record.entryId).toBe('int-record');
+			expect(result.label.skipped).toBe(true);
+			expect(runner.commands.length).toBe(1);
+			expect(runner.commands[0].args).toContain('record');
+		});
+
+		test('emits implementer evidence with a null event object', () => {
+			const runner = createRunner();
+			const result = emitImplementerAuditEvidence(null, {
 				runCommand: runner.runCommand,
 				metaJsonSupported: true,
 			});

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -536,6 +536,35 @@ describe('Dev Command - TDD Cycle Management', () => {
 			]);
 		});
 
+		test('keeps reviewer helper phases pinned to reviewer roles', () => {
+			const specRunner = createRunner();
+			const qualityRunner = createRunner();
+
+			emitSpecReviewerAuditEvidence({
+				phase: 'GREEN',
+				prompt: 'spec prompt',
+				response: 'PASS',
+				verdict: 'PASS',
+			}, {
+				runCommand: specRunner.runCommand,
+				metaJsonSupported: true,
+			});
+			emitQualityReviewerAuditEvidence({
+				phase: 'GREEN',
+				prompt: 'quality prompt',
+				response: 'FAIL',
+				verdict: 'FAIL',
+			}, {
+				runCommand: qualityRunner.runCommand,
+				metaJsonSupported: true,
+			});
+
+			const specPromptIndex = specRunner.commands[0].args.indexOf('--prompt');
+			const qualityPromptIndex = qualityRunner.commands[0].args.indexOf('--prompt');
+			expect(JSON.parse(specRunner.commands[0].args[specPromptIndex + 1]).phase).toBe('SPEC');
+			expect(JSON.parse(qualityRunner.commands[0].args[qualityPromptIndex + 1]).phase).toBe('QUALITY');
+		});
+
 		test('emits quality reviewer FAIL evidence and labels it bad', () => {
 			const runner = createRunner();
 			const result = emitQualityReviewerAuditEvidence({

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -252,6 +252,26 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(result.auditEvidence.record.entryId).toBe(null);
 		});
 
+		test('keeps dev execution successful when audit command is unavailable', async () => {
+			const missingBd = new Error('bd not found');
+			missingBd.code = 'ENOENT';
+
+			const result = await executeDev('audit-feature', {
+				phase: 'RED',
+				audit: true,
+				auditOptions: {
+					runCommand: () => {
+						throw missingBd;
+					},
+				},
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.auditEvidence.success).toBe(false);
+			expect(result.auditEvidence.skipped).toBe(true);
+			expect(result.auditEvidence.error).toBe('bd not found');
+		});
+
 		test('records failed GREEN audit evidence with the concrete error response', async () => {
 			const commands = [];
 			const runCommand = (cmd, args) => {

--- a/test/commands/dev.test.js
+++ b/test/commands/dev.test.js
@@ -303,6 +303,22 @@ describe('Dev Command - TDD Cycle Management', () => {
 			expect(JSON.parse(commands[0].args[promptIndex + 1]).content).toBe('forge dev audit-feature RED');
 		});
 
+		test('handler rejects missing issue-id and phase flag values', async () => {
+			const missingIssueId = await handler(['audit-feature', '--issue-id'], {});
+			const missingIssueIdBeforeFlag = await handler(['audit-feature', '--issue-id', '--phase', 'RED'], {});
+			const missingIssueIdEquals = await handler(['audit-feature', '--issue-id=', 'RED'], {});
+			const missingPhase = await handler(['audit-feature', '--phase'], {});
+			const missingPhaseBeforeFlag = await handler(['audit-feature', '--phase', '--issue-id', 'forge-besw.20'], {});
+			const missingPhaseEquals = await handler(['audit-feature', '--phase='], {});
+
+			expect(missingIssueId).toEqual({ success: false, error: '--issue-id requires a value' });
+			expect(missingIssueIdBeforeFlag).toEqual({ success: false, error: '--issue-id requires a value' });
+			expect(missingIssueIdEquals).toEqual({ success: false, error: '--issue-id requires a value' });
+			expect(missingPhase).toEqual({ success: false, error: '--phase requires a value' });
+			expect(missingPhaseBeforeFlag).toEqual({ success: false, error: '--phase requires a value' });
+			expect(missingPhaseEquals).toEqual({ success: false, error: '--phase requires a value' });
+		});
+
 		test('should validate tests pass before allowing REFACTOR', async () => {
 			const result = await executeDev('feature', { phase: 'REFACTOR', testsPassing: false });
 			expect(result.success).toBe(false);


### PR DESCRIPTION
## Problem
`/dev` and future `/build` subagent calls needed durable audit/evidence records tied to Beads instead of ad hoc local logs.

## Root Cause
The executable `/dev` helper had no audit adapter for implementer/spec-reviewer/quality-reviewer calls, and the current `bd audit` surface supports `record`/`label` but not `--meta-json` or a working `verify` subcommand.

## Fix
Adds a reusable audit evidence adapter around `bd audit record` and `bd audit label`, wires `/dev` helper exports for implementer, spec reviewer, and quality reviewer evidence, and documents the minimal `.forge/log.jsonl` metadata fallback.

## Value
Review/eval data can now be persisted through Beads as the source of truth with redaction-safe payloads and PASS/FAIL labels for reviewer verdicts.

## Beads
Closes forge-besw.20
References forge-besw.27 for the design-only upstream `--meta-json` / fallback decision.

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 729 passing in `bun run check`; focused tests: 48 passing, 5 existing skips.
- Scenarios covered: event shape, redaction-safe payloads, `bd audit record` invocation, reviewer `good`/`bad` label behavior, unknown verdict skip, fallback metadata path.

### Security Review
- OWASP Top 10: A09 logging/evidence improved; A02/A03 risk mitigated by redacting secret-like keys/values and using `execFileSync` argument arrays.
- Automated scan: `bun run check` passed.

### Design Doc
See: `docs/work/2026-05-12-0.0.14-audit-evidence/design.md`

### Key Decisions
- Beads remains the source of truth for interaction records and labels.
- `.forge/log.jsonl` is supplemental metadata only when upstream `bd audit --meta-json` is unavailable.
- No 0.0.13 config, L1 rails, protected paths, or options API changes.
- No executable `/build` command exists on this branch, so the adapter is reusable for future `/build` wiring.

### Documentation Updated
- `docs/work/2026-05-12-0.0.14-audit-evidence/design.md`
- `docs/work/2026-05-12-0.0.14-audit-evidence/tasks.md`
- `docs/work/2026-05-12-0.0.14-audit-evidence/decisions.md`

### Validation
- [x] Type check passing: `bun run typecheck`
- [x] Lint passing: `bun run lint`
- [x] All tests passing: `bun run check` (`729 pass`, `9 skip`, `0 fail`)
- [x] Security review completed

Additional validation:
- `bun test test/commands/dev.test.js test/audit-evidence.test.js` (`48 pass`, `5 skip`, `0 fail`)
- Temp `.beads` copy: `bd audit record --json` returned `int-b7279cae`; `bd audit label ... --label good` returned `int-d08f3696`.
- `bd audit verify --json` currently exits 0 but prints audit help, so this PR documents fallback behavior rather than claiming hash-chain verification is available.

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff locally
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun run check`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes
- [x] TDD compliance: All source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist audit evidence from dev flows: automatic record + verdict labeling for implementer, spec, and quality reviewer events; local minimal metadata fallback when upstream metadata isn’t available; dev command surfaces audit results.

* **Privacy**
  * Redacts sensitive data in audit payloads and any fallback metadata.

* **Tests**
  * Added coverage for redaction, record+label flows, fallback write behavior, verdict→label mapping, and dev-flow integration.

* **Documentation**
  * Added decision, design, and task docs describing persistence, labeling, and fallback behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/159)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->