### PR TITLE
0.0.16 patch intent baseline

### DIFF
--- a/docs/reference/patch-md-format.md
+++ b/docs/reference/patch-md-format.md
@@ -1,0 +1,77 @@
+# patch.md Format
+
+`patch.md` records user patch intent against stable Forge anchors. It is a reviewable markdown file, not an upgrade engine. Later upgrade and rollback work can consume these records to explain conflicts, preserve local edits, or refuse unsafe operations with a clear hint.
+
+## Anchor Declaration
+
+Managed files declare stable anchors with HTML comments:
+
+```md
+<!-- forge-anchor:stage.validate -->
+```
+
+The anchor ID is the durable identity. File paths can change. When a file is renamed, Forge scans the workspace and resolves the record to the file that still declares the anchor.
+
+## Record Block
+
+Each patch intent record is a markdown block with YAML metadata and a unified diff:
+
+````md
+<!-- forge-patch-intent:v1
+id: patch_stage_validate_8f14e45fceea
+anchorId: stage.validate
+path: .claude/commands/validate.md
+createdAt: 2026-05-13T00:00:00.000Z
+source: git-diff
+status: active
+anchorLine: 3
+baseAnchorHash: sha256:72a7d2a11b2ef199
+-->
+```diff
+diff --git a/.claude/commands/validate.md b/.claude/commands/validate.md
+--- a/.claude/commands/validate.md
++++ b/.claude/commands/validate.md
+@@ -1,4 +1,4 @@
+ # Validate
+ <!-- forge-anchor:stage.validate -->
+-Run checks.
++Run checks carefully.
+```
+<!-- /forge-patch-intent -->
+````
+
+Record IDs are deterministic from the anchor ID and diff body. Recording the same diff replaces the same block instead of appending duplicates.
+
+## Example 1: Basic Edit
+
+1. A managed file declares `<!-- forge-anchor:stage.dev -->`.
+2. The user edits text below that anchor.
+3. `forge patch record --from-diff` writes a record whose `anchorId` is `stage.dev` and whose diff can be reapplied to recreate the edit.
+
+## Example 2: Rename
+
+If `.claude/commands/validate.md` moves to `.codex/skills/validate/SKILL.md` but keeps `<!-- forge-anchor:stage.validate -->`, Forge resolves the record as `renamed` with `currentPath: .codex/skills/validate/SKILL.md`. Later upgrade code can use that resolved path instead of treating the patch as lost.
+
+## Example 3: Orphan
+
+If a record references `stage.ship` and no file declares that anchor, `forge patch status` reports it as orphaned. Later upgrade work should refuse to apply that record automatically and tell the user to re-record or restore the anchor.
+
+## Config
+
+`.forge/config.yaml` may configure patch intent:
+
+```yaml
+patchIntent:
+  enabled: true
+  path: .forge/patch.md
+  anchorAliases:
+    stage.old-validate: stage.validate
+```
+
+- `enabled: false` disables `forge patch record --from-diff`.
+- `path` moves the record file.
+- `anchorAliases` lets renamed anchors resolve without editing historical records.
+
+## Later Upgrade and Rollback Safety
+
+Upgrade can use patch intent records to decide whether a local edit is anchored, moved, or orphaned before touching managed files. Rollback can use the same metadata to explain which user edits were intentionally preserved. This baseline does not implement upgrade application, rollback snapshots, self-heal, marketplace, or adapter behavior.

--- a/docs/work/2026-05-13-0.0.16-patch-intent/decisions.md
+++ b/docs/work/2026-05-13-0.0.16-patch-intent/decisions.md
@@ -1,0 +1,16 @@
+# 0.0.16 Patch Intent Decisions
+
+## Decisions
+
+- Patch intent records are markdown blocks in `.forge/patch.md` with YAML metadata plus a fenced unified diff.
+- Record IDs are deterministic from anchor ID plus diff body so recording the same diff replaces the same block.
+- Anchors are declared in managed files with HTML comments such as `<!-- forge-anchor:stage.validate -->`.
+- Rename behavior is anchor-driven: if the recorded path disappears but the anchor is found elsewhere, the record resolves as renamed.
+- `.forge/config.yaml` may set `patchIntent.enabled`, `patchIntent.path`, and `patchIntent.anchorAliases`.
+
+## Deferred
+
+- Upgrade application/self-heal.
+- Rollback snapshot capture.
+- Extension marketplace/adapters.
+

--- a/docs/work/2026-05-13-0.0.16-patch-intent/design.md
+++ b/docs/work/2026-05-13-0.0.16-patch-intent/design.md
@@ -1,0 +1,44 @@
+# 0.0.16 Patch Intent Baseline
+
+## Issue
+
+- `forge-besw.10`: 0.0.16 patch intent records and patch.md anchors
+
+## Intent
+
+Establish the baseline contract for user patch intent without implementing upgrade self-heal, rollback snapshots, marketplace, or adapter flows. This slice makes patch intent records first-class enough that later upgrade and rollback work can reason about local edits by stable anchors instead of only file paths.
+
+## Current Code
+
+- CLI commands are auto-discovered from `lib/commands/*.js` by `lib/commands/_registry.js`.
+- Runtime config is loaded from `.forge/config.yaml` by `lib/core/runtime-graph.js`.
+- Prior spike evidence exists for `patch.md` anchor rename/orphan behavior in `scripts/spikes/patch-anchor-stability-bench.js`.
+
+## Approach
+
+1. Add `lib/patch-intent.js` as the focused patch intent surface:
+   - parse stable anchor comments from managed files
+   - parse unified git diffs into per-anchor patch intent records
+   - serialize records into `.forge/patch.md`
+   - resolve records back to current anchor locations, including rename detection
+   - report orphaned records when their anchor is undeclared
+2. Add `lib/commands/patch.js` with `forge patch record --from-diff`.
+3. Load `patchIntent` config from `.forge/config.yaml`:
+   - `enabled`
+   - `path`
+   - `anchorAliases`
+4. Add focused tests for:
+   - stable record IDs and `patch.md` replacement
+   - rename behavior through anchor scan
+   - orphan detection
+   - config path / disabled interaction
+   - CLI record path
+5. Document the record format and how it feeds later upgrade/rollback safety.
+
+## Non-Scope
+
+- `forge upgrade`
+- rollback snapshots
+- self-healing patch application
+- marketplace/adapters
+

--- a/docs/work/2026-05-13-0.0.16-patch-intent/tasks.md
+++ b/docs/work/2026-05-13-0.0.16-patch-intent/tasks.md
@@ -1,0 +1,23 @@
+# 0.0.16 Patch Intent Baseline Tasks
+
+## Task 1: Patch Intent Core
+
+- Add tests first for anchor discovery, stable IDs, rename resolution, orphan detection, and config interaction.
+- Implement `lib/patch-intent.js`.
+
+## Task 2: CLI Record Command
+
+- Add tests first for `forge patch record --from-diff`.
+- Implement `lib/commands/patch.js`.
+
+## Task 3: Documentation
+
+- Add `docs/reference/patch-md-format.md` with three worked examples.
+- Explain how records feed later upgrade/rollback safety and what remains non-scope.
+
+## Task 4: Validation and Ship
+
+- Run focused tests.
+- Run typecheck, lint, tests, and security/check validation.
+- Push `codex/0.0.16-patch-intent` and create the requested PR.
+

