### PR TITLE
0.0.15 adoption entrypoint

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -3872,6 +3872,15 @@ function handlePathSetup(targetPath, options = {}) {
   return resolvedPath;
 }
 
+function resolvePathForDryRun(targetPath) {
+  const resolvedPath = path.resolve(targetPath);
+  if (fs.existsSync(resolvedPath) && !fs.statSync(resolvedPath).isDirectory()) {
+    console.error(`Error: ${resolvedPath} is not a directory`);
+    process.exit(1);
+  }
+  return resolvedPath;
+}
+
 // Helper: Determine selected agents from flags
 function determineSelectedAgents(flags) {
   if (flags.all) {
@@ -4166,7 +4175,9 @@ async function main() {
   // Handle --path option: change to target directory
   if (flags.path) {
     // Update projectRoot after changing directory to maintain state consistency
-    projectRoot = handlePathSetup(flags.path, { quiet: suppressStructuredOutput });
+    projectRoot = suppressAdoptionDryRunOutput
+      ? resolvePathForDryRun(flags.path)
+      : handlePathSetup(flags.path, { quiet: suppressStructuredOutput });
   }
 
   // Load command registry (auto-discovered commands from lib/commands/)

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -4126,8 +4126,11 @@ async function main() {
   const command = args[0];
   const flags = parseFlags();
   const suppressJsonIntrospectionOutput = ['options', 'explain'].includes(command) && args.includes('--json');
-  const suppressInitDryRunOutput = command === 'init' && flags.dryRun;
-  const suppressStructuredOutput = suppressJsonIntrospectionOutput || suppressInitDryRunOutput;
+  const profileDryRunArgs = ['--minimal', '--standard', '--full'];
+  const suppressAdoptionDryRunOutput = flags.dryRun && (
+    command === 'init' || (command === 'setup' && profileDryRunArgs.some(arg => args.includes(arg)))
+  );
+  const suppressStructuredOutput = suppressJsonIntrospectionOutput || suppressAdoptionDryRunOutput;
 
   // Wire up incremental setup state from parsed flags
   FORCE_MODE = flags.force;

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -4126,6 +4126,8 @@ async function main() {
   const command = args[0];
   const flags = parseFlags();
   const suppressJsonIntrospectionOutput = ['options', 'explain'].includes(command) && args.includes('--json');
+  const suppressInitDryRunOutput = command === 'init' && flags.dryRun;
+  const suppressStructuredOutput = suppressJsonIntrospectionOutput || suppressInitDryRunOutput;
 
   // Wire up incremental setup state from parsed flags
   FORCE_MODE = flags.force;
@@ -4135,7 +4137,7 @@ async function main() {
   SYNC_ENABLED = flags.sync;
   actionLog = new SetupActionLog();
 
-  if (NON_INTERACTIVE && !suppressJsonIntrospectionOutput) {
+  if (NON_INTERACTIVE && !suppressStructuredOutput) {
     const agentFlag = flags.agents;
     if (agentFlag && agentFlag.length > 0) {
       // flags.agents is a comma-separated string (e.g. "claude,cursor")
@@ -4161,7 +4163,7 @@ async function main() {
   // Handle --path option: change to target directory
   if (flags.path) {
     // Update projectRoot after changing directory to maintain state consistency
-    projectRoot = handlePathSetup(flags.path, { quiet: suppressJsonIntrospectionOutput });
+    projectRoot = handlePathSetup(flags.path, { quiet: suppressStructuredOutput });
   }
 
   // Load command registry (auto-discovered commands from lib/commands/)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -66,6 +66,7 @@ See [work/](work/) for the full list of date-prefixed work folders. Each folder 
 - [ROADMAP.md](reference/ROADMAP.md) — Forge roadmap
 - [TOOLCHAIN.md](reference/TOOLCHAIN.md) — Toolchain conventions (Bun, lefthook, beads, MCP, shell model)
 - [VALIDATION.md](reference/VALIDATION.md) — Validation stage requirements
+- [TEMPLATES.md](reference/TEMPLATES.md) — Adoption templates and `forge init` profiles
 - [EXAMPLES.md](reference/EXAMPLES.md) — Worked examples
 - [RESEARCH_TEMPLATE.md](reference/RESEARCH_TEMPLATE.md) — Template for research docs (formerly docs/research/TEMPLATE.md)
 

--- a/docs/guides/SETUP.md
+++ b/docs/guides/SETUP.md
@@ -17,6 +17,19 @@ Complete setup instructions for all AI agents and optional toolchain.
 
 ## Installation Options
 
+### Option 0: Fresh Repo Adoption Config
+
+```bash
+# Writes only .forge/config.yaml
+bunx forge init --profile minimal --yes
+
+# Inspect the generated runtime graph config
+bunx forge options lint
+bunx forge options diff
+```
+
+Use `minimal`, `standard`, or `full`. These profiles are adoption scaffolds over runtime primitives; see [Adoption Templates](../reference/TEMPLATES.md).
+
 ### Option 1: Bun (Recommended)
 
 ```bash

--- a/docs/reference/TEMPLATES.md
+++ b/docs/reference/TEMPLATES.md
@@ -1,0 +1,35 @@
+# Adoption Templates
+
+Forge templates are adoption scaffolds over runtime graph primitives. They are not the product surface: the generated `.forge/config.yaml` stays inspectable with `forge options`.
+
+## Entry Point
+
+```bash
+forge init --profile minimal --yes
+forge init --profile standard --yes
+forge init --profile full --yes
+```
+
+`forge init --yes` uses `standard`. `forge setup --minimal` is a shortcut for clean repositories that only need the minimal adoption config and do not want Beads or agent files installed yet.
+
+## Profiles
+
+| Profile | Purpose | Output |
+|---------|---------|--------|
+| `minimal` | Config-only adoption for a clean repository. | Writes `.forge/config.yaml`, disables workflow gates and adapters, and records template ancestry. |
+| `standard` | Default Forge command flow metadata. | Writes `.forge/config.yaml` with default gates enabled and Beads/GitHub issue adapter metadata. |
+| `full` | Explicit full scaffold. | Writes `.forge/config.yaml` with rails, gates, adapters, and protected paths made explicit. |
+
+## Inspect The Result
+
+```bash
+forge options lint
+forge options diff
+forge options stages --json
+```
+
+The generated config includes `template.kind`, `template.version`, `template.profile`, and `template.ancestry` so users can see which scaffold produced the current defaults.
+
+## Non-Scope
+
+This flow does not implement harness translation, adapter marketplace installation, upgrade or rollback, or patch intent.

--- a/docs/work/2026-05-13-0.0.15-adoption-entrypoint/decisions.md
+++ b/docs/work/2026-05-13-0.0.15-adoption-entrypoint/decisions.md
@@ -1,0 +1,3 @@
+# 0.0.15 adoption entrypoint decisions
+
+No decision gates fired yet.

--- a/docs/work/2026-05-13-0.0.15-adoption-entrypoint/design.md
+++ b/docs/work/2026-05-13-0.0.15-adoption-entrypoint/design.md
@@ -1,0 +1,41 @@
+# 0.0.15 adoption entrypoint
+
+**Date**: 2026-05-13
+**Branch**: `codex/0.0.15-adoption-entrypoint`
+**Status**: planned
+**Issues**: `forge-fvh9`, `forge-besw.5`, `forge-6hzl`, `forge-besw.14`
+
+## Purpose
+
+Make Forge adoptable in a fresh repository through `forge init`. The entrypoint should write inspectable `.forge/config.yaml` defaults and template ancestry metadata so users can inspect the resolved runtime graph immediately with existing `forge options` commands.
+
+## Success Criteria
+
+- `forge init --profile minimal|standard|full --yes` creates `.forge/config.yaml` in a clean repository.
+- The three profiles produce distinct runtime graph config defaults.
+- The generated config records template ancestry metadata and validates with `forge options lint`.
+- A thin interactive onboarding path delegates to the same profile definitions.
+- Docs describe the shipped init/profile flow and explicitly frame templates as adoption scaffolds.
+
+## Out Of Scope
+
+- Harness translator.
+- Adapter marketplace.
+- Upgrade or rollback flows.
+- Patch intent.
+- Treating templates as the Forge product instead of scaffolds over runtime primitives.
+
+## Approach Selected
+
+Add a registry-backed `init` command and a small profile library. The command writes only `.forge/config.yaml` and delegates inspection to the existing runtime graph loader and `forge options` surface. Profiles are data definitions, not a separate workflow engine.
+
+## Constraints
+
+- Keep config compatible with `lib/core/runtime-graph.js`.
+- Keep onboarding thin: ask for a profile only, then call the same non-interactive initializer.
+- Do not require Beads for minimal adoption.
+- Preserve existing `setup` behavior except for allowing `setup --minimal` as an alias to `init --profile minimal`.
+
+## Implementation Tasks
+
+See `tasks.md`.

--- a/docs/work/2026-05-13-0.0.15-adoption-entrypoint/tasks.md
+++ b/docs/work/2026-05-13-0.0.15-adoption-entrypoint/tasks.md
@@ -1,0 +1,42 @@
+# 0.0.15 adoption entrypoint tasks
+
+## Task 1: Profile config scaffolds
+
+TDD:
+- Add tests that assert `minimal`, `standard`, and `full` profiles produce distinct `.forge/config.yaml` objects with ancestry metadata.
+- Implement a small profile module that serializes config using runtime graph primitive ids already accepted by `lib/core/runtime-graph.js`.
+
+Acceptance:
+- Unknown profiles fail with a clear profile list.
+- Generated YAML parses and passes runtime graph config lint.
+
+## Task 2: `forge init` command
+
+TDD:
+- Add command tests that initialize a temp clean repo with `--profile minimal --yes`.
+- Assert `.forge/config.yaml` exists, no Beads directory is required, and `forge options lint --json` succeeds against that repo.
+
+Acceptance:
+- `forge init --profile minimal|standard|full --yes` is non-interactive.
+- Existing config is preserved unless `--force` is supplied.
+- Command output tells users how to inspect the config without adding another inspection system.
+
+## Task 3: Thin onboarding and setup alias
+
+TDD:
+- Add tests for `forge init --yes` defaulting to `standard`.
+- Add tests for `forge setup --minimal` delegating to the minimal init profile without requiring Beads.
+
+Acceptance:
+- Interactive mode only selects a profile and then calls the same init path.
+- `setup --minimal` remains an adoption shortcut, not a full setup replacement.
+
+## Task 4: Docs refresh
+
+TDD:
+- Add docs checks or command tests proving documented profile names match exported profiles.
+
+Acceptance:
+- Add a template/profile reference doc for the shipped `forge init` flow.
+- Cross-link it from `docs/INDEX.md` and setup docs.
+- Explicitly list non-scope.

--- a/lib/adoption-profiles.js
+++ b/lib/adoption-profiles.js
@@ -2,73 +2,73 @@ const YAML = require('yaml');
 
 const ADOPTION_VERSION = '0.0.15';
 const RUNTIME_ANCESTRY = 'forge.runtimeGraph.currentCommandFlow@0.0.12';
+const WORKFLOW_PHASES = Object.freeze(['plan', 'dev', 'validate', 'ship']);
+const WORKFLOW_GATES = Object.freeze(['gate.plan-exit', 'gate.dev-exit', 'gate.validate-exit', 'gate.ship-entry']);
+
+function enabledEntries(names, enabled = true) {
+  return Object.fromEntries(names.map(name => [name, { enabled }]));
+}
+
+function issueAdapter(enabled) {
+  if (!enabled) {
+    return {
+      enabled: false,
+      primary: 'none',
+      mirrors: [],
+    };
+  }
+
+  return {
+    enabled: true,
+    primary: 'beads',
+    mirrors: ['github'],
+  };
+}
+
+function harnessAdapter(targets) {
+  return {
+    enabled: targets.length > 0,
+    targets,
+  };
+}
+
+function adoptionConfig({ gatesEnabled, issueEnabled, harnessTargets, protectedPaths, rails }) {
+  return {
+    ...(rails ? { rails } : {}),
+    workflow: {
+      phases: enabledEntries(WORKFLOW_PHASES),
+      gates: enabledEntries(WORKFLOW_GATES, gatesEnabled),
+    },
+    adapters: {
+      issue: issueAdapter(issueEnabled),
+      harness: harnessAdapter(harnessTargets),
+    },
+    protectedPaths,
+  };
+}
 
 const PROFILE_CONFIGS = Object.freeze({
   minimal: {
     description: 'Config-only adoption for a clean repository.',
-    config: {
-      workflow: {
-        phases: {
-          plan: { enabled: true },
-          dev: { enabled: true },
-          validate: { enabled: true },
-          ship: { enabled: true },
-        },
-        gates: {
-          'gate.plan-exit': { enabled: false },
-          'gate.dev-exit': { enabled: false },
-          'gate.validate-exit': { enabled: false },
-          'gate.ship-entry': { enabled: false },
-        },
-      },
-      adapters: {
-        issue: {
-          enabled: false,
-          primary: 'none',
-          mirrors: [],
-        },
-        harness: {
-          enabled: false,
-          targets: [],
-        },
-      },
+    config: adoptionConfig({
+      gatesEnabled: false,
+      issueEnabled: false,
+      harnessTargets: [],
       protectedPaths: ['.forge/config.yaml'],
-    },
+    }),
   },
   standard: {
     description: 'Default Forge command flow with Beads/GitHub issue tracking metadata.',
-    config: {
-      workflow: {
-        phases: {
-          plan: { enabled: true },
-          dev: { enabled: true },
-          validate: { enabled: true },
-          ship: { enabled: true },
-        },
-        gates: {
-          'gate.plan-exit': { enabled: true },
-          'gate.dev-exit': { enabled: true },
-          'gate.validate-exit': { enabled: true },
-          'gate.ship-entry': { enabled: true },
-        },
-      },
-      adapters: {
-        issue: {
-          enabled: true,
-          primary: 'beads',
-          mirrors: ['github'],
-        },
-        harness: {
-          enabled: true,
-          targets: ['codex', 'claude', 'cursor'],
-        },
-      },
+    config: adoptionConfig({
+      gatesEnabled: true,
+      issueEnabled: true,
+      harnessTargets: ['codex', 'claude', 'cursor'],
       protectedPaths: ['.forge/config.yaml', 'AGENTS.md'],
-    },
+    }),
   },
   full: {
     description: 'Full adoption scaffold with all default rails explicit.',
-    config: {
+    config: adoptionConfig({
       rails: {
         tdd_intent: { enabled: true },
         secret_scan: { enabled: true },
@@ -76,33 +76,11 @@ const PROFILE_CONFIGS = Object.freeze({
         signed_commits: { enabled: true },
         schema_integrity: { enabled: true },
       },
-      workflow: {
-        phases: {
-          plan: { enabled: true },
-          dev: { enabled: true },
-          validate: { enabled: true },
-          ship: { enabled: true },
-        },
-        gates: {
-          'gate.plan-exit': { enabled: true },
-          'gate.dev-exit': { enabled: true },
-          'gate.validate-exit': { enabled: true },
-          'gate.ship-entry': { enabled: true },
-        },
-      },
-      adapters: {
-        issue: {
-          enabled: true,
-          primary: 'beads',
-          mirrors: ['github'],
-        },
-        harness: {
-          enabled: true,
-          targets: ['codex', 'claude', 'cursor', 'opencode', 'copilot'],
-        },
-      },
+      gatesEnabled: true,
+      issueEnabled: true,
+      harnessTargets: ['codex', 'claude', 'cursor', 'opencode', 'copilot'],
       protectedPaths: ['.forge/config.yaml', 'AGENTS.md', '.github/workflows/**'],
-    },
+    }),
   },
 });
 

--- a/lib/adoption-profiles.js
+++ b/lib/adoption-profiles.js
@@ -109,7 +109,7 @@ const PROFILE_CONFIGS = Object.freeze({
 const ADOPTION_PROFILE_NAMES = Object.freeze(Object.keys(PROFILE_CONFIGS));
 
 function clone(value) {
-  return JSON.parse(JSON.stringify(value));
+  return structuredClone(value);
 }
 
 function assertProfile(profile) {

--- a/lib/adoption-profiles.js
+++ b/lib/adoption-profiles.js
@@ -1,0 +1,148 @@
+const YAML = require('yaml');
+
+const ADOPTION_VERSION = '0.0.15';
+const RUNTIME_ANCESTRY = 'forge.runtimeGraph.currentCommandFlow@0.0.12';
+
+const PROFILE_CONFIGS = Object.freeze({
+  minimal: {
+    description: 'Config-only adoption for a clean repository.',
+    config: {
+      workflow: {
+        phases: {
+          plan: { enabled: true },
+          dev: { enabled: true },
+          validate: { enabled: true },
+          ship: { enabled: true },
+        },
+        gates: {
+          'gate.plan-exit': { enabled: false },
+          'gate.dev-exit': { enabled: false },
+          'gate.validate-exit': { enabled: false },
+          'gate.ship-entry': { enabled: false },
+        },
+      },
+      adapters: {
+        issue: {
+          enabled: false,
+          primary: 'none',
+          mirrors: [],
+        },
+        harness: {
+          enabled: false,
+          targets: [],
+        },
+      },
+      protectedPaths: ['.forge/config.yaml'],
+    },
+  },
+  standard: {
+    description: 'Default Forge command flow with Beads/GitHub issue tracking metadata.',
+    config: {
+      workflow: {
+        phases: {
+          plan: { enabled: true },
+          dev: { enabled: true },
+          validate: { enabled: true },
+          ship: { enabled: true },
+        },
+        gates: {
+          'gate.plan-exit': { enabled: true },
+          'gate.dev-exit': { enabled: true },
+          'gate.validate-exit': { enabled: true },
+          'gate.ship-entry': { enabled: true },
+        },
+      },
+      adapters: {
+        issue: {
+          enabled: true,
+          primary: 'beads',
+          mirrors: ['github'],
+        },
+        harness: {
+          enabled: true,
+          targets: ['codex', 'claude', 'cursor'],
+        },
+      },
+      protectedPaths: ['.forge/config.yaml', 'AGENTS.md'],
+    },
+  },
+  full: {
+    description: 'Full adoption scaffold with all default rails explicit.',
+    config: {
+      rails: {
+        tdd_intent: { enabled: true },
+        secret_scan: { enabled: true },
+        branch_protection: { enabled: true },
+        signed_commits: { enabled: true },
+        schema_integrity: { enabled: true },
+      },
+      workflow: {
+        phases: {
+          plan: { enabled: true },
+          dev: { enabled: true },
+          validate: { enabled: true },
+          ship: { enabled: true },
+        },
+        gates: {
+          'gate.plan-exit': { enabled: true },
+          'gate.dev-exit': { enabled: true },
+          'gate.validate-exit': { enabled: true },
+          'gate.ship-entry': { enabled: true },
+        },
+      },
+      adapters: {
+        issue: {
+          enabled: true,
+          primary: 'beads',
+          mirrors: ['github'],
+        },
+        harness: {
+          enabled: true,
+          targets: ['codex', 'claude', 'cursor', 'opencode', 'copilot'],
+        },
+      },
+      protectedPaths: ['.forge/config.yaml', 'AGENTS.md', '.github/workflows/**'],
+    },
+  },
+});
+
+const ADOPTION_PROFILE_NAMES = Object.freeze(Object.keys(PROFILE_CONFIGS));
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function assertProfile(profile) {
+  if (!Object.hasOwn(PROFILE_CONFIGS, profile)) {
+    throw new Error(`Unknown adoption profile '${profile}'. Available profiles: ${ADOPTION_PROFILE_NAMES.join(', ')}`);
+  }
+}
+
+function buildAdoptionConfig(profile = 'standard') {
+  assertProfile(profile);
+  const definition = PROFILE_CONFIGS[profile];
+  return {
+    template: {
+      kind: 'forge.adoptionTemplate',
+      version: ADOPTION_VERSION,
+      profile,
+      description: definition.description,
+      ancestry: [
+        RUNTIME_ANCESTRY,
+        `forge.profile.${profile}@${ADOPTION_VERSION}`,
+      ],
+    },
+    ...clone(definition.config),
+  };
+}
+
+function renderAdoptionConfigYaml(profile = 'standard') {
+  return YAML.stringify(buildAdoptionConfig(profile));
+}
+
+module.exports = {
+  ADOPTION_PROFILE_NAMES,
+  ADOPTION_VERSION,
+  buildAdoptionConfig,
+  renderAdoptionConfigYaml,
+};

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -64,7 +64,7 @@ async function resolveProfile(parsed) {
   if (parsed.profile) {
     return parsed.profile;
   }
-  if (parsed.yes) {
+  if (parsed.yes || !process.stdin.isTTY) {
     return 'standard';
   }
 

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -18,6 +18,7 @@ function usage() {
 function parseInitFlags(args = [], flags = {}) {
   const parsed = {
     profile: flags.profile || null,
+    error: null,
     yes: Boolean(flags.yes || flags.nonInteractive),
     force: Boolean(flags.force),
     dryRun: Boolean(flags.dryRun),
@@ -25,10 +26,21 @@ function parseInitFlags(args = [], flags = {}) {
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
-    if (arg === '--profile' && args[index + 1]) {
-      parsed.profile = args[++index];
+    if (arg === '--profile') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        parsed.error = '--profile requires a non-empty value: minimal, standard, or full.';
+      } else {
+        parsed.profile = value;
+        index++;
+      }
     } else if (arg.startsWith('--profile=')) {
-      parsed.profile = arg.slice('--profile='.length);
+      const value = arg.slice('--profile='.length);
+      if (!value) {
+        parsed.error = '--profile requires a non-empty value: minimal, standard, or full.';
+      } else {
+        parsed.profile = value;
+      }
     } else if (arg === '--yes' || arg === '-y') {
       parsed.yes = true;
     } else if (arg === '--force') {
@@ -74,6 +86,9 @@ async function resolveProfile(parsed) {
 
 async function handler(args, flags, projectRoot = process.cwd()) {
   const parsed = parseInitFlags(args, flags);
+  if (parsed.error) {
+    return { success: false, error: parsed.error };
+  }
   const profile = await resolveProfile(parsed);
   const configYaml = renderAdoptionConfigYaml(profile);
   const forgeDir = path.join(projectRoot, '.forge');

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,0 +1,117 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const readline = require('node:readline');
+
+const {
+  ADOPTION_PROFILE_NAMES,
+  renderAdoptionConfigYaml,
+} = require('../adoption-profiles');
+
+function usage() {
+  return [
+    'Usage: forge init [--profile minimal|standard|full] [--yes] [--force]',
+    '',
+    'Initialize .forge/config.yaml for a fresh repository.',
+  ].join('\n');
+}
+
+function parseInitFlags(args = [], flags = {}) {
+  const parsed = {
+    profile: flags.profile || null,
+    yes: Boolean(flags.yes || flags.nonInteractive),
+    force: Boolean(flags.force),
+    dryRun: Boolean(flags.dryRun),
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--profile' && args[index + 1]) {
+      parsed.profile = args[++index];
+    } else if (arg.startsWith('--profile=')) {
+      parsed.profile = arg.slice('--profile='.length);
+    } else if (arg === '--yes' || arg === '-y') {
+      parsed.yes = true;
+    } else if (arg === '--force') {
+      parsed.force = true;
+    } else if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else if (arg === '--minimal') {
+      parsed.profile = 'minimal';
+      parsed.yes = true;
+    } else if (arg === '--standard') {
+      parsed.profile = 'standard';
+      parsed.yes = true;
+    } else if (arg === '--full') {
+      parsed.profile = 'full';
+      parsed.yes = true;
+    }
+  }
+
+  return parsed;
+}
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
+
+async function resolveProfile(parsed) {
+  if (parsed.profile) {
+    return parsed.profile;
+  }
+  if (parsed.yes) {
+    return 'standard';
+  }
+
+  const answer = await ask(`Select Forge adoption profile (${ADOPTION_PROFILE_NAMES.join('/')}): `);
+  return answer.trim() || 'standard';
+}
+
+async function handler(args, flags, projectRoot = process.cwd()) {
+  const parsed = parseInitFlags(args, flags);
+  const profile = await resolveProfile(parsed);
+  const configYaml = renderAdoptionConfigYaml(profile);
+  const forgeDir = path.join(projectRoot, '.forge');
+  const configPath = path.join(forgeDir, 'config.yaml');
+
+  if (fs.existsSync(configPath) && !parsed.force) {
+    return {
+      success: false,
+      error: `.forge/config.yaml already exists. Re-run with --force to overwrite it.`,
+    };
+  }
+
+  if (parsed.dryRun) {
+    console.log(configYaml);
+    return { success: true, profile, configPath };
+  }
+
+  fs.mkdirSync(forgeDir, { recursive: true });
+  fs.writeFileSync(configPath, configYaml, 'utf8');
+
+  console.log(`Initialized Forge adoption profile '${profile}' at .forge/config.yaml`);
+  console.log('Inspect with: forge options lint && forge options diff');
+
+  return { success: true, profile, configPath };
+}
+
+module.exports = {
+  name: 'init',
+  description: 'Initialize Forge adoption config in a fresh repository',
+  usage: usage(),
+  flags: {
+    '--profile <name>': 'Adoption profile: minimal, standard, or full',
+    '--minimal': 'Shortcut for --profile minimal --yes',
+    '--standard': 'Shortcut for --profile standard --yes',
+    '--full': 'Shortcut for --profile full --yes',
+    '--yes': 'Use the standard profile when no profile is provided',
+    '--force': 'Overwrite an existing .forge/config.yaml',
+  },
+  handler,
+  parseInitFlags,
+};

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -76,11 +76,14 @@ function parseInitFlags(args = [], flags = {}) {
     setProfile(parsed, flags.profile);
   }
 
-  for (let index = 0; index < args.length; index++) {
+  let index = 0;
+  while (index < args.length) {
     const arg = args[index];
     if (arg === '--profile' || arg.startsWith('--profile=')) {
-      index = consumeProfileArg(args, index, parsed);
+      index = consumeProfileArg(args, index, parsed) + 1;
+      continue;
     } else if (applyProfileShortcut(arg, parsed)) {
+      index += 1;
       continue;
     } else if (arg === '--yes' || arg === '-y') {
       parsed.yes = true;
@@ -89,6 +92,7 @@ function parseInitFlags(args = [], flags = {}) {
     } else if (arg === '--dry-run') {
       parsed.dryRun = true;
     }
+    index += 1;
   }
 
   return parsed;

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -9,7 +9,7 @@ const {
 
 function usage() {
   return [
-    'Usage: forge init [--profile minimal|standard|full] [--yes] [--force]',
+    'Usage: forge init [--profile minimal|standard|full] [--yes] [--force] [--dry-run]',
     '',
     'Initialize .forge/config.yaml for a fresh repository.',
   ].join('\n');
@@ -87,8 +87,7 @@ async function handler(args, flags, projectRoot = process.cwd()) {
   }
 
   if (parsed.dryRun) {
-    console.log(configYaml);
-    return { success: true, profile, configPath };
+    return { success: true, profile, configPath, output: configYaml };
   }
 
   fs.mkdirSync(forgeDir, { recursive: true });
@@ -111,6 +110,7 @@ module.exports = {
     '--full': 'Shortcut for --profile full --yes',
     '--yes': 'Use the standard profile when no profile is provided',
     '--force': 'Overwrite an existing .forge/config.yaml',
+    '--dry-run': 'Print the generated config YAML without writing files',
   },
   handler,
   parseInitFlags,

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -7,6 +7,13 @@ const {
   renderAdoptionConfigYaml,
 } = require('../adoption-profiles');
 
+const PROFILE_REQUIRED_ERROR = '--profile requires a non-empty value: minimal, standard, or full.';
+const PROFILE_SHORTCUTS = Object.freeze({
+  '--minimal': 'minimal',
+  '--standard': 'standard',
+  '--full': 'full',
+});
+
 function usage() {
   return [
     'Usage: forge init [--profile minimal|standard|full] [--yes] [--force] [--dry-run]',
@@ -15,47 +22,72 @@ function usage() {
   ].join('\n');
 }
 
+function normalizeProfile(value) {
+  if (typeof value !== 'string') return value ?? null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : '';
+}
+
+function setProfile(parsed, value) {
+  const profile = normalizeProfile(value);
+  if (profile === '') {
+    parsed.error = PROFILE_REQUIRED_ERROR;
+    parsed.profile = null;
+    return;
+  }
+  parsed.profile = profile;
+}
+
+function consumeProfileArg(args, index, parsed) {
+  const arg = args[index];
+  if (arg === '--profile') {
+    const value = args[index + 1];
+    if (typeof value === 'string' && !value.startsWith('--')) {
+      setProfile(parsed, value);
+      return index + 1;
+    }
+    parsed.error = PROFILE_REQUIRED_ERROR;
+    return index;
+  }
+
+  setProfile(parsed, arg.slice('--profile='.length));
+  return index;
+}
+
+function applyProfileShortcut(arg, parsed) {
+  const profile = PROFILE_SHORTCUTS[arg];
+  if (profile) {
+    parsed.profile = profile;
+    parsed.yes = true;
+  }
+  return Boolean(profile);
+}
+
 function parseInitFlags(args = [], flags = {}) {
   const parsed = {
-    profile: flags.profile || null,
+    profile: null,
     error: null,
     yes: Boolean(flags.yes || flags.nonInteractive),
     force: Boolean(flags.force),
     dryRun: Boolean(flags.dryRun),
   };
 
+  if (Object.hasOwn(flags, 'profile')) {
+    setProfile(parsed, flags.profile);
+  }
+
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
-    if (arg === '--profile') {
-      const value = args[index + 1];
-      if (!value || value.startsWith('--')) {
-        parsed.error = '--profile requires a non-empty value: minimal, standard, or full.';
-      } else {
-        parsed.profile = value;
-        index++;
-      }
-    } else if (arg.startsWith('--profile=')) {
-      const value = arg.slice('--profile='.length);
-      if (!value) {
-        parsed.error = '--profile requires a non-empty value: minimal, standard, or full.';
-      } else {
-        parsed.profile = value;
-      }
+    if (arg === '--profile' || arg.startsWith('--profile=')) {
+      index = consumeProfileArg(args, index, parsed);
+    } else if (applyProfileShortcut(arg, parsed)) {
+      continue;
     } else if (arg === '--yes' || arg === '-y') {
       parsed.yes = true;
     } else if (arg === '--force') {
       parsed.force = true;
     } else if (arg === '--dry-run') {
       parsed.dryRun = true;
-    } else if (arg === '--minimal') {
-      parsed.profile = 'minimal';
-      parsed.yes = true;
-    } else if (arg === '--standard') {
-      parsed.profile = 'standard';
-      parsed.yes = true;
-    } else if (arg === '--full') {
-      parsed.profile = 'full';
-      parsed.yes = true;
     }
   }
 
@@ -90,6 +122,12 @@ async function handler(args, flags, projectRoot = process.cwd()) {
     return { success: false, error: parsed.error };
   }
   const profile = await resolveProfile(parsed);
+  if (!ADOPTION_PROFILE_NAMES.includes(profile)) {
+    return {
+      success: false,
+      error: `Unknown adoption profile '${profile}'. Available profiles: ${ADOPTION_PROFILE_NAMES.join(', ')}`,
+    };
+  }
   const configYaml = renderAdoptionConfigYaml(profile);
   const forgeDir = path.join(projectRoot, '.forge');
   const configPath = path.join(forgeDir, 'config.yaml');

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -58,6 +58,7 @@ const {
   generateKiloConfig,
   generateOpenCodeConfig,
 } = require('../agents-config');
+const initCommand = require('./init');
 const fileUtils = require('../file-utils');
 const detectionUtils = require('../detection-utils');
 const { detectHusky, migrateHusky } = require('../husky-migration');
@@ -4275,6 +4276,9 @@ const SETUP_FLAG_DEFAULTS = Object.freeze({
   verbose: false,
   dryRun: false,
   quick: false,
+  minimal: false,
+  standard: false,
+  full: false,
   skipExternal: false,
   sync: false,
   symlink: false,
@@ -4289,6 +4293,9 @@ const SIMPLE_SETUP_FLAG_UPDATES = Object.freeze({
   '--verbose': { verbose: true },
   '--dry-run': { dryRun: true },
   '--quick': { quick: true },
+  '--minimal': { minimal: true },
+  '--standard': { standard: true },
+  '--full': { full: true },
   '--skip-external': { skipExternal: true },
   '--sync': { sync: true },
   '--symlink': { symlink: true },
@@ -4366,6 +4373,9 @@ function mergeSetupFlags(flags, argv) {
     verbose: Boolean(flags.verbose || setupFlags.verbose),
     dryRun: Boolean(flags.dryRun || setupFlags.dryRun),
     quick: Boolean(flags.quick || setupFlags.quick),
+    minimal: Boolean(flags.minimal || setupFlags.minimal),
+    standard: Boolean(flags.standard || setupFlags.standard),
+    full: Boolean(flags.full || setupFlags.full),
     skipExternal: Boolean(flags.skipExternal || setupFlags.skipExternal),
     sync: Boolean(flags.sync || setupFlags.sync),
     symlink: Boolean(flags.symlink || setupFlags.symlink),
@@ -4421,6 +4431,11 @@ module.exports = {
     actionLog = new SetupActionLog();
     resetSetupNotes();
     PKG_MANAGER = detectPackageManager();
+
+    if (flags.minimal || flags.standard || flags.full) {
+      const profile = flags.minimal ? 'minimal' : flags.full ? 'full' : 'standard';
+      return initCommand.handler([`--profile=${profile}`, '--yes', ...(flags.force ? ['--force'] : [])], flags, projectRoot);
+    }
 
     // Determine agents to install
     let selectedAgents = determineSelectedAgents(flags);

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -4433,7 +4433,18 @@ module.exports = {
     PKG_MANAGER = detectPackageManager();
 
     if (flags.minimal || flags.standard || flags.full) {
-      const profile = flags.minimal ? 'minimal' : flags.full ? 'full' : 'standard';
+      const selectedProfiles = [];
+      if (flags.minimal) selectedProfiles.push('minimal');
+      if (flags.standard) selectedProfiles.push('standard');
+      if (flags.full) selectedProfiles.push('full');
+      if (selectedProfiles.length > 1) {
+        return {
+          success: false,
+          error: `Conflicting profile flags: ${selectedProfiles.join(', ')}. Choose exactly one of --minimal, --standard, or --full.`,
+        };
+      }
+
+      const [profile] = selectedProfiles;
       return initCommand.handler([`--profile=${profile}`, '--yes', ...(flags.force ? ['--force'] : [])], flags, projectRoot);
     }
 

--- a/test/adoption-docs.test.js
+++ b/test/adoption-docs.test.js
@@ -1,0 +1,15 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { describe, expect, test } = require('bun:test');
+
+const { ADOPTION_PROFILE_NAMES } = require('../lib/adoption-profiles');
+
+describe('adoption profile docs', () => {
+  test('template reference documents all shipped profiles', () => {
+    const content = fs.readFileSync(path.join(__dirname, '..', 'docs', 'reference', 'TEMPLATES.md'), 'utf8');
+
+    for (const profile of ADOPTION_PROFILE_NAMES) {
+      expect(content).toContain(`\`${profile}\``);
+    }
+  });
+});

--- a/test/adoption-profiles.test.js
+++ b/test/adoption-profiles.test.js
@@ -1,0 +1,61 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const YAML = require('yaml');
+const { afterEach, describe, expect, test } = require('bun:test');
+
+const {
+  ADOPTION_PROFILE_NAMES,
+  buildAdoptionConfig,
+  renderAdoptionConfigYaml,
+} = require('../lib/adoption-profiles');
+const { lintRuntimeGraphConfig } = require('../lib/core/runtime-graph');
+
+const tempRoots = [];
+
+function makeProject(configBody) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-adoption-profile-'));
+  tempRoots.push(root);
+  fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.forge', 'config.yaml'), configBody);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('adoption profiles', () => {
+  test('exports minimal, standard, and full profiles', () => {
+    expect(ADOPTION_PROFILE_NAMES).toEqual(['minimal', 'standard', 'full']);
+  });
+
+  test('profile configs are distinct and include template ancestry metadata', () => {
+    const configs = ADOPTION_PROFILE_NAMES.map(name => buildAdoptionConfig(name));
+
+    expect(new Set(configs.map(config => JSON.stringify(config))).size).toBe(3);
+    for (const config of configs) {
+      expect(config.template.kind).toBe('forge.adoptionTemplate');
+      expect(config.template.version).toBe('0.0.15');
+      expect(config.template.ancestry).toContain('forge.runtimeGraph.currentCommandFlow@0.0.12');
+    }
+  });
+
+  test('rendered profile YAML parses and passes runtime graph config lint', () => {
+    for (const profile of ADOPTION_PROFILE_NAMES) {
+      const yaml = renderAdoptionConfigYaml(profile);
+      const parsed = YAML.parse(yaml);
+      const root = makeProject(yaml);
+      const result = lintRuntimeGraphConfig({ projectRoot: root });
+
+      expect(parsed.template.profile).toBe(profile);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  test('unknown profiles fail with the available profile list', () => {
+    expect(() => buildAdoptionConfig('custom')).toThrow('minimal, standard, full');
+  });
+});

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -75,6 +75,19 @@ describe('forge init command', () => {
     expect(config.template.profile).toBe('standard');
   });
 
+  test('non-interactive CLI init defaults to standard instead of hanging or no-oping', () => {
+    const projectRoot = makeCleanRepo();
+    const result = spawnSync(process.execPath, [forgePath, 'init', '--path', projectRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      input: '',
+    });
+    const config = YAML.parse(fs.readFileSync(path.join(projectRoot, '.forge', 'config.yaml'), 'utf8'));
+
+    expect(result.status).toBe(0);
+    expect(config.template.profile).toBe('standard');
+  });
+
   test('preserves existing config unless --force is supplied', async () => {
     const projectRoot = makeCleanRepo();
     const forgeDir = path.join(projectRoot, '.forge');

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -1,0 +1,93 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+const YAML = require('yaml');
+const { afterEach, describe, expect, test } = require('bun:test');
+
+const initCommand = require('../../lib/commands/init');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const forgePath = path.join(repoRoot, 'bin', 'forge.js');
+const tempRoots = [];
+
+function makeCleanRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-init-clean-'));
+  tempRoots.push(root);
+  execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
+  return root;
+}
+
+async function runInit(args, projectRoot) {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...parts) => logs.push(parts.join(' '));
+  try {
+    const result = await initCommand.handler(args, {}, projectRoot);
+    return { result, output: logs.join('\n') };
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('forge init command', () => {
+  test('initializes a fresh repo with the minimal profile without Beads', async () => {
+    const projectRoot = makeCleanRepo();
+    const { result, output } = await runInit(['--profile', 'minimal', '--yes'], projectRoot);
+    const configPath = path.join(projectRoot, '.forge', 'config.yaml');
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(fs.existsSync(path.join(projectRoot, '.beads'))).toBe(false);
+    expect(YAML.parse(fs.readFileSync(configPath, 'utf8')).template.profile).toBe('minimal');
+    expect(output).toContain('forge options lint');
+
+    const lint = spawnSync(process.execPath, [forgePath, 'options', 'lint', '--json', '--path', projectRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    expect(lint.status).toBe(0);
+    expect(JSON.parse(lint.stdout).ok).toBe(true);
+  });
+
+  test('supports all shipped profile flags with distinct config defaults', async () => {
+    const configs = [];
+    for (const flag of ['--minimal', '--standard', '--full']) {
+      const projectRoot = makeCleanRepo();
+      await runInit([flag, '--yes'], projectRoot);
+      configs.push(fs.readFileSync(path.join(projectRoot, '.forge', 'config.yaml'), 'utf8'));
+    }
+
+    expect(new Set(configs).size).toBe(3);
+  });
+
+  test('--yes defaults thin onboarding to the standard profile', async () => {
+    const projectRoot = makeCleanRepo();
+    await runInit(['--yes'], projectRoot);
+    const config = YAML.parse(fs.readFileSync(path.join(projectRoot, '.forge', 'config.yaml'), 'utf8'));
+
+    expect(config.template.profile).toBe('standard');
+  });
+
+  test('preserves existing config unless --force is supplied', async () => {
+    const projectRoot = makeCleanRepo();
+    const forgeDir = path.join(projectRoot, '.forge');
+    fs.mkdirSync(forgeDir, { recursive: true });
+    const configPath = path.join(forgeDir, 'config.yaml');
+    fs.writeFileSync(configPath, 'template:\n  profile: custom\n', 'utf8');
+
+    const blocked = await runInit(['--profile', 'minimal', '--yes'], projectRoot);
+    expect(blocked.result.success).toBe(false);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain('custom');
+
+    const forced = await runInit(['--profile', 'minimal', '--yes', '--force'], projectRoot);
+    expect(forced.result.success).toBe(true);
+    expect(YAML.parse(fs.readFileSync(configPath, 'utf8')).template.profile).toBe('minimal');
+  });
+});

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -104,7 +104,7 @@ describe('forge init command', () => {
   });
 
   test('rejects empty profile values instead of defaulting', () => {
-    for (const profileArgs of [['--profile='], ['--profile']]) {
+    for (const profileArgs of [['--profile='], ['--profile=   '], ['--profile']]) {
       const projectRoot = makeCleanRepo();
       const result = spawnSync(process.execPath, [forgePath, 'init', ...profileArgs, '--path', projectRoot], {
         cwd: repoRoot,
@@ -116,6 +116,19 @@ describe('forge init command', () => {
       expect(result.stderr).toContain('--profile requires a non-empty value');
       expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
     }
+  });
+
+  test('rejects unknown profile values with a structured error', () => {
+    const projectRoot = makeCleanRepo();
+    const result = spawnSync(process.execPath, [forgePath, 'init', '--profile', 'unknown', '--path', projectRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      input: '',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Unknown adoption profile 'unknown'");
+    expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
   });
 
   test('preserves existing config unless --force is supplied', async () => {

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -88,6 +88,21 @@ describe('forge init command', () => {
     expect(config.template.profile).toBe('standard');
   });
 
+  test('non-interactive CLI init dry-run prints parseable YAML only', () => {
+    const projectRoot = makeCleanRepo();
+    const result = spawnSync(process.execPath, [forgePath, 'init', '--dry-run', '--path', projectRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      input: '',
+    });
+    const parsed = YAML.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(parsed.template.profile).toBe('standard');
+    expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
+  });
+
   test('preserves existing config unless --force is supplied', async () => {
     const projectRoot = makeCleanRepo();
     const forgeDir = path.join(projectRoot, '.forge');

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -103,6 +103,21 @@ describe('forge init command', () => {
     expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
   });
 
+  test('rejects empty profile values instead of defaulting', () => {
+    for (const profileArgs of [['--profile='], ['--profile']]) {
+      const projectRoot = makeCleanRepo();
+      const result = spawnSync(process.execPath, [forgePath, 'init', ...profileArgs, '--path', projectRoot], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        input: '',
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('--profile requires a non-empty value');
+      expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
+    }
+  });
+
   test('preserves existing config unless --force is supplied', async () => {
     const projectRoot = makeCleanRepo();
     const forgeDir = path.join(projectRoot, '.forge');

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -103,6 +103,21 @@ describe('forge init command', () => {
     expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
   });
 
+  test('non-interactive CLI setup profile dry-run prints parseable YAML only', () => {
+    const projectRoot = makeCleanRepo();
+    const result = spawnSync(process.execPath, [forgePath, 'setup', '--minimal', '--dry-run', '--path', projectRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      input: '',
+    });
+    const parsed = YAML.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(parsed.template.profile).toBe('minimal');
+    expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
+  });
+
   test('rejects empty profile values instead of defaulting', () => {
     for (const profileArgs of [['--profile='], ['--profile=   '], ['--profile']]) {
       const projectRoot = makeCleanRepo();

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -103,6 +103,23 @@ describe('forge init command', () => {
     expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
   });
 
+  test('non-interactive CLI init dry-run does not create a missing --path target', () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-init-dry-run-parent-'));
+    tempRoots.push(parent);
+    const projectRoot = path.join(parent, 'missing-target');
+    const result = spawnSync(process.execPath, [forgePath, 'init', '--dry-run', '--path', projectRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      input: '',
+    });
+    const parsed = YAML.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(parsed.template.profile).toBe('standard');
+    expect(fs.existsSync(projectRoot)).toBe(false);
+  });
+
   test('non-interactive CLI setup profile dry-run prints parseable YAML only', () => {
     const projectRoot = makeCleanRepo();
     const result = spawnSync(process.execPath, [forgePath, 'setup', '--minimal', '--dry-run', '--path', projectRoot], {
@@ -116,6 +133,23 @@ describe('forge init command', () => {
     expect(result.stderr).toBe('');
     expect(parsed.template.profile).toBe('minimal');
     expect(fs.existsSync(path.join(projectRoot, '.forge', 'config.yaml'))).toBe(false);
+  });
+
+  test('non-interactive CLI setup profile dry-run does not create a missing --path target', () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-setup-dry-run-parent-'));
+    tempRoots.push(parent);
+    const projectRoot = path.join(parent, 'missing-target');
+    const result = spawnSync(process.execPath, [forgePath, 'setup', '--minimal', '--dry-run', '--path', projectRoot], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      input: '',
+    });
+    const parsed = YAML.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(parsed.template.profile).toBe('minimal');
+    expect(fs.existsSync(projectRoot)).toBe(false);
   });
 
   test('rejects empty profile values instead of defaulting', () => {

--- a/test/migrate-dry-run.test.js
+++ b/test/migrate-dry-run.test.js
@@ -188,5 +188,5 @@ describe('migrate dry-run', () => {
     ]);
     expect(result.results.find(item => item.name === 'clean-v2-install').ok).toBe(true);
     expect(result.results.find(item => item.name === 'broken-beads-state').ok).toBe(false);
-  }, 15000);
+  }, 60000);
 });

--- a/test/setup-runtime-flags.test.js
+++ b/test/setup-runtime-flags.test.js
@@ -152,6 +152,19 @@ describe('setup runtime flags', () => {
     expect(result.stdout).not.toContain('.claude/commands/plan.md');
   });
 
+  serialTest('--minimal delegates to forge init minimal profile without requiring Beads', async () => {
+    const tmpDir = makeTempDir();
+
+    const result = await runSetup(['--minimal'], tmpDir, {
+      FORGE_TEST_DISABLE_GH: '1',
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, '.forge', 'config.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.beads'))).toBe(false);
+    expect(fs.readFileSync(path.join(tmpDir, '.forge', 'config.yaml'), 'utf8')).toContain('profile: minimal');
+  });
+
   serialTest('--keep preserves existing Claude commands at runtime', async () => {
     const tmpDir = makeTempDir();
     const claudeDir = path.join(tmpDir, '.claude', 'commands');

--- a/test/setup-runtime-flags.test.js
+++ b/test/setup-runtime-flags.test.js
@@ -95,11 +95,11 @@ async function runSetup(args, cwd, env = {}) {
       PKG_MANAGER: 'npm',
     });
 
-    await setupCommand.handler(args, { commandRunner }, cwd);
+    const commandResult = await setupCommand.handler(args, { commandRunner }, cwd);
     return {
-      status: 0,
+      status: commandResult && commandResult.success === false ? 1 : 0,
       stdout: stdout.join(''),
-      stderr: stderr.join(''),
+      stderr: `${stderr.join('')}${commandResult && commandResult.error ? commandResult.error : ''}`,
     };
   } catch (error) {
     return {
@@ -163,6 +163,16 @@ describe('setup runtime flags', () => {
     expect(fs.existsSync(path.join(tmpDir, '.forge', 'config.yaml'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.beads'))).toBe(false);
     expect(fs.readFileSync(path.join(tmpDir, '.forge', 'config.yaml'), 'utf8')).toContain('profile: minimal');
+  });
+
+  serialTest('setup rejects conflicting adoption profile flags', async () => {
+    const tmpDir = makeTempDir();
+
+    const result = await runSetup(['--minimal', '--full'], tmpDir);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Conflicting profile flags');
+    expect(fs.existsSync(path.join(tmpDir, '.forge', 'config.yaml'))).toBe(false);
   });
 
   serialTest('--keep preserves existing Claude commands at runtime', async () => {


### PR DESCRIPTION
## Problem
Forge needed a fresh-repo adoption entrypoint for 0.0.15 so users can initialize inspectable runtime graph config without treating templates as the product.

## Root Cause
The runtime graph/config/audit slices were merged, but there was no thin `forge init` command that writes `.forge/config.yaml`, records profile ancestry, and delegates inspection to existing `forge options` commands.

## Fix
Adds a registry-backed `forge init` command, profile-backed `.forge/config.yaml` scaffolds for `minimal`, `standard`, and `full`, and a narrow `forge setup --minimal` shortcut that delegates to the minimal init profile. Adds docs and tests for clean-repo initialization and profile reference coverage.

## Value
Fresh repos can adopt Forge incrementally: config-only minimal adoption, standard graph defaults, or full explicit scaffolding, all inspectable with existing runtime graph tooling.

## Beads
Closes forge-fvh9
Closes forge-besw.5
Closes forge-6hzl
Closes forge-besw.14

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 3176 passing, 58 skipped with `bun test --timeout 60000`; focused adoption tests: 27 passing
- Scenarios covered: profile YAML generation, ancestry metadata, clean repo init without Beads, profile shortcuts, existing config preservation, setup minimal delegation, docs profile coverage

### Security Review
- OWASP Top 10: no auth, secrets, external network, or command execution surface added; writes are limited to `.forge/config.yaml` under the selected project root
- Automated scan: `bun audit` returned no vulnerabilities found

### Design Doc
See: `docs/work/2026-05-13-0.0.15-adoption-entrypoint/design.md`

### Key Decisions
- `forge init` is a registry command and writes only `.forge/config.yaml`.
- Profiles are data definitions over runtime primitives, not a separate workflow engine.
- Onboarding stays thin: default `--yes` uses `standard`; explicit shortcuts select profiles.
- Existing inspection remains `forge options lint/diff/stages`.

### Documentation Updated
- `docs/reference/TEMPLATES.md`
- `docs/guides/SETUP.md`
- `docs/INDEX.md`
- `docs/work/2026-05-13-0.0.15-adoption-entrypoint/*`

### Explicit Non-Scope
- Harness translator
- Adapter marketplace
- Upgrade or rollback
- Patch intent

### Validation
- [x] Type check passing: `bun run typecheck`
- [x] Lint passing (0 errors, 0 warnings): `bun run lint`
- [x] All tests passing: `bun test --timeout 60000`
- [x] Security review completed: `bun audit`

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff locally
- [x] No debug code, commented code, or temporary changes
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun test --timeout 60000`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes
- [x] TDD compliance: All source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add non-interactive init to generate inspectable adoption configs with three profiles (minimal, standard, full); supports profile shortcuts, --yes, --force, and --dry-run; setup gains profile flags that delegate to init.

* **Documentation**
  * New reference page for adoption templates; updated setup guide, index, and work docs with entrypoint, design, tasks, and usage guidance.

* **Tests**
  * Added tests for profiles, init/setup CLI behavior, docs coverage, and helper updates.

* **Chore**
  * Refined CLI output suppression for dry-run and non-interactive flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/163)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->