### PR TITLE
0.0.13 config rails and graph introspection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: bash test-env/automation/setup-fixtures.sh --force
       - name: Run matrix unit tests
-        run: bun test test/ --reporter=junit --reporter-outfile test-results/full-matrix-${{ matrix.os }}-node${{ matrix.node-version }}.xml
+        run: bun test --timeout 15000 test/ --reporter=junit --reporter-outfile test-results/full-matrix-${{ matrix.os }}-node${{ matrix.node-version }}.xml
       - name: Build matrix test profile
         run: node scripts/test-profile.js --input-dir test-results --output test-results/full-matrix-${{ matrix.os }}-node${{ matrix.node-version }}.profile.json --label full-matrix-${{ matrix.os }}-node${{ matrix.node-version }} --integration-skipped true
       - name: Upload matrix artifacts
@@ -291,13 +291,13 @@ jobs:
           mapfile -t test_targets <<'EOF'
           ${{ steps.affected.outputs.targets }}
           EOF
-          bun test "${test_targets[@]}" --reporter=junit --reporter-outfile test-results/followup-targeted.xml
+          bun test --timeout 15000 "${test_targets[@]}" --reporter=junit --reporter-outfile test-results/followup-targeted.xml
       - name: Run single-platform unit suite fallback
         if: steps.affected.outputs.mode == 'full'
-        run: bun test test/ --reporter=junit --reporter-outfile test-results/followup-full.xml
+        run: bun test --timeout 15000 test/ --reporter=junit --reporter-outfile test-results/followup-full.xml
       - name: Run affected e2e tests
         if: steps.affected.outputs.run_e2e == 'true'
-        run: bun test test/e2e/ --reporter=junit --reporter-outfile test-results/followup-e2e.xml
+        run: bun test --timeout 15000 test/e2e/ --reporter=junit --reporter-outfile test-results/followup-e2e.xml
       - name: Run affected edge-case tests
         if: steps.affected.outputs.run_test_env == 'true'
         run: node --test test-env/**/*.test.js || true
@@ -339,7 +339,7 @@ jobs:
       - name: Setup test fixtures
         run: bash test-env/automation/setup-fixtures.sh --force
       - name: Run tests with coverage
-        run: bun test --coverage test/ --reporter=junit --reporter-outfile test-results/coverage.xml
+        run: bun test --timeout 15000 --coverage test/ --reporter=junit --reporter-outfile test-results/coverage.xml
       - name: Build coverage profile
         run: node scripts/test-profile.js --input-dir test-results --output test-results/coverage.profile.json --label coverage --integration-skipped true
       - name: Publish coverage runtime summary
@@ -391,7 +391,7 @@ jobs:
         run: |
           node -e "require('node:fs').mkdirSync('test-results', { recursive: true })"
       - name: Run E2E tests
-        run: bun test test/e2e/ --reporter=junit --reporter-outfile test-results/e2e.xml
+        run: bun test --timeout 15000 test/e2e/ --reporter=junit --reporter-outfile test-results/e2e.xml
       - name: Build E2E profile
         run: node scripts/test-profile.js --input-dir test-results --output test-results/e2e.profile.json --label e2e --integration-skipped true
       - name: Publish E2E runtime summary
@@ -431,7 +431,7 @@ jobs:
         run: |
           node -e "require('node:fs').mkdirSync('test-results', { recursive: true })"
       - name: Run Beads integration tests