--- a/lib/commands/patch.js
+++ b/lib/commands/patch.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const {
+  recordPatchIntentFromDiff,
+  resolvePatchIntentRecords,
+} = require('../patch-intent');
+
+const usage = [
+  'forge patch record --from-diff',
+  'forge patch status',
+].join('\n');
+
+function formatRecordSummary(result) {
+  const count = result.records.length;
+  const label = count === 1 ? 'patch intent' : 'patch intents';
+  return [
+    `Recorded ${count} ${label} in ${result.path}.`,
+    ...result.records.map(record => `- ${record.id} -> ${record.anchorId} (${record.path})`),
+  ].join('\n');
+}
+
+async function handler(args, _flags, projectRoot) {
+  const [subcommand, ...rest] = args;
+
+  if (subcommand === 'record') {
+    if (!rest.includes('--from-diff')) {
+      return {
+        success: false,
+        error: `Missing --from-diff.\n\nUsage:\n${usage}`,
+      };
+    }
+    const result = recordPatchIntentFromDiff(projectRoot);
+    return {
+      success: true,
+      output: formatRecordSummary(result),
+    };
+  }
+
+  if (subcommand === 'status') {
+    const result = resolvePatchIntentRecords(projectRoot);
+    const lines = [
+      `Patch intent file: ${result.path}`,
+      `Records: ${result.records.length}`,
+      `Orphans: ${result.orphans.length}`,
+    ];
+    for (const record of result.records) {
+      lines.push(`- ${record.id}: ${record.status} ${record.anchorId} -> ${record.currentPath || record.path}`);
+    }
+    return {
+      success: true,
+      output: lines.join('\n'),
+    };
+  }
+
+  return {
+    success: false,
+    error: `Unknown patch subcommand: ${subcommand || '(none)'}\n\nUsage:\n${usage}`,
+  };
+}
+
+module.exports = {
+  name: 'patch',
+  description: 'Record and inspect patch intent anchored in patch.md',
+  usage,
+  handler,
+};
+

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -193,20 +193,34 @@ function anchorInDiffHunk(diff, relativePath) {
   const shouldTrackFences = isMarkdownFile(relativePath);
 
   for (const line of diff.split(/\r?\n/)) {
-    if (isDiffContentChange(line)) break;
-    if (!line.startsWith(' ')) continue;
-    const content = line.slice(1);
-    const fence = shouldTrackFences ? parseMarkdownFence(content) : null;
-    if (fence) {
-      openFence = nextMarkdownFenceState(openFence, fence);
-      continue;
-    }
-    if (openFence) continue;
-    if (shouldTrackFences && isMarkdownIndentedCodeLine(content)) continue;
-    const id = parseAnchorLine(content);
+    const scan = scanAnchorDiffContextLine(line, { openFence, shouldTrackFences });
+    openFence = scan.openFence;
+    if (scan.stop) break;
+    const id = scan.anchorId;
     if (id) return { id, line: null };
   }
   return null;
+}
+
+function scanAnchorDiffContextLine(line, state) {
+  const { shouldTrackFences } = state;
+  if (isDiffContentChange(line)) return { ...state, stop: true, anchorId: null };
+  if (!line.startsWith(' ')) return { ...state, stop: false, anchorId: null };
+
+  const content = line.slice(1);
+  const fence = shouldTrackFences ? parseMarkdownFence(content) : null;
+  if (fence) {
+    return {
+      shouldTrackFences,
+      openFence: nextMarkdownFenceState(state.openFence, fence),
+      stop: false,
+      anchorId: null,
+    };
+  }
+  if (state.openFence || (shouldTrackFences && isMarkdownIndentedCodeLine(content))) {
+    return { ...state, stop: false, anchorId: null };
+  }
+  return { ...state, stop: false, anchorId: parseAnchorLine(content) };
 }
 
 function isDiffContentChange(line) {
@@ -602,17 +616,18 @@ function readGitDiff(projectRoot, excludedPatchPath = DEFAULT_PATCH_PATH) {
   ];
 
   try {
-    return execFileSync('git', args, {
-      cwd: projectRoot,
-      encoding: 'utf8',
-    });
+    return execGit(projectRoot, args);
   } catch (error) {
     if (!String(error.message || '').includes('bad revision')) throw error;
-    return execFileSync('git', ['diff', '--no-ext-diff', '--unified=3', ...pathspecArgs], {
-      cwd: projectRoot,
-      encoding: 'utf8',
-    });
+    return execGit(projectRoot, ['diff', '--no-ext-diff', '--unified=3', ...pathspecArgs]);
   }
+}
+
+function execGit(projectRoot, args) {
+  return execFileSync('git', args, {
+    cwd: projectRoot,
+    encoding: 'utf8',
+  });
 }
 
 function createRecordsFromDiff(projectRoot, diff, options = {}) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -74,7 +74,7 @@ function shouldScanFile(relativePath, excludedPatchPath = DEFAULT_PATCH_PATH) {
   const normalized = toPosixPath(relativePath);
   if (normalized === DEFAULT_PATCH_PATH) return false;
   if (normalized === toPosixPath(excludedPatchPath)) return false;
-  return /\.(cjs|js|json|jsx|md|mjs|ts|tsx|txt|yaml|yml)$/.test(normalized);
+  return isAnchorDeclarationFile(normalized);
 }
 
 function walkFiles(root, dir = root, files = [], options = {}) {
@@ -124,6 +124,11 @@ function discoverAnchors(projectRoot, options = {}) {
 function isMarkdownFile(relativePath) {
   const lowerPath = relativePath.toLowerCase();
   return lowerPath.endsWith('.md') || lowerPath.endsWith('.mdx');
+}
+
+function isAnchorDeclarationFile(relativePath) {
+  const lowerPath = relativePath.toLowerCase();
+  return lowerPath.endsWith('.md') || lowerPath.endsWith('.mdx') || lowerPath.endsWith('.txt');
 }
 
 function isMarkdownFence(line) {
@@ -278,6 +283,12 @@ function loadPatchIntentConfig(projectRoot) {
   };
 }
 
+function assertUsableConfig(config) {
+  if (config.errors.length > 0) {
+    throw new Error(config.errors.map(error => `${error.code}: ${error.message}`).join('\n'));
+  }
+}
+
 function recordBlock(record) {
   const metadata = {
     id: record.id,
@@ -415,9 +426,7 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
 
 function recordPatchIntentFromDiff(projectRoot, options = {}) {
   const config = loadPatchIntentConfig(projectRoot);
-  if (config.errors.length > 0) {
-    throw new Error(config.errors.map(error => error.message).join('\n'));
-  }
+  assertUsableConfig(config);
   if (!config.enabled) {
     throw new Error('Patch intent recording is disabled by .forge/config.yaml.');
   }
@@ -432,6 +441,7 @@ function recordPatchIntentFromDiff(projectRoot, options = {}) {
 
 function resolvePatchIntentRecords(projectRoot, options = {}) {
   const config = options.config || loadPatchIntentConfig(projectRoot);
+  assertUsableConfig(config);
   const loaded = loadPatchIntentRecords(projectRoot, { config });
   const anchors = discoverAnchors(projectRoot, { excludedPatchPath: config.path });
   const records = [];

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -116,6 +116,7 @@ function scanFileAnchors(projectRoot, relativePath) {
       continue;
     }
     if (openFence) continue;
+    if (shouldTrackFences && isMarkdownIndentedCodeLine(line)) continue;
     const id = parseAnchorLine(line);
     if (id) {
       anchors.push({ id, path: relativePath, line: index + 1 });
@@ -161,6 +162,10 @@ function nextMarkdownFenceState(openFence, fence) {
   return openFence;
 }
 
+function isMarkdownIndentedCodeLine(line) {
+  return /^(?: {4,}|\t)/.test(line);
+}
+
 function nearestAnchorBefore(content, lineNumber, relativePath) {
   const lines = content.split(/\r?\n/);
   const end = Math.max(0, Math.min(lineNumber - 1, lines.length - 1));
@@ -175,6 +180,7 @@ function nearestAnchorBefore(content, lineNumber, relativePath) {
       continue;
     }
     if (openFence) continue;
+    if (shouldTrackFences && isMarkdownIndentedCodeLine(lines[index])) continue;
     const id = parseAnchorLine(lines[index]);
     if (id) nearest = { id, line: index + 1 };
   }
@@ -196,6 +202,7 @@ function anchorInDiffHunk(diff, relativePath) {
       continue;
     }
     if (openFence) continue;
+    if (shouldTrackFences && isMarkdownIndentedCodeLine(content)) continue;
     const id = parseAnchorLine(content);
     if (id) return { id, line: null };
   }
@@ -581,19 +588,31 @@ function writePatchIntentRecords(projectRoot, records, options = {}) {
 
 function readGitDiff(projectRoot, excludedPatchPath = DEFAULT_PATCH_PATH) {
   const excluded = new Set([DEFAULT_PATCH_PATH, toPosixPath(excludedPatchPath)]);
-  const args = [
-    'diff',
-    '--no-ext-diff',
-    '--unified=3',
+  const pathspecArgs = [
     '--',
     '.',
     ...[...excluded].filter(Boolean).map(patchPath => `:(exclude)${patchPath}`),
   ];
+  const args = [
+    'diff',
+    '--no-ext-diff',
+    '--unified=3',
+    'HEAD',
+    ...pathspecArgs,
+  ];
 
-  return execFileSync('git', args, {
-    cwd: projectRoot,
-    encoding: 'utf8',
-  });
+  try {
+    return execFileSync('git', args, {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    });
+  } catch (error) {
+    if (!String(error.message || '').includes('bad revision')) throw error;
+    return execFileSync('git', ['diff', '--no-ext-diff', '--unified=3', ...pathspecArgs], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    });
+  }
 }
 
 function createRecordsFromDiff(projectRoot, diff, options = {}) {
@@ -650,6 +669,7 @@ function collectRemovedAnchorsInHunkDiff(diff, relativePath) {
       continue;
     }
     if (openFence || !removedLine) continue;
+    if (shouldTrackFences && isMarkdownIndentedCodeLine(content)) continue;
     const id = parseAnchorLine(content);
     if (id) anchors.push({ id, line: null });
   }
@@ -691,6 +711,7 @@ function collectAnchorsInLineRange(content, startLine, endLine, relativePath) {
       continue;
     }
     if (openFence || index + 1 < start) continue;
+    if (shouldTrackFences && isMarkdownIndentedCodeLine(line)) continue;
     const id = parseAnchorLine(line);
     if (id) anchors.push({ id, line: index + 1 });
   }

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -615,18 +615,31 @@ function readGitDiff(projectRoot, excludedPatchPath = DEFAULT_PATCH_PATH) {
     ...pathspecArgs,
   ];
 
+  if (hasGitHead(projectRoot)) return execGit(projectRoot, args);
+  return readGitDiffWithoutHead(projectRoot, pathspecArgs);
+}
+
+function hasGitHead(projectRoot) {
   try {
-    return execGit(projectRoot, args);
-  } catch (error) {
-    if (!String(error.message || '').includes('bad revision')) throw error;
-    return execGit(projectRoot, ['diff', '--no-ext-diff', '--unified=3', ...pathspecArgs]);
+    execGit(projectRoot, ['rev-parse', '--verify', 'HEAD'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
   }
 }
 
-function execGit(projectRoot, args) {
+function readGitDiffWithoutHead(projectRoot, pathspecArgs) {
+  return [
+    execGit(projectRoot, ['diff', '--cached', '--no-ext-diff', '--unified=3', ...pathspecArgs]),
+    execGit(projectRoot, ['diff', '--no-ext-diff', '--unified=3', ...pathspecArgs]),
+  ].filter(Boolean).join('\n');
+}
+
+function execGit(projectRoot, args, options = {}) {
   return execFileSync('git', args, {
     cwd: projectRoot,
     encoding: 'utf8',
+    ...options,
   });
 }
 

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -94,31 +94,42 @@ function walkFiles(root, dir = root, files = [], options = {}) {
 function discoverAnchors(projectRoot, options = {}) {
   const anchors = new Map();
   for (const relativePath of walkFiles(projectRoot, projectRoot, [], options)) {
-    const fullPath = path.join(projectRoot, relativePath);
-    const lines = fs.readFileSync(fullPath, 'utf8').split(/\r?\n/);
-    let inFence = false;
-    for (const [index, line] of lines.entries()) {
-      if (isMarkdownFile(relativePath) && isMarkdownFence(line)) {
-        inFence = !inFence;
-        continue;
-      }
-      if (inFence) continue;
-      const id = parseAnchorLine(line);
-      if (!id) continue;
-      if (anchors.has(id)) {
-        const existing = anchors.get(id);
-        throw new Error(
-          `Duplicate forge anchor '${id}' in '${existing.path}' and '${relativePath}'. Anchor IDs must be unique.`
-        );
-      }
-      anchors.set(id, {
-        id,
-        path: relativePath,
-        line: index + 1,
-      });
+    for (const anchor of scanFileAnchors(projectRoot, relativePath)) {
+      addDiscoveredAnchor(anchors, anchor);
     }
   }
   return anchors;
+}
+
+function scanFileAnchors(projectRoot, relativePath) {
+  const fullPath = path.join(projectRoot, relativePath);
+  const lines = fs.readFileSync(fullPath, 'utf8').split(/\r?\n/);
+  const anchors = [];
+  let inFence = false;
+
+  for (const [index, line] of lines.entries()) {
+    if (isMarkdownFile(relativePath) && isMarkdownFence(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const id = parseAnchorLine(line);
+    if (id) {
+      anchors.push({ id, path: relativePath, line: index + 1 });
+    }
+  }
+
+  return anchors;
+}
+
+function addDiscoveredAnchor(anchors, anchor) {
+  if (anchors.has(anchor.id)) {
+    const existing = anchors.get(anchor.id);
+    throw new Error(
+      `Duplicate forge anchor '${anchor.id}' in '${existing.path}' and '${anchor.path}'. Anchor IDs must be unique.`
+    );
+  }
+  anchors.set(anchor.id, anchor);
 }
 
 function isMarkdownFile(relativePath) {
@@ -139,17 +150,34 @@ function isMarkdownFence(line) {
 function nearestAnchorBefore(content, lineNumber) {
   const lines = content.split(/\r?\n/);
   const end = Math.max(0, Math.min(lineNumber - 1, lines.length - 1));
-  for (let index = end; index >= 0; index -= 1) {
+  let nearest = null;
+  let inFence = false;
+
+  for (let index = 0; index <= end; index += 1) {
+    if (isMarkdownFence(lines[index])) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
     const id = parseAnchorLine(lines[index]);
-    if (id) return { id, line: index + 1 };
+    if (id) nearest = { id, line: index + 1 };
   }
-  return null;
+
+  return nearest;
 }
 
 function anchorInDiffHunk(diff) {
+  let inFence = false;
+
   for (const line of diff.split(/\r?\n/)) {
     if (!/^[ +]/.test(line)) continue;
-    const id = parseAnchorLine(line.slice(1));
+    const content = line.slice(1);
+    if (isMarkdownFence(content)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const id = parseAnchorLine(content);
     if (id) return { id, line: null };
   }
   return null;

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -1,0 +1,384 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+const YAML = require('yaml');
+
+const DEFAULT_PATCH_PATH = '.forge/patch.md';
+const PATCH_SOURCE = 'git-diff';
+const RECORD_START = '<!-- forge-patch-intent:v1';
+const RECORD_END = '<!-- /forge-patch-intent -->';
+const ANCHOR_ID_PATTERN = '[A-Za-z0-9._:-]+';
+const EXCLUDED_DIRS = new Set([
+  '.git',
+  '.beads',
+  'node_modules',
+  'test-results',
+  '.worktrees',
+]);
+
+function toPosixPath(value) {
+  return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function hashText(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function patchId(anchorId, diff) {
+  const safeAnchor = anchorId.replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return `patch_${safeAnchor}_${hashText(diff).slice(0, 12)}`;
+}
+
+function parseAnchorLine(line) {
+  const patterns = [
+    new RegExp(`<!--\\s*forge-anchor:(${ANCHOR_ID_PATTERN})\\s*-->`),
+    new RegExp(`<!--\\s*forge-anchor\\s+id=["']?(${ANCHOR_ID_PATTERN})["']?\\s*-->`),
+    new RegExp(`<!--\\s*forge:anchor\\s+id=["'](${ANCHOR_ID_PATTERN})["']\\s*-->`),
+  ];
+  for (const pattern of patterns) {
+    const match = line.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function shouldScanFile(relativePath) {
+  const normalized = toPosixPath(relativePath);
+  if (normalized === DEFAULT_PATCH_PATH) return false;
+  return /\.(cjs|js|json|jsx|md|mjs|ts|tsx|txt|yaml|yml)$/.test(normalized);
+}
+
+function walkFiles(root, dir = root, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory() && EXCLUDED_DIRS.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(root, fullPath, files);
+      continue;
+    }
+    const relativePath = toPosixPath(path.relative(root, fullPath));
+    if (shouldScanFile(relativePath)) files.push(relativePath);
+  }
+  return files;
+}
+
+function discoverAnchors(projectRoot) {
+  const anchors = new Map();
+  for (const relativePath of walkFiles(projectRoot)) {
+    const fullPath = path.join(projectRoot, relativePath);
+    const lines = fs.readFileSync(fullPath, 'utf8').split(/\r?\n/);
+    for (const [index, line] of lines.entries()) {
+      const id = parseAnchorLine(line);
+      if (!id || anchors.has(id)) continue;
+      anchors.set(id, {
+        id,
+        path: relativePath,
+        line: index + 1,
+      });
+    }
+  }
+  return anchors;
+}
+
+function nearestAnchorBefore(content, lineNumber) {
+  const lines = content.split(/\r?\n/);
+  const end = Math.max(0, Math.min(lineNumber - 1, lines.length - 1));
+  for (let index = end; index >= 0; index -= 1) {
+    const id = parseAnchorLine(lines[index]);
+    if (id) return { id, line: index + 1 };
+  }
+  return null;
+}
+
+function anchorInDiffHunk(diff) {
+  for (const line of diff.split(/\r?\n/)) {
+    if (!/^[ +]/.test(line)) continue;
+    const id = parseAnchorLine(line.slice(1));
+    if (id) return { id, line: null };
+  }
+  return null;
+}
+
+function parseHunkNewStart(header) {
+  const match = header.match(/@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/);
+  return match ? Number(match[1]) : 1;
+}
+
+function parseUnifiedDiff(diff) {
+  const lines = String(diff || '').split(/\r?\n/);
+  const records = [];
+  let currentFile = null;
+  let fileHeader = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (line.startsWith('diff --git ')) {
+      const match = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+      currentFile = match ? toPosixPath(match[2]) : null;
+      fileHeader = [line];
+      index += 1;
+      while (index < lines.length && !lines[index].startsWith('@@ ') && !lines[index].startsWith('diff --git ')) {
+        fileHeader.push(lines[index]);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (line.startsWith('@@ ') && currentFile) {
+      const hunk = [line];
+      const newStart = parseHunkNewStart(line);
+      index += 1;
+      while (index < lines.length && !lines[index].startsWith('@@ ') && !lines[index].startsWith('diff --git ')) {
+        hunk.push(lines[index]);
+        index += 1;
+      }
+      records.push({
+        path: currentFile,
+        newStart,
+        diff: [...fileHeader, ...hunk].join('\n').trimEnd() + '\n',
+      });
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return records;
+}
+
+function loadPatchIntentConfig(projectRoot) {
+  const { loadRuntimeGraphConfig } = require('./core/runtime-graph');
+  const loaded = loadRuntimeGraphConfig({ projectRoot });
+  const section = loaded.config.patchIntent || {};
+  const errors = [...loaded.errors];
+
+  if (section && (typeof section !== 'object' || Array.isArray(section))) {
+    errors.push({
+      code: 'PATCH_INTENT_CONFIG_INVALID',
+      message: 'patchIntent must be an object.',
+    });
+  }
+
+  const config = section && typeof section === 'object' && !Array.isArray(section) ? section : {};
+  const enabled = Object.hasOwn(config, 'enabled') ? config.enabled : true;
+  if (typeof enabled !== 'boolean') {
+    errors.push({
+      code: 'PATCH_INTENT_ENABLED_INVALID',
+      message: 'patchIntent.enabled must be a boolean.',
+    });
+  }
+
+  const patchPath = typeof config.path === 'string' && config.path.trim() !== ''
+    ? toPosixPath(config.path.trim())
+    : DEFAULT_PATCH_PATH;
+  const anchorAliases = config.anchorAliases && typeof config.anchorAliases === 'object' && !Array.isArray(config.anchorAliases)
+    ? Object.fromEntries(Object.entries(config.anchorAliases).map(([from, to]) => [String(from), String(to)]))
+    : {};
+
+  return {
+    enabled: enabled !== false,
+    path: patchPath,
+    anchorAliases,
+    errors,
+  };
+}
+
+function recordBlock(record) {
+  const metadata = {
+    id: record.id,
+    anchorId: record.anchorId,
+    path: record.path,
+    createdAt: record.createdAt,
+    source: record.source || PATCH_SOURCE,
+    status: record.status || 'active',
+  };
+  if (record.anchorLine) metadata.anchorLine = record.anchorLine;
+  if (record.baseAnchorHash) metadata.baseAnchorHash = record.baseAnchorHash;
+
+  return [
+    RECORD_START,
+    YAML.stringify(metadata).trimEnd(),
+    '-->',
+    '```diff',
+    record.diff.trimEnd(),
+    '```',
+    RECORD_END,
+  ].join('\n');
+}
+
+function parsePatchIntentMarkdown(content) {
+  const records = [];
+  const pattern = /<!--\s*forge-patch-intent:v1\s*\n([\s\S]*?)\n-->\s*\n```diff\n([\s\S]*?)\n```\s*\n<!--\s*\/forge-patch-intent\s*-->/g;
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    const metadata = YAML.parse(match[1]) || {};
+    records.push({
+      ...metadata,
+      anchorId: String(metadata.anchorId || ''),
+      path: toPosixPath(metadata.path || ''),
+      diff: match[2].trimEnd() + '\n',
+    });
+  }
+  return records;
+}
+
+function loadPatchIntentRecords(projectRoot, options = {}) {
+  const config = options.config || loadPatchIntentConfig(projectRoot);
+  const patchPath = options.patchPath || config.path;
+  const fullPath = path.join(projectRoot, patchPath);
+  if (!fs.existsSync(fullPath)) {
+    return { path: patchPath, records: [] };
+  }
+  return {
+    path: patchPath,
+    records: parsePatchIntentMarkdown(fs.readFileSync(fullPath, 'utf8')),
+  };
+}
+
+function writePatchIntentRecords(projectRoot, records, options = {}) {
+  const config = options.config || loadPatchIntentConfig(projectRoot);
+  const patchPath = options.patchPath || config.path;
+  const fullPath = path.join(projectRoot, patchPath);
+  const existing = loadPatchIntentRecords(projectRoot, { config, patchPath }).records;
+  const byId = new Map(existing.map(record => [record.id, record]));
+  for (const record of records) {
+    byId.set(record.id, record);
+  }
+  const ordered = [...byId.values()].sort((left, right) => {
+    return `${left.anchorId}:${left.id}`.localeCompare(`${right.anchorId}:${right.id}`);
+  });
+
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, [
+    '# Forge Patch Intent',
+    '',
+    '<!-- Managed by forge patch record. Edit with care; records are keyed by stable anchors. -->',
+    '',
+    ...ordered.map(recordBlock),
+    '',
+  ].join('\n'), 'utf8');
+
+  return { path: patchPath, records: ordered };
+}
+
+function readGitDiff(projectRoot) {
+  return execFileSync('git', [
+    'diff',
+    '--no-ext-diff',
+    '--unified=3',
+    '--',
+    '.',
+    ':(exclude).forge/patch.md',
+  ], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+  });
+}
+
+function createRecordsFromDiff(projectRoot, diff, options = {}) {
+  const hunks = parseUnifiedDiff(diff);
+  const createdAt = (options.now || new Date()).toISOString();
+  const records = [];
+
+  for (const hunk of hunks) {
+    const fullPath = path.join(projectRoot, hunk.path);
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`Patch target '${hunk.path}' does not exist. Declare a stable anchor before recording intent.`);
+    }
+    const content = fs.readFileSync(fullPath, 'utf8');
+    const anchor = anchorInDiffHunk(hunk.diff) || nearestAnchorBefore(content, hunk.newStart);
+    if (!anchor) {
+      throw new Error(`Patch target '${hunk.path}' has no declared forge anchor before diff hunk. Add '<!-- forge-anchor:<id> -->' near the managed block.`);
+    }
+    records.push({
+      id: patchId(anchor.id, hunk.diff),
+      anchorId: anchor.id,
+      anchorLine: anchor.line,
+      path: hunk.path,
+      createdAt,
+      source: PATCH_SOURCE,
+      status: 'active',
+      baseAnchorHash: `sha256:${hashText(anchor.id).slice(0, 16)}`,
+      diff: hunk.diff,
+    });
+  }
+
+  return records;
+}
+
+function recordPatchIntentFromDiff(projectRoot, options = {}) {
+  const config = loadPatchIntentConfig(projectRoot);
+  if (config.errors.length > 0) {
+    throw new Error(config.errors.map(error => error.message).join('\n'));
+  }
+  if (!config.enabled) {
+    throw new Error('Patch intent recording is disabled by .forge/config.yaml.');
+  }
+
+  const diff = options.diff ?? readGitDiff(projectRoot);
+  const records = createRecordsFromDiff(projectRoot, diff, options);
+  if (records.length === 0) {
+    return { path: config.path, records: [] };
+  }
+  return writePatchIntentRecords(projectRoot, records, { config });
+}
+
+function resolvePatchIntentRecords(projectRoot, options = {}) {
+  const config = options.config || loadPatchIntentConfig(projectRoot);
+  const loaded = loadPatchIntentRecords(projectRoot, { config });
+  const anchors = discoverAnchors(projectRoot);
+  const records = [];
+  const orphans = [];
+
+  for (const record of loaded.records) {
+    const resolvedAnchorId = config.anchorAliases[record.anchorId] || record.anchorId;
+    const anchor = anchors.get(resolvedAnchorId);
+    if (!anchor) {
+      const orphan = {
+        ...record,
+        resolvedAnchorId,
+        status: 'orphaned',
+      };
+      records.push(orphan);
+      orphans.push(orphan);
+      continue;
+    }
+
+    const status = anchor.path === record.path ? 'active' : 'renamed';
+    records.push({
+      ...record,
+      resolvedAnchorId,
+      currentPath: anchor.path,
+      currentLine: anchor.line,
+      status,
+    });
+  }
+
+  return {
+    path: loaded.path,
+    records,
+    orphans,
+  };
+}
+
+function buildUnifiedDiffFromRecords(records) {
+  return records.map(record => record.diff.trimEnd()).join('\n') + '\n';
+}
+
+module.exports = {
+  DEFAULT_PATCH_PATH,
+  buildUnifiedDiffFromRecords,
+  createRecordsFromDiff,
+  discoverAnchors,
+  loadPatchIntentConfig,
+  loadPatchIntentRecords,
+  parsePatchIntentMarkdown,
+  parseUnifiedDiff,
+  recordPatchIntentFromDiff,
+  resolvePatchIntentRecords,
+  writePatchIntentRecords,
+};

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -654,7 +654,7 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
       continue;
     }
     const content = fs.readFileSync(fullPath, 'utf8');
-    const anchor = anchorInDiffHunk(hunk.diff, hunk.path) || nearestAnchorBefore(content, hunk.newStart, hunk.path);
+    const anchor = resolveAnchorForHunk(content, hunk);
     if (!anchor) {
       throw new Error(`Patch target '${hunk.path}' has no declared forge anchor before diff hunk. Add '<!-- forge-anchor:<id> -->' near the managed block.`);
     }
@@ -673,6 +673,21 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
   }
 
   return records;
+}
+
+function resolveAnchorForHunk(content, hunk) {
+  return anchorInDiffHunk(hunk.diff, hunk.path)
+    || nearestAnchorBefore(content, hunk.newStart, hunk.path)
+    || firstAnchorInAddedFileHunk(content, hunk);
+}
+
+function firstAnchorInAddedFileHunk(content, hunk) {
+  if (!isAddedFileHunk(hunk.diff)) return null;
+  return collectAnchorsInLineRange(content, hunk.newStart, hunk.newEnd, hunk.path)[0] || null;
+}
+
+function isAddedFileHunk(diff) {
+  return diff.split(/\r?\n/).includes('--- /dev/null');
 }
 
 function assertSingleAnchorHunk(content, hunk, anchor) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -48,7 +48,7 @@ function ensureTrailingNewline(value) {
 
 function patchId(anchorId, diff) {
   const safeAnchor = normalizePatchIdAnchor(anchorId);
-  return `patch_${safeAnchor}_${hashText(diff).slice(0, 12)}`;
+  return `patch_${safeAnchor}_${hashText(`${String(anchorId || '')}\0${diff}`).slice(0, 12)}`;
 }
 
 function normalizePatchIdAnchor(anchorId) {
@@ -559,8 +559,10 @@ function parsePatchIntentMarkdown(content) {
     }
 
     const metadata = YAML.parse(normalizedContent.slice(start + RECORD_START.length, metadataEnd).trim()) || {};
+    assertPatchIntentRecordMetadata(metadata, `Malformed patch intent record block near offset ${start}`);
     records.push({
       ...metadata,
+      id: String(metadata.id),
       anchorId: String(metadata.anchorId || ''),
       path: toPosixPath(metadata.path || ''),
       diff: ensureTrailingNewline(normalizedContent.slice(diffStart, diffEnd)),
@@ -568,6 +570,15 @@ function parsePatchIntentMarkdown(content) {
     cursor = end + RECORD_END.length;
   }
   return records;
+}
+
+function assertPatchIntentRecordMetadata(record, context = 'Patch intent record') {
+  const missing = ['id', 'anchorId', 'path'].filter(field => {
+    return typeof record[field] !== 'string' || record[field].trim() === '';
+  });
+  if (missing.length > 0) {
+    throw new Error(`${context} missing required metadata: ${missing.join(', ')}`);
+  }
 }
 
 function loadPatchIntentRecords(projectRoot, options = {}) {
@@ -588,6 +599,9 @@ function writePatchIntentRecords(projectRoot, records, options = {}) {
   const patchPath = resolveManagedPatchPath(projectRoot, options.patchPath || config.path);
   const fullPath = path.join(projectRoot, patchPath);
   const existing = loadPatchIntentRecords(projectRoot, { config, patchPath }).records;
+  for (const record of records) {
+    assertPatchIntentRecordMetadata(record);
+  }
   const byId = new Map(existing.map(record => [record.id, record]));
   for (const record of records) {
     byId.set(record.id, record);

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -170,7 +170,8 @@ function anchorInDiffHunk(diff) {
   let inFence = false;
 
   for (const line of diff.split(/\r?\n/)) {
-    if (!/^[ +]/.test(line)) continue;
+    if (isDiffContentChange(line)) break;
+    if (!line.startsWith(' ')) continue;
     const content = line.slice(1);
     if (isMarkdownFence(content)) {
       inFence = !inFence;
@@ -181,6 +182,11 @@ function anchorInDiffHunk(diff) {
     if (id) return { id, line: null };
   }
   return null;
+}
+
+function isDiffContentChange(line) {
+  if (!line.startsWith('+') && !line.startsWith('-')) return false;
+  return !line.startsWith('+++ ') && !line.startsWith('--- ');
 }
 
 function parseHunkNewStart(header) {
@@ -341,24 +347,27 @@ function recordBlock(record) {
 }
 
 function parsePatchIntentMarkdown(content) {
+  const normalizedContent = String(content || '').replace(/\r\n?/g, '\n');
   const records = [];
   let cursor = 0;
-  while (cursor < content.length) {
-    const start = content.indexOf(RECORD_START, cursor);
+  while (cursor < normalizedContent.length) {
+    const start = normalizedContent.indexOf(RECORD_START, cursor);
     if (start < 0) break;
-    const metadataEnd = content.indexOf('\n-->', start + RECORD_START.length);
-    const diffStartFence = metadataEnd < 0 ? -1 : content.indexOf(PATCH_DIFF_FENCE, metadataEnd);
+    const metadataEnd = normalizedContent.indexOf('\n-->', start + RECORD_START.length);
+    const diffStartFence = metadataEnd < 0 ? -1 : normalizedContent.indexOf(PATCH_DIFF_FENCE, metadataEnd);
     const diffStart = diffStartFence < 0 ? -1 : diffStartFence + PATCH_DIFF_FENCE.length;
-    const diffEnd = diffStart < 0 ? -1 : content.indexOf(PATCH_FENCE_END, diffStart);
-    const end = diffEnd < 0 ? -1 : content.indexOf(RECORD_END, diffEnd + PATCH_FENCE_END.length);
-    if (metadataEnd < 0 || diffStart < 0 || diffEnd < 0 || end < 0) break;
+    const diffEnd = diffStart < 0 ? -1 : normalizedContent.indexOf(PATCH_FENCE_END, diffStart);
+    const end = diffEnd < 0 ? -1 : normalizedContent.indexOf(RECORD_END, diffEnd + PATCH_FENCE_END.length);
+    if (metadataEnd < 0 || diffStart < 0 || diffEnd < 0 || end < 0) {
+      throw new Error(`Malformed patch intent record block near offset ${start}.`);
+    }
 
-    const metadata = YAML.parse(content.slice(start + RECORD_START.length, metadataEnd).trim()) || {};
+    const metadata = YAML.parse(normalizedContent.slice(start + RECORD_START.length, metadataEnd).trim()) || {};
     records.push({
       ...metadata,
       anchorId: String(metadata.anchorId || ''),
       path: toPosixPath(metadata.path || ''),
-      diff: content.slice(diffStart, diffEnd).trimEnd() + '\n',
+      diff: normalizedContent.slice(diffStart, diffEnd).trimEnd() + '\n',
     });
     cursor = end + RECORD_END.length;
   }

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -16,8 +16,8 @@ const ANCHOR_PATTERNS = [
   new RegExp(String.raw`^\s*<!--\s*forge-anchor\s+id=["']?(${ANCHOR_ID_PATTERN})["']?\s*-->\s*$`),
   new RegExp(String.raw`^\s*<!--\s*forge:anchor\s+id=["'](${ANCHOR_ID_PATTERN})["']\s*-->\s*$`),
 ];
-const DIFF_HEADER_PATTERN = /^diff --git a\/(.+?) b\/(.+)$/;
-const HUNK_HEADER_PATTERN = /@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/;
+const DIFF_HEADER_PREFIX = 'diff --git a/';
+const HUNK_HEADER_PATTERN = /@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@/;
 const PATCH_DIFF_FENCE = '\n```diff\n';
 const PATCH_FENCE_END = '\n```';
 const EXCLUDED_DIRS = new Set([
@@ -206,9 +206,12 @@ function isDiffContentChange(line) {
   return !line.startsWith('+++ ') && !line.startsWith('--- ');
 }
 
-function parseHunkNewStart(header) {
+function parseHunkNewRange(header) {
   const match = HUNK_HEADER_PATTERN.exec(header);
-  return match ? Number(match[1]) : 1;
+  if (!match) return { start: 1, count: 1, end: 1 };
+  const start = Number(match[1]);
+  const count = match[2] === undefined ? 1 : Number(match[2]);
+  return { start, count, end: start + count - 1 };
 }
 
 function parseUnifiedDiff(diff) {
@@ -231,8 +234,6 @@ function parseUnifiedDiff(diff) {
 }
 
 function parseUnifiedDiffFile(lines, startIndex) {
-  const match = DIFF_HEADER_PATTERN.exec(lines[startIndex]);
-  const currentFile = match ? toPosixPath(match[2]) : null;
   const fileHeader = [lines[startIndex]];
   const records = [];
   let index = startIndex + 1;
@@ -242,6 +243,7 @@ function parseUnifiedDiffFile(lines, startIndex) {
     index += 1;
   }
 
+  const currentFile = parseUnifiedDiffCurrentPath(fileHeader);
   if (!currentFile) {
     return { nextIndex: index, records };
   }
@@ -251,6 +253,7 @@ function parseUnifiedDiffFile(lines, startIndex) {
     records.push({
       path: currentFile,
       newStart: parsedHunk.newStart,
+      newEnd: parsedHunk.newEnd,
       diff: [...fileHeader, ...parsedHunk.hunk].join('\n').trimEnd() + '\n',
     });
     index = parsedHunk.nextIndex;
@@ -259,15 +262,35 @@ function parseUnifiedDiffFile(lines, startIndex) {
   return { nextIndex: index, records };
 }
 
+function parseUnifiedDiffCurrentPath(fileHeader) {
+  const newFileHeader = fileHeader.find(line => line.startsWith('+++ '));
+  if (newFileHeader === '+++ /dev/null') return null;
+  if (newFileHeader && newFileHeader.startsWith('+++ b/')) {
+    return toPosixPath(stripDiffPathMetadata(newFileHeader.slice('+++ b/'.length)));
+  }
+
+  const diffHeader = fileHeader[0] || '';
+  if (!diffHeader.startsWith(DIFF_HEADER_PREFIX)) return null;
+  const separatorIndex = diffHeader.indexOf(' b/', DIFF_HEADER_PREFIX.length);
+  if (separatorIndex === -1) return null;
+  return toPosixPath(stripDiffPathMetadata(diffHeader.slice(separatorIndex + ' b/'.length)));
+}
+
+function stripDiffPathMetadata(value) {
+  const tabIndex = value.indexOf('\t');
+  const pathValue = tabIndex === -1 ? value : value.slice(0, tabIndex);
+  return pathValue.trimEnd();
+}
+
 function parseUnifiedDiffHunk(lines, startIndex) {
   const hunk = [lines[startIndex]];
-  const newStart = parseHunkNewStart(lines[startIndex]);
+  const { start: newStart, end: newEnd } = parseHunkNewRange(lines[startIndex]);
   let index = startIndex + 1;
   while (index < lines.length && !lines[index].startsWith('@@ ') && !lines[index].startsWith('diff --git ')) {
     hunk.push(lines[index]);
     index += 1;
   }
-  return { hunk, newStart, nextIndex: index };
+  return { hunk, newStart, newEnd, nextIndex: index };
 }
 
 function resolvePatchPath(projectRoot, configuredPath, errors) {
@@ -333,6 +356,15 @@ function resolveProjectFilePath(projectRoot, relativePath) {
     throw new Error(`Diff path must stay inside the project root: ${relativePath}`);
   }
   return resolved;
+}
+
+function resolveManagedPatchPath(projectRoot, patchPath) {
+  const errors = [];
+  const normalized = resolvePatchPath(projectRoot, patchPath, errors);
+  if (errors.length > 0) {
+    throw new Error(errors.map(error => `${error.code}: ${error.message}`).join('\n'));
+  }
+  return normalized;
 }
 
 function loadPatchIntentConfig(projectRoot) {
@@ -429,7 +461,7 @@ function parsePatchIntentMarkdown(content) {
 
 function loadPatchIntentRecords(projectRoot, options = {}) {
   const config = options.config || loadPatchIntentConfig(projectRoot);
-  const patchPath = options.patchPath || config.path;
+  const patchPath = resolveManagedPatchPath(projectRoot, options.patchPath || config.path);
   const fullPath = path.join(projectRoot, patchPath);
   if (!fs.existsSync(fullPath)) {
     return { path: patchPath, records: [] };
@@ -442,7 +474,7 @@ function loadPatchIntentRecords(projectRoot, options = {}) {
 
 function writePatchIntentRecords(projectRoot, records, options = {}) {
   const config = options.config || loadPatchIntentConfig(projectRoot);
-  const patchPath = options.patchPath || config.path;
+  const patchPath = resolveManagedPatchPath(projectRoot, options.patchPath || config.path);
   const fullPath = path.join(projectRoot, patchPath);
   const existing = loadPatchIntentRecords(projectRoot, { config, patchPath }).records;
   const byId = new Map(existing.map(record => [record.id, record]));
@@ -498,6 +530,7 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
     if (!anchor) {
       throw new Error(`Patch target '${hunk.path}' has no declared forge anchor before diff hunk. Add '<!-- forge-anchor:<id> -->' near the managed block.`);
     }
+    assertSingleAnchorHunk(content, hunk, anchor);
     records.push({
       id: patchId(anchor.id, hunk.diff),
       anchorId: anchor.id,
@@ -512,6 +545,37 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
   }
 
   return records;
+}
+
+function assertSingleAnchorHunk(content, hunk, anchor) {
+  const anchors = collectAnchorsInLineRange(content, hunk.newStart, hunk.newEnd, hunk.path);
+  const anchorIds = new Set([anchor.id, ...anchors.map(found => found.id)]);
+  if (anchorIds.size <= 1) return;
+  throw new Error(`Patch target '${hunk.path}' diff hunk crosses multiple forge anchors (${[...anchorIds].join(', ')}). Split the change into separate hunks before recording patch intent.`);
+}
+
+function collectAnchorsInLineRange(content, startLine, endLine, relativePath) {
+  if (endLine < startLine) return [];
+  const lines = content.split(/\r?\n/);
+  const start = Math.max(1, startLine);
+  const end = Math.min(endLine, lines.length);
+  const anchors = [];
+  let openFence = null;
+  const shouldTrackFences = isMarkdownFile(relativePath);
+
+  for (let index = 0; index < end; index += 1) {
+    const line = lines[index];
+    const fence = shouldTrackFences ? parseMarkdownFence(line) : null;
+    if (fence) {
+      openFence = nextMarkdownFenceState(openFence, fence);
+      continue;
+    }
+    if (openFence || index + 1 < start) continue;
+    const id = parseAnchorLine(line);
+    if (id) anchors.push({ id, line: index + 1 });
+  }
+
+  return anchors;
 }
 
 function recordPatchIntentFromDiff(projectRoot, options = {}) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -12,9 +12,9 @@ const RECORD_START = '<!-- forge-patch-intent:v1';
 const RECORD_END = '<!-- /forge-patch-intent -->';
 const ANCHOR_ID_PATTERN = '[A-Za-z0-9._:-]+';
 const ANCHOR_PATTERNS = [
-  new RegExp(String.raw`<!--\s*forge-anchor:(${ANCHOR_ID_PATTERN})\s*-->`),
-  new RegExp(String.raw`<!--\s*forge-anchor\s+id=["']?(${ANCHOR_ID_PATTERN})["']?\s*-->`),
-  new RegExp(String.raw`<!--\s*forge:anchor\s+id=["'](${ANCHOR_ID_PATTERN})["']\s*-->`),
+  new RegExp(String.raw`^\s*<!--\s*forge-anchor:(${ANCHOR_ID_PATTERN})\s*-->\s*$`),
+  new RegExp(String.raw`^\s*<!--\s*forge-anchor\s+id=["']?(${ANCHOR_ID_PATTERN})["']?\s*-->\s*$`),
+  new RegExp(String.raw`^\s*<!--\s*forge:anchor\s+id=["'](${ANCHOR_ID_PATTERN})["']\s*-->\s*$`),
 ];
 const DIFF_HEADER_PATTERN = /^diff --git a\/(.+?) b\/(.+)$/;
 const HUNK_HEADER_PATTERN = /@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/;
@@ -105,14 +105,16 @@ function scanFileAnchors(projectRoot, relativePath) {
   const fullPath = path.join(projectRoot, relativePath);
   const lines = fs.readFileSync(fullPath, 'utf8').split(/\r?\n/);
   const anchors = [];
-  let inFence = false;
+  let openFence = null;
+  const shouldTrackFences = isMarkdownFile(relativePath);
 
   for (const [index, line] of lines.entries()) {
-    if (isMarkdownFile(relativePath) && isMarkdownFence(line)) {
-      inFence = !inFence;
+    const fence = shouldTrackFences ? parseMarkdownFence(line) : null;
+    if (fence) {
+      openFence = nextMarkdownFenceState(openFence, fence);
       continue;
     }
-    if (inFence) continue;
+    if (openFence) continue;
     const id = parseAnchorLine(line);
     if (id) {
       anchors.push({ id, path: relativePath, line: index + 1 });
@@ -142,23 +144,36 @@ function isAnchorDeclarationFile(relativePath) {
   return lowerPath.endsWith('.md') || lowerPath.endsWith('.mdx') || lowerPath.endsWith('.txt');
 }
 
-function isMarkdownFence(line) {
+function parseMarkdownFence(line) {
   const trimmed = line.trimStart();
-  return trimmed.startsWith('```') || trimmed.startsWith('~~~');
+  const match = /^(`{3,}|~{3,})/.exec(trimmed);
+  if (!match) return null;
+  return {
+    marker: match[1][0],
+    length: match[1].length,
+  };
 }
 
-function nearestAnchorBefore(content, lineNumber) {
+function nextMarkdownFenceState(openFence, fence) {
+  if (!openFence) return fence;
+  if (fence.marker === openFence.marker && fence.length >= openFence.length) return null;
+  return openFence;
+}
+
+function nearestAnchorBefore(content, lineNumber, relativePath) {
   const lines = content.split(/\r?\n/);
   const end = Math.max(0, Math.min(lineNumber - 1, lines.length - 1));
   let nearest = null;
-  let inFence = false;
+  let openFence = null;
+  const shouldTrackFences = isMarkdownFile(relativePath);
 
   for (let index = 0; index <= end; index += 1) {
-    if (isMarkdownFence(lines[index])) {
-      inFence = !inFence;
+    const fence = shouldTrackFences ? parseMarkdownFence(lines[index]) : null;
+    if (fence) {
+      openFence = nextMarkdownFenceState(openFence, fence);
       continue;
     }
-    if (inFence) continue;
+    if (openFence) continue;
     const id = parseAnchorLine(lines[index]);
     if (id) nearest = { id, line: index + 1 };
   }
@@ -166,18 +181,20 @@ function nearestAnchorBefore(content, lineNumber) {
   return nearest;
 }
 
-function anchorInDiffHunk(diff) {
-  let inFence = false;
+function anchorInDiffHunk(diff, relativePath) {
+  let openFence = null;
+  const shouldTrackFences = isMarkdownFile(relativePath);
 
   for (const line of diff.split(/\r?\n/)) {
     if (isDiffContentChange(line)) break;
     if (!line.startsWith(' ')) continue;
     const content = line.slice(1);
-    if (isMarkdownFence(content)) {
-      inFence = !inFence;
+    const fence = shouldTrackFences ? parseMarkdownFence(content) : null;
+    if (fence) {
+      openFence = nextMarkdownFenceState(openFence, fence);
       continue;
     }
-    if (inFence) continue;
+    if (openFence) continue;
     const id = parseAnchorLine(content);
     if (id) return { id, line: null };
   }
@@ -302,6 +319,20 @@ function nearestExistingPath(targetPath) {
     currentPath = parentPath;
   }
   return currentPath;
+}
+
+function resolveProjectFilePath(projectRoot, relativePath) {
+  const root = path.resolve(projectRoot);
+  const resolved = path.resolve(root, relativePath);
+  const relativeToRoot = path.relative(root, resolved);
+  if (
+    relativeToRoot.startsWith('..')
+    || path.isAbsolute(relativeToRoot)
+    || !isPhysicalPathInsideProject(projectRoot, resolved)
+  ) {
+    throw new Error(`Diff path must stay inside the project root: ${relativePath}`);
+  }
+  return resolved;
 }
 
 function loadPatchIntentConfig(projectRoot) {
@@ -458,12 +489,12 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
   const records = [];
 
   for (const hunk of hunks) {
-    const fullPath = path.join(projectRoot, hunk.path);
+    const fullPath = resolveProjectFilePath(projectRoot, hunk.path);
     if (!fs.existsSync(fullPath)) {
       continue;
     }
     const content = fs.readFileSync(fullPath, 'utf8');
-    const anchor = anchorInDiffHunk(hunk.diff) || nearestAnchorBefore(content, hunk.newStart);
+    const anchor = anchorInDiffHunk(hunk.diff, hunk.path) || nearestAnchorBefore(content, hunk.newStart, hunk.path);
     if (!anchor) {
       throw new Error(`Patch target '${hunk.path}' has no declared forge anchor before diff hunk. Add '<!-- forge-anchor:<id> -->' near the managed block.`);
     }

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -170,7 +170,11 @@ function parseUnifiedDiffFile(lines, startIndex) {
     index += 1;
   }
 
-  while (currentFile && index < lines.length && lines[index].startsWith('@@ ')) {
+  if (!currentFile) {
+    return { nextIndex: index, records };
+  }
+
+  while (index < lines.length && lines[index].startsWith('@@ ')) {
     const parsedHunk = parseUnifiedDiffHunk(lines, index);
     records.push({
       path: currentFile,

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -96,7 +96,13 @@ function discoverAnchors(projectRoot, options = {}) {
   for (const relativePath of walkFiles(projectRoot, projectRoot, [], options)) {
     const fullPath = path.join(projectRoot, relativePath);
     const lines = fs.readFileSync(fullPath, 'utf8').split(/\r?\n/);
+    let inFence = false;
     for (const [index, line] of lines.entries()) {
+      if (isMarkdownFile(relativePath) && isMarkdownFence(line)) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
       const id = parseAnchorLine(line);
       if (!id) continue;
       if (anchors.has(id)) {
@@ -113,6 +119,16 @@ function discoverAnchors(projectRoot, options = {}) {
     }
   }
   return anchors;
+}
+
+function isMarkdownFile(relativePath) {
+  const lowerPath = relativePath.toLowerCase();
+  return lowerPath.endsWith('.md') || lowerPath.endsWith('.mdx');
+}
+
+function isMarkdownFence(line) {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith('```') || trimmed.startsWith('~~~');
 }
 
 function nearestAnchorBefore(content, lineNumber) {
@@ -210,12 +226,13 @@ function resolvePatchPath(projectRoot, configuredPath, errors) {
     return DEFAULT_PATCH_PATH;
   }
 
-  const patchPath = toPosixPath(configuredPath.trim());
-  if (!patchPath) return DEFAULT_PATCH_PATH;
+  const rawPatchPath = configuredPath.trim();
+  if (!rawPatchPath) return DEFAULT_PATCH_PATH;
 
   const root = path.resolve(projectRoot);
-  const resolved = path.resolve(projectRoot, patchPath);
-  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+  const resolved = path.resolve(projectRoot, rawPatchPath);
+  const relativeToRoot = path.relative(root, resolved);
+  if (relativeToRoot === '' || relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
     errors.push({
       code: 'PATCH_INTENT_PATH_OUTSIDE_ROOT',
       message: 'patchIntent.path must stay inside the project root.',
@@ -223,16 +240,16 @@ function resolvePatchPath(projectRoot, configuredPath, errors) {
     return DEFAULT_PATCH_PATH;
   }
 
-  return patchPath;
+  return toPosixPath(relativeToRoot);
 }
 
 function loadPatchIntentConfig(projectRoot) {
   const { loadRuntimeGraphConfig } = require('./core/runtime-graph');
   const loaded = loadRuntimeGraphConfig({ projectRoot });
-  const section = loaded.config.patchIntent || {};
+  const section = Object.hasOwn(loaded.config, 'patchIntent') ? loaded.config.patchIntent : {};
   const errors = [...loaded.errors];
 
-  if (section && (typeof section !== 'object' || Array.isArray(section))) {
+  if (!section || typeof section !== 'object' || Array.isArray(section)) {
     errors.push({
       code: 'PATCH_INTENT_CONFIG_INVALID',
       message: 'patchIntent must be an object.',
@@ -373,7 +390,7 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
   for (const hunk of hunks) {
     const fullPath = path.join(projectRoot, hunk.path);
     if (!fs.existsSync(fullPath)) {
-      throw new Error(`Patch target '${hunk.path}' does not exist. Declare a stable anchor before recording intent.`);
+      continue;
     }
     const content = fs.readFileSync(fullPath, 'utf8');
     const anchor = anchorInDiffHunk(hunk.diff) || nearestAnchorBefore(content, hunk.newStart);

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -48,7 +48,8 @@ function ensureTrailingNewline(value) {
 
 function patchId(anchorId, diff) {
   const safeAnchor = normalizePatchIdAnchor(anchorId);
-  return `patch_${safeAnchor}_${hashText(`${String(anchorId || '')}\0${diff}`).slice(0, 12)}`;
+  const hashInput = `${String(anchorId || '')}\0${diff}`;
+  return `patch_${safeAnchor}_${hashText(hashInput).slice(0, 12)}`;
 }
 
 function normalizePatchIdAnchor(anchorId) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -20,6 +20,7 @@ const DIFF_HEADER_PREFIX = 'diff --git a/';
 const HUNK_HEADER_PATTERN = /@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@/;
 const PATCH_DIFF_FENCE = '\n```diff\n';
 const PATCH_FENCE_END = '\n```';
+const KNOWN_DIFF_PATH_PREFIXES = new Set(['a', 'b', 'c', 'i', 'o', 'w']);
 const EXCLUDED_DIRS = new Set([
   '.git',
   '.beads',
@@ -265,12 +266,19 @@ function parseUnifiedDiffFile(lines, startIndex) {
 function parseUnifiedDiffCurrentPath(fileHeader) {
   const newFileHeader = fileHeader.find(line => line.startsWith('+++ '));
   const newPath = newFileHeader ? parseDiffHeaderPath(newFileHeader, '+++ ') : null;
-  if (newPath === '/dev/null') return null;
-  if (newPath?.startsWith('b/')) {
-    return toPosixPath(newPath.slice('b/'.length));
-  }
+  const normalizedNewPath = normalizeDiffSidePath(newPath);
+  if (normalizedNewPath) return toPosixPath(normalizedNewPath);
 
   return parseUnifiedDiffCurrentPathFallback(fileHeader[0] || '');
+}
+
+function normalizeDiffSidePath(diffPath) {
+  if (!diffPath || diffPath === '/dev/null') return null;
+  const slashIndex = diffPath.indexOf('/');
+  if (slashIndex > 0 && KNOWN_DIFF_PATH_PREFIXES.has(diffPath.slice(0, slashIndex))) {
+    return diffPath.slice(slashIndex + 1);
+  }
+  return diffPath;
 }
 
 function parseUnifiedDiffCurrentPathFallback(diffHeader) {
@@ -632,21 +640,10 @@ function assertSingleAnchorHunk(content, hunk, anchor) {
 
 function collectRemovedAnchorsInHunkDiff(diff, relativePath) {
   const anchors = [];
-  let inHunk = false;
   let openFence = null;
   const shouldTrackFences = isMarkdownFile(relativePath);
 
-  for (const line of diff.split(/\r?\n/)) {
-    if (line.startsWith('@@ ')) {
-      inHunk = true;
-      continue;
-    }
-    if (!inHunk) continue;
-    if (line.startsWith('diff --git ')) break;
-    if (!line.startsWith(' ') && !line.startsWith('-')) continue;
-
-    const removedLine = line.startsWith('-');
-    const content = line.slice(1);
+  for (const { content, removedLine } of iterateOldDiffContentLines(diff)) {
     const fence = shouldTrackFences ? parseMarkdownFence(content) : null;
     if (fence) {
       openFence = nextMarkdownFenceState(openFence, fence);
@@ -658,6 +655,23 @@ function collectRemovedAnchorsInHunkDiff(diff, relativePath) {
   }
 
   return anchors;
+}
+
+function* iterateOldDiffContentLines(diff) {
+  let inHunk = false;
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith('@@ ')) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith('diff --git ')) return;
+    if (line.startsWith('-')) {
+      yield { content: line.slice(1), removedLine: true };
+    } else if (line.startsWith(' ')) {
+      yield { content: line.slice(1), removedLine: false };
+    }
+  }
 }
 
 function collectAnchorsInLineRange(content, startLine, endLine, relativePath) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -82,6 +82,7 @@ function walkFiles(root, dir = root, files = [], options = {}) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory() && EXCLUDED_DIRS.has(entry.name)) continue;
     const fullPath = path.join(dir, entry.name);
+    if (!isPhysicalPathInsideProject(root, fullPath)) continue;
     if (entry.isDirectory()) {
       walkFiles(root, fullPath, files, options);
       continue;

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -11,6 +11,15 @@ const PATCH_SOURCE = 'git-diff';
 const RECORD_START = '<!-- forge-patch-intent:v1';
 const RECORD_END = '<!-- /forge-patch-intent -->';
 const ANCHOR_ID_PATTERN = '[A-Za-z0-9._:-]+';
+const ANCHOR_PATTERNS = [
+  new RegExp(String.raw`<!--\s*forge-anchor:(${ANCHOR_ID_PATTERN})\s*-->`),
+  new RegExp(String.raw`<!--\s*forge-anchor\s+id=["']?(${ANCHOR_ID_PATTERN})["']?\s*-->`),
+  new RegExp(String.raw`<!--\s*forge:anchor\s+id=["'](${ANCHOR_ID_PATTERN})["']\s*-->`),
+];
+const DIFF_HEADER_PATTERN = /^diff --git a\/(.+?) b\/(.+)$/;
+const HUNK_HEADER_PATTERN = /@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/;
+const PATCH_DIFF_FENCE = '\n```diff\n';
+const PATCH_FENCE_END = '\n```';
 const EXCLUDED_DIRS = new Set([
   '.git',
   '.beads',
@@ -20,7 +29,8 @@ const EXCLUDED_DIRS = new Set([
 ]);
 
 function toPosixPath(value) {
-  return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '');
+  const normalized = String(value || '').replaceAll('\\', '/');
+  return normalized.startsWith('./') ? normalized.slice(2) : normalized;
 }
 
 function hashText(value) {
@@ -28,18 +38,33 @@ function hashText(value) {
 }
 
 function patchId(anchorId, diff) {
-  const safeAnchor = anchorId.replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  const safeAnchor = normalizePatchIdAnchor(anchorId);
   return `patch_${safeAnchor}_${hashText(diff).slice(0, 12)}`;
 }
 
+function normalizePatchIdAnchor(anchorId) {
+  let normalized = '';
+  let previousWasSeparator = true;
+  for (const character of String(anchorId || '')) {
+    const isAlphaNumeric = (
+      (character >= 'A' && character <= 'Z')
+      || (character >= 'a' && character <= 'z')
+      || (character >= '0' && character <= '9')
+    );
+    if (isAlphaNumeric) {
+      normalized += character;
+      previousWasSeparator = false;
+    } else if (!previousWasSeparator) {
+      normalized += '_';
+      previousWasSeparator = true;
+    }
+  }
+  return normalized.endsWith('_') ? normalized.slice(0, -1) : normalized || 'anchor';
+}
+
 function parseAnchorLine(line) {
-  const patterns = [
-    new RegExp(`<!--\\s*forge-anchor:(${ANCHOR_ID_PATTERN})\\s*-->`),
-    new RegExp(`<!--\\s*forge-anchor\\s+id=["']?(${ANCHOR_ID_PATTERN})["']?\\s*-->`),
-    new RegExp(`<!--\\s*forge:anchor\\s+id=["'](${ANCHOR_ID_PATTERN})["']\\s*-->`),
-  ];
-  for (const pattern of patterns) {
-    const match = line.match(pattern);
+  for (const pattern of ANCHOR_PATTERNS) {
+    const match = pattern.exec(line);
     if (match) return match[1];
   }
   return null;
@@ -110,51 +135,63 @@ function anchorInDiffHunk(diff) {
 }
 
 function parseHunkNewStart(header) {
-  const match = header.match(/@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/);
+  const match = HUNK_HEADER_PATTERN.exec(header);
   return match ? Number(match[1]) : 1;
 }
 
 function parseUnifiedDiff(diff) {
   const lines = String(diff || '').split(/\r?\n/);
   const records = [];
-  let currentFile = null;
-  let fileHeader = [];
   let index = 0;
 
   while (index < lines.length) {
-    const line = lines[index];
-    if (line.startsWith('diff --git ')) {
-      const match = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
-      currentFile = match ? toPosixPath(match[2]) : null;
-      fileHeader = [line];
+    if (!lines[index].startsWith('diff --git ')) {
       index += 1;
-      while (index < lines.length && !lines[index].startsWith('@@ ') && !lines[index].startsWith('diff --git ')) {
-        fileHeader.push(lines[index]);
-        index += 1;
-      }
       continue;
     }
 
-    if (line.startsWith('@@ ') && currentFile) {
-      const hunk = [line];
-      const newStart = parseHunkNewStart(line);
-      index += 1;
-      while (index < lines.length && !lines[index].startsWith('@@ ') && !lines[index].startsWith('diff --git ')) {
-        hunk.push(lines[index]);
-        index += 1;
-      }
-      records.push({
-        path: currentFile,
-        newStart,
-        diff: [...fileHeader, ...hunk].join('\n').trimEnd() + '\n',
-      });
-      continue;
-    }
-
-    index += 1;
+    const parsedFile = parseUnifiedDiffFile(lines, index);
+    records.push(...parsedFile.records);
+    index = parsedFile.nextIndex;
   }
 
   return records;
+}
+
+function parseUnifiedDiffFile(lines, startIndex) {
+  const match = DIFF_HEADER_PATTERN.exec(lines[startIndex]);
+  const currentFile = match ? toPosixPath(match[2]) : null;
+  const fileHeader = [lines[startIndex]];
+  const records = [];
+  let index = startIndex + 1;
+
+  while (index < lines.length && !lines[index].startsWith('@@ ') && !lines[index].startsWith('diff --git ')) {
+    fileHeader.push(lines[index]);
+    index += 1;
+  }
+
+  while (currentFile && index < lines.length && lines[index].startsWith('@@ ')) {
+    const parsedHunk = parseUnifiedDiffHunk(lines, index);
+    records.push({
+      path: currentFile,
+      newStart: parsedHunk.newStart,
+      diff: [...fileHeader, ...parsedHunk.hunk].join('\n').trimEnd() + '\n',
+    });
+    index = parsedHunk.nextIndex;
+  }
+
+  return { nextIndex: index, records };
+}
+
+function parseUnifiedDiffHunk(lines, startIndex) {
+  const hunk = [lines[startIndex]];
+  const newStart = parseHunkNewStart(lines[startIndex]);
+  let index = startIndex + 1;
+  while (index < lines.length && !lines[index].startsWith('@@ ') && !lines[index].startsWith('diff --git ')) {
+    hunk.push(lines[index]);
+    index += 1;
+  }
+  return { hunk, newStart, nextIndex: index };
 }
 
 function resolvePatchPath(projectRoot, configuredPath, errors) {
@@ -245,16 +282,25 @@ function recordBlock(record) {
 
 function parsePatchIntentMarkdown(content) {
   const records = [];
-  const pattern = /<!--\s*forge-patch-intent:v1\s*\n([\s\S]*?)\n-->\s*\n```diff\n([\s\S]*?)\n```\s*\n<!--\s*\/forge-patch-intent\s*-->/g;
-  let match;
-  while ((match = pattern.exec(content)) !== null) {
-    const metadata = YAML.parse(match[1]) || {};
+  let cursor = 0;
+  while (cursor < content.length) {
+    const start = content.indexOf(RECORD_START, cursor);
+    if (start < 0) break;
+    const metadataEnd = content.indexOf('\n-->', start + RECORD_START.length);
+    const diffStartFence = metadataEnd < 0 ? -1 : content.indexOf(PATCH_DIFF_FENCE, metadataEnd);
+    const diffStart = diffStartFence < 0 ? -1 : diffStartFence + PATCH_DIFF_FENCE.length;
+    const diffEnd = diffStart < 0 ? -1 : content.indexOf(PATCH_FENCE_END, diffStart);
+    const end = diffEnd < 0 ? -1 : content.indexOf(RECORD_END, diffEnd + PATCH_FENCE_END.length);
+    if (metadataEnd < 0 || diffStart < 0 || diffEnd < 0 || end < 0) break;
+
+    const metadata = YAML.parse(content.slice(start + RECORD_START.length, metadataEnd).trim()) || {};
     records.push({
       ...metadata,
       anchorId: String(metadata.anchorId || ''),
       path: toPosixPath(metadata.path || ''),
-      diff: match[2].trimEnd() + '\n',
+      diff: content.slice(diffStart, diffEnd).trimEnd() + '\n',
     });
+    cursor = end + RECORD_END.length;
   }
   return records;
 }

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -271,7 +271,12 @@ function resolvePatchPath(projectRoot, configuredPath, errors) {
   const root = path.resolve(projectRoot);
   const resolved = path.resolve(projectRoot, rawPatchPath);
   const relativeToRoot = path.relative(root, resolved);
-  if (relativeToRoot === '' || relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+  if (
+    relativeToRoot === ''
+    || relativeToRoot.startsWith('..')
+    || path.isAbsolute(relativeToRoot)
+    || !isPhysicalPathInsideProject(projectRoot, resolved)
+  ) {
     errors.push({
       code: 'PATCH_INTENT_PATH_OUTSIDE_ROOT',
       message: 'patchIntent.path must stay inside the project root.',
@@ -280,6 +285,23 @@ function resolvePatchPath(projectRoot, configuredPath, errors) {
   }
 
   return toPosixPath(relativeToRoot);
+}
+
+function isPhysicalPathInsideProject(projectRoot, targetPath) {
+  const rootRealPath = fs.realpathSync.native(projectRoot);
+  const targetRealPath = fs.realpathSync.native(nearestExistingPath(targetPath));
+  const relativeToRoot = path.relative(rootRealPath, targetRealPath);
+  return relativeToRoot === '' || (!relativeToRoot.startsWith('..') && !path.isAbsolute(relativeToRoot));
+}
+
+function nearestExistingPath(targetPath) {
+  let currentPath = targetPath;
+  while (!fs.existsSync(currentPath)) {
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) return currentPath;
+    currentPath = parentPath;
+  }
+  return currentPath;
 }
 
 function loadPatchIntentConfig(projectRoot) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -38,6 +38,14 @@ function hashText(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
 }
 
+function stripSingleTrailingNewline(value) {
+  return String(value || '').endsWith('\n') ? String(value || '').slice(0, -1) : String(value || '');
+}
+
+function ensureTrailingNewline(value) {
+  return String(value || '').endsWith('\n') ? String(value || '') : `${String(value || '')}\n`;
+}
+
 function patchId(anchorId, diff) {
   const safeAnchor = normalizePatchIdAnchor(anchorId);
   return `patch_${safeAnchor}_${hashText(diff).slice(0, 12)}`;
@@ -87,6 +95,7 @@ function walkFiles(root, dir = root, files = [], options = {}) {
       walkFiles(root, fullPath, files, options);
       continue;
     }
+    if (!entry.isFile()) continue;
     const relativePath = toPosixPath(path.relative(root, fullPath));
     if (shouldScanFile(relativePath, options.excludedPatchPath)) files.push(relativePath);
   }
@@ -276,7 +285,7 @@ function parseUnifiedDiffFile(lines, startIndex) {
       path: currentFile,
       newStart: parsedHunk.newStart,
       newEnd: parsedHunk.newEnd,
-      diff: [...fileHeader, ...parsedHunk.hunk].join('\n').trimEnd() + '\n',
+      diff: ensureTrailingNewline([...fileHeader, ...parsedHunk.hunk].join('\n')),
     });
     index = parsedHunk.nextIndex;
   }
@@ -527,7 +536,7 @@ function recordBlock(record) {
     YAML.stringify(metadata).trimEnd(),
     '-->',
     '```diff',
-    record.diff.trimEnd(),
+    stripSingleTrailingNewline(record.diff),
     '```',
     RECORD_END,
   ].join('\n');
@@ -554,7 +563,7 @@ function parsePatchIntentMarkdown(content) {
       ...metadata,
       anchorId: String(metadata.anchorId || ''),
       path: toPosixPath(metadata.path || ''),
-      diff: normalizedContent.slice(diffStart, diffEnd).trimEnd() + '\n',
+      diff: ensureTrailingNewline(normalizedContent.slice(diffStart, diffEnd)),
     });
     cursor = end + RECORD_END.length;
   }

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -264,16 +264,89 @@ function parseUnifiedDiffFile(lines, startIndex) {
 
 function parseUnifiedDiffCurrentPath(fileHeader) {
   const newFileHeader = fileHeader.find(line => line.startsWith('+++ '));
-  if (newFileHeader === '+++ /dev/null') return null;
-  if (newFileHeader?.startsWith('+++ b/')) {
-    return toPosixPath(stripDiffPathMetadata(newFileHeader.slice('+++ b/'.length)));
+  const newPath = newFileHeader ? parseDiffHeaderPath(newFileHeader, '+++ ') : null;
+  if (newPath === '/dev/null') return null;
+  if (newPath?.startsWith('b/')) {
+    return toPosixPath(newPath.slice('b/'.length));
   }
 
-  const diffHeader = fileHeader[0] || '';
-  if (!diffHeader.startsWith(DIFF_HEADER_PREFIX)) return null;
+  return parseUnifiedDiffCurrentPathFallback(fileHeader[0] || '');
+}
+
+function parseUnifiedDiffCurrentPathFallback(diffHeader) {
+  if (!diffHeader.startsWith(DIFF_HEADER_PREFIX)) {
+    const quotedMatch = /^diff --git "a\/(?:[^"\\]|\\.)*" "b\/((?:[^"\\]|\\.)*)"/.exec(diffHeader);
+    return quotedMatch ? toPosixPath(unescapeGitQuotedPath(quotedMatch[1])) : null;
+  }
   const separatorIndex = diffHeader.indexOf(' b/', DIFF_HEADER_PREFIX.length);
   if (separatorIndex === -1) return null;
   return toPosixPath(stripDiffPathMetadata(diffHeader.slice(separatorIndex + ' b/'.length)));
+}
+
+function parseDiffHeaderPath(line, prefix) {
+  if (!line.startsWith(prefix)) return null;
+  const value = line.slice(prefix.length);
+  if (!value.startsWith('"')) return stripDiffPathMetadata(value);
+  const parsed = parseGitQuotedPathToken(value);
+  return parsed ? parsed.path : null;
+}
+
+function parseGitQuotedPathToken(value) {
+  let pathValue = '';
+  let index = 1;
+  while (index < value.length) {
+    const character = value[index];
+    if (character === '"') return { path: pathValue, rest: value.slice(index + 1) };
+    if (character !== '\\') {
+      pathValue += character;
+      index += 1;
+      continue;
+    }
+
+    if (isOctalDigit(value[index + 1])) {
+      const parsed = parseGitOctalBytes(value, index);
+      pathValue += Buffer.from(parsed.bytes).toString('utf8');
+      index = parsed.nextIndex;
+      continue;
+    }
+
+    const escaped = value[index + 1];
+    pathValue += decodeGitSimpleEscape(escaped);
+    index += 2;
+  }
+  return null;
+}
+
+function unescapeGitQuotedPath(value) {
+  const parsed = parseGitQuotedPathToken(`"${value}"`);
+  return parsed ? parsed.path : value;
+}
+
+function parseGitOctalBytes(value, startIndex) {
+  const bytes = [];
+  let index = startIndex;
+  while (value[index] === '\\' && isOctalDigit(value[index + 1])) {
+    let digits = '';
+    index += 1;
+    while (digits.length < 3 && isOctalDigit(value[index])) {
+      digits += value[index];
+      index += 1;
+    }
+    bytes.push(Number.parseInt(digits, 8));
+  }
+  return { bytes, nextIndex: index };
+}
+
+function isOctalDigit(character) {
+  return character >= '0' && character <= '7';
+}
+
+function decodeGitSimpleEscape(character) {
+  if (character === 't') return '\t';
+  if (character === 'n') return '\n';
+  if (character === 'r') return '\r';
+  if (character === undefined) return '';
+  return character;
 }
 
 function stripDiffPathMetadata(value) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -265,7 +265,7 @@ function parseUnifiedDiffFile(lines, startIndex) {
 function parseUnifiedDiffCurrentPath(fileHeader) {
   const newFileHeader = fileHeader.find(line => line.startsWith('+++ '));
   if (newFileHeader === '+++ /dev/null') return null;
-  if (newFileHeader && newFileHeader.startsWith('+++ b/')) {
+  if (newFileHeader?.startsWith('+++ b/')) {
     return toPosixPath(stripDiffPathMetadata(newFileHeader.slice('+++ b/'.length)));
   }
 
@@ -548,10 +548,43 @@ function createRecordsFromDiff(projectRoot, diff, options = {}) {
 }
 
 function assertSingleAnchorHunk(content, hunk, anchor) {
-  const anchors = collectAnchorsInLineRange(content, hunk.newStart, hunk.newEnd, hunk.path);
+  const anchors = [
+    ...collectAnchorsInLineRange(content, hunk.newStart, hunk.newEnd, hunk.path),
+    ...collectRemovedAnchorsInHunkDiff(hunk.diff, hunk.path),
+  ];
   const anchorIds = new Set([anchor.id, ...anchors.map(found => found.id)]);
   if (anchorIds.size <= 1) return;
   throw new Error(`Patch target '${hunk.path}' diff hunk crosses multiple forge anchors (${[...anchorIds].join(', ')}). Split the change into separate hunks before recording patch intent.`);
+}
+
+function collectRemovedAnchorsInHunkDiff(diff, relativePath) {
+  const anchors = [];
+  let inHunk = false;
+  let openFence = null;
+  const shouldTrackFences = isMarkdownFile(relativePath);
+
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith('@@ ')) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith('diff --git ')) break;
+    if (!line.startsWith(' ') && !line.startsWith('-')) continue;
+
+    const removedLine = line.startsWith('-');
+    const content = line.slice(1);
+    const fence = shouldTrackFences ? parseMarkdownFence(content) : null;
+    if (fence) {
+      openFence = nextMarkdownFenceState(openFence, fence);
+      continue;
+    }
+    if (openFence || !removedLine) continue;
+    const id = parseAnchorLine(content);
+    if (id) anchors.push({ id, line: null });
+  }
+
+  return anchors;
 }
 
 function collectAnchorsInLineRange(content, startLine, endLine, relativePath) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -629,10 +629,41 @@ function hasGitHead(projectRoot) {
 }
 
 function readGitDiffWithoutHead(projectRoot, pathspecArgs) {
+  const cachedDiff = execGit(projectRoot, ['diff', '--cached', '--no-ext-diff', '--unified=3', ...pathspecArgs]);
+  const unstagedDiff = execGit(projectRoot, ['diff', '--no-ext-diff', '--unified=3', ...pathspecArgs]);
+  const duplicatePaths = pathsInBothDiffs(cachedDiff, unstagedDiff);
+  if (duplicatePaths.size === 0) return [cachedDiff, unstagedDiff].filter(Boolean).join('\n');
+
+  const duplicateExcludes = [...duplicatePaths].map(relativePath => `:(exclude)${relativePath}`);
+  const filteredPathspecArgs = [...pathspecArgs, ...duplicateExcludes];
   return [
-    execGit(projectRoot, ['diff', '--cached', '--no-ext-diff', '--unified=3', ...pathspecArgs]),
-    execGit(projectRoot, ['diff', '--no-ext-diff', '--unified=3', ...pathspecArgs]),
+    execGit(projectRoot, ['diff', '--cached', '--no-ext-diff', '--unified=3', ...filteredPathspecArgs]),
+    execGit(projectRoot, ['diff', '--no-ext-diff', '--unified=3', ...filteredPathspecArgs]),
+    ...[...duplicatePaths].map(relativePath => addedFileDiffFromWorkingTree(projectRoot, relativePath)),
   ].filter(Boolean).join('\n');
+}
+
+function pathsInBothDiffs(leftDiff, rightDiff) {
+  const leftPaths = new Set(parseUnifiedDiff(leftDiff).map(hunk => hunk.path));
+  return new Set(parseUnifiedDiff(rightDiff)
+    .map(hunk => hunk.path)
+    .filter(relativePath => leftPaths.has(relativePath)));
+}
+
+function addedFileDiffFromWorkingTree(projectRoot, relativePath) {
+  const fullPath = resolveProjectFilePath(projectRoot, relativePath);
+  if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isFile()) return '';
+  const content = fs.readFileSync(fullPath, 'utf8').replace(/\r\n?/g, '\n');
+  const lines = content === '' ? [] : content.replace(/\n$/, '').split('\n');
+  return [
+    `diff --git a/${relativePath} b/${relativePath}`,
+    'new file mode 100644',
+    '--- /dev/null',
+    `+++ b/${relativePath}`,
+    `@@ -0,0 +1,${lines.length} @@`,
+    ...lines.map(line => `+${line}`),
+    '',
+  ].join('\n');
 }
 
 function execGit(projectRoot, args, options = {}) {

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -45,34 +45,41 @@ function parseAnchorLine(line) {
   return null;
 }
 
-function shouldScanFile(relativePath) {
+function shouldScanFile(relativePath, excludedPatchPath = DEFAULT_PATCH_PATH) {
   const normalized = toPosixPath(relativePath);
   if (normalized === DEFAULT_PATCH_PATH) return false;
+  if (normalized === toPosixPath(excludedPatchPath)) return false;
   return /\.(cjs|js|json|jsx|md|mjs|ts|tsx|txt|yaml|yml)$/.test(normalized);
 }
 
-function walkFiles(root, dir = root, files = []) {
+function walkFiles(root, dir = root, files = [], options = {}) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory() && EXCLUDED_DIRS.has(entry.name)) continue;
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      walkFiles(root, fullPath, files);
+      walkFiles(root, fullPath, files, options);
       continue;
     }
     const relativePath = toPosixPath(path.relative(root, fullPath));
-    if (shouldScanFile(relativePath)) files.push(relativePath);
+    if (shouldScanFile(relativePath, options.excludedPatchPath)) files.push(relativePath);
   }
   return files;
 }
 
-function discoverAnchors(projectRoot) {
+function discoverAnchors(projectRoot, options = {}) {
   const anchors = new Map();
-  for (const relativePath of walkFiles(projectRoot)) {
+  for (const relativePath of walkFiles(projectRoot, projectRoot, [], options)) {
     const fullPath = path.join(projectRoot, relativePath);
     const lines = fs.readFileSync(fullPath, 'utf8').split(/\r?\n/);
     for (const [index, line] of lines.entries()) {
       const id = parseAnchorLine(line);
-      if (!id || anchors.has(id)) continue;
+      if (!id) continue;
+      if (anchors.has(id)) {
+        const existing = anchors.get(id);
+        throw new Error(
+          `Duplicate forge anchor '${id}' in '${existing.path}' and '${relativePath}'. Anchor IDs must be unique.`
+        );
+      }
       anchors.set(id, {
         id,
         path: relativePath,
@@ -150,6 +157,34 @@ function parseUnifiedDiff(diff) {
   return records;
 }
 
+function resolvePatchPath(projectRoot, configuredPath, errors) {
+  if (configuredPath === undefined || configuredPath === null || configuredPath === '') {
+    return DEFAULT_PATCH_PATH;
+  }
+  if (typeof configuredPath !== 'string') {
+    errors.push({
+      code: 'PATCH_INTENT_PATH_INVALID',
+      message: 'patchIntent.path must be a non-empty string.',
+    });
+    return DEFAULT_PATCH_PATH;
+  }
+
+  const patchPath = toPosixPath(configuredPath.trim());
+  if (!patchPath) return DEFAULT_PATCH_PATH;
+
+  const root = path.resolve(projectRoot);
+  const resolved = path.resolve(projectRoot, patchPath);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    errors.push({
+      code: 'PATCH_INTENT_PATH_OUTSIDE_ROOT',
+      message: 'patchIntent.path must stay inside the project root.',
+    });
+    return DEFAULT_PATCH_PATH;
+  }
+
+  return patchPath;
+}
+
 function loadPatchIntentConfig(projectRoot) {
   const { loadRuntimeGraphConfig } = require('./core/runtime-graph');
   const loaded = loadRuntimeGraphConfig({ projectRoot });
@@ -172,9 +207,7 @@ function loadPatchIntentConfig(projectRoot) {
     });
   }
 
-  const patchPath = typeof config.path === 'string' && config.path.trim() !== ''
-    ? toPosixPath(config.path.trim())
-    : DEFAULT_PATCH_PATH;
+  const patchPath = resolvePatchPath(projectRoot, config.path, errors);
   const anchorAliases = config.anchorAliases && typeof config.anchorAliases === 'object' && !Array.isArray(config.anchorAliases)
     ? Object.fromEntries(Object.entries(config.anchorAliases).map(([from, to]) => [String(from), String(to)]))
     : {};
@@ -265,15 +298,18 @@ function writePatchIntentRecords(projectRoot, records, options = {}) {
   return { path: patchPath, records: ordered };
 }
 
-function readGitDiff(projectRoot) {
-  return execFileSync('git', [
+function readGitDiff(projectRoot, excludedPatchPath = DEFAULT_PATCH_PATH) {
+  const excluded = new Set([DEFAULT_PATCH_PATH, toPosixPath(excludedPatchPath)]);
+  const args = [
     'diff',
     '--no-ext-diff',
     '--unified=3',
     '--',
     '.',
-    ':(exclude).forge/patch.md',
-  ], {
+    ...[...excluded].filter(Boolean).map(patchPath => `:(exclude)${patchPath}`),
+  ];
+
+  return execFileSync('git', args, {
     cwd: projectRoot,
     encoding: 'utf8',
   });
@@ -319,7 +355,7 @@ function recordPatchIntentFromDiff(projectRoot, options = {}) {
     throw new Error('Patch intent recording is disabled by .forge/config.yaml.');
   }
 
-  const diff = options.diff ?? readGitDiff(projectRoot);
+  const diff = options.diff ?? readGitDiff(projectRoot, config.path);
   const records = createRecordsFromDiff(projectRoot, diff, options);
   if (records.length === 0) {
     return { path: config.path, records: [] };
@@ -330,7 +366,7 @@ function recordPatchIntentFromDiff(projectRoot, options = {}) {
 function resolvePatchIntentRecords(projectRoot, options = {}) {
   const config = options.config || loadPatchIntentConfig(projectRoot);
   const loaded = loadPatchIntentRecords(projectRoot, { config });
-  const anchors = discoverAnchors(projectRoot);
+  const anchors = discoverAnchors(projectRoot, { excludedPatchPath: config.path });
   const records = [];
   const orphans = [];
 

--- a/lib/patch-intent.js
+++ b/lib/patch-intent.js
@@ -147,8 +147,7 @@ function isAnchorDeclarationFile(relativePath) {
 }
 
 function parseMarkdownFence(line) {
-  const trimmed = line.trimStart();
-  const match = /^(`{3,}|~{3,})/.exec(trimmed);
+  const match = /^(?: {0,3})(`{3,}|~{3,})/.exec(line);
   if (!match) return null;
   return {
     marker: match[1][0],

--- a/test/beads-context-validate.test.js
+++ b/test/beads-context-validate.test.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const { resolveShellRuntime } = require('../lib/runtime-health');
 
 const ROOT = path.resolve(__dirname, '..');
+const SHELL_TEST_TIMEOUT_MS = 30000;
 
 function bashCommand() {
   if (process.platform !== 'win32') {
@@ -16,6 +17,13 @@ function bashCommand() {
 
 function shQuote(value) {
   return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function toBashPath(filePath) {
+  if (process.platform !== 'win32') {
+    return filePath;
+  }
+  return filePath.replace(/\\/g, '/').replace(/^([A-Za-z]):/, (_, drive) => `/${drive.toLowerCase()}`);
 }
 
 /**
@@ -68,10 +76,10 @@ exit 0
     cwd: ROOT,
     env: {
       ...process.env,
-      BD_CMD: shimPath,
+      BD_CMD: toBashPath(shimPath),
     },
     encoding: 'utf8',
-    timeout: 20000,
+    timeout: SHELL_TEST_TIMEOUT_MS,
   });
 
   try {
@@ -94,7 +102,7 @@ describe('beads-context.sh validate', () => {
     });
     const hasError = result.exitCode !== 0 || result.output.toLowerCase().includes('error');
     expect(hasError).toBe(true);
-  }, 15000);
+  }, SHELL_TEST_TIMEOUT_MS);
 
   test('warns when description is missing', () => {
     const result = runValidate('test-issue-010', {
@@ -104,7 +112,7 @@ describe('beads-context.sh validate', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(result.output.toLowerCase()).toContain('description');
-  }, 15000);
+  }, SHELL_TEST_TIMEOUT_MS);
 
   test('warns when no stage transition exists', () => {
     const result = runValidate('test-issue-011', {
@@ -114,7 +122,7 @@ describe('beads-context.sh validate', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(result.output.toLowerCase()).toContain('stage transition');
-  }, 15000);
+  }, SHELL_TEST_TIMEOUT_MS);
 
   test('warns when most recent transition has no summary', () => {
     const result = runValidate('test-issue-012', {
@@ -124,7 +132,7 @@ describe('beads-context.sh validate', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(result.output.toLowerCase()).toContain('summary');
-  }, 15000);
+  }, SHELL_TEST_TIMEOUT_MS);
 
   test('warns when design metadata is missing for post-plan stage', () => {
     const result = runValidate('test-issue-013', {
@@ -134,7 +142,7 @@ describe('beads-context.sh validate', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(result.output.toLowerCase()).toContain('design');
-  }, 15000);
+  }, SHELL_TEST_TIMEOUT_MS);
 
   test('outputs success when all fields are present', () => {
     const result = runValidate('test-issue-014', {
@@ -144,5 +152,5 @@ describe('beads-context.sh validate', () => {
     });
     expect(result.exitCode).toBe(0);
     expect(result.output).toContain('All context fields present');
-  }, 15000);
+  }, SHELL_TEST_TIMEOUT_MS);
 });

--- a/test/commands/patch.test.js
+++ b/test/commands/patch.test.js
@@ -1,0 +1,62 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { afterEach, describe, expect, test } = require('bun:test');
+
+const patchCommand = require('../../lib/commands/patch');
+
+const tempRoots = [];
+
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-patch-command-'));
+  tempRoots.push(root);
+  execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: root });
+  fs.writeFileSync(path.join(root, 'AGENTS.md'), '# Agent\n', 'utf8');
+  fs.mkdirSync(path.join(root, '.claude', 'commands'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.claude', 'commands', 'patch.md'), [
+    '# Patch',
+    '',
+    '<!-- forge-anchor:stage.patch -->',
+    'Original.',
+    '',
+  ].join('\n'), 'utf8');
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-m', 'baseline'], { cwd: root, stdio: 'ignore' });
+  fs.writeFileSync(path.join(root, '.claude', 'commands', 'patch.md'), [
+    '# Patch',
+    '',
+    '<!-- forge-anchor:stage.patch -->',
+    'Changed.',
+    '',
+  ].join('\n'), 'utf8');
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('forge patch command', () => {
+  test('record --from-diff reports written patch intent records', async () => {
+    const projectRoot = makeRepo();
+
+    const result = await patchCommand.handler(['record', '--from-diff'], {}, projectRoot);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Recorded 1 patch intent');
+    expect(result.output).toContain('stage.patch');
+  });
+
+  test('record requires --from-diff', async () => {
+    const result = await patchCommand.handler(['record'], {}, process.cwd());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Missing --from-diff');
+  });
+});
+

--- a/test/commands/validate.test.js
+++ b/test/commands/validate.test.js
@@ -13,7 +13,7 @@ const {
 	executeDebugMode,
 } = require('../../lib/commands/validate.js');
 
-setDefaultTimeout(15000);
+setDefaultTimeout(30000);
 
 describe('Validate Command - Validation Orchestration', () => {
 	describe('Type checking', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -127,6 +127,26 @@ describe('patch intent records', () => {
     expect(anchors.get('docs.decisions').path).toBe('docs/work/decisions.md');
   });
 
+  test('ignores indented markdown code anchor examples', () => {
+    const root = makeRepo();
+    writeFile(root, 'docs/work/decisions.md', [
+      'Example:',
+      '',
+      '    <!-- forge-anchor:stage.validate -->',
+      '    example text',
+      '',
+      '<!-- forge-anchor:docs.decisions -->',
+      'Decision text.',
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.has('stage.validate')).toBe(false);
+    expect(anchors.get('docs.decisions').path).toBe('docs/work/decisions.md');
+  });
+
+
   test('ignores anchor literals in source and test fixtures', () => {
     const root = makeRepo();
     writeFile(root, 'commands/validate.md', '<!-- forge-anchor:stage.validate -->\nRun checks.\n');
@@ -288,6 +308,28 @@ describe('patch intent records', () => {
     expect(result.records).toHaveLength(1);
     expect(result.records[0].path).toBe('commands/validate.md');
     expect(result.records[0].anchorId).toBe('stage.mnemonic');
+  });
+
+  test('records staged managed hunks from diff', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.staged -->',
+      'Old text.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.staged -->',
+      'New text.',
+      '',
+    ].join('\n'));
+    execFileSync('git', ['add', 'commands/validate.md'], { cwd: root });
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('commands/validate.md');
+    expect(result.records[0].anchorId).toBe('stage.staged');
   });
 
   test('round-trips record output back through git apply', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -268,6 +268,28 @@ describe('patch intent records', () => {
     expect(result.records[0].anchorId).toBe('docs.quoted');
   });
 
+  test('records managed files with mnemonic Git diff prefixes', () => {
+    const root = makeRepo();
+    execFileSync('git', ['config', 'diff.mnemonicPrefix', 'true'], { cwd: root });
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.mnemonic -->',
+      'Old text.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.mnemonic -->',
+      'New text.',
+      '',
+    ].join('\n'));
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('commands/validate.md');
+    expect(result.records[0].anchorId).toBe('stage.mnemonic');
+  });
+
   test('round-trips record output back through git apply', () => {
     const root = makeRepo();
     writeFile(root, '.claude/commands/dev.md', [

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -146,6 +146,25 @@ describe('patch intent records', () => {
     expect(anchors.get('docs.decisions').path).toBe('docs/work/decisions.md');
   });
 
+  test('does not treat indented code fences as markdown fences', () => {
+    const root = makeRepo();
+    writeFile(root, 'docs/work/decisions.md', [
+      'Example:',
+      '',
+      '    ```',
+      '    code fence example',
+      '    ```',
+      '',
+      '<!-- forge-anchor:docs.decisions -->',
+      'Decision text.',
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.get('docs.decisions').path).toBe('docs/work/decisions.md');
+  });
+
 
   test('ignores anchor literals in source and test fixtures', () => {
     const root = makeRepo();

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -102,6 +102,37 @@ describe('patch intent records', () => {
     expect(anchors.has('fixture.only')).toBe(false);
   });
 
+  test('ignores fenced markdown anchors while attributing diff hunks', () => {
+    const root = makeRepo();
+    writeFile(root, 'docs/tool.md', [
+      '<!-- forge-anchor:stage.real -->',
+      'Intro text.',
+      '',
+      '```md',
+      '<!-- forge-anchor:stage.example -->',
+      'old fenced text',
+      '```',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'docs/tool.md', [
+      '<!-- forge-anchor:stage.real -->',
+      'Intro text.',
+      '',
+      '```md',
+      '<!-- forge-anchor:stage.example -->',
+      'new fenced text',
+      '```',
+      '',
+    ].join('\n'));
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].anchorId).toBe('stage.real');
+    expect(result.records[0].diff).toContain('new fenced text');
+  });
+
   test('records diff hunks with stable IDs and replaces existing patch.md blocks', () => {
     const root = makeRepo();
     writeFile(root, '.claude/commands/validate.md', [

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -453,6 +453,31 @@ describe('patch intent records', () => {
     expect(actualDiff).toBe(expectedDiff);
   });
 
+  test('preserves diff payload trailing whitespace in patch records', () => {
+    const root = makeRepo();
+    const diff = [
+      'diff --git a/docs/example.md b/docs/example.md',
+      '--- a/docs/example.md',
+      '+++ b/docs/example.md',
+      '@@ -1,2 +1,2 @@',
+      '-old',
+      '+new   ',
+      ' ',
+    ].join('\n') + '\n';
+
+    writePatchIntentRecords(root, [{
+      id: 'patch_docs_trailing',
+      anchorId: 'docs.trailing',
+      path: 'docs/example.md',
+      createdAt: '2026-05-16T00:00:00.000Z',
+      source: 'git-diff',
+      status: 'active',
+      diff,
+    }]);
+
+    expect(loadPatchIntentRecords(root).records[0].diff).toBe(diff);
+  });
+
   test('resolves record paths after a managed file rename', () => {
     const root = makeRepo();
     writeFile(root, 'old/validate.md', [
@@ -733,6 +758,25 @@ describe('patch intent records', () => {
     writeFile(outside, 'external.md', '<!-- forge-anchor:external.anchor -->\nOutside text.\n');
     try {
       fs.symlinkSync(outside, path.join(root, 'linked-docs'), process.platform === 'win32' ? 'junction' : 'dir');
+    } catch (err) {
+      if (['EPERM', 'EACCES', 'ENOTSUP'].includes(err.code)) {
+        return;
+      }
+      throw err;
+    }
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.has('external.anchor')).toBe(false);
+  });
+
+  test('ignores symlinked anchor files during discovery', () => {
+    const root = makeRepo();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-patch-outside-'));
+    tempRoots.push(outside);
+    writeFile(outside, 'external.md', '<!-- forge-anchor:external.anchor -->\nOutside text.\n');
+    try {
+      fs.symlinkSync(path.join(outside, 'external.md'), path.join(root, 'linked.md'), 'file');
     } catch (err) {
       if (['EPERM', 'EACCES', 'ENOTSUP'].includes(err.code)) {
         return;

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -66,6 +66,27 @@ describe('patch intent records', () => {
     expect(() => discoverAnchors(root)).toThrow('Duplicate forge anchor');
   });
 
+  test('ignores anchor examples inside markdown fences', () => {
+    const root = makeRepo();
+    writeFile(root, 'docs/reference/patch-md-format.md', [
+      '# Patch format',
+      '',
+      '```md',
+      '<!-- forge-anchor:stage.validate -->',
+      '<!-- forge-anchor:stage.validate -->',
+      '```',
+      '',
+      '<!-- forge-anchor:docs.patch-format -->',
+      'Reference text.',
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.has('stage.validate')).toBe(false);
+    expect(anchors.get('docs.patch-format').path).toBe('docs/reference/patch-md-format.md');
+  });
+
   test('records diff hunks with stable IDs and replaces existing patch.md blocks', () => {
     const root = makeRepo();
     writeFile(root, '.claude/commands/validate.md', [
@@ -245,6 +266,43 @@ describe('patch intent records', () => {
     expect(() => recordPatchIntentFromDiff(root)).toThrow('disabled');
   });
 
+  test('normalizes absolute patchIntent.path values inside the project root', () => {
+    const root = makeRepo();
+    const absolutePatchPath = path.join(root, '.forge', 'absolute-patch.md').replace(/\\/g, '/');
+    writeFile(root, '.forge/config.yaml', [
+      'patchIntent:',
+      `  path: ${absolutePatchPath}`,
+      '',
+    ].join('\n'));
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks carefully.',
+      '',
+    ].join('\n'));
+
+    const config = loadPatchIntentConfig(root);
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(config.path).toBe('.forge/absolute-patch.md');
+    expect(result.path).toBe('.forge/absolute-patch.md');
+    expect(fs.existsSync(path.join(root, '.forge', 'absolute-patch.md'))).toBe(true);
+  });
+
+  test('reports scalar patchIntent config values as invalid', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/config.yaml', 'patchIntent: false\n');
+
+    const config = loadPatchIntentConfig(root);
+
+    expect(config.errors.some(error => error.code === 'PATCH_INTENT_CONFIG_INVALID')).toBe(true);
+  });
+
   test('excludes configured patchIntent.path from anchor discovery and git diff recording', () => {
     const root = makeRepo();
     writeFile(root, '.forge/config.yaml', [
@@ -287,6 +345,28 @@ describe('patch intent records', () => {
 
     expect(config.errors[0].code).toBe('PATCH_INTENT_PATH_OUTSIDE_ROOT');
     expect(() => recordPatchIntentFromDiff(root)).toThrow('inside the project root');
+  });
+
+  test('skips deleted files while recording valid patch intents from mixed diffs', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+    writeFile(root, 'deleted.md', 'Remove me.\n');
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks carefully.',
+      '',
+    ].join('\n'));
+    fs.unlinkSync(path.join(root, 'deleted.md'));
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('commands/validate.md');
   });
 
   test('forge patch record --from-diff writes patch.md', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -87,6 +87,21 @@ describe('patch intent records', () => {
     expect(anchors.get('docs.patch-format').path).toBe('docs/reference/patch-md-format.md');
   });
 
+  test('ignores anchor literals in source and test fixtures', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', '<!-- forge-anchor:stage.validate -->\nRun checks.\n');
+    writeFile(root, 'test/patch-intent.test.js', [
+      "const fixture = '<!-- forge-anchor:stage.validate -->';",
+      "const other = '<!-- forge-anchor:fixture.only -->';",
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.get('stage.validate').path).toBe('commands/validate.md');
+    expect(anchors.has('fixture.only')).toBe(false);
+  });
+
   test('records diff hunks with stable IDs and replaces existing patch.md blocks', () => {
     const root = makeRepo();
     writeFile(root, '.claude/commands/validate.md', [
@@ -301,6 +316,7 @@ describe('patch intent records', () => {
     const config = loadPatchIntentConfig(root);
 
     expect(config.errors.some(error => error.code === 'PATCH_INTENT_CONFIG_INVALID')).toBe(true);
+    expect(() => resolvePatchIntentRecords(root)).toThrow('PATCH_INTENT_CONFIG_INVALID');
   });
 
   test('excludes configured patchIntent.path from anchor discovery and git diff recording', () => {
@@ -345,6 +361,7 @@ describe('patch intent records', () => {
 
     expect(config.errors[0].code).toBe('PATCH_INTENT_PATH_OUTSIDE_ROOT');
     expect(() => recordPatchIntentFromDiff(root)).toThrow('inside the project root');
+    expect(() => resolvePatchIntentRecords(root)).toThrow('inside the project root');
   });
 
   test('skips deleted files while recording valid patch intents from mixed diffs', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -11,6 +11,7 @@ const {
   loadPatchIntentRecords,
   recordPatchIntentFromDiff,
   resolvePatchIntentRecords,
+  writePatchIntentRecords,
 } = require('../lib/patch-intent');
 
 const tempRoots = [];
@@ -221,6 +222,27 @@ describe('patch intent records', () => {
     expect(records).toHaveLength(1);
     expect(records[0].anchorId).toBe('stage.validate');
     expect(records[0].diff).toContain('Run checks carefully.');
+  });
+
+  test('records managed files with spaces in their diff paths', () => {
+    const root = makeRepo();
+    writeFile(root, 'a b/c.md', [
+      '<!-- forge-anchor:docs.space -->',
+      'Old text.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'a b/c.md', [
+      '<!-- forge-anchor:docs.space -->',
+      'New text.',
+      '',
+    ].join('\n'));
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('a b/c.md');
+    expect(result.records[0].anchorId).toBe('docs.space');
   });
 
   test('round-trips record output back through git apply', () => {
@@ -501,6 +523,13 @@ describe('patch intent records', () => {
     expect(() => resolvePatchIntentRecords(root)).toThrow('inside the project root');
   });
 
+  test('validates explicit patchPath overrides before loading or writing records', () => {
+    const root = makeRepo();
+
+    expect(() => loadPatchIntentRecords(root, { patchPath: '../outside.md' })).toThrow('inside the project root');
+    expect(() => writePatchIntentRecords(root, [], { patchPath: '../outside.md' })).toThrow('inside the project root');
+  });
+
   test('rejects patchIntent.path that escapes through a symlink', () => {
     const root = makeRepo();
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-patch-outside-'));
@@ -578,6 +607,29 @@ describe('patch intent records', () => {
     ].join('\n'));
 
     expect(() => recordPatchIntentFromDiff(root)).toThrow('no declared forge anchor before diff hunk');
+  });
+
+  test('rejects hunks that cross multiple anchors', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.one -->',
+      'One old.',
+      '',
+      '<!-- forge-anchor:stage.two -->',
+      'Two old.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.one -->',
+      'One new.',
+      '',
+      '<!-- forge-anchor:stage.two -->',
+      'Two new.',
+      '',
+    ].join('\n'));
+
+    expect(() => recordPatchIntentFromDiff(root)).toThrow('crosses multiple forge anchors');
   });
 
   test('forge patch record --from-diff writes patch.md', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -268,6 +268,51 @@ describe('patch intent records', () => {
     expect(resolved.orphans[0].anchorId).toBe('stage.missing');
   });
 
+  test('parses CRLF patch intent record files', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/patch.md', [
+      '# Forge Patch Intent',
+      '',
+      '<!-- forge-patch-intent:v1',
+      'id: patch_stage_validate_example',
+      'anchorId: stage.validate',
+      'path: commands/validate.md',
+      'createdAt: 2026-05-13T00:00:00.000Z',
+      'source: git-diff',
+      'status: active',
+      '-->',
+      '```diff',
+      'diff --git a/commands/validate.md b/commands/validate.md',
+      '--- a/commands/validate.md',
+      '+++ b/commands/validate.md',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '```',
+      '<!-- /forge-patch-intent -->',
+      '',
+    ].join('\r\n'));
+
+    const loaded = loadPatchIntentRecords(root);
+
+    expect(loaded.records).toHaveLength(1);
+    expect(loaded.records[0].anchorId).toBe('stage.validate');
+  });
+
+  test('fails loudly on malformed patch intent record blocks', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/patch.md', [
+      '# Forge Patch Intent',
+      '',
+      '<!-- forge-patch-intent:v1',
+      'id: patch_broken',
+      'anchorId: stage.broken',
+      '',
+    ].join('\n'));
+
+    expect(() => loadPatchIntentRecords(root)).toThrow('Malformed patch intent record block');
+  });
+
   test('honors patchIntent config path, aliases, and disabled state', () => {
     const root = makeRepo();
     writeFile(root, '.forge/config.yaml', [
@@ -415,6 +460,27 @@ describe('patch intent records', () => {
 
     expect(result.records).toHaveLength(1);
     expect(result.records[0].path).toBe('commands/validate.md');
+  });
+
+  test('does not attribute edits to anchors that only appear after the changed lines', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', [
+      'Edit me.',
+      '',
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      'Edited above anchor.',
+      '',
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+
+    expect(() => recordPatchIntentFromDiff(root)).toThrow('no declared forge anchor before diff hunk');
   });
 
   test('forge patch record --from-diff writes patch.md', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -58,6 +58,14 @@ describe('patch intent records', () => {
     expect(anchors.get('stage.validate').line).toBe(3);
   });
 
+  test('fails fast when duplicate anchor IDs are declared', () => {
+    const root = makeRepo();
+    writeFile(root, 'one.md', '<!-- forge-anchor:stage.validate -->\nOne.\n');
+    writeFile(root, 'two.md', '<!-- forge-anchor:stage.validate -->\nTwo.\n');
+
+    expect(() => discoverAnchors(root)).toThrow('Duplicate forge anchor');
+  });
+
   test('records diff hunks with stable IDs and replaces existing patch.md blocks', () => {
     const root = makeRepo();
     writeFile(root, '.claude/commands/validate.md', [
@@ -237,6 +245,50 @@ describe('patch intent records', () => {
     expect(() => recordPatchIntentFromDiff(root)).toThrow('disabled');
   });
 
+  test('excludes configured patchIntent.path from anchor discovery and git diff recording', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/config.yaml', [
+      'patchIntent:',
+      '  path: .forge/custom-patch.md',
+      '',
+    ].join('\n'));
+    writeFile(root, '.forge/custom-patch.md', '<!-- forge-anchor:stored.diff -->\nStored record text.\n');
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, '.forge/custom-patch.md', '<!-- forge-anchor:stored.diff -->\nChanged stored record text.\n');
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks carefully.',
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root, { excludedPatchPath: '.forge/custom-patch.md' });
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(anchors.has('stored.diff')).toBe(false);
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('commands/validate.md');
+    expect(result.records[0].diff).not.toContain('custom-patch.md');
+  });
+
+  test('rejects patchIntent.path outside the project root', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/config.yaml', [
+      'patchIntent:',
+      '  path: ../outside-patch.md',
+      '',
+    ].join('\n'));
+
+    const config = loadPatchIntentConfig(root);
+
+    expect(config.errors[0].code).toBe('PATCH_INTENT_PATH_OUTSIDE_ROOT');
+    expect(() => recordPatchIntentFromDiff(root)).toThrow('inside the project root');
+  });
+
   test('forge patch record --from-diff writes patch.md', () => {
     const root = makeRepo();
     writeFile(root, 'AGENTS.md', '# Agent\n');
@@ -266,4 +318,3 @@ describe('patch intent records', () => {
     expect(fs.readFileSync(path.join(root, '.forge', 'patch.md'), 'utf8')).toContain('stage.ship');
   });
 });
-

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -662,8 +662,11 @@ describe('patch intent records', () => {
     tempRoots.push(outside);
     try {
       fs.symlinkSync(outside, path.join(root, 'link'), process.platform === 'win32' ? 'junction' : 'dir');
-    } catch {
-      return;
+    } catch (err) {
+      if (['EPERM', 'EACCES', 'ENOTSUP'].includes(err.code)) {
+        return;
+      }
+      throw err;
     }
     writeFile(root, '.forge/config.yaml', [
       'patchIntent:',

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -440,6 +440,27 @@ describe('patch intent records', () => {
     expect(() => resolvePatchIntentRecords(root)).toThrow('inside the project root');
   });
 
+  test('rejects patchIntent.path that escapes through a symlink', () => {
+    const root = makeRepo();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-patch-outside-'));
+    tempRoots.push(outside);
+    try {
+      fs.symlinkSync(outside, path.join(root, 'link'), process.platform === 'win32' ? 'junction' : 'dir');
+    } catch {
+      return;
+    }
+    writeFile(root, '.forge/config.yaml', [
+      'patchIntent:',
+      '  path: link/patch.md',
+      '',
+    ].join('\n'));
+
+    const config = loadPatchIntentConfig(root);
+
+    expect(config.errors[0].code).toBe('PATCH_INTENT_PATH_OUTSIDE_ROOT');
+    expect(() => recordPatchIntentFromDiff(root)).toThrow('inside the project root');
+  });
+
   test('skips deleted files while recording valid patch intents from mixed diffs', () => {
     const root = makeRepo();
     writeFile(root, 'commands/validate.md', [

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -332,6 +332,22 @@ describe('patch intent records', () => {
     expect(result.records[0].anchorId).toBe('stage.staged');
   });
 
+  test('records staged managed hunks on unborn branches', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.unborn -->',
+      'Initial text.',
+      '',
+    ].join('\n'));
+    execFileSync('git', ['add', 'commands/validate.md'], { cwd: root });
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('commands/validate.md');
+    expect(result.records[0].anchorId).toBe('stage.unborn');
+  });
+
   test('round-trips record output back through git apply', () => {
     const root = makeRepo();
     writeFile(root, '.claude/commands/dev.md', [

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -632,6 +632,26 @@ describe('patch intent records', () => {
     expect(() => recordPatchIntentFromDiff(root)).toThrow('crosses multiple forge anchors');
   });
 
+  test('rejects hunks that delete a later anchor', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.one -->',
+      'One old.',
+      '',
+      '<!-- forge-anchor:stage.two -->',
+      'Two old.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      '<!-- forge-anchor:stage.one -->',
+      'One new.',
+      '',
+    ].join('\n'));
+
+    expect(() => recordPatchIntentFromDiff(root)).toThrow('crosses multiple forge anchors');
+  });
+
   test('forge patch record --from-diff writes patch.md', () => {
     const root = makeRepo();
     writeFile(root, 'AGENTS.md', '# Agent\n');

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -245,6 +245,29 @@ describe('patch intent records', () => {
     expect(result.records[0].anchorId).toBe('docs.space');
   });
 
+  test('records managed files with Git-quoted diff paths', () => {
+    const root = makeRepo();
+    execFileSync('git', ['config', 'core.quotePath', 'true'], { cwd: root });
+    const quotedPath = 'caf\u00e9.md';
+    writeFile(root, quotedPath, [
+      '<!-- forge-anchor:docs.quoted -->',
+      'Old text.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, quotedPath, [
+      '<!-- forge-anchor:docs.quoted -->',
+      'New text.',
+      '',
+    ].join('\n'));
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe(quotedPath);
+    expect(result.records[0].anchorId).toBe('docs.quoted');
+  });
+
   test('round-trips record output back through git apply', () => {
     const root = makeRepo();
     writeFile(root, '.claude/commands/dev.md', [

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -350,6 +350,33 @@ describe('patch intent records', () => {
     expect(result.records[0].anchorId).toBe('stage.unborn');
   });
 
+  test('records one final hunk for staged then edited files on unborn branches', () => {
+    const root = makeRepo();
+    writeFile(root, 'commands/validate.md', [
+      '# Validate',
+      '',
+      '<!-- forge-anchor:stage.unborn-final -->',
+      'Staged text.',
+      '',
+    ].join('\n'));
+    execFileSync('git', ['add', 'commands/validate.md'], { cwd: root });
+    writeFile(root, 'commands/validate.md', [
+      '# Validate',
+      '',
+      '<!-- forge-anchor:stage.unborn-final -->',
+      'Final text.',
+      '',
+    ].join('\n'));
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('commands/validate.md');
+    expect(result.records[0].anchorId).toBe('stage.unborn-final');
+    expect(result.records[0].diff).toContain('Final text.');
+    expect(result.records[0].diff).not.toContain('Staged text.');
+  });
+
   test('records staged added managed files with anchors after headings', () => {
     const root = makeRepo();
     writeFile(root, 'AGENTS.md', '# Agent\n');

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -726,6 +726,25 @@ describe('patch intent records', () => {
     expect(() => recordPatchIntentFromDiff(root)).toThrow('inside the project root');
   });
 
+  test('ignores anchor files that escape through a symlink', () => {
+    const root = makeRepo();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-patch-outside-'));
+    tempRoots.push(outside);
+    writeFile(outside, 'external.md', '<!-- forge-anchor:external.anchor -->\nOutside text.\n');
+    try {
+      fs.symlinkSync(outside, path.join(root, 'linked-docs'), process.platform === 'win32' ? 'junction' : 'dir');
+    } catch (err) {
+      if (['EPERM', 'EACCES', 'ENOTSUP'].includes(err.code)) {
+        return;
+      }
+      throw err;
+    }
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.has('external.anchor')).toBe(false);
+  });
+
   test('rejects diff paths outside the project root', () => {
     const root = makeRepo();
     const diff = [

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -335,6 +335,8 @@ describe('patch intent records', () => {
   test('records staged managed hunks on unborn branches', () => {
     const root = makeRepo();
     writeFile(root, 'commands/validate.md', [
+      '# Validate',
+      '',
       '<!-- forge-anchor:stage.unborn -->',
       'Initial text.',
       '',
@@ -346,6 +348,27 @@ describe('patch intent records', () => {
     expect(result.records).toHaveLength(1);
     expect(result.records[0].path).toBe('commands/validate.md');
     expect(result.records[0].anchorId).toBe('stage.unborn');
+  });
+
+  test('records staged added managed files with anchors after headings', () => {
+    const root = makeRepo();
+    writeFile(root, 'AGENTS.md', '# Agent\n');
+    commitAll(root);
+    writeFile(root, 'commands/validate.md', [
+      '# Validate',
+      '',
+      '<!-- forge-anchor:stage.added -->',
+      'Initial text.',
+      '',
+    ].join('\n'));
+    execFileSync('git', ['add', 'commands/validate.md'], { cwd: root });
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].path).toBe('commands/validate.md');
+    expect(result.records[0].anchorId).toBe('stage.added');
+    expect(result.records[0].anchorLine).toBe(3);
   });
 
   test('round-trips record output back through git apply', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -263,6 +263,31 @@ describe('patch intent records', () => {
     expect(records[0].diff).toContain('Run checks carefully.');
   });
 
+  test('distinguishes patch IDs for anchors with the same normalized prefix', () => {
+    const root = makeRepo();
+    const diff = [
+      'diff --git a/commands/validate.md b/commands/validate.md',
+      '--- a/commands/validate.md',
+      '+++ b/commands/validate.md',
+      '@@ -2 +2 @@',
+      '-old',
+      '+new',
+      '',
+    ].join('\n');
+
+    writeFile(root, 'commands/validate.md', '<!-- forge-anchor:stage-one -->\nnew\n');
+    const first = recordPatchIntentFromDiff(root, { diff, now: new Date('2026-05-13T00:00:00Z') });
+    writeFile(root, 'commands/validate.md', '<!-- forge-anchor:stage:one -->\nnew\n');
+    const second = recordPatchIntentFromDiff(root, { diff, now: new Date('2026-05-13T00:00:01Z') });
+
+    const records = loadPatchIntentRecords(root).records;
+    const secondRecord = second.records.find(record => record.anchorId === 'stage:one');
+
+    expect(first.records[0].id).not.toBe(secondRecord.id);
+    expect(records).toHaveLength(2);
+    expect(records.map(record => record.anchorId).sort()).toEqual(['stage-one', 'stage:one']);
+  });
+
   test('records managed files with spaces in their diff paths', () => {
     const root = makeRepo();
     writeFile(root, 'a b/c.md', [
@@ -591,6 +616,42 @@ describe('patch intent records', () => {
     ].join('\n'));
 
     expect(() => loadPatchIntentRecords(root)).toThrow('Malformed patch intent record block');
+  });
+
+  test('rejects patch intent records with missing required metadata', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/patch.md', [
+      '# Forge Patch Intent',
+      '',
+      '<!-- forge-patch-intent:v1',
+      'anchorId: stage.missing-id',
+      'path: commands/validate.md',
+      'createdAt: 2026-05-13T00:00:00.000Z',
+      'source: git-diff',
+      'status: active',
+      '-->',
+      '```diff',
+      'diff --git a/commands/validate.md b/commands/validate.md',
+      '--- a/commands/validate.md',
+      '+++ b/commands/validate.md',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '```',
+      '<!-- /forge-patch-intent -->',
+      '',
+    ].join('\n'));
+
+    expect(() => loadPatchIntentRecords(root)).toThrow('missing required metadata: id');
+    expect(() => writePatchIntentRecords(root, [])).toThrow('missing required metadata: id');
+
+    const cleanRoot = makeRepo();
+    expect(() => writePatchIntentRecords(cleanRoot, [{
+      id: '',
+      anchorId: 'stage.missing-id',
+      path: 'commands/validate.md',
+      diff: 'diff --git a/commands/validate.md b/commands/validate.md\n',
+    }])).toThrow('missing required metadata: id');
   });
 
   test('honors patchIntent config path, aliases, and disabled state', () => {

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -1,0 +1,269 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+const { afterEach, describe, expect, test } = require('bun:test');
+
+const {
+  buildUnifiedDiffFromRecords,
+  discoverAnchors,
+  loadPatchIntentConfig,
+  loadPatchIntentRecords,
+  recordPatchIntentFromDiff,
+  resolvePatchIntentRecords,
+} = require('../lib/patch-intent');
+
+const tempRoots = [];
+
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-patch-intent-'));
+  tempRoots.push(root);
+  execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: root });
+  return root;
+}
+
+function writeFile(root, relativePath, body) {
+  const fullPath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, body, 'utf8');
+}
+
+function commitAll(root, message = 'baseline') {
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-m', message], { cwd: root, stdio: 'ignore' });
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('patch intent records', () => {
+  test('discovers stable anchors in managed files', () => {
+    const root = makeRepo();
+    writeFile(root, '.claude/commands/validate.md', [
+      '# Validate',
+      '',
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.get('stage.validate').path).toBe('.claude/commands/validate.md');
+    expect(anchors.get('stage.validate').line).toBe(3);
+  });
+
+  test('records diff hunks with stable IDs and replaces existing patch.md blocks', () => {
+    const root = makeRepo();
+    writeFile(root, '.claude/commands/validate.md', [
+      '# Validate',
+      '',
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, '.claude/commands/validate.md', [
+      '# Validate',
+      '',
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks carefully.',
+      '',
+    ].join('\n'));
+
+    const first = recordPatchIntentFromDiff(root, { now: new Date('2026-05-13T00:00:00Z') });
+    const second = recordPatchIntentFromDiff(root, { now: new Date('2026-05-13T00:00:01Z') });
+    const records = loadPatchIntentRecords(root).records;
+
+    expect(first.records).toHaveLength(1);
+    expect(second.records[0].id).toBe(first.records[0].id);
+    expect(records).toHaveLength(1);
+    expect(records[0].anchorId).toBe('stage.validate');
+    expect(records[0].diff).toContain('Run checks carefully.');
+  });
+
+  test('round-trips record output back through git apply', () => {
+    const root = makeRepo();
+    writeFile(root, '.claude/commands/dev.md', [
+      '# Dev',
+      '',
+      '<!-- forge-anchor:stage.dev -->',
+      'Implement.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, '.claude/commands/dev.md', [
+      '# Dev',
+      '',
+      '<!-- forge-anchor:stage.dev -->',
+      'Implement with tests.',
+      '',
+    ].join('\n'));
+    const expectedDiff = execFileSync('git', ['diff', '--', '.claude/commands/dev.md'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+
+    const result = recordPatchIntentFromDiff(root);
+    execFileSync('git', ['checkout', '--', '.claude/commands/dev.md'], { cwd: root });
+    execFileSync('git', ['apply'], {
+      cwd: root,
+      input: buildUnifiedDiffFromRecords(result.records),
+    });
+
+    const actualDiff = execFileSync('git', ['diff', '--', '.claude/commands/dev.md'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    expect(actualDiff).toBe(expectedDiff);
+  });
+
+  test('resolves record paths after a managed file rename', () => {
+    const root = makeRepo();
+    writeFile(root, 'old/validate.md', [
+      '<!-- forge-anchor:stage.validate -->',
+      'Run checks.',
+      '',
+    ].join('\n'));
+    writeFile(root, '.forge/patch.md', [
+      '# Forge Patch Intent',
+      '',
+      '<!-- forge-patch-intent:v1',
+      'id: patch_stage_validate_example',
+      'anchorId: stage.validate',
+      'path: old/validate.md',
+      'createdAt: 2026-05-13T00:00:00.000Z',
+      'source: git-diff',
+      'status: active',
+      '-->',
+      '```diff',
+      'diff --git a/old/validate.md b/old/validate.md',
+      '--- a/old/validate.md',
+      '+++ b/old/validate.md',
+      '@@ -1,2 +1,2 @@',
+      ' <!-- forge-anchor:stage.validate -->',
+      '-Run checks.',
+      '+Run checks carefully.',
+      '```',
+      '<!-- /forge-patch-intent -->',
+      '',
+    ].join('\n'));
+    fs.mkdirSync(path.join(root, 'new'), { recursive: true });
+    fs.renameSync(path.join(root, 'old', 'validate.md'), path.join(root, 'new', 'validate.md'));
+
+    const resolved = resolvePatchIntentRecords(root);
+
+    expect(resolved.records[0].status).toBe('renamed');
+    expect(resolved.records[0].currentPath).toBe('new/validate.md');
+  });
+
+  test('reports orphaned records when the target anchor is undeclared', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/patch.md', [
+      '# Forge Patch Intent',
+      '',
+      '<!-- forge-patch-intent:v1',
+      'id: patch_missing',
+      'anchorId: stage.missing',
+      'path: missing.md',
+      'createdAt: 2026-05-13T00:00:00.000Z',
+      'source: git-diff',
+      'status: active',
+      '-->',
+      '```diff',
+      'diff --git a/missing.md b/missing.md',
+      '--- a/missing.md',
+      '+++ b/missing.md',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '```',
+      '<!-- /forge-patch-intent -->',
+      '',
+    ].join('\n'));
+
+    const resolved = resolvePatchIntentRecords(root);
+
+    expect(resolved.orphans).toHaveLength(1);
+    expect(resolved.orphans[0].anchorId).toBe('stage.missing');
+  });
+
+  test('honors patchIntent config path, aliases, and disabled state', () => {
+    const root = makeRepo();
+    writeFile(root, '.forge/config.yaml', [
+      'patchIntent:',
+      '  path: .forge/custom-patch.md',
+      '  anchorAliases:',
+      '    stage.old: stage.new',
+      '',
+    ].join('\n'));
+    writeFile(root, 'commands/new.md', '<!-- forge-anchor:stage.new -->\nNew anchor.\n');
+    writeFile(root, '.forge/custom-patch.md', [
+      '# Forge Patch Intent',
+      '',
+      '<!-- forge-patch-intent:v1',
+      'id: patch_alias',
+      'anchorId: stage.old',
+      'path: commands/old.md',
+      'createdAt: 2026-05-13T00:00:00.000Z',
+      'source: git-diff',
+      'status: active',
+      '-->',
+      '```diff',
+      'diff --git a/commands/old.md b/commands/old.md',
+      '--- a/commands/old.md',
+      '+++ b/commands/old.md',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '```',
+      '<!-- /forge-patch-intent -->',
+      '',
+    ].join('\n'));
+
+    const config = loadPatchIntentConfig(root);
+    const resolved = resolvePatchIntentRecords(root);
+
+    expect(config.path).toBe('.forge/custom-patch.md');
+    expect(resolved.records[0].resolvedAnchorId).toBe('stage.new');
+    expect(resolved.records[0].currentPath).toBe('commands/new.md');
+
+    writeFile(root, '.forge/config.yaml', 'patchIntent:\n  enabled: false\n');
+    expect(() => recordPatchIntentFromDiff(root)).toThrow('disabled');
+  });
+
+  test('forge patch record --from-diff writes patch.md', () => {
+    const root = makeRepo();
+    writeFile(root, 'AGENTS.md', '# Agent\n');
+    writeFile(root, '.claude/commands/ship.md', [
+      '# Ship',
+      '',
+      '<!-- forge-anchor:stage.ship -->',
+      'Create PR.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, '.claude/commands/ship.md', [
+      '# Ship',
+      '',
+      '<!-- forge-anchor:stage.ship -->',
+      'Create PR with evidence.',
+      '',
+    ].join('\n'));
+
+    const cli = path.join(__dirname, '..', 'bin', 'forge.js');
+    const result = spawnSync(process.execPath, [cli, 'patch', 'record', '--from-diff', '--path', root], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Recorded 1 patch intent');
+    expect(fs.readFileSync(path.join(root, '.forge', 'patch.md'), 'utf8')).toContain('stage.ship');
+  });
+});
+

--- a/test/patch-intent.test.js
+++ b/test/patch-intent.test.js
@@ -87,6 +87,45 @@ describe('patch intent records', () => {
     expect(anchors.get('docs.patch-format').path).toBe('docs/reference/patch-md-format.md');
   });
 
+  test('tracks markdown fence delimiters by marker and length', () => {
+    const root = makeRepo();
+    writeFile(root, 'docs/reference/patch-md-format.md', [
+      '# Patch format',
+      '',
+      '````md',
+      '<!-- forge-anchor:stage.validate -->',
+      '```',
+      '<!-- forge-anchor:stage.validate -->',
+      '```',
+      '````',
+      '',
+      '<!-- forge-anchor:docs.patch-format -->',
+      'Reference text.',
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.has('stage.validate')).toBe(false);
+    expect(anchors.get('docs.patch-format').path).toBe('docs/reference/patch-md-format.md');
+  });
+
+  test('ignores inline code anchor examples', () => {
+    const root = makeRepo();
+    writeFile(root, 'docs/work/decisions.md', [
+      'Use `<!-- forge-anchor:stage.validate -->` as an example.',
+      '',
+      '<!-- forge-anchor:docs.decisions -->',
+      'Decision text.',
+      '',
+    ].join('\n'));
+
+    const anchors = discoverAnchors(root);
+
+    expect(anchors.has('stage.validate')).toBe(false);
+    expect(anchors.get('docs.decisions').path).toBe('docs/work/decisions.md');
+  });
+
   test('ignores anchor literals in source and test fixtures', () => {
     const root = makeRepo();
     writeFile(root, 'commands/validate.md', '<!-- forge-anchor:stage.validate -->\nRun checks.\n');
@@ -131,6 +170,28 @@ describe('patch intent records', () => {
     expect(result.records).toHaveLength(1);
     expect(result.records[0].anchorId).toBe('stage.real');
     expect(result.records[0].diff).toContain('new fenced text');
+  });
+
+  test('does not treat txt fence markers as markdown fences during attribution', () => {
+    const root = makeRepo();
+    writeFile(root, 'notes.txt', [
+      '```',
+      '<!-- forge-anchor:txt.real -->',
+      'Old text.',
+      '',
+    ].join('\n'));
+    commitAll(root);
+    writeFile(root, 'notes.txt', [
+      '```',
+      '<!-- forge-anchor:txt.real -->',
+      'New text.',
+      '',
+    ].join('\n'));
+
+    const result = recordPatchIntentFromDiff(root);
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].anchorId).toBe('txt.real');
   });
 
   test('records diff hunks with stable IDs and replaces existing patch.md blocks', () => {
@@ -459,6 +520,21 @@ describe('patch intent records', () => {
 
     expect(config.errors[0].code).toBe('PATCH_INTENT_PATH_OUTSIDE_ROOT');
     expect(() => recordPatchIntentFromDiff(root)).toThrow('inside the project root');
+  });
+
+  test('rejects diff paths outside the project root', () => {
+    const root = makeRepo();
+    const diff = [
+      'diff --git a/../outside.md b/../outside.md',
+      '--- a/../outside.md',
+      '+++ b/../outside.md',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '',
+    ].join('\n');
+
+    expect(() => recordPatchIntentFromDiff(root, { diff })).toThrow('Diff path must stay inside the project root');
   });
 
   test('skips deleted files while recording valid patch intents from mixed diffs', () => {

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -451,7 +451,7 @@ describe('project memory', () => {
         sourceAgent: 'Codex',
         tags: [],
       }, {
-        lockTimeoutMs: 25,
+        lockTimeoutMs: 250,
         lockRetryMs: 5,
       })).toThrow('operation not permitted');
     } finally {

--- a/test/scripts/beads-upgrade-smoke.test.js
+++ b/test/scripts/beads-upgrade-smoke.test.js
@@ -8,7 +8,7 @@ const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'beads-upgrade-smoke.
 const GIT_BASH_PATH = 'C:\\Program Files\\Git\\bin\\bash.exe';
 const tempDirs = [];
 
-setDefaultTimeout(20000);
+setDefaultTimeout(30000);
 
 function resolveBashCommand() {
   if (process.env.BASH_CMD) {

--- a/test/scripts/dep-guard.helpers.js
+++ b/test/scripts/dep-guard.helpers.js
@@ -31,14 +31,32 @@ function resolveBashCommand() {
   return cachedBashCommand;
 }
 
+function toBashPath(filePath) {
+  if (process.platform !== 'win32') {
+    return filePath;
+  }
+  return filePath.replace(/\\/g, '/').replace(/^([A-Za-z]):/, (_, drive) => `/${drive.toLowerCase()}`);
+}
+
+function normalizeBashEnv(env = {}) {
+  return {
+    ...env,
+    ...(env.BD_CMD ? { BD_CMD: toBashPath(env.BD_CMD) } : {}),
+    ...(env.DEP_GUARD_ANALYZE_SCRIPT ? { DEP_GUARD_ANALYZE_SCRIPT: toBashPath(env.DEP_GUARD_ANALYZE_SCRIPT) } : {}),
+    ...(env.DEP_GUARD_RENDER_SCRIPT ? { DEP_GUARD_RENDER_SCRIPT: toBashPath(env.DEP_GUARD_RENDER_SCRIPT) } : {}),
+    ...(env.DEP_GUARD_REPOSITORY_ROOT ? { DEP_GUARD_REPOSITORY_ROOT: toBashPath(env.DEP_GUARD_REPOSITORY_ROOT) } : {}),
+    ...(env.NODE_CMD ? { NODE_CMD: toBashPath(env.NODE_CMD) } : {}),
+  };
+}
+
 function runDepGuard(args = [], env = {}, cwd = PROJECT_ROOT) {
-  const result = spawnSync(resolveBashCommand(), [SCRIPT, ...args], {
+  const result = spawnSync(resolveBashCommand(), [toBashPath(SCRIPT), ...args], {
     cwd,
     encoding: 'utf-8',
     timeout: 15000,
     env: {
       ...process.env,
-      ...env,
+      ...normalizeBashEnv(env),
     },
   });
 
@@ -77,7 +95,9 @@ function createTempRepo(files) {
 module.exports = {
   createMockBd,
   createTempRepo,
+  normalizeBashEnv,
   PROJECT_ROOT,
   runDepGuard,
   SCRIPT,
+  toBashPath,
 };

--- a/test/scripts/smart-status.scoring.output.test.js
+++ b/test/scripts/smart-status.scoring.output.test.js
@@ -10,9 +10,10 @@ const {
   parseIssues,
   resolveBashCommand,
   runSmartStatus,
+  toBashPath,
 } = require('./smart-status.helpers');
 
-setDefaultTimeout(20000);
+setDefaultTimeout(60000);
 
 const ansiEscapePrefix = '\u001b[';
 
@@ -78,7 +79,7 @@ describe('smart-status.sh', () => {
 
       const env = { ...process.env, BD_CMD: colorMock.mockScript, GIT_CMD: 'true' };
       delete env.NO_COLOR;
-      colorStdout = (spawnSync(resolveBashCommand(), [SCRIPT], {
+      colorStdout = (spawnSync(resolveBashCommand(), [toBashPath(SCRIPT)], {
         cwd: PROJECT_ROOT,
         encoding: 'utf-8',
         timeout: 15000,


### PR DESCRIPTION
﻿## Issue covered
- `forge-besw.10`: patch intent records and `patch.md` anchors

## Validation commands
- `bun test test/patch-intent.test.js test/commands/patch.test.js` -> 9 pass, 0 fail
- `bun run check` -> passed on rerun, 877 pass, 0 fail
- `git push -u origin codex/0.0.16-patch-intent` -> pre-push lint/tests passed

## Anchor stability behavior
- Patch intent records are keyed by deterministic IDs from anchor ID + diff body, so re-recording the same diff replaces the existing block.
- Anchors are declared with `<!-- forge-anchor:<id> -->` and recorded in `.forge/patch.md` as YAML metadata plus a fenced unified diff.
- Rename handling resolves records by scanning current files for the anchor ID; if the old path disappears but the anchor exists elsewhere, status becomes `renamed` with the current path.
- Orphan detection reports records whose anchor cannot be found, including support for `patchIntent.anchorAliases` in `.forge/config.yaml`.

## Non-scope
- No `forge upgrade` implementation.
- No rollback snapshots.
- No upgrade self-heal or automatic patch application.
- No marketplace or adapter implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add CLI to record and inspect patch-intent records from git diffs; deterministic upserted records with active/renamed/orphan status, configurable storage path, enable/disable, and anchor aliasing.

* **Documentation**
  * New reference, design, decisions, and task docs describing patch-intent markdown format, anchor declaration/resolution rules, examples, config options, and out-of-scope items.

* **Tests**
  * Extensive cross-platform unit and E2E tests covering discovery, recording, resolution, rename/orphan handling, config validation, CLI flows, and updated test helpers/timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->