-        run: bun test scripts/beads-context.test.js --reporter=junit --reporter-outfile test-results/beads-integration.xml
+        run: bun test --timeout 15000 scripts/beads-context.test.js --reporter=junit --reporter-outfile test-results/beads-integration.xml
       - name: Build Beads integration profile
         run: node scripts/test-profile.js --input-dir test-results --output test-results/beads-integration.profile.json --label beads-integration --integration-skipped false
       - name: Publish Beads integration summary

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -4130,7 +4130,8 @@ async function main() {
   SYNC_ENABLED = flags.sync;
   actionLog = new SetupActionLog();
 
-  if (NON_INTERACTIVE) {
+  const suppressNonInteractiveBanner = command === 'options' && args.includes('--json');
+  if (NON_INTERACTIVE && !suppressNonInteractiveBanner) {
     const agentFlag = flags.agents;
     if (agentFlag && agentFlag.length > 0) {
       // flags.agents is a comma-separated string (e.g. "claude,cursor")

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -3834,14 +3834,16 @@ async function interactiveSetupWithFlags(flags) {
 
 // Main
 // Helper: Handle --path setup
-function handlePathSetup(targetPath) {
+function handlePathSetup(targetPath, options = {}) {
   const resolvedPath = path.resolve(targetPath);
 
   // Create directory if it doesn't exist
   if (!fs.existsSync(resolvedPath)) {
     try {
-      fs.mkdirSync(resolvedPath, { recursive: true });
+    fs.mkdirSync(resolvedPath, { recursive: true });
+    if (!options.quiet) {
       console.log(`Created directory: ${resolvedPath}`);
+    }
     } catch (err) {
       console.error(`Error creating directory: ${err.message}`);
       process.exit(1);
@@ -3857,8 +3859,10 @@ function handlePathSetup(targetPath) {
   // Change to target directory
   try {
     process.chdir(resolvedPath);
-    console.log(`Working directory: ${resolvedPath}`);
-    console.log('');
+    if (!options.quiet) {
+      console.log(`Working directory: ${resolvedPath}`);
+      console.log('');
+    }
   } catch (err) {
     console.error(`Error changing to directory: ${err.message}`);
     process.exit(1);
@@ -4121,6 +4125,7 @@ async function handleExternalServices(skipExternal, selectedAgents) {
 async function main() {
   const command = args[0];
   const flags = parseFlags();
+  const suppressJsonIntrospectionOutput = ['options', 'explain'].includes(command) && args.includes('--json');
 
   // Wire up incremental setup state from parsed flags
   FORCE_MODE = flags.force;
@@ -4130,8 +4135,7 @@ async function main() {
   SYNC_ENABLED = flags.sync;
   actionLog = new SetupActionLog();
 
-  const suppressNonInteractiveBanner = command === 'options' && args.includes('--json');
-  if (NON_INTERACTIVE && !suppressNonInteractiveBanner) {
+  if (NON_INTERACTIVE && !suppressJsonIntrospectionOutput) {
     const agentFlag = flags.agents;
     if (agentFlag && agentFlag.length > 0) {
       // flags.agents is a comma-separated string (e.g. "claude,cursor")
@@ -4157,7 +4161,7 @@ async function main() {
   // Handle --path option: change to target directory
   if (flags.path) {
     // Update projectRoot after changing directory to maintain state consistency
-    projectRoot = handlePathSetup(flags.path);
+    projectRoot = handlePathSetup(flags.path, { quiet: suppressJsonIntrospectionOutput });
   }
 
   // Load command registry (auto-discovered commands from lib/commands/)

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@babel/parser": "^7.29.2",
         "fastest-levenshtein": "^1.0.16",
+        "yaml": "^2.8.3",
       },
       "devDependencies": {
         "@commitlint/cli": "^20.4.1",
@@ -19,7 +20,6 @@
         "globals": "^17.3.0",
         "js-yaml": "^4.1.1",
         "lefthook": "^2.1.4",
-        "yaml": "^2.8.3",
       },
       "peerDependencies": {
         "lefthook": "^1.0.0",

--- a/docs/work/2026-05-12-0.0.13-config-rails/decisions.md
+++ b/docs/work/2026-05-12-0.0.13-config-rails/decisions.md
@@ -1,0 +1,21 @@
+# Decisions Log: 0.0.13 Config Rails And Graph Introspection
+
+## Decision 1
+
+**Date**: 2026-05-12
+**Task**: Task 1 - Config Resolution And Locked Rails
+**Gap**: Whether to bump the runtime graph schema version for additive config fields.
+**Score**: 2/14
+**Route**: PROCEED
+**Choice made**: Keep `RUNTIME_GRAPH_SCHEMA_VERSION` at `0.0.12` because this PR builds on the landed contract and adds resolved graph fields without replacing the envelope contract.
+**Status**: RESOLVED
+
+## Decision 2
+
+**Date**: 2026-05-12
+**Task**: Task 2 - Options Introspection Command
+**Gap**: Whether `forge explain` should be included.
+**Score**: 1/14
+**Route**: PROCEED
+**Choice made**: Add `forge explain <id>` only as a thin alias over `forge options why <id>`, with no separate explanation semantics.
+**Status**: RESOLVED

--- a/docs/work/2026-05-12-0.0.13-config-rails/design.md
+++ b/docs/work/2026-05-12-0.0.13-config-rails/design.md
@@ -1,0 +1,59 @@
+# 0.0.13 Config Rails And Graph Introspection
+
+**Date**: 2026-05-12
+**Status**: in progress
+**Branch**: `codex/0.0.13-config-rails`
+**Issues covered**: `forge-besw.2`, `forge-besw.3`, `forge-besw.4`, and protected paths from `forge-5146` where it fits the config lint surface.
+
+## Purpose
+
+Build on the landed 0.0.12 runtime graph contract by resolving project `.forge/config.yaml` into the graph, enforcing locked L1 rails, and exposing graph primitives through `forge options`.
+
+## Success Criteria
+
+- `.forge/config.yaml` is optional, parsed when present, and merged into the resolved runtime graph.
+- Locked L1 rails cannot be disabled by project config.
+- Disabled primitives remain present, addressable, and auditable in the graph.
+- `forge options stages|gates|adapters|diff|why <id>|lint` supports human output and `--json`.
+- Bad config, disabled locked rails, and protected path policy mistakes produce validation errors.
+
+## Out Of Scope
+
+- `/build` audit persistence.
+- Beads audit wiring.
+- 0.0.14 audit/evidence storage.
+- Runtime execution of graph actions beyond introspection.
+
+## Approach Selected
+
+Extend `lib/core/runtime-graph.js` rather than creating a new graph model. Add a small registry command in `lib/commands/options.js` for introspection, keeping command behavior unchanged unless this new command is called.
+
+## Constraints
+
+- Preserve the 0.0.12 graph shape and command flow.
+- Config resolution is project-local only in this PR.
+- Protected path support is validation/introspection only, not enforcement against file changes.
+
+## Edge Cases
+
+- Missing `.forge/config.yaml` resolves to package defaults.
+- Malformed YAML returns a lint/config error.
+- Unknown primitive IDs in config return lint/config errors.
+- Attempts to disable locked L1 rails return lint/config errors.
+- Broad or invalid protected path entries return lint/config errors.
+
+## Technical Research
+
+- `docs/work/2026-04-28-skeleton-pivot/layered-skeleton-config.md` defines `.forge/config.yaml`, resolution order, `forge options *`, off semantics, and locked rails.
+- `lib/core/runtime-graph.js` is the existing runtime graph model from 0.0.12.
+- `lib/commands/_registry.js` auto-discovers command modules, so `lib/commands/options.js` is the least invasive CLI surface.
+
+## TDD Scenarios
+
+- Happy path: valid `.forge/config.yaml` disables an unlocked gate and `forge options gates --json` reports it disabled with config provenance.
+- Error path: config disables a locked L1 rail and graph resolution/lint reports a blocking error.
+- Edge path: malformed YAML and invalid protected paths are reported by `forge options lint`.
+
+## Ambiguity Policy
+
+Use the 7-dimension /dev decision rubric. Proceed only for local, reversible CLI/model details that do not change public execution semantics. Stop for schema, persistence, audit, or command behavior changes outside this PR.

--- a/docs/work/2026-05-12-0.0.13-config-rails/tasks.md
+++ b/docs/work/2026-05-12-0.0.13-config-rails/tasks.md
@@ -1,0 +1,52 @@
+# 0.0.13 Config Rails And Graph Introspection Tasks
+
+## Task 1: Config Resolution And Locked Rails
+
+**OWNS**: `lib/core/runtime-graph.js`, `test/runtime-graph-config.test.js`
+
+**What to implement**: Load optional `.forge/config.yaml`, merge supported config into graph primitives, track provenance, preserve disabled primitives, and reject disabled locked L1 rails.
+
+**TDD steps**:
+1. Write failing tests for valid config resolution, unknown primitive IDs, malformed YAML, and locked rail disable errors.
+2. Run `bun test test/runtime-graph-config.test.js` and confirm failures.
+3. Implement graph config loading and validation.
+4. Run `bun test test/runtime-graph-config.test.js` and confirm pass.
+5. Commit: `feat: resolve runtime graph config rails`
+
+## Task 2: Options Introspection Command
+
+**OWNS**: `lib/commands/options.js`, `test/options-command.test.js`
+
+**What to implement**: Add `forge options stages|gates|adapters|diff|why <id>|lint` with human and `--json` output over graph primitives.
+
+**TDD steps**:
+1. Write failing tests for stages/gates/adapters/diff/why/lint JSON and human output.
+2. Run `bun test test/options-command.test.js` and confirm failures.
+3. Implement the registry command using runtime graph APIs.
+4. Run `bun test test/options-command.test.js` and confirm pass.
+5. Commit: `feat: add graph options introspection`
+
+## Task 3: Protected Path Policy Validation
+
+**OWNS**: `lib/core/runtime-graph.js`, `test/runtime-graph-config.test.js`, `test/options-command.test.js`
+
+**What to implement**: Validate `protectedPaths` entries in config and expose policy errors through `forge options lint`.
+
+**TDD steps**:
+1. Add failing tests for invalid protected path entries and broad catch-all patterns.
+2. Run targeted tests and confirm failures.
+3. Implement protected path validation.
+4. Run targeted tests and confirm pass.
+5. Commit: `feat: validate graph protected paths`
+
+## Task 4: Workflow Docs And Final Validation
+
+**OWNS**: `docs/work/2026-05-12-0.0.13-config-rails/decisions.md`
+
+**What to implement**: Record resolved implementation decisions and run validation.
+
+**TDD steps**:
+1. Create decisions log.
+2. Run targeted graph/options tests.
+3. Run `/validate` checks.
+4. Commit documentation if changed.

--- a/lib/commands/explain.js
+++ b/lib/commands/explain.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const optionsCommand = require('./options');
+
+module.exports = {
+  name: 'explain',
+  description: 'Explain a runtime graph primitive',
+  usage: 'forge explain <id> [--json]',
+  flags: {
+    '--json': 'Emit machine-readable JSON output',
+  },
+  async handler(args, flags, projectRoot) {
+    return optionsCommand.handler(['why', ...args], flags, projectRoot);
+  },
+};

--- a/lib/commands/options.js
+++ b/lib/commands/options.js
@@ -129,64 +129,69 @@ function usage() {
   ].join('\n');
 }
 
-async function handler(args, _flags, projectRoot) {
-  const json = hasJson(args);
-  const tokens = withoutFlags(args);
-  const subcommand = tokens[0];
+function lintCommand(projectRoot, json) {
+  const result = lintRuntimeGraphConfig({ projectRoot });
+  const output = json ? jsonOutput(result) : renderLint(result);
+  return {
+    success: result.ok,
+    output,
+    error: result.ok ? undefined : output,
+  };
+}
 
-  if (!subcommand) {
-    return { success: false, error: usage() };
-  }
-
-  if (subcommand === 'lint') {
-    const result = lintRuntimeGraphConfig({ projectRoot });
-    return {
-      success: result.ok,
-      output: json ? jsonOutput(result) : renderLint(result),
-      error: result.ok ? undefined : renderLint(result),
-    };
-  }
-
-  let graph;
+function resolveGraphResult(projectRoot, json) {
   try {
-    graph = getResolvedRuntimeGraph({ projectRoot });
+    return { success: true, graph: getResolvedRuntimeGraph({ projectRoot }) };
   } catch (err) {
     const output = json
       ? jsonOutput({ ok: false, errors: err.message.split('\n').map(message => ({ message })) })
       : `${err.message}\n`;
     return { success: false, output, error: output };
   }
+}
 
-  if (COLLECTIONS[subcommand]) {
-    const { key, label } = COLLECTIONS[subcommand];
-    const items = graph[key];
-    return {
-      success: true,
-      output: json ? jsonOutput({ kind: subcommand, items }) : renderCollection(label, items),
-    };
+function collectionCommand(graph, subcommand, json) {
+  const { key, label } = COLLECTIONS[subcommand];
+  const items = graph[key];
+  return {
+    success: true,
+    output: json ? jsonOutput({ kind: subcommand, items }) : renderCollection(label, items),
+  };
+}
+
+function whyCommand(graph, id, json) {
+  const match = id ? findPrimitive(graph, id) : null;
+  if (!match) {
+    return { success: false, error: `Unknown graph primitive: ${id ?? '<missing>'}` };
   }
+  const [type, item] = match;
+  return {
+    success: true,
+    output: json ? jsonOutput({ type, item }) : renderWhy(type, item),
+  };
+}
 
-  if (subcommand === 'why') {
-    const id = tokens[1];
-    const match = id ? findPrimitive(graph, id) : null;
-    if (!match) {
-      return { success: false, error: `Unknown graph primitive: ${id ?? '<missing>'}` };
-    }
-    const [type, item] = match;
-    return {
-      success: true,
-      output: json ? jsonOutput({ type, item }) : renderWhy(type, item),
-    };
-  }
+function diffCommand(graph, json) {
+  const changes = collectDiff(getDefaultRuntimeGraph(), graph);
+  return {
+    success: true,
+    output: json ? jsonOutput({ changes }) : renderDiff(changes),
+  };
+}
 
-  if (subcommand === 'diff') {
-    const changes = collectDiff(getDefaultRuntimeGraph(), graph);
-    return {
-      success: true,
-      output: json ? jsonOutput({ changes }) : renderDiff(changes),
-    };
-  }
+async function handler(args, _flags, projectRoot) {
+  const json = hasJson(args);
+  const tokens = withoutFlags(args);
+  const subcommand = tokens[0];
 
+  if (!subcommand) return { success: false, error: usage() };
+  if (subcommand === 'lint') return lintCommand(projectRoot, json);
+
+  const graphResult = resolveGraphResult(projectRoot, json);
+  if (!graphResult.success) return graphResult;
+  if (COLLECTIONS[subcommand]) return collectionCommand(graphResult.graph, subcommand, json);
+  if (subcommand === 'why') return whyCommand(graphResult.graph, tokens[1], json);
+  if (subcommand === 'diff') return diffCommand(graphResult.graph, json);
   return { success: false, error: usage() };
 }
 

--- a/lib/commands/options.js
+++ b/lib/commands/options.js
@@ -1,0 +1,202 @@
+'use strict';
+
+const {
+  getDefaultRuntimeGraph,
+  getResolvedRuntimeGraph,
+  lintRuntimeGraphConfig,
+} = require('../core/runtime-graph');
+
+const COLLECTIONS = {
+  stages: { key: 'phases', label: 'Stages' },
+  gates: { key: 'gates', label: 'Gates' },
+  adapters: { key: 'adapters', label: 'Adapters' },
+};
+
+function hasJson(args) {
+  return args.includes('--json');
+}
+
+function withoutFlags(args) {
+  return args.filter(arg => arg !== '--json');
+}
+
+function jsonOutput(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function summarizeItem(item) {
+  const state = item.enabled === false ? 'disabled' : 'enabled';
+  const locked = item.locked ? ', locked' : '';
+  return `${item.id} (${state}${locked}) - ${item.label ?? item.kind ?? item.command ?? 'graph primitive'}`;
+}
+
+function renderCollection(label, items) {
+  return [
+    label,
+    ...items.map(item => `- ${summarizeItem(item)}`),
+  ].join('\n') + '\n';
+}
+
+function allPrimitiveEntries(graph) {
+  return [
+    ...graph.phases.map(item => ['stage', item]),
+    ...graph.gates.map(item => ['gate', item]),
+    ...graph.adapters.map(item => ['adapter', item]),
+    ...graph.rails.map(item => ['rail', item]),
+    ...graph.actions.map(item => ['action', item]),
+    ...graph.artifacts.map(item => ['artifact', item]),
+    ...graph.evaluatorRegions.map(item => ['evaluatorRegion', item]),
+    ...graph.evidence.map(item => ['evidence', item]),
+  ];
+}
+
+function findPrimitive(graph, id) {
+  return allPrimitiveEntries(graph).find(([type, item]) => item.id === id || item.key === id || `${type}.${item.id}` === id);
+}
+
+function renderWhy(type, item) {
+  const lines = [
+    `${item.id}`,
+    `type: ${type}`,
+    `state: ${item.enabled === false ? 'disabled' : 'enabled'}`,
+    `source: ${item.configSource ?? 'package-defaults'}`,
+  ];
+  if (item.locked) lines.push('locked: true');
+  if (item.requires) lines.push(`requires: ${item.requires.join(', ')}`);
+  if (item.reads?.length) lines.push(`reads: ${item.reads.join(', ')}`);
+  if (item.writes?.length) lines.push(`writes: ${item.writes.join(', ')}`);
+  if (item.description) lines.push(`description: ${item.description}`);
+  return `${lines.join('\n')}\n`;
+}
+
+function primitiveMap(graph, key) {
+  return new Map((graph[key] ?? []).map(item => [item.id, item]));
+}
+
+function collectDiff(defaultGraph, resolvedGraph) {
+  const changes = [];
+  for (const key of ['phases', 'gates', 'adapters', 'rails']) {
+    const defaults = primitiveMap(defaultGraph, key);
+    const resolved = primitiveMap(resolvedGraph, key);
+    for (const [id, afterItem] of resolved) {
+      const beforeItem = defaults.get(id);
+      if (!beforeItem) continue;
+      for (const field of ['enabled', 'disabled', 'configSource', 'config']) {
+        const before = beforeItem[field];
+        const after = afterItem[field];
+        if (JSON.stringify(before) !== JSON.stringify(after)) {
+          changes.push({ collection: key, id, field, before, after });
+        }
+      }
+    }
+  }
+  if (JSON.stringify(defaultGraph.protectedPaths) !== JSON.stringify(resolvedGraph.protectedPaths)) {
+    changes.push({
+      collection: 'protectedPaths',
+      id: 'protectedPaths',
+      field: 'patterns',
+      before: defaultGraph.protectedPaths,
+      after: resolvedGraph.protectedPaths,
+    });
+  }
+  return changes;
+}
+
+function renderDiff(changes) {
+  if (changes.length === 0) {
+    return 'No graph config changes.\n';
+  }
+  return changes
+    .map(change => `${change.id}.${change.field}: ${JSON.stringify(change.before)} -> ${JSON.stringify(change.after)}`)
+    .join('\n') + '\n';
+}
+
+function renderLint(result) {
+  if (result.ok) {
+    return 'Graph config lint passed.\n';
+  }
+  return [
+    'Graph config lint failed.',
+    ...result.errors.map(error => `- ${error.code}: ${error.message}`),
+  ].join('\n') + '\n';
+}
+
+function usage() {
+  return [
+    'Usage: forge options <stages|gates|adapters|diff|why <id>|lint> [--json]',
+    '',
+    'Inspect resolved runtime graph primitives and project config effects.',
+  ].join('\n');
+}
+
+async function handler(args, _flags, projectRoot) {
+  const json = hasJson(args);
+  const tokens = withoutFlags(args);
+  const subcommand = tokens[0];
+
+  if (!subcommand) {
+    return { success: false, error: usage() };
+  }
+
+  if (subcommand === 'lint') {
+    const result = lintRuntimeGraphConfig({ projectRoot });
+    return {
+      success: result.ok,
+      output: json ? jsonOutput(result) : renderLint(result),
+      error: result.ok ? undefined : renderLint(result),
+    };
+  }
+
+  let graph;
+  try {
+    graph = getResolvedRuntimeGraph({ projectRoot });
+  } catch (err) {
+    const output = json
+      ? jsonOutput({ ok: false, errors: err.message.split('\n').map(message => ({ message })) })
+      : `${err.message}\n`;
+    return { success: false, output, error: output };
+  }
+
+  if (COLLECTIONS[subcommand]) {
+    const { key, label } = COLLECTIONS[subcommand];
+    const items = graph[key];
+    return {
+      success: true,
+      output: json ? jsonOutput({ kind: subcommand, items }) : renderCollection(label, items),
+    };
+  }
+
+  if (subcommand === 'why') {
+    const id = tokens[1];
+    const match = id ? findPrimitive(graph, id) : null;
+    if (!match) {
+      return { success: false, error: `Unknown graph primitive: ${id ?? '<missing>'}` };
+    }
+    const [type, item] = match;
+    return {
+      success: true,
+      output: json ? jsonOutput({ type, item }) : renderWhy(type, item),
+    };
+  }
+
+  if (subcommand === 'diff') {
+    const changes = collectDiff(getDefaultRuntimeGraph(), graph);
+    return {
+      success: true,
+      output: json ? jsonOutput({ changes }) : renderDiff(changes),
+    };
+  }
+
+  return { success: false, error: usage() };
+}
+
+module.exports = {
+  name: 'options',
+  description: 'Inspect runtime graph primitives and config',
+  usage: usage(),
+  flags: {
+    '--json': 'Emit machine-readable JSON output',
+  },
+  handler,
+  collectDiff,
+};

--- a/lib/commands/options.js
+++ b/lib/commands/options.js
@@ -162,7 +162,11 @@ function collectionCommand(graph, subcommand, json) {
 function whyCommand(graph, id, json) {
   const match = id ? findPrimitive(graph, id) : null;
   if (!match) {
-    return { success: false, error: `Unknown graph primitive: ${id ?? '<missing>'}` };
+    const message = `Unknown graph primitive: ${id ?? '<missing>'}`;
+    const output = json
+      ? jsonOutput({ ok: false, errors: [{ code: 'UNKNOWN_GRAPH_PRIMITIVE', message }] })
+      : message;
+    return { success: false, output, error: output };
   }
   const [type, item] = match;
   return {

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -506,9 +506,20 @@ function applyAdapterConfig(graph, config, errors) {
       });
       continue;
     }
+    const enabled = readEnabledOption(options, errors, 'adapter', kind);
+    if (!enabled.valid) {
+      continue;
+    }
+    const nextConfig = { ...options };
+    delete nextConfig.enabled;
+    if (enabled.present) {
+      markConfigured(adapter, { enabled: enabled.value });
+    }
     adapter.config = { ...adapter.config };
-    Object.assign(adapter.config, options);
-    adapter.configSource = CONFIG_SOURCE;
+    Object.assign(adapter.config, nextConfig);
+    if (enabled.present || Object.keys(nextConfig).length > 0) {
+      adapter.configSource = CONFIG_SOURCE;
+    }
   }
 }
 

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -376,7 +376,14 @@ function markConfigured(primitive, options) {
 }
 
 function readEnabledOption(options, errors, typeName, id) {
-  if (!options || typeof options !== 'object' || !Object.hasOwn(options, 'enabled')) {
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    errors.push({
+      code: 'INVALID_PRIMITIVE_CONFIG',
+      message: `${typeName} '${id}' config must be an object.`,
+    });
+    return { present: false, valid: false, value: undefined };
+  }
+  if (!Object.hasOwn(options, 'enabled')) {
     return { present: false, valid: true, value: undefined };
   }
   if (typeof options.enabled !== 'boolean') {
@@ -400,8 +407,8 @@ function applyEnabledConfig(collection, id, options, errors, typeName) {
   }
 
   const enabled = readEnabledOption(options, errors, typeName, id);
+  if (!enabled.valid) return;
   if (enabled.present) {
-    if (!enabled.valid) return;
     if (enabled.value === false && primitive.locked === true) {
       errors.push({
         code: 'LOCKED_PRIMITIVE_DISABLED',
@@ -425,7 +432,7 @@ function applyRailConfig(graph, config, errors) {
       continue;
     }
     const enabled = readEnabledOption(options, errors, 'rail', key);
-    if (enabled.present && !enabled.valid) {
+    if (!enabled.valid) {
       continue;
     }
     if (enabled.value === false) {

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -385,7 +385,7 @@ function applyEnabledConfig(collection, id, options, errors, typeName) {
     return;
   }
 
-  if (Object.prototype.hasOwnProperty.call(options, 'enabled')) {
+  if (Object.hasOwn(options, 'enabled')) {
     if (options.enabled === false && primitive.locked === true) {
       errors.push({
         code: 'LOCKED_PRIMITIVE_DISABLED',
@@ -445,13 +445,16 @@ function applyAdapterConfig(graph, config, errors) {
       });
       continue;
     }
-    adapter.config = { ...adapter.config, ...(options ?? {}) };
+    adapter.config = { ...adapter.config };
+    if (options && typeof options === 'object') {
+      Object.assign(adapter.config, options);
+    }
     adapter.configSource = CONFIG_SOURCE;
   }
 }
 
 function validateProtectedPaths(config, errors) {
-  if (!Object.prototype.hasOwnProperty.call(config, 'protectedPaths')) {
+  if (!Object.hasOwn(config, 'protectedPaths')) {
     return [];
   }
   if (!Array.isArray(config.protectedPaths)) {

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -348,7 +348,8 @@ function loadRuntimeGraphConfig({ projectRoot = process.cwd() } = {}) {
   }
 
   try {
-    const parsed = YAML.parse(fs.readFileSync(configPath, 'utf8')) ?? {};
+    const rawConfig = fs.readFileSync(configPath, 'utf8');
+    const parsed = rawConfig.trim() === '' ? {} : YAML.parse(rawConfig);
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return {
         config: {},
@@ -479,12 +480,12 @@ function applyWorkflowConfig(graph, config, errors) {
   const workflow = readConfigSection(config, 'workflow', errors, 'workflow');
   const phases = readConfigSection(workflow, 'phases', errors, 'workflow.phases');
   for (const [id, options] of Object.entries(phases)) {
-    applyEnabledConfig(graph.phases, id, options ?? {}, errors, 'stage');
+    applyEnabledConfig(graph.phases, id, options, errors, 'stage');
   }
 
   const gates = readConfigSection(workflow, 'gates', errors, 'workflow.gates');
   for (const [id, options] of Object.entries(gates)) {
-    applyEnabledConfig(graph.gates, id, options ?? {}, errors, 'gate');
+    applyEnabledConfig(graph.gates, id, options, errors, 'gate');
   }
 }
 

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -348,8 +348,20 @@ function loadRuntimeGraphConfig({ projectRoot = process.cwd() } = {}) {
   }
 
   try {
+    const parsed = YAML.parse(fs.readFileSync(configPath, 'utf8')) ?? {};
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {
+        config: {},
+        configPath,
+        exists: true,
+        errors: [{
+          code: 'CONFIG_ROOT_INVALID',
+          message: `${CONFIG_SOURCE} root must be an object.`,
+        }],
+      };
+    }
     return {
-      config: YAML.parse(fs.readFileSync(configPath, 'utf8')) ?? {},
+      config: parsed,
       configPath,
       exists: true,
       errors: [],

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const fs = require('node:fs');
+const path = require('node:path');
+const YAML = require('yaml');
+
 const RUNTIME_GRAPH_SCHEMA_VERSION = '0.0.12';
+const CONFIG_SOURCE = '.forge/config.yaml';
 
 const RUNTIME_GRAPH_SCHEMA = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
@@ -25,18 +30,30 @@ const RUNTIME_GRAPH_SCHEMA = {
         'evaluatorRegions',
         'gates',
         'evidence',
+        'rails',
+        'adapters',
         'edges',
       ],
     },
   },
 };
 
-function Phase({ id, label, command, actions, artifacts, gates, evidence }) {
-  return { id, label, command, actions, artifacts, gates, evidence };
+function withRuntimeState(primitive, { enabled = true, locked = false, configSource = 'package-defaults' } = {}) {
+  return {
+    ...primitive,
+    enabled,
+    disabled: enabled === false,
+    locked,
+    configSource,
+  };
 }
 
-function Action({ id, kind, command, label, reads = [], writes = [], evidence = [] }) {
-  return { id, kind, command, label, reads, writes, evidence };
+function Phase({ id, label, command, actions, artifacts, gates, evidence, enabled = true, locked = false }) {
+  return withRuntimeState({ id, label, command, actions, artifacts, gates, evidence }, { enabled, locked });
+}
+
+function Action({ id, kind, command, label, reads = [], writes = [], evidence = [], enabled = true, locked = false }) {
+  return withRuntimeState({ id, kind, command, label, reads, writes, evidence }, { enabled, locked });
 }
 
 function Artifact({ id, kind, path, description }) {
@@ -47,12 +64,20 @@ function EvaluatorRegion({ id, label, phase, description }) {
   return { id, label, phase, description };
 }
 
-function Gate({ id, phase, label, requires }) {
-  return { id, phase, label, requires };
+function Gate({ id, phase, label, requires, enabled = true, locked = false }) {
+  return withRuntimeState({ id, phase, label, requires }, { enabled, locked });
 }
 
 function Evidence({ id, kind, source, description }) {
   return { id, kind, source, description };
+}
+
+function Rail({ id, key, label, description, locked = true, enabled = true }) {
+  return withRuntimeState({ id, key, label, description, layer: 'L1' }, { enabled, locked });
+}
+
+function Adapter({ id, kind, label, config = {}, enabled = true }) {
+  return withRuntimeState({ id, kind, label, config }, { enabled });
 }
 
 const RESOLVED_RUNTIME_GRAPH = {
@@ -66,6 +91,8 @@ const RESOLVED_RUNTIME_GRAPH = {
     EvaluatorRegion: 'evaluatorRegions',
     Gate: 'gates',
     Evidence: 'evidence',
+    Rail: 'rails',
+    Adapter: 'adapters',
   },
   phases: [
     Phase({
@@ -252,6 +279,53 @@ const RESOLVED_RUNTIME_GRAPH = {
       description: 'Resolved graph can be printed without side effects.',
     }),
   ],
+  rails: [
+    Rail({
+      id: 'rail.tdd_intent',
+      key: 'tdd_intent',
+      label: 'TDD intent evidence',
+      description: 'Source changes require test intent and TDD evidence.',
+    }),
+    Rail({
+      id: 'rail.secret_scan',
+      key: 'secret_scan',
+      label: 'Secret scan',
+      description: 'Validation must not knowingly ship secrets.',
+    }),
+    Rail({
+      id: 'rail.branch_protection',
+      key: 'branch_protection',
+      label: 'Branch protection',
+      description: 'Ship through reviewed branches instead of direct protected-branch edits.',
+    }),
+    Rail({
+      id: 'rail.signed_commits',
+      key: 'signed_commits',
+      label: 'Signed commits',
+      description: 'Preserve commit provenance requirements where configured.',
+    }),
+    Rail({
+      id: 'rail.schema_integrity',
+      key: 'schema_integrity',
+      label: 'Schema integrity',
+      description: 'Keep runtime graph and config schemas internally consistent.',
+    }),
+  ],
+  adapters: [
+    Adapter({
+      id: 'adapter.issue',
+      kind: 'issue',
+      label: 'Issue tracking adapter',
+      config: { primary: 'beads', mirrors: ['github'] },
+    }),
+    Adapter({
+      id: 'adapter.harness',
+      kind: 'harness',
+      label: 'Agent harness adapter',
+      config: { targets: ['codex', 'claude', 'cursor'] },
+    }),
+  ],
+  protectedPaths: [],
   edges: [
     { from: 'phase.plan', to: 'phase.dev', reason: 'design and task list feed implementation' },
     { from: 'phase.dev', to: 'phase.validate', reason: 'implementation feeds validation' },
@@ -263,8 +337,194 @@ function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function getResolvedRuntimeGraph() {
+function getConfigPath(projectRoot = process.cwd()) {
+  return path.join(projectRoot, '.forge', 'config.yaml');
+}
+
+function loadRuntimeGraphConfig({ projectRoot = process.cwd() } = {}) {
+  const configPath = getConfigPath(projectRoot);
+  if (!fs.existsSync(configPath)) {
+    return { config: {}, configPath, exists: false, errors: [] };
+  }
+
+  try {
+    return {
+      config: YAML.parse(fs.readFileSync(configPath, 'utf8')) ?? {},
+      configPath,
+      exists: true,
+      errors: [],
+    };
+  } catch (err) {
+    return {
+      config: {},
+      configPath,
+      exists: true,
+      errors: [{
+        code: 'CONFIG_PARSE_ERROR',
+        message: `Invalid ${CONFIG_SOURCE}: ${err.message}`,
+      }],
+    };
+  }
+}
+
+function markConfigured(primitive, options) {
+  Object.assign(primitive, withRuntimeState(primitive, {
+    enabled: options.enabled,
+    locked: primitive.locked === true,
+    configSource: CONFIG_SOURCE,
+  }));
+}
+
+function applyEnabledConfig(collection, id, options, errors, typeName) {
+  const primitive = collection.find(candidate => candidate.id === id);
+  if (!primitive) {
+    errors.push({
+      code: `UNKNOWN_${typeName.toUpperCase()}`,
+      message: `Unknown ${typeName} '${id}' in ${CONFIG_SOURCE}.`,
+    });
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(options, 'enabled')) {
+    if (options.enabled === false && primitive.locked === true) {
+      errors.push({
+        code: 'LOCKED_PRIMITIVE_DISABLED',
+        message: `Cannot disable locked ${typeName} '${id}'.`,
+      });
+      return;
+    }
+    markConfigured(primitive, { enabled: options.enabled !== false });
+  }
+}
+
+function applyRailConfig(graph, config, errors) {
+  const rails = config.rails && typeof config.rails === 'object' ? config.rails : {};
+  for (const [key, options] of Object.entries(rails)) {
+    const rail = graph.rails.find(candidate => candidate.key === key || candidate.id === key);
+    if (!rail) {
+      errors.push({
+        code: 'UNKNOWN_RAIL',
+        message: `Unknown rail '${key}' in ${CONFIG_SOURCE}.`,
+      });
+      continue;
+    }
+    if (options?.enabled === false) {
+      errors.push({
+        code: 'LOCKED_L1_RAIL_DISABLED',
+        message: `Cannot disable locked L1 rail '${key}'.`,
+      });
+      continue;
+    }
+    if (options && Object.keys(options).length > 0) {
+      rail.configSource = CONFIG_SOURCE;
+    }
+  }
+}
+
+function applyWorkflowConfig(graph, config, errors) {
+  const workflow = config.workflow && typeof config.workflow === 'object' ? config.workflow : {};
+  const phases = workflow.phases && typeof workflow.phases === 'object' ? workflow.phases : {};
+  for (const [id, options] of Object.entries(phases)) {
+    applyEnabledConfig(graph.phases, id, options ?? {}, errors, 'stage');
+  }
+
+  const gates = workflow.gates && typeof workflow.gates === 'object' ? workflow.gates : {};
+  for (const [id, options] of Object.entries(gates)) {
+    applyEnabledConfig(graph.gates, id, options ?? {}, errors, 'gate');
+  }
+}
+
+function applyAdapterConfig(graph, config, errors) {
+  const adapters = config.adapters && typeof config.adapters === 'object' ? config.adapters : {};
+  for (const [kind, options] of Object.entries(adapters)) {
+    const adapter = graph.adapters.find(candidate => candidate.kind === kind || candidate.id === kind);
+    if (!adapter) {
+      errors.push({
+        code: 'UNKNOWN_ADAPTER',
+        message: `Unknown adapter '${kind}' in ${CONFIG_SOURCE}.`,
+      });
+      continue;
+    }
+    adapter.config = { ...adapter.config, ...(options ?? {}) };
+    adapter.configSource = CONFIG_SOURCE;
+  }
+}
+
+function validateProtectedPaths(config, errors) {
+  if (!Object.prototype.hasOwnProperty.call(config, 'protectedPaths')) {
+    return [];
+  }
+  if (!Array.isArray(config.protectedPaths)) {
+    errors.push({
+      code: 'PROTECTED_PATHS_INVALID',
+      message: 'protectedPaths must be a list of path patterns.',
+    });
+    return [];
+  }
+
+  const protectedPaths = [];
+  for (const [index, entry] of config.protectedPaths.entries()) {
+    if (typeof entry !== 'string' || entry.trim() === '') {
+      errors.push({
+        code: 'PROTECTED_PATH_INVALID',
+        message: `protectedPaths[${index}] must be a non-empty string.`,
+      });
+      continue;
+    }
+    const pattern = entry.trim();
+    if (['*', '**', '**/*', '.', './', '/'].includes(pattern)) {
+      errors.push({
+        code: 'PROTECTED_PATH_TOO_BROAD',
+        message: `protectedPaths[${index}] is too broad: ${pattern}`,
+      });
+      continue;
+    }
+    protectedPaths.push(pattern);
+  }
+  return protectedPaths;
+}
+
+function resolveRuntimeGraph({ projectRoot = process.cwd(), throwOnError = true } = {}) {
+  const graph = cloneJson(RESOLVED_RUNTIME_GRAPH);
+  const loaded = loadRuntimeGraphConfig({ projectRoot });
+  const errors = [...loaded.errors];
+
+  if (loaded.errors.length === 0) {
+    applyRailConfig(graph, loaded.config, errors);
+    applyWorkflowConfig(graph, loaded.config, errors);
+    applyAdapterConfig(graph, loaded.config, errors);
+    graph.protectedPaths = validateProtectedPaths(loaded.config, errors);
+  }
+
+  graph.config = {
+    path: CONFIG_SOURCE,
+    loaded: loaded.exists,
+    errors,
+  };
+
+  if (throwOnError && errors.length > 0) {
+    throw new Error(errors.map(error => error.message).join('\n'));
+  }
+
+  return { graph, errors };
+}
+
+function getResolvedRuntimeGraph(options = {}) {
+  return resolveRuntimeGraph(options).graph;
+}
+
+function getDefaultRuntimeGraph() {
   return cloneJson(RESOLVED_RUNTIME_GRAPH);
+}
+
+function lintRuntimeGraphConfig(options = {}) {
+  const { graph, errors } = resolveRuntimeGraph({ ...options, throwOnError: false });
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings: [],
+    graph,
+  };
 }
 
 function buildRuntimeGraphEnvelope(graph = getResolvedRuntimeGraph()) {
@@ -285,6 +545,12 @@ module.exports = {
   EvaluatorRegion,
   Gate,
   Evidence,
+  Rail,
+  Adapter,
+  loadRuntimeGraphConfig,
+  lintRuntimeGraphConfig,
+  resolveRuntimeGraph,
+  getDefaultRuntimeGraph,
   buildRuntimeGraphEnvelope,
   getResolvedRuntimeGraph,
 };

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -375,6 +375,20 @@ function markConfigured(primitive, options) {
   }));
 }
 
+function readEnabledOption(options, errors, typeName, id) {
+  if (!options || typeof options !== 'object' || !Object.hasOwn(options, 'enabled')) {
+    return { present: false, valid: true, value: undefined };
+  }
+  if (typeof options.enabled !== 'boolean') {
+    errors.push({
+      code: 'INVALID_ENABLED_VALUE',
+      message: `${typeName} '${id}' enabled must be a boolean.`,
+    });
+    return { present: true, valid: false, value: undefined };
+  }
+  return { present: true, valid: true, value: options.enabled };
+}
+
 function applyEnabledConfig(collection, id, options, errors, typeName) {
   const primitive = collection.find(candidate => candidate.id === id);
   if (!primitive) {
@@ -385,15 +399,17 @@ function applyEnabledConfig(collection, id, options, errors, typeName) {
     return;
   }
 
-  if (Object.hasOwn(options, 'enabled')) {
-    if (options.enabled === false && primitive.locked === true) {
+  const enabled = readEnabledOption(options, errors, typeName, id);
+  if (enabled.present) {
+    if (!enabled.valid) return;
+    if (enabled.value === false && primitive.locked === true) {
       errors.push({
         code: 'LOCKED_PRIMITIVE_DISABLED',
         message: `Cannot disable locked ${typeName} '${id}'.`,
       });
       return;
     }
-    markConfigured(primitive, { enabled: options.enabled !== false });
+    markConfigured(primitive, { enabled: enabled.value });
   }
 }
 
@@ -408,7 +424,11 @@ function applyRailConfig(graph, config, errors) {
       });
       continue;
     }
-    if (options?.enabled === false) {
+    const enabled = readEnabledOption(options, errors, 'rail', key);
+    if (enabled.present && !enabled.valid) {
+      continue;
+    }
+    if (enabled.value === false) {
       errors.push({
         code: 'LOCKED_L1_RAIL_DISABLED',
         message: `Cannot disable locked L1 rail '${key}'.`,

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -396,6 +396,21 @@ function readEnabledOption(options, errors, typeName, id) {
   return { present: true, valid: true, value: options.enabled };
 }
 
+function readConfigSection(parent, key, errors, path) {
+  if (!Object.hasOwn(parent, key)) {
+    return {};
+  }
+  const value = parent[key];
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    errors.push({
+      code: 'INVALID_CONFIG_SECTION',
+      message: `${path} must be an object.`,
+    });
+    return {};
+  }
+  return value;
+}
+
 function applyEnabledConfig(collection, id, options, errors, typeName) {
   const primitive = collection.find(candidate => candidate.id === id);
   if (!primitive) {
@@ -421,7 +436,7 @@ function applyEnabledConfig(collection, id, options, errors, typeName) {
 }
 
 function applyRailConfig(graph, config, errors) {
-  const rails = config.rails && typeof config.rails === 'object' ? config.rails : {};
+  const rails = readConfigSection(config, 'rails', errors, 'rails');
   for (const [key, options] of Object.entries(rails)) {
     const rail = graph.rails.find(candidate => candidate.key === key || candidate.id === key);
     if (!rail) {
@@ -449,20 +464,20 @@ function applyRailConfig(graph, config, errors) {
 }
 
 function applyWorkflowConfig(graph, config, errors) {
-  const workflow = config.workflow && typeof config.workflow === 'object' ? config.workflow : {};
-  const phases = workflow.phases && typeof workflow.phases === 'object' ? workflow.phases : {};
+  const workflow = readConfigSection(config, 'workflow', errors, 'workflow');
+  const phases = readConfigSection(workflow, 'phases', errors, 'workflow.phases');
   for (const [id, options] of Object.entries(phases)) {
     applyEnabledConfig(graph.phases, id, options ?? {}, errors, 'stage');
   }
 
-  const gates = workflow.gates && typeof workflow.gates === 'object' ? workflow.gates : {};
+  const gates = readConfigSection(workflow, 'gates', errors, 'workflow.gates');
   for (const [id, options] of Object.entries(gates)) {
     applyEnabledConfig(graph.gates, id, options ?? {}, errors, 'gate');
   }
 }
 
 function applyAdapterConfig(graph, config, errors) {
-  const adapters = config.adapters && typeof config.adapters === 'object' ? config.adapters : {};
+  const adapters = readConfigSection(config, 'adapters', errors, 'adapters');
   for (const [kind, options] of Object.entries(adapters)) {
     const adapter = graph.adapters.find(candidate => candidate.kind === kind || candidate.id === kind);
     if (!adapter) {
@@ -472,10 +487,15 @@ function applyAdapterConfig(graph, config, errors) {
       });
       continue;
     }
-    adapter.config = { ...adapter.config };
-    if (options && typeof options === 'object') {
-      Object.assign(adapter.config, options);
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      errors.push({
+        code: 'INVALID_ADAPTER_CONFIG',
+        message: `adapter '${kind}' config must be an object.`,
+      });
+      continue;
     }
+    adapter.config = { ...adapter.config };
+    Object.assign(adapter.config, options);
     adapter.configSource = CONFIG_SOURCE;
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "eslint": "^10.0.2",
     "globals": "^17.3.0",
     "js-yaml": "^4.1.1",
-    "lefthook": "^2.1.4",
-    "yaml": "^2.8.3"
+    "lefthook": "^2.1.4"
   },
   "keywords": [
     "ai",
@@ -117,7 +116,8 @@
   ],
   "dependencies": {
     "@babel/parser": "^7.29.2",
-    "fastest-levenshtein": "^1.0.16"
+    "fastest-levenshtein": "^1.0.16",
+    "yaml": "^2.8.3"
   },
   "overrides": {
     "eslint": "^10.0.2",

--- a/scripts/test-ci-shard.js
+++ b/scripts/test-ci-shard.js
@@ -177,17 +177,23 @@ function getShardPlan(args, { allUnitTests, durationMap }) {
   };
 }
 
-function runTests(label, files) {
-  fs.mkdirSync(reportDir, { recursive: true });
-  const junitPath = path.join(reportDir, `${label}.xml`);
-  const bunCommand = process.env.BUN_EXE || 'bun';
-  const result = spawnSync(bunCommand, [
+function buildBunTestArgs({ junitPath, files }) {
+  return [
     'test',
+    '--timeout',
+    '15000',
     '--reporter=junit',
     '--reporter-outfile',
     junitPath,
     ...files,
-  ], {
+  ];
+}
+
+function runTests(label, files) {
+  fs.mkdirSync(reportDir, { recursive: true });
+  const junitPath = path.join(reportDir, `${label}.xml`);
+  const bunCommand = process.env.BUN_EXE || 'bun';
+  const result = spawnSync(bunCommand, buildBunTestArgs({ junitPath, files }), {
     cwd: rootDir,
     stdio: 'inherit',
     shell: process.platform === 'win32',
@@ -226,6 +232,7 @@ if (require.main === module) {
 module.exports = {
   DEFAULT_SMOKE_FILES,
   PROFILE_MAX_AGE_MS,
+  buildBunTestArgs,
   createDurationMap,
   ensureFilesExist,
   getShardPlan,

--- a/test/ci-workflow.test.js
+++ b/test/ci-workflow.test.js
@@ -81,6 +81,18 @@ describe('CI Workflow Configuration', () => {
       expect(workflowContent.includes('node-version: [22, 24]')).toBe(true);
     });
 
+    test('Bun test commands use the repo timeout in CI', () => {
+      const directBunTestCommands = workflowContent
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith('run: bun test ') || line.startsWith('bun test '));
+
+      expect(directBunTestCommands.length).toBeGreaterThan(0);
+      for (const command of directBunTestCommands) {
+        expect(command).toContain('--timeout 15000');
+      }
+    });
+
     test('beads integration is isolated into its own job', () => {
       expectSection('beads-integration');
       expect(workflowContent.includes("RUN_BEADS_INTEGRATION: '1'")).toBe(true);

--- a/test/options-command.test.js
+++ b/test/options-command.test.js
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
+const { execFileSync, spawnSync } = require('node:child_process');
 const { describe, expect, test } = require('bun:test');
 
 const optionsCommand = require('../lib/commands/options');
@@ -28,6 +28,30 @@ describe('forge options command', () => {
     });
 
     expect(JSON.parse(output).kind).toBe('stages');
+  });
+
+  test('CLI lint --json failure output remains parseable JSON', () => {
+    const projectRoot = makeProject(`
+protectedPaths:
+  - "**/*"
+`);
+    const result = spawnSync(process.execPath, ['bin/forge.js', 'options', 'lint', '--json', '--path', projectRoot], {
+      cwd: path.resolve(__dirname, '..'),
+      encoding: 'utf8',
+    });
+    const output = `${result.stdout}${result.stderr}`.trim();
+
+    expect(result.status).toBe(1);
+    expect(JSON.parse(output).errors[0].code).toBe('PROTECTED_PATH_TOO_BROAD');
+  });
+
+  test('CLI explain --json output is parseable without non-interactive banner', () => {
+    const output = execFileSync(process.execPath, ['bin/forge.js', 'explain', 'gate.ship-entry', '--json'], {
+      cwd: path.resolve(__dirname, '..'),
+      encoding: 'utf8',
+    });
+
+    expect(JSON.parse(output).item.id).toBe('gate.ship-entry');
   });
 
   test('prints stages, gates, and adapters as JSON over graph primitives', async () => {

--- a/test/options-command.test.js
+++ b/test/options-command.test.js
@@ -81,6 +81,15 @@ protectedPaths:
     expect(parsed.item.requires).toContain('artifact.validation-output');
   });
 
+  test('why --json reports unknown primitives as parseable JSON', async () => {
+    const result = await run(['why', 'gate.nope', '--json']);
+    const parsed = JSON.parse(result.output);
+
+    expect(result.success).toBe(false);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.errors[0].code).toBe('UNKNOWN_GRAPH_PRIMITIVE');
+  });
+
   test('forge explain is a thin alias over options why', async () => {
     const result = await explainCommand.handler(['gate.ship-entry', '--json'], {}, makeProject(null));
     const parsed = JSON.parse(result.output);

--- a/test/options-command.test.js
+++ b/test/options-command.test.js
@@ -1,0 +1,99 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { describe, expect, test } = require('bun:test');
+
+const optionsCommand = require('../lib/commands/options');
+const explainCommand = require('../lib/commands/explain');
+
+function makeProject(configBody) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-options-'));
+  fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
+  if (configBody !== null) {
+    fs.writeFileSync(path.join(root, '.forge', 'config.yaml'), configBody);
+  }
+  return root;
+}
+
+async function run(args, projectRoot = makeProject(null)) {
+  return optionsCommand.handler(args, {}, projectRoot);
+}
+
+describe('forge options command', () => {
+  test('CLI --json output is parseable without non-interactive banner', () => {
+    const output = execFileSync(process.execPath, ['bin/forge.js', 'options', 'stages', '--json'], {
+      cwd: path.resolve(__dirname, '..'),
+      encoding: 'utf8',
+    });
+
+    expect(JSON.parse(output).kind).toBe('stages');
+  });
+
+  test('prints stages, gates, and adapters as JSON over graph primitives', async () => {
+    const stages = await run(['stages', '--json']);
+    const gates = await run(['gates', '--json']);
+    const adapters = await run(['adapters', '--json']);
+
+    expect(JSON.parse(stages.output).items.map(item => item.id)).toContain('plan');
+    expect(JSON.parse(gates.output).items.map(item => item.id)).toContain('gate.ship-entry');
+    expect(JSON.parse(adapters.output).items.map(item => item.id)).toContain('adapter.issue');
+  });
+
+  test('prints human stages output', async () => {
+    const result = await run(['stages']);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Stages');
+    expect(result.output).toContain('plan');
+  });
+
+  test('explains why a primitive exists', async () => {
+    const result = await run(['why', 'gate.ship-entry', '--json']);
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.item.id).toBe('gate.ship-entry');
+    expect(parsed.item.configSource).toBe('package-defaults');
+    expect(parsed.item.requires).toContain('artifact.validation-output');
+  });
+
+  test('forge explain is a thin alias over options why', async () => {
+    const result = await explainCommand.handler(['gate.ship-entry', '--json'], {}, makeProject(null));
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.item.id).toBe('gate.ship-entry');
+  });
+
+  test('diff reports project config changes', async () => {
+    const projectRoot = makeProject(`
+workflow:
+  gates:
+    gate.ship-entry:
+      enabled: false
+`);
+
+    const result = await run(['diff', '--json'], projectRoot);
+    const parsed = JSON.parse(result.output);
+
+    expect(parsed.changes).toContainEqual(expect.objectContaining({
+      id: 'gate.ship-entry',
+      field: 'enabled',
+      before: true,
+      after: false,
+    }));
+  });
+
+  test('lint reports invalid config as JSON and human output', async () => {
+    const projectRoot = makeProject(`
+protectedPaths:
+  - "**/*"
+`);
+
+    const json = await run(['lint', '--json'], projectRoot);
+    const human = await run(['lint'], projectRoot);
+
+    expect(json.success).toBe(false);
+    expect(JSON.parse(json.output).errors[0].code).toBe('PROTECTED_PATH_TOO_BROAD');
+    expect(human.output).toContain('PROTECTED_PATH_TOO_BROAD');
+  });
+});

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -63,6 +63,19 @@ workflow:
     expect(result.errors[0].message).toContain('Unknown gate');
   });
 
+  test('rejects non-object top-level config roots', () => {
+    const scalarRoot = makeProject('false');
+    const arrayRoot = makeProject('[]');
+
+    for (const projectRoot of [scalarRoot, arrayRoot]) {
+      const result = lintRuntimeGraphConfig({ projectRoot });
+
+      expect(result.ok).toBe(false);
+      expect(result.errors[0].code).toBe('CONFIG_ROOT_INVALID');
+      expect(result.errors[0].message).toContain('root must be an object');
+    }
+  });
+
   test('rejects non-boolean enabled values in workflow config', () => {
     const projectRoot = makeProject(`
 workflow:

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -93,8 +93,9 @@ workflow:
   test('rejects non-object top-level config roots', () => {
     const scalarRoot = makeProject('false');
     const arrayRoot = makeProject('[]');
+    const nullRoot = makeProject('null');
 
-    for (const projectRoot of [scalarRoot, arrayRoot]) {
+    for (const projectRoot of [scalarRoot, arrayRoot, nullRoot]) {
       const result = lintRuntimeGraphConfig({ projectRoot });
 
       expect(result.ok).toBe(false);
@@ -123,6 +124,20 @@ workflow:
 workflow:
   gates:
     gate.ship-entry: false
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe('INVALID_PRIMITIVE_CONFIG');
+    expect(result.errors[0].message).toContain('config must be an object');
+  });
+
+  test('rejects null workflow primitive config entries', () => {
+    const projectRoot = makeProject(`
+workflow:
+  gates:
+    gate.ship-entry: null
 `);
 
     const result = lintRuntimeGraphConfig({ projectRoot });

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -1,0 +1,79 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { describe, expect, test } = require('bun:test');
+
+const {
+  getResolvedRuntimeGraph,
+  lintRuntimeGraphConfig,
+} = require('../lib/core/runtime-graph');
+
+function makeProject(configBody) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-graph-config-'));
+  fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
+  if (configBody !== null) {
+    fs.writeFileSync(path.join(root, '.forge', 'config.yaml'), configBody);
+  }
+  return root;
+}
+
+describe('runtime graph config resolution', () => {
+  test('loads .forge/config.yaml and preserves disabled primitives with provenance', () => {
+    const projectRoot = makeProject(`
+workflow:
+  gates:
+    gate.ship-entry:
+      enabled: false
+adapters:
+  issue:
+    primary: github
+`);
+
+    const graph = getResolvedRuntimeGraph({ projectRoot });
+    const shipGate = graph.gates.find(gate => gate.id === 'gate.ship-entry');
+
+    expect(shipGate.enabled).toBe(false);
+    expect(shipGate.disabled).toBe(true);
+    expect(shipGate.configSource).toBe('.forge/config.yaml');
+    expect(graph.adapters.find(adapter => adapter.id === 'adapter.issue').config.primary).toBe('github');
+  });
+
+  test('rejects config that disables a locked L1 rail', () => {
+    const projectRoot = makeProject(`
+rails:
+  tdd_intent:
+    enabled: false
+`);
+
+    expect(() => getResolvedRuntimeGraph({ projectRoot })).toThrow('locked L1 rail');
+  });
+
+  test('reports malformed YAML and unknown primitive IDs during config lint', () => {
+    const malformedRoot = makeProject('workflow: [');
+    const unknownRoot = makeProject(`
+workflow:
+  gates:
+    gate.nope:
+      enabled: false
+`);
+
+    expect(lintRuntimeGraphConfig({ projectRoot: malformedRoot }).ok).toBe(false);
+    const result = lintRuntimeGraphConfig({ projectRoot: unknownRoot });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].message).toContain('Unknown gate');
+  });
+
+  test('validates protected path policy entries', () => {
+    const projectRoot = makeProject(`
+protectedPaths:
+  - "**/*"
+  - 42
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map(error => error.code)).toContain('PROTECTED_PATH_TOO_BROAD');
+    expect(result.errors.map(error => error.code)).toContain('PROTECTED_PATH_INVALID');
+  });
+});

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -92,6 +92,32 @@ workflow:
     expect(result.errors[0].message).toContain('config must be an object');
   });
 
+  test('rejects scalar workflow section config entries', () => {
+    const projectRoot = makeProject(`
+workflow:
+  gates: false
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe('INVALID_CONFIG_SECTION');
+    expect(result.errors[0].message).toContain('workflow.gates must be an object');
+  });
+
+  test('rejects scalar adapter config entries', () => {
+    const projectRoot = makeProject(`
+adapters:
+  issue: false
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe('INVALID_ADAPTER_CONFIG');
+    expect(result.errors[0].message).toContain("adapter 'issue' config must be an object");
+  });
+
   test('validates protected path policy entries', () => {
     const projectRoot = makeProject(`
 protectedPaths:

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -78,6 +78,20 @@ workflow:
     expect(result.errors[0].message).toContain('enabled must be a boolean');
   });
 
+  test('rejects scalar workflow primitive config entries', () => {
+    const projectRoot = makeProject(`
+workflow:
+  gates:
+    gate.ship-entry: false
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe('INVALID_PRIMITIVE_CONFIG');
+    expect(result.errors[0].message).toContain('config must be an object');
+  });
+
   test('validates protected path policy entries', () => {
     const projectRoot = makeProject(`
 protectedPaths:

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -1,21 +1,30 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { describe, expect, test } = require('bun:test');
+const { afterEach, describe, expect, test } = require('bun:test');
 
 const {
   getResolvedRuntimeGraph,
   lintRuntimeGraphConfig,
 } = require('../lib/core/runtime-graph');
 
+const tempRoots = [];
+
 function makeProject(configBody) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-graph-config-'));
+  tempRoots.push(root);
   fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
   if (configBody !== null) {
     fs.writeFileSync(path.join(root, '.forge', 'config.yaml'), configBody);
   }
   return root;
 }
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 describe('runtime graph config resolution', () => {
   test('loads .forge/config.yaml and preserves disabled primitives with provenance', () => {

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -63,6 +63,21 @@ workflow:
     expect(result.errors[0].message).toContain('Unknown gate');
   });
 
+  test('rejects non-boolean enabled values in workflow config', () => {
+    const projectRoot = makeProject(`
+workflow:
+  gates:
+    gate.ship-entry:
+      enabled: "false"
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe('INVALID_ENABLED_VALUE');
+    expect(result.errors[0].message).toContain('enabled must be a boolean');
+  });
+
   test('validates protected path policy entries', () => {
     const projectRoot = makeProject(`
 protectedPaths:

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -38,6 +38,24 @@ adapters:
     expect(graph.adapters.find(adapter => adapter.id === 'adapter.issue').config.primary).toBe('github');
   });
 
+  test('loads adapter enabled state separately from adapter config', () => {
+    const projectRoot = makeProject(`
+adapters:
+  issue:
+    enabled: false
+    primary: github
+`);
+
+    const graph = getResolvedRuntimeGraph({ projectRoot });
+    const issueAdapter = graph.adapters.find(adapter => adapter.id === 'adapter.issue');
+
+    expect(issueAdapter.enabled).toBe(false);
+    expect(issueAdapter.disabled).toBe(true);
+    expect(issueAdapter.configSource).toBe('.forge/config.yaml');
+    expect(issueAdapter.config.primary).toBe('github');
+    expect(issueAdapter.config.enabled).toBeUndefined();
+  });
+
   test('rejects config that disables a locked L1 rail', () => {
     const projectRoot = makeProject(`
 rails:
@@ -129,6 +147,20 @@ adapters:
     expect(result.ok).toBe(false);
     expect(result.errors[0].code).toBe('INVALID_ADAPTER_CONFIG');
     expect(result.errors[0].message).toContain("adapter 'issue' config must be an object");
+  });
+
+  test('rejects non-boolean enabled values in adapter config', () => {
+    const projectRoot = makeProject(`
+adapters:
+  issue:
+    enabled: "false"
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe('INVALID_ENABLED_VALUE');
+    expect(result.errors[0].message).toContain("adapter 'issue' enabled must be a boolean");
   });
 
   test('validates protected path policy entries', () => {

--- a/test/runtime-graph.test.js
+++ b/test/runtime-graph.test.js
@@ -31,6 +31,8 @@ describe('runtime graph contract', () => {
     expect(graph.evaluatorRegions.length).toBeGreaterThanOrEqual(3);
     expect(graph.gates.length).toBeGreaterThanOrEqual(4);
     expect(graph.evidence.length).toBeGreaterThanOrEqual(4);
+    expect(graph.rails.length).toBeGreaterThanOrEqual(5);
+    expect(graph.adapters.length).toBeGreaterThanOrEqual(2);
 
     expect(graph.primitives).toEqual({
       Phase: 'phases',
@@ -39,6 +41,8 @@ describe('runtime graph contract', () => {
       EvaluatorRegion: 'evaluatorRegions',
       Gate: 'gates',
       Evidence: 'evidence',
+      Rail: 'rails',
+      Adapter: 'adapters',
     });
     expect(graph.evidence.find(evidence => evidence.id === 'evidence.validation-output').source)
       .toBe('bun run typecheck; bun run lint; bun test; bun audit');

--- a/test/scripts/test-ci-shard.test.js
+++ b/test/scripts/test-ci-shard.test.js
@@ -7,6 +7,7 @@ const { afterEach, describe, expect, test } = require('bun:test');
 
 const {
   PROFILE_MAX_AGE_MS,
+  buildBunTestArgs,
   createDurationMap,
   getShardPlan,
   listAllUnitTests,
@@ -107,6 +108,21 @@ describe('scripts/test-ci-shard.js', () => {
 
     expect(plan.source).toBe('runtime-balanced');
     expect(plan.files).toEqual(['test/a.test.js']);
+  });
+
+  test('buildBunTestArgs uses the repo timeout for CI shard runs', () => {
+    expect(buildBunTestArgs({
+      junitPath: 'test-results/unit.xml',
+      files: ['test/a.test.js'],
+    })).toEqual([
+      'test',
+      '--timeout',
+      '15000',
+      '--reporter=junit',
+      '--reporter-outfile',
+      'test-results/unit.xml',
+      'test/a.test.js',
+    ]);
   });
 
   test('listAllUnitTests includes package test roots for shard planning', () => {


### PR DESCRIPTION
## Problem
The 0.0.12 runtime graph contract exposed graph primitives, but project config, locked L1 rails, protected path policy, and graph introspection were not wired into a shipped command surface.

## Root Cause
The graph model was package-default only and there was no registry command for agents or users to inspect resolved stages, gates, adapters, config diffs, or primitive provenance.

## Fix
Load optional `.forge/config.yaml` into the runtime graph model, enforce locked L1 rails as cannot-disable, keep disabled primitives addressable, add protected path policy linting, and add `forge options stages|gates|adapters|diff|why <id>|lint` plus thin `forge explain <id>`.

## Value
Agents can inspect graph primitives without reading YAML directly, invalid config fails clearly, and L1 safety rails cannot be disabled by project config.

## Beads
Covers forge-besw.2, forge-besw.3, forge-besw.4, forge-5146, and forge-ol43.

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: `bun run check` passed with 840 pass, 13 skip, 0 fail in the validation run.
- Pre-push hook also passed lint and tests before branch push.
- Scenarios covered: valid config resolution, malformed YAML, unknown primitive IDs, locked L1 rail disable attempts, protected path lint errors, JSON and human options output, config diff, primitive why, and `forge explain` aliasing.

### Security Review
- OWASP Top 10: Config parsing is local filesystem input only; malformed YAML and invalid policy entries fail closed. No auth, secrets, network, persistence, or audit wiring added.
- Automated scan: `bun audit` returned no vulnerabilities.

### Design Doc
See: `docs/work/2026-05-12-0.0.13-config-rails/design.md`

### Key Decisions
- Kept `RUNTIME_GRAPH_SCHEMA_VERSION` at `0.0.12` because this builds on the landed envelope contract.
- Added `Rail` and `Adapter` as additive graph primitives.
- Included `forge explain` only as a thin alias over `forge options why`.
- Kept protected paths to config validation/introspection; no file-change enforcement in this PR.

### Documentation Updated
- `docs/work/2026-05-12-0.0.13-config-rails/design.md`
- `docs/work/2026-05-12-0.0.13-config-rails/tasks.md`
- `docs/work/2026-05-12-0.0.13-config-rails/decisions.md`

### Validation
- [x] Type check passing: `bun run typecheck`
- [x] Lint passing (0 errors, 0 warnings): `bun run lint`
- [x] All tests passing: `node scripts/test.js --validate`; `bun run check`
- [x] Security review completed: `bun audit`

### Explicit Non-Scope
- No `/build` audit persistence.
- No Beads audit wiring.
- No 0.0.14 audit/evidence storage.
- No runtime execution of graph actions beyond introspection.

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff locally
- [x] No debug code, commented code, or temporary changes
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun run check`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes
- [x] TDD compliance: Source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `forge explain` (alias of `options why`) and expanded `forge options` with `stages`, `gates`, `adapters`, `diff`, `why`, and `lint`.
  * Resolved runtime graph now includes rails and adapters; project-local .forge/config.yaml can customize enabled/disabled primitives, adapter configs, and protectedPaths.

* **Bug Fixes**
  * `--json` mode suppresses interactive banners and creation/working-directory messages for clean machine output.

* **Documentation**
  * Added design, decisions, and tasks for v0.0.13.

* **Tests / CI**
  * New tests for config resolution, introspection, diffs, linting, CLI JSON; CI enforces test timeout.

* **Chores**
  * YAML library moved to runtime dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/160)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->