### PR TITLE
0.0.17 planning and memory loop

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -16,6 +16,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/.cline/workflows/plan.md
+++ b/.cline/workflows/plan.md
@@ -13,6 +13,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -16,6 +16,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -13,6 +13,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-04T13:59:18.806Z",
+  "generatedAt": "2026-05-16T10:24:53.855Z",
   "files": [
     ".cursor/commands/dev.md",
     ".cline/workflows/dev.md",

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -18,6 +18,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/.kilocode/workflows/plan.md
+++ b/.kilocode/workflows/plan.md
@@ -17,6 +17,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -16,6 +16,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/.roo/commands/plan.md
+++ b/.roo/commands/plan.md
@@ -17,6 +17,8 @@ Plan a feature from scratch: brainstorm design intent, research technical approa
 
 Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
 
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
 ---
 
 ```

--- a/docs/reference/TEMPLATES.md
+++ b/docs/reference/TEMPLATES.md
@@ -12,6 +12,43 @@ forge init --profile full --yes
 
 `forge init --yes` uses `standard`. `forge setup --minimal` is a shortcut for clean repositories that only need the minimal adoption config and do not want Beads or agent files installed yet.
 
+## Planning Template
+
+`/plan` is represented as a configurable planning template in the runtime graph. The default template runs the full planning loop:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Projects can tune planning depth in `.forge/config.yaml` without introducing another planner-specific config file:
+
+```yaml
+planning:
+  template:
+    mode: partial
+    convergenceThreshold: 0.8
+    criticSet:
+      - spec
+      - security
+    partialInvocation:
+      only:
+        - plan.parallel_critics
+      skip:
+        - plan.parallel_research
+```
+
+Inspect the resolved behavior with:
+
+```bash
+forge options why plan.parallel_critics
+forge options diff
+forge options lint
+```
+
+Invalid planning modes, thresholds outside `0..1`, blank critics, and unknown planning sub-skills fail through `forge options lint`.
+
 ## Profiles
 
 | Profile | Purpose | Output |

--- a/docs/reference/TOOLCHAIN.md
+++ b/docs/reference/TOOLCHAIN.md
@@ -140,6 +140,24 @@ See the script help for explicit path overrides:
 bash scripts/beads-migrate-to-dolt.sh --help
 ```
 
+### Project Memory
+
+Forge project memory uses Beads as the durable store. Compatibility helpers in `lib/project-memory.js` route writes to `bd remember --key <key>`, reads to `bd recall <key> --json`, and search/list operations to `bd memories --json`.
+
+Typed memory helpers in `lib/memory/typed-api.js` add category and provenance conventions, but they do not create a new datastore. The supported categories are:
+
+| Category | Key prefix | Durable backend |
+| --- | --- | --- |
+| decisions | `decisions:` | Beads memory index for canonical docs/plans decisions |
+| episodes | `episodes:` | Beads-backed memory/audit context |
+| skills | `skills:` | Beads memory index for skill references |
+| state | `state:` | Forge-owned state references |
+| issues | `issues:` | Beads issue references |
+| audit | `audit:` | Beads-backed audit references |
+| preferences | `preferences:` | Beads memory preferences |
+
+Every typed write must include provenance fields: `actor`, `reason`, and `source`. If `bd` is missing or returns malformed JSON, Forge surfaces the Beads command failure instead of falling back to local JSONL files.
+
 ### Post-Upgrade Smoke Verification
 
 Run the repo smoke harness after upgrading:

--- a/docs/work/2026-05-16-0-0-17-planning-memory/decisions.md
+++ b/docs/work/2026-05-16-0-0-17-planning-memory/decisions.md
@@ -1,0 +1,23 @@
+# 0.0.17 Planning And Memory Loop Decisions
+
+Score uses the `/dev` decision-gate rubric: numerator is the summed risk score, denominator is the 14-point maximum.
+
+## Decision 1
+
+Date: 2026-05-16
+Task: Task 1 - Planning Template Runtime Graph
+Gap: `forge-besw.24` is closed as docs-only in Beads, but this PR needs runnable/configurable behavior.
+Score: 2/14
+Route: PROCEED
+Choice made: Implement the runnable/configurable slice in `lib/core/runtime-graph.js`, using the existing `.forge/config.yaml` resolver.
+Status: RESOLVED
+
+## Decision 2
+
+Date: 2026-05-16
+Task: Task 2 - Beads-Backed Project Memory
+Gap: Existing public imports may require `lib/project-memory.js`; deleting it outright risks a compatibility break.
+Score: 3/14
+Route: PROCEED
+Choice made: Preserve the module as a compatibility adapter, but remove local JSONL persistence and route to Beads commands.
+Status: RESOLVED

--- a/docs/work/2026-05-16-0-0-17-planning-memory/design.md
+++ b/docs/work/2026-05-16-0-0-17-planning-memory/design.md
@@ -1,0 +1,54 @@
+# 0.0.17 Planning And Memory Loop
+
+Date: 2026-05-16
+Status: Implementation ready
+Branch: `codex/0.0.17-planning-memory`
+
+## Issues Covered
+
+- `forge-besw.24`: configurable planning skill template, using the landed runtime graph/config surfaces.
+- `forge-besw.19`: route project memory through Beads `bd remember`, `bd recall`, and `bd memories`.
+- `forge-besw.22`: typed memory API only where it prevents ad hoc Beads memory calls.
+
+## Purpose
+
+0.0.17 connects the v3 planning template to runtime graph configuration and moves durable project memory away from Forge-owned JSONL storage. The result should make planning depth and sub-skill behavior inspectable through `forge options`, while memory writes and reads use Beads as the durable store.
+
+## Success Criteria
+
+- Runtime graph exposes planning sub-skills and planning template defaults.
+- `.forge/config.yaml` can configure planning template behavior without a separate config reader.
+- Invalid planning config fails through `forge options lint` with clear errors.
+- Project memory compatibility calls route to `bd remember`, `bd recall`, and `bd memories`.
+- Typed memory helpers enforce category and provenance before writing.
+- Tests cover planning template config, Beads memory write/read/search behavior, and failure modes.
+- Docs explain the planning/memory loop and the Beads-backed storage boundary.
+
+## Out Of Scope
+
+- Upgrade dry-run implementation.
+- Lockfile or trust policy implementation.
+- Rollback implementation.
+- Patch intent implementation.
+- Replacing Beads itself or introducing a new datastore.
+
+## Approach Selected
+
+Extend the existing runtime graph config resolver in `lib/core/runtime-graph.js` with a `planning` config section and first-class planning sub-skill actions. This keeps planning configurability in the same inspectable surface that already powers `forge options`.
+
+Replace `lib/project-memory.js` internals with a small Beads adapter while preserving the public `read`, `write`, `search`, and `list` compatibility surface. Add a typed API in `lib/memory/typed-api.js` so future callers do not hand-roll key prefixes, category validation, or provenance payloads.
+
+## Constraints
+
+- Do not add a new persistent memory file.
+- Do not depend on the caller shell for quoting; use `execFileSync` or injected runners with argument arrays.
+- Keep Windows behavior deterministic.
+- Keep tests independent from the real Beads database by using injected runners.
+
+## Failure Modes
+
+- Missing `bd`: memory calls return or throw clear Beads command errors.
+- Invalid `bd` JSON: parser reports the command whose output could not be parsed.
+- Invalid planning config: `lintRuntimeGraphConfig` returns structured errors and `getResolvedRuntimeGraph` throws.
+- Missing memory key: `read` returns `null`, matching the existing compatibility shape.
+

--- a/docs/work/2026-05-16-0-0-17-planning-memory/tasks.md
+++ b/docs/work/2026-05-16-0-0-17-planning-memory/tasks.md
@@ -1,0 +1,34 @@
+# 0.0.17 Planning And Memory Loop Tasks
+
+## Task 1: Planning Template Runtime Graph
+
+RED: Add tests proving planning sub-skills and template defaults exist in the runtime graph, and that `.forge/config.yaml` can override allowed planning template settings.
+
+GREEN: Extend the runtime graph model and config resolver for planning template configuration.
+
+REFACTOR: Keep config validation helpers small and consistent with existing workflow/adapters validation.
+
+## Task 2: Beads-Backed Project Memory
+
+RED: Replace JSONL storage expectations with tests proving `write`, `read`, `search`, and `list` invoke `bd remember`, `bd recall`, and `bd memories`.
+
+GREEN: Rework `lib/project-memory.js` as a Beads-backed compatibility adapter with injectable command runner support.
+
+REFACTOR: Normalize Beads JSON parsing and errors without adding storage.
+
+## Task 3: Typed Memory API
+
+RED: Add tests for category validation, required provenance, key prefixes, and Beads routing.
+
+GREEN: Add a thin typed memory API that delegates to project memory and stores category/provenance metadata in the Beads memory payload.
+
+REFACTOR: Export only small, explicit category helpers plus generic typed read/search helpers.
+
+## Task 4: Docs And Command Surface
+
+RED: Add docs tests or focused assertions for the new planning/memory loop wording if existing doc tests cover command docs.
+
+GREEN: Update user-facing docs to explain planning config and Beads-backed memory behavior.
+
+REFACTOR: Keep docs short, with non-scope and failure modes visible.
+

--- a/lib/adoption-profiles.js
+++ b/lib/adoption-profiles.js
@@ -1,7 +1,7 @@
 const YAML = require('yaml');
 
 const ADOPTION_VERSION = '0.0.15';
-const RUNTIME_ANCESTRY = 'forge.runtimeGraph.currentCommandFlow@0.0.12';
+const RUNTIME_ANCESTRY = 'forge.runtimeGraph.currentCommandFlow@0.0.17';
 const WORKFLOW_PHASES = Object.freeze(['plan', 'dev', 'validate', 'ship']);
 const WORKFLOW_GATES = Object.freeze(['gate.plan-exit', 'gate.dev-exit', 'gate.validate-exit', 'gate.ship-entry']);
 

--- a/lib/commands/options.js
+++ b/lib/commands/options.js
@@ -47,6 +47,7 @@ function allPrimitiveEntries(graph) {
     ...graph.artifacts.map(item => ['artifact', item]),
     ...graph.evaluatorRegions.map(item => ['evaluatorRegion', item]),
     ...graph.evidence.map(item => ['evidence', item]),
+    ...(graph.planning?.subSkills ?? []).map(item => ['planningSubSkill', item]),
   ];
 }
 
@@ -97,6 +98,15 @@ function collectDiff(defaultGraph, resolvedGraph) {
       field: 'patterns',
       before: defaultGraph.protectedPaths,
       after: resolvedGraph.protectedPaths,
+    });
+  }
+  if (JSON.stringify(defaultGraph.planning?.template) !== JSON.stringify(resolvedGraph.planning?.template)) {
+    changes.push({
+      collection: 'planning',
+      id: 'planning.template',
+      field: 'config',
+      before: defaultGraph.planning?.template,
+      after: resolvedGraph.planning?.template,
     });
   }
   return changes;

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -4,12 +4,12 @@ const fs = require('node:fs');
 const path = require('node:path');
 const YAML = require('yaml');
 
-const RUNTIME_GRAPH_SCHEMA_VERSION = '0.0.12';
+const RUNTIME_GRAPH_SCHEMA_VERSION = '0.0.17';
 const CONFIG_SOURCE = '.forge/config.yaml';
 
 const RUNTIME_GRAPH_SCHEMA = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://forge.local/schemas/runtime-graph-0.0.12.json',
+  $id: 'https://forge.local/schemas/runtime-graph-0.0.17.json',
   title: 'Forge Runtime Graph Artifact',
   type: 'object',
   required: ['schemaVersion', 'kind', 'schema', 'graph'],
@@ -80,6 +80,83 @@ function Adapter({ id, kind, label, config = {}, enabled = true }) {
   return withRuntimeState({ id, kind, label, config }, { enabled });
 }
 
+function PlanningSubSkill({ id, label, inputs, outputs, evidence, gate, enabled = true }) {
+  return withRuntimeState({ id, label, inputs, outputs, evidence, gate }, { enabled });
+}
+
+const PLAN_SUBSKILL_DEFINITIONS = [
+  {
+    id: 'plan.intent_capture',
+    label: 'Intent capture',
+    inputs: ['feature request', 'constraints'],
+    outputs: ['purpose', 'success criteria', 'out of scope'],
+    actionLabel: 'Capture planning intent',
+    reads: [],
+    writes: ['artifact.design-doc'],
+  },
+  {
+    id: 'plan.parallel_research',
+    label: 'Parallel research',
+    inputs: ['intent capture'],
+    outputs: ['technical approach options', 'risk notes'],
+    actionLabel: 'Research planning options',
+    reads: ['artifact.design-doc'],
+    writes: ['artifact.design-doc'],
+  },
+  {
+    id: 'plan.parallel_critics',
+    label: 'Parallel critics',
+    inputs: ['approach options'],
+    outputs: ['spec critique', 'risk critique', 'test critique'],
+    actionLabel: 'Critique planning options',
+    reads: ['artifact.design-doc'],
+    writes: ['artifact.design-doc'],
+  },
+  {
+    id: 'plan.synthesis',
+    label: 'Synthesis',
+    inputs: ['research', 'critic output'],
+    outputs: ['selected approach', 'tradeoffs'],
+    actionLabel: 'Synthesize selected plan',
+    reads: ['artifact.design-doc'],
+    writes: ['artifact.design-doc'],
+  },
+  {
+    id: 'plan.final_lock',
+    label: 'Final lock',
+    inputs: ['selected approach'],
+    outputs: ['design doc', 'task list'],
+    actionLabel: 'Lock planning artifacts',
+    reads: ['artifact.design-doc'],
+    writes: ['artifact.design-doc', 'artifact.task-list'],
+  },
+];
+
+const PLAN_SUBSKILL_IDS = new Set(PLAN_SUBSKILL_DEFINITIONS.map(definition => definition.id));
+
+function planningSubSkillFromDefinition(definition) {
+  return PlanningSubSkill({
+    id: definition.id,
+    label: definition.label,
+    inputs: definition.inputs,
+    outputs: definition.outputs,
+    evidence: ['evidence.command-docs'],
+    gate: 'gate.plan-exit',
+  });
+}
+
+function planningActionFromDefinition(definition) {
+  return Action({
+    id: `action.${definition.id}`,
+    kind: 'plan-subskill',
+    command: definition.id,
+    label: definition.actionLabel,
+    reads: definition.reads,
+    writes: definition.writes,
+    evidence: ['evidence.command-docs'],
+  });
+}
+
 const RESOLVED_RUNTIME_GRAPH = {
   id: 'forge.runtimeGraph.currentCommandFlow',
   version: RUNTIME_GRAPH_SCHEMA_VERSION,
@@ -87,6 +164,7 @@ const RESOLVED_RUNTIME_GRAPH = {
   primitives: {
     Phase: 'phases',
     Action: 'actions',
+    PlanningSubSkill: 'planning.subSkills',
     Artifact: 'artifacts',
     EvaluatorRegion: 'evaluatorRegions',
     Gate: 'gates',
@@ -99,7 +177,7 @@ const RESOLVED_RUNTIME_GRAPH = {
       id: 'plan',
       label: '/plan',
       command: 'plan',
-      actions: ['action.plan.command'],
+      actions: PLAN_SUBSKILL_DEFINITIONS.map(definition => `action.${definition.id}`),
       artifacts: ['artifact.design-doc', 'artifact.task-list'],
       gates: ['gate.plan-exit'],
       evidence: ['evidence.command-docs'],
@@ -132,6 +210,19 @@ const RESOLVED_RUNTIME_GRAPH = {
       evidence: ['evidence.dry-run-report'],
     }),
   ],
+  planning: {
+    template: {
+      mode: 'full',
+      convergenceThreshold: 0.75,
+      criticSet: ['spec', 'risk', 'test'],
+      partialInvocation: {
+        only: [],
+        skip: [],
+      },
+      configSource: 'package-defaults',
+    },
+    subSkills: PLAN_SUBSKILL_DEFINITIONS.map(planningSubSkillFromDefinition),
+  },
   actions: [
     Action({
       id: 'action.plan.command',
@@ -141,6 +232,7 @@ const RESOLVED_RUNTIME_GRAPH = {
       writes: ['artifact.design-doc', 'artifact.task-list'],
       evidence: ['evidence.command-docs'],
     }),
+    ...PLAN_SUBSKILL_DEFINITIONS.map(planningActionFromDefinition),
     Action({
       id: 'action.dev.command',
       kind: 'command',
@@ -524,6 +616,112 @@ function applyAdapterConfig(graph, config, errors) {
   }
 }
 
+function assertStringList(value, errors, code, message) {
+  if (!Array.isArray(value)) {
+    errors.push({ code, message });
+    return false;
+  }
+
+  let valid = true;
+  for (const item of value) {
+    if (typeof item !== 'string' || item.trim() === '') {
+      errors.push({ code, message });
+      valid = false;
+      break;
+    }
+  }
+  return valid;
+}
+
+function validatePlanSubSkillList(value, errors, path) {
+  if (!assertStringList(
+    value,
+    errors,
+    'INVALID_PLAN_SUBSKILL_LIST',
+    `${path} must be a list of planning sub-skill IDs.`
+  )) {
+    return undefined;
+  }
+
+  const normalized = value.map(item => item.trim());
+  let hasUnknown = false;
+  for (const id of normalized) {
+    if (!PLAN_SUBSKILL_IDS.has(id)) {
+      hasUnknown = true;
+      errors.push({
+        code: 'UNKNOWN_PLAN_SUBSKILL',
+        message: `Unknown planning sub-skill '${id}' in ${CONFIG_SOURCE}.`,
+      });
+    }
+  }
+  if (hasUnknown) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function applyPlanningMode(template, nextTemplate, errors) {
+  if (!Object.hasOwn(template, 'mode')) return;
+  if (!['full', 'partial'].includes(template.mode)) {
+    errors.push({
+      code: 'INVALID_PLANNING_MODE',
+      message: 'planning.template.mode must be full or partial.',
+    });
+    return;
+  }
+  nextTemplate.mode = template.mode;
+}
+
+function applyConvergenceThreshold(template, nextTemplate, errors) {
+  if (!Object.hasOwn(template, 'convergenceThreshold')) return;
+  if (!Number.isFinite(template.convergenceThreshold)
+    || template.convergenceThreshold < 0
+    || template.convergenceThreshold > 1) {
+    errors.push({
+      code: 'INVALID_CONVERGENCE_THRESHOLD',
+      message: 'planning.template.convergenceThreshold must be a number from 0 to 1.',
+    });
+    return;
+  }
+  nextTemplate.convergenceThreshold = template.convergenceThreshold;
+}
+
+function applyCriticSet(template, nextTemplate, errors) {
+  if (!Object.hasOwn(template, 'criticSet')) return;
+  if (assertStringList(template.criticSet, errors, 'INVALID_CRITIC', 'planning.template.criticSet must contain non-empty strings.')) {
+    nextTemplate.criticSet = template.criticSet.map(item => item.trim());
+  }
+}
+
+function applyPartialInvocation(template, nextTemplate, errors) {
+  if (!Object.hasOwn(template, 'partialInvocation')) return;
+  const partial = readConfigSection(template, 'partialInvocation', errors, 'planning.template.partialInvocation');
+  if (Object.hasOwn(partial, 'only')) {
+    const only = validatePlanSubSkillList(partial.only, errors, 'planning.template.partialInvocation.only');
+    if (only) nextTemplate.partialInvocation.only = only;
+  }
+  if (Object.hasOwn(partial, 'skip')) {
+    const skip = validatePlanSubSkillList(partial.skip, errors, 'planning.template.partialInvocation.skip');
+    if (skip) nextTemplate.partialInvocation.skip = skip;
+  }
+}
+
+function applyPlanningConfig(graph, config, errors) {
+  const planning = readConfigSection(config, 'planning', errors, 'planning');
+  const template = readConfigSection(planning, 'template', errors, 'planning.template');
+  if (Object.keys(template).length === 0) {
+    return;
+  }
+
+  const nextTemplate = { ...graph.planning.template, partialInvocation: { ...graph.planning.template.partialInvocation } };
+  applyPlanningMode(template, nextTemplate, errors);
+  applyConvergenceThreshold(template, nextTemplate, errors);
+  applyCriticSet(template, nextTemplate, errors);
+  applyPartialInvocation(template, nextTemplate, errors);
+  nextTemplate.configSource = CONFIG_SOURCE;
+  graph.planning.template = nextTemplate;
+}
+
 function validateProtectedPaths(config, errors) {
   if (!Object.hasOwn(config, 'protectedPaths')) {
     return [];
@@ -567,6 +765,7 @@ function resolveRuntimeGraph({ projectRoot = process.cwd(), throwOnError = true 
     applyRailConfig(graph, loaded.config, errors);
     applyWorkflowConfig(graph, loaded.config, errors);
     applyAdapterConfig(graph, loaded.config, errors);
+    applyPlanningConfig(graph, loaded.config, errors);
     graph.protectedPaths = validateProtectedPaths(loaded.config, errors);
   }
 
@@ -621,6 +820,7 @@ module.exports = {
   Evidence,
   Rail,
   Adapter,
+  PlanningSubSkill,
   loadRuntimeGraphConfig,
   lintRuntimeGraphConfig,
   resolveRuntimeGraph,

--- a/lib/memory/typed-api.js
+++ b/lib/memory/typed-api.js
@@ -1,0 +1,102 @@
+const projectMemory = require('../project-memory');
+
+const CATEGORIES = new Set([
+  'decisions',
+  'episodes',
+  'skills',
+  'state',
+  'issues',
+  'audit',
+  'preferences',
+]);
+
+function assertCategory(category) {
+  if (!CATEGORIES.has(category)) {
+    throw new Error(`Unknown memory category: ${category}`);
+  }
+}
+
+function assertProvenance(provenance) {
+  if (!provenance || typeof provenance !== 'object') {
+    throw new TypeError('typed memory provenance is required');
+  }
+  for (const field of ['actor', 'reason', 'source']) {
+    if (typeof provenance[field] !== 'string' || provenance[field].trim() === '') {
+      throw new TypeError(`typed memory provenance.${field} is required`);
+    }
+  }
+}
+
+function keyFor(category, key) {
+  if (typeof key !== 'string' || key.trim() === '') {
+    throw new TypeError('typed memory key is required');
+  }
+  return `${category}:${key.trim()}`;
+}
+
+function adapter(options = {}) {
+  return options.memory ?? projectMemory;
+}
+
+function stringArrayOption(value, fieldName) {
+  if (value === undefined) return undefined;
+  const values = Array.isArray(value) ? value : [value];
+  if (values.some(item => typeof item !== 'string')) {
+    throw new TypeError(`typed memory ${fieldName} must contain only strings`);
+  }
+  return values.map(item => item.trim()).filter(Boolean);
+}
+
+function writeTyped(projectRoot, category, key, data, options = {}) {
+  assertCategory(category);
+  assertProvenance(options.provenance);
+
+  const provenance = {
+    actor: options.provenance.actor.trim(),
+    reason: options.provenance.reason.trim(),
+    source: options.provenance.source.trim(),
+  };
+
+  return adapter(options).write(projectRoot, {
+    key: keyFor(category, key),
+    value: {
+      category,
+      data,
+      provenance,
+    },
+    sourceAgent: provenance.actor,
+    tags: [category, ...(stringArrayOption(options.tags, 'tags') ?? [])],
+    beadsRefs: stringArrayOption(options.beadsRefs, 'beadsRefs'),
+  }, options);
+}
+
+function readTyped(projectRoot, category, key, options = {}) {
+  assertCategory(category);
+  return adapter(options).read(projectRoot, keyFor(category, key), options);
+}
+
+function searchTyped(projectRoot, category, query, options = {}) {
+  assertCategory(category);
+  const prefix = `${category}:`;
+  const results = adapter(options).search(projectRoot, `${category} ${query ?? ''}`.trim(), options) ?? [];
+  if (!Array.isArray(results)) return [];
+  return results.filter(entry => typeof entry?.key === 'string' && entry.key.startsWith(prefix));
+}
+
+function categoryWriter(category) {
+  return (projectRoot, key, data, options = {}) => writeTyped(projectRoot, category, key, data, options);
+}
+
+module.exports = {
+  CATEGORIES: [...CATEGORIES],
+  writeTyped,
+  readTyped,
+  searchTyped,
+  writeDecision: categoryWriter('decisions'),
+  writeEpisode: categoryWriter('episodes'),
+  writeSkill: categoryWriter('skills'),
+  writeState: categoryWriter('state'),
+  writeIssue: categoryWriter('issues'),
+  writeAudit: categoryWriter('audit'),
+  writePreference: categoryWriter('preferences'),
+};

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -1,329 +1,24 @@
-const fs = require('node:fs');
-const path = require('node:path');
-const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
 
-const DEFAULT_MEMORY_FILE = path.join('.forge', 'memory', 'entries.jsonl');
-const DEFAULT_LOCK_TIMEOUT_MS = 5000;
-const DEFAULT_LOCK_RETRY_MS = 10;
-const DEFAULT_DEAD_LOCK_GRACE_MS = 1000;
-const INVALID_LOCK_INITIALIZATION_BUFFER_MS = 1000;
+const EXEC_TIMEOUT = 30_000;
+const EXEC_MAX_BUFFER = 10 * 1024 * 1024;
 
-function assertInsideProjectRoot(root, targetPath) {
-  const relative = path.relative(root, targetPath);
-  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error('project memory filePath must stay within projectRoot');
-  }
+function defaultRunner(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.projectRoot,
+    encoding: 'utf8',
+    maxBuffer: options.maxBuffer ?? EXEC_MAX_BUFFER,
+    timeout: options.timeoutMs ?? EXEC_TIMEOUT,
+  });
 }
 
-function nearestExistingPath(targetPath) {
-  let current = targetPath;
-  while (!fs.existsSync(current)) {
-    const next = path.dirname(current);
-    if (next === current) break;
-    current = next;
-  }
-
-  return current;
-}
-
-function assertRealPathInsideProjectRoot(root, targetPath) {
-  const realRoot = fs.realpathSync.native(root);
-  const existingPath = fs.existsSync(targetPath)
-    ? targetPath
-    : nearestExistingPath(path.dirname(targetPath));
-  const realExistingPath = fs.realpathSync.native(existingPath);
-
-  if (realExistingPath === realRoot) {
-    return;
-  }
-
-  assertInsideProjectRoot(realRoot, realExistingPath);
-}
-
-function memoryPath(projectRoot, options = {}) {
-  const root = path.resolve(projectRoot);
-  if (!options.filePath) {
-    const defaultPath = path.join(root, DEFAULT_MEMORY_FILE);
-    assertRealPathInsideProjectRoot(root, defaultPath);
-    return defaultPath;
-  }
-
-  const candidate = path.isAbsolute(options.filePath)
-    ? options.filePath
-    : path.join(root, options.filePath);
-  const resolved = path.resolve(candidate);
-  assertInsideProjectRoot(root, resolved);
-  assertRealPathInsideProjectRoot(root, resolved);
-
-  return resolved;
-}
-
-function sleep(ms) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function isProcessAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    return err.code === 'EPERM';
-  }
-}
-
-function readLock(lockPath) {
-  try {
-    const lockStat = fs.statSync(lockPath);
-    const metadataPath = lockStat.isDirectory()
-      ? path.join(lockPath, 'owner.json')
-      : lockPath;
-    return JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
-  } catch (err) {
-    return {
-      pid: null,
-      createdAt: null,
-      invalid: true,
-      readError: err.message,
-    };
-  }
-}
-
-function lockPathAgeMs(lockPath) {
-  try {
-    return Date.now() - fs.statSync(lockPath).mtimeMs;
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      throw err;
-    }
-    return null;
-  }
-}
-
-function lockAgeMs(lock) {
-  const createdAt = Date.parse(lock?.createdAt);
-  if (Number.isNaN(createdAt)) return null;
-  return Date.now() - createdAt;
-}
-
-function isWithinGraceWindow(ageMs, graceMs) {
-  return ageMs !== null && Math.abs(ageMs) < graceMs;
-}
-
-function debugSuppressedLockError(message, err) {
-  if (process.env.FORGE_DEBUG_LOCKS) {
-    console.debug(`${message}: ${err.message}`);
-  }
-}
-
-function shouldKeepInvalidLock(lockPath, lock, options) {
-  if (!lock.invalid) {
-    return false;
-  }
-
-  const lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
-  const lockRetryMs = options.lockRetryMs ?? DEFAULT_LOCK_RETRY_MS;
-  const invalidLockGraceMs = lockTimeoutMs + Math.max(lockRetryMs, INVALID_LOCK_INITIALIZATION_BUFFER_MS);
-  const lockPathAge = lockPathAgeMs(lockPath);
-  return isWithinGraceWindow(lockPathAge, invalidLockGraceMs);
-}
-
-function shouldKeepDeadOwnerLock(lock, options) {
-  if (lock.invalid) {
-    return false;
-  }
-
-  const configuredGraceMs = options.deadLockGraceMs ?? DEFAULT_DEAD_LOCK_GRACE_MS;
-  const lockTimeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
-  const deadLockGraceMs = lockTimeoutMs <= configuredGraceMs ? 0 : configuredGraceMs;
-  const age = lockAgeMs(lock);
-  const tokenizedLock = typeof lock?.token === 'string' && lock.token !== '';
-  const tokenRecoveryGraceMs = Math.max(deadLockGraceMs, Math.floor(lockTimeoutMs * 0.9));
-
-  if (tokenizedLock && age !== null && age >= 0 && age < tokenRecoveryGraceMs) {
-    return true;
-  }
-
-  return age !== null && age >= 0 && age < deadLockGraceMs;
-}
-
-function removeLockPath(lockPath) {
-  try {
-    fs.lstatSync(lockPath);
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      return false;
-    }
-    debugSuppressedLockError(`project memory lock stat skipped for ${lockPath}`, err);
-    return false;
-  }
-
-  try {
-    fs.rmSync(lockPath, { recursive: true, force: true });
-    return true;
-  } catch (err) {
-    debugSuppressedLockError(`project memory lock cleanup skipped for ${lockPath}`, err);
-    return false;
-  }
-}
-
-function removeStaleLock(lockPath, options = {}) {
-  const lock = readLock(lockPath);
-  if (shouldKeepInvalidLock(lockPath, lock, options)) {
-    return false;
-  }
-
-  if (isProcessAlive(lock?.pid)) {
-    return false;
-  }
-
-  if (shouldKeepDeadOwnerLock(lock, options)) {
-    return false;
-  }
-
-  return removeLockPath(lockPath);
-}
-
-function isExistingLockError(err, lockPath) {
-  if (err.code === 'EEXIST' || err.code === 'EISDIR') {
-    return true;
-  }
-
-  if (err.code !== 'EPERM' && err.code !== 'EACCES') {
-    return false;
-  }
-
-  if (fs.existsSync(lockPath)) {
-    return true;
-  }
-
-  return err.path
-    && path.resolve(err.path) === path.resolve(lockPath)
-    && fs.existsSync(path.dirname(lockPath));
-}
-
-function cleanupCreatedLockFile(lockPath) {
-  try {
-    fs.unlinkSync(lockPath);
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      debugSuppressedLockError(`project memory lock init cleanup skipped for ${lockPath}`, err);
-    }
-  }
-}
-
-function closeLockFd(lockFd, lockPath) {
-  try {
-    fs.closeSync(lockFd);
-  } catch (err) {
-    debugSuppressedLockError(`project memory lock fd close failed for ${lockPath}`, err);
-    throw err;
-  }
-}
-
-function closeLockFdAfterFailure(lockFd, lockPath) {
-  try {
-    closeLockFd(lockFd, lockPath);
-  } catch (err) {
-    debugSuppressedLockError(`project memory lock fd close skipped after failure for ${lockPath}`, err);
-  }
-}
-
-function writeLockMetadata(lockFd, token) {
-  fs.writeFileSync(lockFd, JSON.stringify({
-    pid: process.pid,
-    createdAt: new Date().toISOString(),
-    token,
-  }), 'utf8');
-  fs.fsyncSync(lockFd);
-}
-
-function initializeLockFile(lockPath, token) {
-  const lockFd = fs.openSync(lockPath, 'wx');
-  try {
-    writeLockMetadata(lockFd, token);
-    closeLockFd(lockFd, lockPath);
-  } catch (err) {
-    closeLockFdAfterFailure(lockFd, lockPath);
-    cleanupCreatedLockFile(lockPath);
-    throw err;
-  }
-}
-
-function releaseLockFile(lockPath, token) {
-  const lock = readLock(lockPath);
-  if (!lock.invalid && lock.pid === process.pid && lock.token === token) {
-    fs.rmSync(lockPath, { force: true });
-  }
-}
-
-function acquireLock(filePath, options = {}) {
-  const lockPath = `${filePath}.lock`;
-  const timeoutMs = options.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
-  const retryMs = options.lockRetryMs ?? DEFAULT_LOCK_RETRY_MS;
-  const startedAt = Date.now();
-  const token = `${process.pid}-${Date.now()}-${crypto.randomUUID()}`;
-
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-
-  while (true) {
-    try {
-      initializeLockFile(lockPath, token);
-      return () => releaseLockFile(lockPath, token);
-    } catch (err) {
-      if (!isExistingLockError(err, lockPath)) {
-        throw err;
-      }
-      if (removeStaleLock(lockPath, options)) {
-        continue;
-      }
-      if (Date.now() - startedAt >= timeoutMs) {
-        throw err;
-      }
-      sleep(retryMs);
-    }
-  }
-}
-
-function toApiEntry(entry) {
-  const apiEntry = {
-    key: entry.key,
-    value: entry.value,
-    sourceAgent: entry['source-agent'],
-    timestamp: entry.timestamp,
-    tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
-  };
-
-  if (entry.scope !== undefined) apiEntry.scope = entry.scope;
-  if (entry.confidence !== undefined) apiEntry.confidence = entry.confidence;
-  if (entry.supersedes !== undefined) apiEntry.supersedes = [...entry.supersedes];
-  if (entry['beads-refs'] !== undefined) apiEntry.beadsRefs = [...entry['beads-refs']];
-
-  return apiEntry;
-}
-
-function toDiskEntry(entry) {
-  const diskEntry = {
-    key: entry.key,
-    value: entry.value,
-    'source-agent': entry.sourceAgent || entry['source-agent'],
-    timestamp: entry.timestamp || new Date().toISOString(),
-    tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
-  };
-
-  if (entry.scope !== undefined) diskEntry.scope = entry.scope;
-  if (entry.confidence !== undefined) diskEntry.confidence = entry.confidence;
-  if (entry.supersedes !== undefined) diskEntry.supersedes = [...entry.supersedes];
-  if (entry.beadsRefs !== undefined || entry['beads-refs'] !== undefined) {
-    diskEntry['beads-refs'] = [...(entry.beadsRefs || entry['beads-refs'])];
-  }
-
-  return diskEntry;
+function runBd(projectRoot, args, options = {}) {
+  const runner = options.runner ?? defaultRunner;
+  return runner('bd', args, { projectRoot, timeoutMs: options.timeoutMs, maxBuffer: options.maxBuffer });
 }
 
 function assertEntryObject(entry) {
-  if (!entry || typeof entry !== 'object') {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
     throw new TypeError('project memory entry must be an object');
   }
 }
@@ -335,234 +30,170 @@ function assertRequiredString(value, fieldName) {
 }
 
 function assertStringArray(value, fieldName) {
-  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
     throw new TypeError(`project memory entry ${fieldName} must be an array of strings`);
   }
 }
 
-function validateRequiredFields(entry) {
-  if (typeof entry.key !== 'string' || entry.key.trim() === '') {
-    throw new TypeError('project memory entry key is required');
+function assertOptionalConfidence(value) {
+  if (value !== undefined && (!Number.isFinite(value) || value < 0 || value > 1)) {
+    throw new TypeError('project memory entry confidence must be a number from 0 to 1');
   }
-  if (!Object.hasOwn(entry, 'value') || entry.value === undefined) {
-    throw new TypeError('project memory entry value is required');
-  }
-
-  const sourceAgent = entry.sourceAgent || entry['source-agent'];
-  assertRequiredString(sourceAgent, 'sourceAgent');
-}
-
-function validateTimestamp(entry) {
-  if (entry.timestamp !== undefined) {
-    const parsed = Date.parse(entry.timestamp);
-    if (typeof entry.timestamp !== 'string' || Number.isNaN(parsed)) {
-      throw new TypeError('project memory entry timestamp must be an ISO-compatible string');
-    }
-  }
-}
-
-function validateScope(entry) {
-  if (entry.scope !== undefined && (typeof entry.scope !== 'string' || entry.scope.trim() === '')) {
-    throw new TypeError('project memory entry scope must be a non-empty string');
-  }
-}
-
-function validateConfidence(entry) {
-  if (entry.confidence !== undefined) {
-    if (typeof entry.confidence !== 'number' || entry.confidence < 0 || entry.confidence > 1) {
-      throw new TypeError('project memory entry confidence must be a number from 0 to 1');
-    }
-  }
-}
-
-function validateOptionalArrays(entry) {
-  if (entry.tags !== undefined) assertStringArray(entry.tags, 'tags');
-  if (entry.supersedes !== undefined) assertStringArray(entry.supersedes, 'supersedes');
-  const beadsRefs = entry.beadsRefs || entry['beads-refs'];
-  if (beadsRefs !== undefined) assertStringArray(beadsRefs, 'beadsRefs');
 }
 
 function validateEntry(entry) {
   assertEntryObject(entry);
-  validateRequiredFields(entry);
-  validateTimestamp(entry);
-  validateScope(entry);
-  validateConfidence(entry);
-  validateOptionalArrays(entry);
+  assertRequiredString(entry.key, 'key');
+  if (!Object.hasOwn(entry, 'value') || entry.value === undefined) {
+    throw new TypeError('project memory entry value is required');
+  }
+  assertRequiredString(entry.sourceAgent || entry['source-agent'], 'sourceAgent');
+  if (entry.timestamp !== undefined
+    && (typeof entry.timestamp !== 'string' || Number.isNaN(Date.parse(entry.timestamp)))) {
+    throw new TypeError('project memory entry timestamp must be an ISO timestamp string');
+  }
+  if (entry.scope !== undefined && (typeof entry.scope !== 'string' || entry.scope.trim() === '')) {
+    throw new TypeError('project memory entry scope must be a non-empty string');
+  }
+  assertOptionalConfidence(entry.confidence);
+  if (entry.tags !== undefined) assertStringArray(entry.tags, 'tags');
+  if (entry.supersedes !== undefined) assertStringArray(entry.supersedes, 'supersedes');
+  if (entry.beadsRefs !== undefined) assertStringArray(entry.beadsRefs, 'beadsRefs');
+  if (entry['beads-refs'] !== undefined) assertStringArray(entry['beads-refs'], 'beads-refs');
 }
 
-function validateStoredEntry(entry) {
-  validateEntry(entry);
-  assertRequiredString(entry['source-agent'], 'source-agent');
-  assertStringArray(entry.tags, 'tags');
+function payloadFromEntry(entry) {
+  const payload = {
+    value: entry.value,
+    sourceAgent: entry.sourceAgent || entry['source-agent'],
+    tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
+  };
+
+  if (entry.timestamp !== undefined) payload.timestamp = entry.timestamp;
+  if (entry.scope !== undefined) payload.scope = entry.scope;
+  if (entry.confidence !== undefined) payload.confidence = entry.confidence;
+  if (entry.supersedes !== undefined) payload.supersedes = [...entry.supersedes];
+  if (entry.beadsRefs !== undefined || entry['beads-refs'] !== undefined) {
+    payload.beadsRefs = [...(entry.beadsRefs || entry['beads-refs'])];
+  }
+
+  return payload;
 }
 
-function readEntries(projectRoot, options = {}) {
-  const filePath = memoryPath(projectRoot, options);
-  if (!fs.existsSync(filePath)) {
-    return [];
+function entryFromPayload(key, payload = {}) {
+  const entry = {
+    key,
+    value: payload.value,
+    sourceAgent: payload.sourceAgent || payload['source-agent'],
+    tags: Array.isArray(payload.tags) ? [...payload.tags] : [],
+  };
+
+  if (payload.timestamp !== undefined) entry.timestamp = payload.timestamp;
+  if (payload.scope !== undefined) entry.scope = payload.scope;
+  if (payload.confidence !== undefined) entry.confidence = payload.confidence;
+  if (payload.supersedes !== undefined) entry.supersedes = [...payload.supersedes];
+  if (payload.beadsRefs !== undefined || payload['beads-refs'] !== undefined) {
+    entry.beadsRefs = [...(payload.beadsRefs || payload['beads-refs'])];
   }
 
-  const content = fs.readFileSync(filePath, 'utf8');
-  if (content.trim() === '') return [];
-
-  const hasTerminatingNewline = /\r?\n$/.test(content);
-  const lines = content.split(/\r?\n/);
-  if (hasTerminatingNewline && lines.at(-1) === '') {
-    lines.pop();
-  }
-
-  const entries = [];
-  lines.forEach((line, index) => {
-    const trailingIncompleteLine = !hasTerminatingNewline && index === lines.length - 1;
-    if (trailingIncompleteLine) return;
-
-    let parsed;
-    try {
-      parsed = JSON.parse(line);
-    } catch (err) {
-      if (trailingIncompleteLine) return;
-      throw new Error(`invalid project memory JSONL at line ${index + 1}: ${err.message}`);
-    }
-    try {
-      validateStoredEntry(parsed);
-    } catch (err) {
-      if (trailingIncompleteLine) return;
-      throw new Error(`invalid project memory entry at line ${index + 1}: ${err.message}`);
-    }
-    entries.push(parsed);
-  });
-
-  return dedupeEntries(entries);
+  return entry;
 }
 
-function dedupeEntries(entries) {
-  const positions = new Map();
-  const deduped = [];
-
-  for (const entry of entries) {
-    const existingIndex = positions.get(entry.key);
-    if (existingIndex === undefined) {
-      positions.set(entry.key, deduped.length);
-      deduped.push(entry);
-    } else {
-      deduped[existingIndex] = entry;
-    }
-  }
-
-  return deduped;
-}
-
-function writeAllSync(fd, buffer) {
-  let offset = 0;
-  while (offset < buffer.length) {
-    offset += fs.writeSync(fd, buffer, offset, buffer.length - offset);
-  }
-}
-
-function normalizeJsonlTail(filePath) {
-  if (!fs.existsSync(filePath)) {
-    return false;
-  }
-
-  const content = fs.readFileSync(filePath, 'utf8');
-  if (content === '' || /\r?\n$/.test(content)) {
-    return false;
-  }
-
-  const lastLineStart = Math.max(content.lastIndexOf('\n'), content.lastIndexOf('\r')) + 1;
-  fs.truncateSync(filePath, Buffer.byteLength(content.slice(0, lastLineStart), 'utf8'));
-  return false;
-}
-
-function appendEntry(projectRoot, entry, options = {}) {
-  const filePath = memoryPath(projectRoot, options);
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-
-  const needsLineBreak = normalizeJsonlTail(filePath);
-  const record = Buffer.from(`${needsLineBreak ? '\n' : ''}${JSON.stringify(entry)}\n`, 'utf8');
-  const rollbackSize = fs.existsSync(filePath) ? fs.statSync(filePath).size : 0;
-  const fd = fs.openSync(filePath, 'a');
-  let fdClosed = false;
+function parseJsonOutput(commandName, output) {
+  const text = String(output ?? '').trim();
+  if (text === '') return null;
   try {
-    writeAllSync(fd, record);
-    fs.fsyncSync(fd);
+    return JSON.parse(text);
   } catch (err) {
-    try {
-      fs.closeSync(fd);
-      fdClosed = true;
-    } catch (_rollbackCloseErr) {
-      // Preserve the original append/fsync error.
-    }
-    try {
-      fs.truncateSync(filePath, rollbackSize);
-    } catch (_rollbackErr) {
-      // Preserve the original append/fsync error.
-    }
-    throw err;
-  } finally {
-    if (!fdClosed) {
-      fs.closeSync(fd);
-    }
+    throw new Error(`Invalid ${commandName} JSON: ${err.message}`);
   }
 }
 
-function list(projectRoot, options = {}) {
-  return readEntries(projectRoot, options).map(toApiEntry);
+function tryParseJsonOutput(output) {
+  const text = String(output ?? '').trim();
+  if (text === '') return { ok: true, value: null };
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    return { ok: false, text };
+  }
 }
 
-function read(projectRoot, key, options = {}) {
-  if (typeof key !== 'string' || key.trim() === '') {
-    throw new Error('project memory read key is required');
-  }
-  const normalizedKey = key.trim();
+function parseMemoryRecord(record, fallbackKey) {
+  if (!record) return null;
+  if (record.found === false) return null;
 
-  const entry = readEntries(projectRoot, options).find((candidate) => candidate.key === normalizedKey);
-  return entry ? toApiEntry(entry) : null;
+  const key = record.key || fallbackKey;
+  const content = record.content ?? record.value ?? record.memory ?? record.insight;
+  if (typeof content === 'string') {
+    const trimmed = content.trim();
+    if (trimmed.startsWith('{')) {
+      const parsedContent = tryParseJsonOutput(trimmed);
+      if (parsedContent.ok) {
+        return entryFromPayload(key, parsedContent.value);
+      }
+    }
+    return entryFromPayload(key, {
+      value: content,
+      sourceAgent: record.sourceAgent || record.actor || 'bd',
+      tags: Array.isArray(record.tags) ? record.tags : [],
+    });
+  }
+
+  if (content && typeof content === 'object') {
+    return entryFromPayload(key, content);
+  }
+
+  return entryFromPayload(key, {
+    value: record.value,
+    sourceAgent: record.sourceAgent || record.actor || 'bd',
+    tags: Array.isArray(record.tags) ? record.tags : [],
+  });
 }
 
 function write(projectRoot, entry, options = {}) {
   validateEntry(entry);
-  const filePath = memoryPath(projectRoot, options);
-  const releaseLock = acquireLock(filePath, options);
-
-  try {
-    const normalized = toDiskEntry({
-      ...entry,
-      key: entry.key.trim(),
-      sourceAgent: (entry.sourceAgent || entry['source-agent']).trim(),
-      tags: entry.tags || [],
-    });
-
-    appendEntry(projectRoot, normalized, options);
-    return toApiEntry(normalized);
-  } finally {
-    releaseLock();
-  }
+  const key = entry.key.trim();
+  const payload = payloadFromEntry({
+    ...entry,
+    key,
+    timestamp: entry.timestamp ?? new Date().toISOString(),
+  });
+  runBd(projectRoot, ['remember', JSON.stringify(payload), '--key', key], options);
+  return entryFromPayload(key, payload);
 }
 
-function searchableText(entry) {
-  return [
-    entry.key,
-    JSON.stringify(entry.value),
-    entry['source-agent'],
-    entry.scope,
-    String(entry.confidence ?? ''),
-    ...(Array.isArray(entry.tags) ? entry.tags : []),
-    ...(Array.isArray(entry.supersedes) ? entry.supersedes : []),
-    ...(Array.isArray(entry['beads-refs']) ? entry['beads-refs'] : []),
-  ].join('\n').toLowerCase();
+function read(projectRoot, key, options = {}) {
+  assertRequiredString(key, 'read key');
+  const normalizedKey = key.trim();
+  const output = runBd(projectRoot, ['recall', normalizedKey, '--json'], options);
+  const parsedOutput = tryParseJsonOutput(output);
+  const parsed = parsedOutput.ok ? parsedOutput.value : { key: normalizedKey, content: parsedOutput.text };
+  return parseMemoryRecord(parsed, normalizedKey);
+}
+
+function entriesFromMemoriesOutput(output) {
+  const parsed = parseJsonOutput('bd memories', output);
+  if (parsed === null) return [];
+  let rows = Array.isArray(parsed) ? parsed : (parsed.memories || parsed.items);
+  if (!rows && typeof parsed === 'object') {
+    rows = Object.entries(parsed)
+      .filter(([key]) => key !== 'schema_version')
+      .map(([key, value]) => ({ key, value }));
+  }
+  if (!Array.isArray(rows)) return [];
+  return rows.map(row => parseMemoryRecord(row, row.key)).filter(Boolean);
 }
 
 function search(projectRoot, query, options = {}) {
   if (typeof query !== 'string' || query.trim() === '') {
     return [];
   }
+  return entriesFromMemoriesOutput(runBd(projectRoot, ['memories', query.trim(), '--json'], options));
+}
 
-  const needle = query.trim().toLowerCase();
-  return readEntries(projectRoot, options)
-    .filter((entry) => searchableText(entry).includes(needle))
-    .map(toApiEntry);
+function list(projectRoot, options = {}) {
+  return entriesFromMemoriesOutput(runBd(projectRoot, ['memories', '--json'], options));
 }
 
 module.exports = {

--- a/test/adoption-profiles.test.js
+++ b/test/adoption-profiles.test.js
@@ -39,7 +39,7 @@ describe('adoption profiles', () => {
     for (const config of configs) {
       expect(config.template.kind).toBe('forge.adoptionTemplate');
       expect(config.template.version).toBe('0.0.15');
-      expect(config.template.ancestry).toContain('forge.runtimeGraph.currentCommandFlow@0.0.12');
+      expect(config.template.ancestry).toContain('forge.runtimeGraph.currentCommandFlow@0.0.17');
     }
   });
 

--- a/test/migrate-dry-run.test.js
+++ b/test/migrate-dry-run.test.js
@@ -153,7 +153,7 @@ describe('migrate dry-run', () => {
     expect(report.runtimeGraph.kind).toBe('forge.runtimeGraph');
     expect(output).toContain('Runtime graph');
     expect(output).toContain('Phases: plan -> dev -> validate -> ship');
-    expect(output).toContain('Actions: action.plan.command, action.dev.command, action.validate.command, action.ship.command');
+    expect(output).toContain('Actions: action.plan.command, action.plan.intent_capture, action.plan.parallel_research, action.plan.parallel_critics, action.plan.synthesis, action.plan.final_lock, action.dev.command, action.validate.command, action.ship.command');
     expect(output).toContain(
       'Artifacts: artifact.design-doc, artifact.task-list, artifact.changed-files, artifact.validation-output, artifact.pull-request'
     );

--- a/test/options-command.test.js
+++ b/test/options-command.test.js
@@ -81,6 +81,15 @@ protectedPaths:
     expect(parsed.item.requires).toContain('artifact.validation-output');
   });
 
+  test('explains planning sub-skill primitives', async () => {
+    const result = await run(['why', 'plan.parallel_critics', '--json']);
+    const parsed = JSON.parse(result.output);
+
+    expect(result.success).toBe(true);
+    expect(parsed.type).toBe('planningSubSkill');
+    expect(parsed.item.id).toBe('plan.parallel_critics');
+  });
+
   test('why --json reports unknown primitives as parseable JSON', async () => {
     const result = await run(['why', 'gate.nope', '--json']);
     const parsed = JSON.parse(result.output);
@@ -114,6 +123,20 @@ workflow:
       before: true,
       after: false,
     }));
+  });
+
+  test('diff reports planning template config changes', async () => {
+    const projectRoot = makeProject(`
+planning:
+  template:
+    mode: partial
+    convergenceThreshold: 0.8
+`);
+
+    const result = await run(['diff'], projectRoot);
+
+    expect(result.output).toContain('planning.template.config');
+    expect(result.output).toContain('"mode":"partial"');
   });
 
   test('lint reports invalid config as JSON and human output', async () => {

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -1,994 +1,167 @@
-const { describe, test, expect, afterEach } = require('bun:test');
-const { spawn } = require('node:child_process');
-const fs = require('node:fs');
-const os = require('node:os');
-const path = require('node:path');
+const { describe, test, expect } = require('bun:test');
 
 const projectMemory = require('../lib/project-memory');
 
-const tempRoots = [];
-const workerModulePath = path.resolve(__dirname, '..', 'lib', 'project-memory');
-
-function tempRoot() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-project-memory-'));
-  tempRoots.push(root);
-  return root;
+function runner(responses = {}) {
+  const calls = [];
+  return {
+    calls,
+    run(command, args) {
+      calls.push({ command, args });
+      const key = `${command} ${args.join(' ')}`;
+      if (responses[key] instanceof Error) {
+        throw responses[key];
+      }
+      return responses[key] ?? '{}';
+    },
+  };
 }
 
-function delay(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
+describe('project memory Beads adapter', () => {
+  test('writes entries with bd remember and a stable key', () => {
+    const beads = runner({
+      'bd remember {"value":"Use Beads for durable memory.","sourceAgent":"Codex","tags":["memory"],"timestamp":"2026-05-16T10:00:00.000Z","scope":"project"} --key policy.memory': '{"key":"policy.memory","value":"stored"}',
+    });
 
-async function waitForSearchCount(root, query, expectedCount, timeoutMs = 5_000) {
-  const deadline = Date.now() + timeoutMs;
-  let results;
-  do {
-    results = projectMemory.search(root, query);
-    if (results.length === expectedCount) {
-      return results;
-    }
-    await delay(25);
-  } while (Date.now() < deadline);
-
-  return results;
-}
-
-afterEach(() => {
-  for (const root of tempRoots.splice(0)) {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
-describe('project memory', () => {
-  test('writes entries to the default .forge/memory JSONL file and reads them back', () => {
-    const root = tempRoot();
-
-    const entry = projectMemory.write(root, {
-      key: 'policy.stage-order',
-      value: 'Run /plan before /dev for standard feature work.',
+    const entry = projectMemory.write(process.cwd(), {
+      key: 'policy.memory',
+      value: 'Use Beads for durable memory.',
       sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['policy', 'workflow'],
+      tags: ['memory'],
+      timestamp: '2026-05-16T10:00:00.000Z',
       scope: 'project',
-      confidence: 0.95,
-      beadsRefs: ['forge-xdh7', 'forge-f3lx'],
-    });
-
-    expect(entry).toEqual({
-      key: 'policy.stage-order',
-      value: 'Run /plan before /dev for standard feature work.',
-      sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['policy', 'workflow'],
-      scope: 'project',
-      confidence: 0.95,
-      beadsRefs: ['forge-xdh7', 'forge-f3lx'],
-    });
-
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    expect(fs.existsSync(memoryFile)).toBe(true);
-    const lines = fs.readFileSync(memoryFile, 'utf8').trim().split('\n');
-    expect(lines).toHaveLength(1);
-    expect(JSON.parse(lines[0])).toMatchObject({
-      key: 'policy.stage-order',
-      'source-agent': 'Codex',
-      'beads-refs': ['forge-xdh7', 'forge-f3lx'],
-    });
-    expect(projectMemory.read(root, 'policy.stage-order')).toEqual(entry);
-    expect(projectMemory.list(root)).toEqual([entry]);
-  });
-
-  test('upserts entries by key without duplicating previous decisions', () => {
-    const root = tempRoot();
-
-    projectMemory.write(root, {
-      key: 'preference.agent-surface',
-      value: 'Support Claude and Codex first.',
-      sourceAgent: 'Claude',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['preference'],
-    });
-    projectMemory.write(root, {
-      key: 'preference.agent-surface',
-      value: 'Support Claude, Cursor, Codex, Cline, and OpenCode.',
-      sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:01:00.000Z',
-      tags: ['preference', 'agents'],
-    });
-
-    expect(projectMemory.list(root)).toHaveLength(1);
-    expect(projectMemory.read(root, 'preference.agent-surface')).toMatchObject({
-      value: 'Support Claude, Cursor, Codex, Cline, and OpenCode.',
-      sourceAgent: 'Codex',
-      tags: ['preference', 'agents'],
-    });
-  });
-
-  test('normalizes read keys before lookup', () => {
-    const root = tempRoot();
-
-    projectMemory.write(root, {
-      key: ' preference.trimmed-read ',
-      value: 'read callers may pass padded keys',
-      sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['preference'],
-    });
-
-    expect(projectMemory.read(root, ' preference.trimmed-read ')).toMatchObject({
-      key: 'preference.trimmed-read',
-      value: 'read callers may pass padded keys',
-    });
-  });
-
-  test('deduplicates all existing records for a key during upsert', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(memoryFile, [
-      JSON.stringify({
-        key: 'decision.duplicate',
-        value: 'stale manual merge copy',
-        'source-agent': 'Claude',
-        timestamp: '2026-04-26T00:00:00.000Z',
-        tags: ['stale'],
-      }),
-      JSON.stringify({
-        key: 'decision.keep',
-        value: 'unrelated entry',
-        'source-agent': 'Cursor',
-        timestamp: '2026-04-26T00:01:00.000Z',
-        tags: ['keep'],
-      }),
-      JSON.stringify({
-        key: 'decision.duplicate',
-        value: 'second stale manual merge copy',
-        'source-agent': 'Codex',
-        timestamp: '2026-04-26T00:02:00.000Z',
-        tags: ['stale'],
-      }),
-    ].join('\n') + '\n', 'utf8');
-
-    projectMemory.write(root, {
-      key: 'decision.duplicate',
-      value: 'current value',
-      sourceAgent: 'OpenCode',
-      timestamp: '2026-04-26T00:03:00.000Z',
-      tags: ['current'],
-    });
-
-    expect(projectMemory.list(root).map((entry) => entry.key)).toEqual([
-      'decision.duplicate',
-      'decision.keep',
-    ]);
-    expect(projectMemory.search(root, 'stale')).toEqual([]);
-    expect(projectMemory.read(root, 'decision.duplicate')).toMatchObject({
-      value: 'current value',
-      sourceAgent: 'OpenCode',
-      tags: ['current'],
-    });
-  });
-
-  test('searches keys, string values, source agents, and tags case-insensitively', () => {
-    const root = tempRoot();
-
-    projectMemory.write(root, {
-      key: 'decision.memory-format',
-      value: { format: 'json', directory: '.forge/memory' },
-      sourceAgent: 'Cursor',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['decision', 'memory'],
-    });
-    projectMemory.write(root, {
-      key: 'policy.issue-tracking',
-      value: 'Memory complements Beads and does not replace issue lifecycle state.',
-      sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:01:00.000Z',
-      tags: ['policy', 'beads'],
-    });
-
-    expect(projectMemory.search(root, 'json')).toHaveLength(1);
-    expect(projectMemory.search(root, 'BEADS')[0].key).toBe('policy.issue-tracking');
-    expect(projectMemory.search(root, 'cursor')[0].key).toBe('decision.memory-format');
-    expect(projectMemory.search(root, 'memory')).toHaveLength(2);
-  });
-
-  test('searches optional shared-memory metadata fields', () => {
-    const root = tempRoot();
-
-    projectMemory.write(root, {
-      key: 'decision.canonical-store',
-      value: 'Forge memory is canonical; agent-native stores are caches or adapters.',
-      sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['decision'],
-      scope: 'repo',
-      confidence: 1,
-      supersedes: ['decision.agent-private-memory'],
-      beadsRefs: ['forge-xdh7'],
-    });
-
-    expect(projectMemory.search(root, 'repo')[0].key).toBe('decision.canonical-store');
-    expect(projectMemory.search(root, 'forge-xdh7')[0].key).toBe('decision.canonical-store');
-    expect(projectMemory.search(root, 'agent-private')[0].key).toBe('decision.canonical-store');
-  });
-
-  test('resolves relative filePath overrides from the project root', () => {
-    const root = tempRoot();
-    const originalCwd = process.cwd();
-    const overridePath = path.join('.forge', 'memory', `${path.basename(root)}-custom.jsonl`);
-
-    try {
-      process.chdir(os.tmpdir());
-      projectMemory.write(root, {
-        key: 'decision.relative-override',
-        value: 'Relative override paths stay project-scoped.',
-        sourceAgent: 'Codex',
-        timestamp: '2026-04-26T00:00:00.000Z',
-        tags: ['paths'],
-      }, {
-        filePath: overridePath,
-      });
-    } finally {
-      process.chdir(originalCwd);
-    }
-
-    expect(fs.existsSync(path.join(root, overridePath))).toBe(true);
-    expect(fs.existsSync(path.join(os.tmpdir(), overridePath))).toBe(false);
-    expect(projectMemory.read(root, 'decision.relative-override', {
-      filePath: overridePath,
-    })).toMatchObject({
-      key: 'decision.relative-override',
-      sourceAgent: 'Codex',
-    });
-  });
-
-  test('rejects filePath overrides outside the project root', () => {
-    const root = tempRoot();
-
-    expect(() => projectMemory.write(root, {
-      key: 'policy.escape',
-      value: 'must stay in repo',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      filePath: path.join('..', 'outside.jsonl'),
-    })).toThrow('projectRoot');
-
-    expect(() => projectMemory.write(root, {
-      key: 'policy.absolute-escape',
-      value: 'must stay in repo',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      filePath: path.join(os.tmpdir(), `outside-${path.basename(root)}.jsonl`),
-    })).toThrow('projectRoot');
-  });
-
-  test('rejects memory paths that traverse symlinks outside the project root', () => {
-    if (process.platform === 'win32') {
-      return;
-    }
-
-    const root = tempRoot();
-    const outside = tempRoot();
-    fs.symlinkSync(outside, path.join(root, '.forge'), 'dir');
-
-    expect(() => projectMemory.write(root, {
-      key: 'policy.symlink-escape',
-      value: 'must stay in repo',
-      sourceAgent: 'Codex',
-      tags: [],
-    })).toThrow('projectRoot');
-  });
-
-  test('rejects symlinked memory files outside the project root', () => {
-    if (process.platform === 'win32') {
-      return;
-    }
-
-    const root = tempRoot();
-    const outside = tempRoot();
-    const memoryDir = path.join(root, '.forge', 'memory');
-    const outsideFile = path.join(outside, 'entries.jsonl');
-    fs.mkdirSync(memoryDir, { recursive: true });
-    fs.writeFileSync(outsideFile, JSON.stringify({
-      key: 'policy.external',
-      value: 'external data',
-      'source-agent': 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: [],
-    }) + '\n', 'utf8');
-    fs.symlinkSync(outsideFile, path.join(memoryDir, 'entries.jsonl'), 'file');
-
-    expect(() => projectMemory.list(root)).toThrow('projectRoot');
-  });
-
-  test('recovers stale lockfiles owned by dead processes', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
-      pid: 99999999,
-      createdAt: '2026-04-26T00:00:00.000Z',
-    }), 'utf8');
-
-    projectMemory.write(root, {
-      key: 'policy.stale-lock',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.stale-lock')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('treats Windows EPERM on existing lockfiles as lock contention', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    const lockPath = `${memoryFile}.lock`;
-    const originalOpenSync = fs.openSync;
-    let injected = false;
-
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(lockPath, JSON.stringify({
-      pid: 99999999,
-      createdAt: '2026-04-26T00:00:00.000Z',
-    }), 'utf8');
-
-    fs.openSync = function openSyncWithInjectedEperm(target, flags, ...args) {
-      if (!injected && target === lockPath && flags === 'wx') {
-        injected = true;
-        const err = new Error('operation not permitted');
-        err.code = 'EPERM';
-        throw err;
-      }
-      return originalOpenSync.call(this, target, flags, ...args);
-    };
-
-    try {
-      projectMemory.write(root, {
-        key: 'policy.eperm-lock-file',
-        value: 'recovered',
-        sourceAgent: 'Codex',
-        tags: [],
-      }, {
-        lockTimeoutMs: 250,
-        lockRetryMs: 5,
-      });
-    } finally {
-      fs.openSync = originalOpenSync;
-    }
-
-    expect(injected).toBe(true);
-    expect(projectMemory.read(root, 'policy.eperm-lock-file')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(lockPath)).toBe(false);
-  });
-
-  test('treats transient Windows EPERM on missing lockfiles as lock contention', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    const lockPath = `${memoryFile}.lock`;
-    const originalOpenSync = fs.openSync;
-    let injected = false;
-
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-
-    fs.openSync = function openSyncWithTransientEperm(target, flags, ...args) {
-      if (!injected && target === lockPath && flags === 'wx' && !fs.existsSync(lockPath)) {
-        injected = true;
-        const err = new Error('operation not permitted');
-        err.code = 'EPERM';
-        err.path = lockPath;
-        throw err;
-      }
-      return originalOpenSync.call(this, target, flags, ...args);
-    };
-
-    try {
-      projectMemory.write(root, {
-        key: 'policy.transient-eperm-lock-file',
-        value: 'recovered',
-        sourceAgent: 'Codex',
-        tags: [],
-      }, {
-        lockTimeoutMs: 250,
-        lockRetryMs: 5,
-      });
-    } finally {
-      fs.openSync = originalOpenSync;
-    }
-
-    expect(injected).toBe(true);
-    expect(projectMemory.read(root, 'policy.transient-eperm-lock-file')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(lockPath)).toBe(false);
-  });
-
-  test('surfaces persistent Windows EPERM on missing lockfiles', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    const lockPath = `${memoryFile}.lock`;
-    const originalOpenSync = fs.openSync;
-    const originalRmSync = fs.rmSync;
-    let openAttempts = 0;
-    let removedMissingLock = false;
-
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-
-    fs.openSync = function openSyncWithPersistentEperm(target, flags, ...args) {
-      if (target === lockPath && flags === 'wx' && !fs.existsSync(lockPath)) {
-        openAttempts += 1;
-        const err = new Error('operation not permitted');
-        err.code = 'EPERM';
-        err.path = lockPath;
-        throw err;
-      }
-      return originalOpenSync.call(this, target, flags, ...args);
-    };
-    fs.rmSync = function rmSyncTrackingMissingLock(target, ...args) {
-      if (target === lockPath && !fs.existsSync(lockPath)) {
-        removedMissingLock = true;
-      }
-      return originalRmSync.call(this, target, ...args);
-    };
-
-    try {
-      expect(() => projectMemory.write(root, {
-        key: 'policy.persistent-eperm-lock-file',
-        value: 'blocked',
-        sourceAgent: 'Codex',
-        tags: [],
-      }, {
-        lockTimeoutMs: 250,
-        lockRetryMs: 5,
-      })).toThrow('operation not permitted');
-    } finally {
-      fs.openSync = originalOpenSync;
-      fs.rmSync = originalRmSync;
-    }
-
-    expect(openAttempts).toBeGreaterThan(1);
-    expect(removedMissingLock).toBe(false);
-    expect(fs.existsSync(lockPath)).toBe(false);
-  });
-
-  test('reclaims dangling lock paths during stale cleanup', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    const lockPath = `${memoryFile}.lock`;
-    const originalOpenSync = fs.openSync;
-    const originalLstatSync = fs.lstatSync;
-    const originalRmSync = fs.rmSync;
-    let removedDanglingLock = false;
-
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-
-    fs.openSync = function openSyncWithDanglingLock(target, flags, ...args) {
-      if (!removedDanglingLock && target === lockPath && flags === 'wx') {
-        const err = new Error('file already exists');
-        err.code = 'EEXIST';
-        throw err;
-      }
-      return originalOpenSync.call(this, target, flags, ...args);
-    };
-    fs.lstatSync = function lstatSyncWithDanglingLock(target, ...args) {
-      if (!removedDanglingLock && target === lockPath) {
-        return {
-          isDirectory: () => false,
-        };
-      }
-      return originalLstatSync.call(this, target, ...args);
-    };
-    fs.rmSync = function rmSyncWithDanglingLock(target, ...args) {
-      if (target === lockPath) {
-        removedDanglingLock = true;
-        return undefined;
-      }
-      return originalRmSync.call(this, target, ...args);
-    };
-
-    try {
-      projectMemory.write(root, {
-        key: 'policy.dangling-lock',
-        value: 'recovered',
-        sourceAgent: 'Codex',
-        tags: [],
-      }, {
-        lockTimeoutMs: 250,
-        lockRetryMs: 5,
-      });
-    } finally {
-      fs.openSync = originalOpenSync;
-      fs.lstatSync = originalLstatSync;
-      fs.rmSync = originalRmSync;
-    }
-
-    expect(removedDanglingLock).toBe(true);
-    expect(projectMemory.read(root, 'policy.dangling-lock')).toMatchObject({
-      value: 'recovered',
-    });
-  });
-
-  test('removes lockfiles when lock metadata initialization fails', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    const originalWriteFileSync = fs.writeFileSync;
-    let injected = false;
-
-    fs.writeFileSync = function writeFileSyncWithInjectedFailure(target, ...args) {
-      if (!injected && Number.isInteger(target)) {
-        injected = true;
-        throw new Error('injected lock metadata failure');
-      }
-      return originalWriteFileSync.call(this, target, ...args);
-    };
-
-    try {
-      expect(() => projectMemory.write(root, {
-        key: 'policy.lock-init-failure',
-        value: 'not written',
-        sourceAgent: 'Codex',
-        tags: [],
-      }, {
-        lockTimeoutMs: 50,
-        lockRetryMs: 5,
-      })).toThrow('injected lock metadata failure');
-    } finally {
-      fs.writeFileSync = originalWriteFileSync;
-    }
-
-    expect(injected).toBe(true);
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('recovers metadata-less lock directories within the lock timeout', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(`${memoryFile}.lock`, { recursive: true });
-    const staleTime = new Date(Date.now() - 5_000);
-    fs.utimesSync(`${memoryFile}.lock`, staleTime, staleTime);
-
-    projectMemory.write(root, {
-      key: 'policy.metadata-less-lock-dir',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.metadata-less-lock-dir')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('recovers malformed lockfiles within the lock timeout', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, '', 'utf8');
-    const staleTime = new Date(Date.now() - 5_000);
-    fs.utimesSync(`${memoryFile}.lock`, staleTime, staleTime);
-
-    projectMemory.write(root, {
-      key: 'policy.malformed-lock-file',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.malformed-lock-file')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('does not reclaim a freshly initializing malformed lockfile before waiter timeout', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, '', 'utf8');
-
-    expect(() => projectMemory.write(root, {
-      key: 'policy.fresh-invalid-lock',
-      value: 'blocked',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 100,
-    })).toThrow();
-
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(true);
-    expect(projectMemory.search(root, 'fresh-invalid-lock')).toEqual([]);
-  });
-
-  test('does not reclaim a freshly initializing lockfile with minor future mtime skew', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, '', 'utf8');
-    const skewedTime = new Date(Date.now() + 500);
-    fs.utimesSync(`${memoryFile}.lock`, skewedTime, skewedTime);
-
-    expect(() => projectMemory.write(root, {
-      key: 'policy.fresh-invalid-lock-skew',
-      value: 'blocked',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 100,
-    })).toThrow();
-
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(true);
-    expect(projectMemory.search(root, 'fresh-invalid-lock-skew')).toEqual([]);
-  });
-
-  test('recovers fresh lockfiles owned by dead processes', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
-      pid: 99999999,
-      createdAt: new Date().toISOString(),
-    }), 'utf8');
-
-    projectMemory.write(root, {
-      key: 'policy.fresh-dead-lock',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.fresh-dead-lock')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('recovers fresh dead locks immediately when lock timeout is shorter than grace', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
-      pid: 99999999,
-      createdAt: new Date().toISOString(),
-    }), 'utf8');
-
-    projectMemory.write(root, {
-      key: 'policy.short-timeout-dead-lock',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 50,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.short-timeout-dead-lock')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('recovers dead locks when lock timeout equals grace boundary', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
-      pid: 99999999,
-      createdAt: new Date().toISOString(),
-    }), 'utf8');
-
-    projectMemory.write(root, {
-      key: 'policy.equal-timeout-dead-lock',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 100,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.equal-timeout-dead-lock')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('recovers fresh tokenized dead locks within the lock timeout', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
-      pid: 99999999,
-      createdAt: new Date().toISOString(),
-      token: 'dead-owner-token',
-    }), 'utf8');
-
-    projectMemory.write(root, {
-      key: 'policy.tokenized-dead-lock',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.tokenized-dead-lock')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('recovers future-dated lockfiles owned by dead processes', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    const future = new Date(Date.now() + 60_000).toISOString();
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(`${memoryFile}.lock`, JSON.stringify({
-      pid: 99999999,
-      createdAt: future,
-    }), 'utf8');
-
-    projectMemory.write(root, {
-      key: 'policy.future-dead-lock',
-      value: 'recovered',
-      sourceAgent: 'Codex',
-      tags: [],
-    }, {
-      lockTimeoutMs: 250,
-      lockRetryMs: 5,
-    });
-
-    expect(projectMemory.read(root, 'policy.future-dead-lock')).toMatchObject({
-      value: 'recovered',
-    });
-    expect(fs.existsSync(`${memoryFile}.lock`)).toBe(false);
-  });
-
-  test('serializes concurrent writers without losing entries', async () => {
-    const root = tempRoot();
-    const workerPath = path.join(root, 'project-memory-writer.cjs');
-    const worker = `
-const projectMemory = require(${JSON.stringify(workerModulePath)});
-const root = process.argv.at(-2);
-const index = Number(process.argv.at(-1));
-projectMemory.write(root, {
-  key: \`decision.concurrent.\${index}\`,
-  value: \`writer-\${index}\`,
-  sourceAgent: 'Codex',
-  timestamp: '2026-04-26T00:00:00.000Z',
-  tags: ['concurrent'],
-});
-`;
-    fs.writeFileSync(workerPath, worker);
-
-    await Promise.all(Array.from({ length: 8 }, (_unused, index) => new Promise((resolve, reject) => {
-      const child = spawn(process.execPath, [workerPath, root, String(index)], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      let stdout = '';
-      let stderr = '';
-
-      child.stdout.on('data', (chunk) => { stdout += chunk; });
-      child.stderr.on('data', (chunk) => { stderr += chunk; });
-      child.on('error', (err) => {
-        reject(new Error(`worker ${index} failed to spawn: ${err.message}`));
-      });
-      child.on('close', (status) => {
-        if (status === 0) {
-          resolve();
-          return;
-        }
-        reject(new Error(`worker ${index} exited with ${status}: ${stderr || stdout}`));
-      });
-    })));
-
-    const results = await waitForSearchCount(root, 'concurrent', 8, 15_000);
-    expect(results.map((entry) => entry.key).sort()).toEqual(Array.from(
-      { length: 8 },
-      (_unused, index) => `decision.concurrent.${index}`,
-    ));
-  }, 20_000);
-
-  test('rejects schema-invalid stored JSONL entries when reading', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(memoryFile, [
-      JSON.stringify({
-        key: 'policy.valid',
-        value: 'valid',
-        'source-agent': 'Codex',
-        timestamp: '2026-04-26T00:00:00.000Z',
-        tags: [],
-      }),
-      JSON.stringify({
-        key: 'policy.invalid',
-        value: 'missing disk source-agent',
-        sourceAgent: 'Codex',
-        tags: [],
-      }),
-    ].join('\n') + '\n', 'utf8');
-
-    expect(() => projectMemory.list(root)).toThrow('invalid project memory entry at line 2');
-  });
-
-  test('ignores a torn trailing JSONL append when reading', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(memoryFile, [
-      JSON.stringify({
-        key: 'policy.valid-before-torn-tail',
-        value: 'valid',
-        'source-agent': 'Codex',
-        timestamp: '2026-04-26T00:00:00.000Z',
-        tags: ['valid'],
-      }),
-      '{"key":"policy.torn-tail"',
-    ].join('\n'), 'utf8');
-
-    expect(projectMemory.list(root)).toEqual([{
-      key: 'policy.valid-before-torn-tail',
-      value: 'valid',
-      sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['valid'],
+    }, { runner: beads.run });
+
+    expect(beads.calls).toEqual([{
+      command: 'bd',
+      args: [
+        'remember',
+        JSON.stringify({
+          value: 'Use Beads for durable memory.',
+          sourceAgent: 'Codex',
+          tags: ['memory'],
+          timestamp: '2026-05-16T10:00:00.000Z',
+          scope: 'project',
+        }),
+        '--key',
+        'policy.memory',
+      ],
     }]);
+    expect(entry.key).toBe('policy.memory');
+    expect(entry.value).toBe('Use Beads for durable memory.');
   });
 
-  test('ignores a valid but unterminated trailing JSONL record when reading', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(memoryFile, JSON.stringify({
-      key: 'policy.unterminated',
-      value: 'valid json without commit newline',
-      'source-agent': 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['unterminated'],
-    }), 'utf8');
-
-    expect(projectMemory.list(root)).toEqual([]);
-  });
-
-  test('repairs a torn trailing JSONL append before the next write', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    const validEntry = {
-      key: 'policy.valid-before-repair',
-      value: 'valid',
-      'source-agent': 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['valid'],
-    };
-    fs.writeFileSync(memoryFile, [
-      JSON.stringify(validEntry),
-      '{"key":"policy.torn-tail"',
-    ].join('\n'), 'utf8');
-
-    projectMemory.write(root, {
-      key: 'policy.after-repair',
-      value: 'written',
-      sourceAgent: 'Codex',
-      timestamp: '2026-04-26T00:01:00.000Z',
-      tags: ['repair'],
+  test('reads entries with bd recall and returns null when missing', () => {
+    const beads = runner({
+      'bd recall policy.memory --json': JSON.stringify({
+        key: 'policy.memory',
+        content: '{"value":"stored","sourceAgent":"Codex","tags":["memory"]}',
+      }),
+      'bd recall missing.key --json': '',
     });
 
-    const rawLines = fs.readFileSync(memoryFile, 'utf8').trim().split(/\r?\n/);
-    expect(rawLines).toHaveLength(2);
-    expect(rawLines.map((line) => JSON.parse(line).key)).toEqual([
-      'policy.valid-before-repair',
-      'policy.after-repair',
-    ]);
+    expect(projectMemory.read(process.cwd(), ' policy.memory ', { runner: beads.run })).toMatchObject({
+      key: 'policy.memory',
+      value: 'stored',
+      sourceAgent: 'Codex',
+      tags: ['memory'],
+    });
+    expect(projectMemory.read(process.cwd(), 'missing.key', { runner: beads.run })).toBe(null);
   });
 
-  test('rolls back an appended record when fsync fails', () => {
-    const root = tempRoot();
-    const memoryFile = path.join(root, '.forge', 'memory', 'entries.jsonl');
-    fs.mkdirSync(path.dirname(memoryFile), { recursive: true });
-    fs.writeFileSync(memoryFile, JSON.stringify({
-      key: 'policy.before-fsync-failure',
-      value: 'valid',
-      'source-agent': 'Codex',
-      timestamp: '2026-04-26T00:00:00.000Z',
-      tags: ['valid'],
-    }) + '\n', 'utf8');
+  test('searches and lists entries through bd memories', () => {
+    const memoryRows = JSON.stringify({
+      'decision.one': '{"value":"one","sourceAgent":"Codex","tags":["decision"]}',
+      'decision.two': '{"value":"two","sourceAgent":"Claude","tags":["decision"]}',
+      schema_version: 1,
+    });
+    const beads = runner({
+      'bd memories decision --json': memoryRows,
+      'bd memories --json': memoryRows,
+    });
 
-    const originalOpenSync = fs.openSync;
-    const originalFsyncSync = fs.fsyncSync;
-    const entryFileDescriptors = new Set();
-    let injected = false;
-
-    fs.openSync = function openSyncWithTrackedEntryFile(target, ...args) {
-      const fd = originalOpenSync.call(this, target, ...args);
-      if (path.resolve(String(target)) === memoryFile) {
-        entryFileDescriptors.add(fd);
-      }
-      return fd;
-    };
-    fs.fsyncSync = function fsyncSyncWithInjectedFailure(fd) {
-      if (!injected && entryFileDescriptors.has(fd)) {
-        injected = true;
-        throw new Error('injected entry fsync failure');
-      }
-      return originalFsyncSync.call(this, fd);
-    };
-
-    try {
-      expect(() => projectMemory.write(root, {
-        key: 'policy.fsync-failure',
-        value: 'must not persist',
-        sourceAgent: 'Codex',
-        timestamp: '2026-04-26T00:01:00.000Z',
-        tags: ['failure'],
-      })).toThrow('injected entry fsync failure');
-    } finally {
-      fs.fsyncSync = originalFsyncSync;
-      fs.openSync = originalOpenSync;
-    }
-
-    expect(injected).toBe(true);
-    expect(projectMemory.list(root).map((entry) => entry.key)).toEqual([
-      'policy.before-fsync-failure',
+    expect(projectMemory.search(process.cwd(), 'decision', { runner: beads.run }).map(entry => entry.key)).toEqual([
+      'decision.one',
+      'decision.two',
     ]);
+    expect(projectMemory.list(process.cwd(), { runner: beads.run })).toHaveLength(2);
   });
 
-  test('validates required schema fields before writing', () => {
-    const root = tempRoot();
+  test('falls back to plain text recall output and surfaces Beads command failures', () => {
+    const failed = runner({
+      'bd recall policy.memory --json': new Error('bd failed'),
+    });
+    const plainText = runner({
+      'bd recall policy.memory --json': 'Use Beads for durable memory.',
+    });
 
-    expect(() => projectMemory.write(root, {
-      key: '',
-      value: 'missing key',
+    expect(() => projectMemory.read(process.cwd(), 'policy.memory', { runner: failed.run })).toThrow('bd failed');
+    expect(projectMemory.read(process.cwd(), 'policy.memory', { runner: plainText.run })).toMatchObject({
+      key: 'policy.memory',
+      value: 'Use Beads for durable memory.',
+      sourceAgent: 'bd',
+    });
+  });
+
+  test('keeps brace-prefixed plain text memory content readable', () => {
+    const beads = runner({
+      'bd recall draft.memory --json': JSON.stringify({
+        key: 'draft.memory',
+        content: '{draft notes',
+      }),
+    });
+
+    expect(projectMemory.read(process.cwd(), 'draft.memory', { runner: beads.run })).toMatchObject({
+      key: 'draft.memory',
+      value: '{draft notes',
+      sourceAgent: 'bd',
+    });
+  });
+
+  test('adds a timestamp to compatibility memory writes when omitted', () => {
+    const beads = runner();
+
+    projectMemory.write(process.cwd(), {
+      key: 'decision.timestamped',
+      value: 'timestamp should be generated',
       sourceAgent: 'Codex',
-      tags: [],
-    })).toThrow('key');
+    }, { runner: beads.run });
 
-    expect(() => projectMemory.write(root, {
-      key: 'policy.invalid-tags',
-      value: 'tags must be an array',
+    const payload = JSON.parse(beads.calls[0].args[1]);
+    expect(Number.isNaN(Date.parse(payload.timestamp))).toBe(false);
+  });
+
+  test('validates beads-refs alias before writing', () => {
+    expect(() => projectMemory.write(process.cwd(), {
+      key: 'decision.bad-ref',
+      value: 'invalid alias refs must fail',
       sourceAgent: 'Codex',
-      tags: 'policy',
-    })).toThrow('tags');
+      'beads-refs': ['forge-besw.19', 42],
+    }, { runner: runner().run })).toThrow('beads-refs');
+  });
 
-    expect(() => projectMemory.write(root, {
-      key: 'policy.invalid-agent',
-      value: 'source agent is required',
-      sourceAgent: '',
-      tags: [],
-    })).toThrow('sourceAgent');
+  test('validates compatibility metadata before writing', () => {
+    const beads = runner();
 
-    expect(() => projectMemory.write(root, {
-      key: 'policy.invalid-confidence',
-      value: 'confidence is bounded',
+    expect(() => projectMemory.write(process.cwd(), {
+      key: 'decision.bad-confidence',
+      value: 'bad confidence must fail',
       sourceAgent: 'Codex',
-      confidence: 2,
-      tags: [],
-    })).toThrow('confidence');
+      confidence: Number.POSITIVE_INFINITY,
+    }, { runner: beads.run })).toThrow('confidence');
+
+    expect(() => projectMemory.write(process.cwd(), {
+      key: 'decision.bad-scope',
+      value: 'bad scope must fail',
+      sourceAgent: 'Codex',
+      scope: '',
+    }, { runner: beads.run })).toThrow('scope');
+
+    expect(() => projectMemory.write(process.cwd(), {
+      key: 'decision.bad-timestamp',
+      value: 'bad timestamp must fail',
+      sourceAgent: 'Codex',
+      timestamp: 'not-a-date',
+    }, { runner: beads.run })).toThrow('timestamp');
   });
 });

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -6,6 +6,7 @@ const { afterEach, describe, expect, test } = require('bun:test');
 const {
   getResolvedRuntimeGraph,
   lintRuntimeGraphConfig,
+  resolveRuntimeGraph,
 } = require('../lib/core/runtime-graph');
 
 const tempRoots = [];
@@ -199,5 +200,94 @@ protectedPaths:
     expect(result.ok).toBe(false);
     expect(result.errors.map(error => error.code)).toContain('PROTECTED_PATH_TOO_BROAD');
     expect(result.errors.map(error => error.code)).toContain('PROTECTED_PATH_INVALID');
+  });
+
+  test('exposes configurable planning template defaults in the resolved graph', () => {
+    const graph = getResolvedRuntimeGraph({ projectRoot: makeProject(null) });
+
+    expect(graph.planning.template.mode).toBe('full');
+    expect(graph.planning.template.criticSet).toEqual(['spec', 'risk', 'test']);
+    expect(graph.planning.subSkills.map(skill => skill.id)).toEqual([
+      'plan.intent_capture',
+      'plan.parallel_research',
+      'plan.parallel_critics',
+      'plan.synthesis',
+      'plan.final_lock',
+    ]);
+    expect(graph.primitives.PlanningSubSkill).toBe('planning.subSkills');
+    expect(graph.phases.find(phase => phase.id === 'plan').actions).toEqual([
+      'action.plan.intent_capture',
+      'action.plan.parallel_research',
+      'action.plan.parallel_critics',
+      'action.plan.synthesis',
+      'action.plan.final_lock',
+    ]);
+    expect(graph.actions.find(action => action.id === 'action.plan.intent_capture')).toBeTruthy();
+  });
+
+  test('loads planning template configuration from .forge/config.yaml', () => {
+    const projectRoot = makeProject(`
+planning:
+  template:
+    mode: partial
+    convergenceThreshold: 0.82
+    criticSet:
+      - spec
+      - security
+    partialInvocation:
+      only:
+        - plan.parallel_critics
+      skip:
+        - plan.parallel_research
+`);
+
+    const graph = getResolvedRuntimeGraph({ projectRoot });
+
+    expect(graph.planning.template.mode).toBe('partial');
+    expect(graph.planning.template.convergenceThreshold).toBe(0.82);
+    expect(graph.planning.template.criticSet).toEqual(['spec', 'security']);
+    expect(graph.planning.template.partialInvocation.only).toEqual(['plan.parallel_critics']);
+    expect(graph.planning.template.partialInvocation.skip).toEqual(['plan.parallel_research']);
+    expect(graph.planning.template.configSource).toBe('.forge/config.yaml');
+  });
+
+  test('rejects invalid planning template configuration', () => {
+    const projectRoot = makeProject(`
+planning:
+  template:
+    mode: all-at-once
+    convergenceThreshold: .nan
+    criticSet:
+      - ""
+    partialInvocation:
+      only:
+        - plan.nope
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map(error => error.code)).toContain('INVALID_PLANNING_MODE');
+    expect(result.errors.map(error => error.code)).toContain('INVALID_CONVERGENCE_THRESHOLD');
+    expect(result.errors.map(error => error.code)).toContain('INVALID_CRITIC');
+    expect(result.errors.map(error => error.code)).toContain('UNKNOWN_PLAN_SUBSKILL');
+  });
+
+  test('fails closed when planning template partial invocation contains unknown subskills', () => {
+    const projectRoot = makeProject(`
+planning:
+  template:
+    partialInvocation:
+      only:
+        - plan.intent_capture
+        - plan.nope
+      skip:
+        - plan.final_lock
+`);
+
+    const { graph } = resolveRuntimeGraph({ projectRoot, throwOnError: false });
+
+    expect(graph.planning.template.partialInvocation.only).toEqual([]);
+    expect(graph.planning.template.partialInvocation.skip).toEqual(['plan.final_lock']);
   });
 });

--- a/test/runtime-graph.test.js
+++ b/test/runtime-graph.test.js
@@ -37,6 +37,7 @@ describe('runtime graph contract', () => {
     expect(graph.primitives).toEqual({
       Phase: 'phases',
       Action: 'actions',
+      PlanningSubSkill: 'planning.subSkills',
       Artifact: 'artifacts',
       EvaluatorRegion: 'evaluatorRegions',
       Gate: 'gates',

--- a/test/typed-memory-api.test.js
+++ b/test/typed-memory-api.test.js
@@ -1,0 +1,82 @@
+const { describe, test, expect } = require('bun:test');
+
+const typedMemory = require('../lib/memory/typed-api');
+
+function captureMemory() {
+  const writes = [];
+  return {
+    writes,
+    memory: {
+      write(_projectRoot, entry) {
+        writes.push(entry);
+        return entry;
+      },
+      read(_projectRoot, key) {
+        return { key, value: { category: 'preferences' }, tags: ['preferences'] };
+      },
+      search() {
+        return [
+          { key: 'preferences:editor', value: { category: 'preferences' }, tags: ['preferences'] },
+          { key: 'decisions:editor', value: { category: 'decisions' }, tags: ['decisions'] },
+        ];
+      },
+    },
+  };
+}
+
+describe('typed memory API', () => {
+  test('writes typed memories with category key prefixes and provenance', () => {
+    const captured = captureMemory();
+
+    const result = typedMemory.writePreference(process.cwd(), 'editor', 'Use vim keys', {
+      provenance: {
+        actor: 'Codex',
+        reason: 'User preference',
+        source: 'chat',
+      },
+      memory: captured.memory,
+      tags: 'ui',
+      beadsRefs: 'forge-besw.22',
+    });
+
+    expect(result.key).toBe('preferences:editor');
+    expect(captured.writes[0]).toMatchObject({
+      key: 'preferences:editor',
+      sourceAgent: 'Codex',
+      tags: ['preferences', 'ui'],
+      beadsRefs: ['forge-besw.22'],
+      value: {
+        category: 'preferences',
+        data: 'Use vim keys',
+        provenance: {
+          actor: 'Codex',
+          reason: 'User preference',
+          source: 'chat',
+        },
+      },
+    });
+  });
+
+  test('rejects unknown categories and missing provenance', () => {
+    expect(() => typedMemory.writeTyped(process.cwd(), 'unknown', 'x', 'value', {
+      provenance: { actor: 'Codex', reason: 'test', source: 'test' },
+    })).toThrow('Unknown memory category');
+
+    expect(() => typedMemory.writeDecision(process.cwd(), 'routing', 'Use Beads')).toThrow('provenance');
+    expect(() => typedMemory.writeDecision(process.cwd(), 'routing', 'Use Beads', {
+      provenance: { actor: 'Codex', reason: 'test', source: 'test' },
+      tags: [42],
+    })).toThrow('tags');
+  });
+
+  test('reads and searches through the delegated memory adapter', () => {
+    const captured = captureMemory();
+
+    expect(typedMemory.readTyped(process.cwd(), 'preferences', 'editor', {
+      memory: captured.memory,
+    }).key).toBe('preferences:editor');
+    expect(typedMemory.searchTyped(process.cwd(), 'preferences', 'editor', {
+      memory: captured.memory,
+    }).map(entry => entry.key)).toEqual(['preferences:editor']);
+  });
+});


### PR DESCRIPTION
## Problem
0.0.17 needs the planning super-skill to be configurable through the runtime graph/config surface, and durable project memory should use Beads memory instead of Forge-owned JSONL storage.

## Root Cause
Planning sub-skills were documented but not represented as first-class runtime graph/config primitives. `lib/project-memory.js` still owned a local `.forge/memory` JSONL implementation instead of routing through `bd remember`, `bd recall`, and `bd memories`.

## Fix
This PR adds runtime graph planning template defaults/config validation, exposes planning sub-skills through `forge options why`, routes project memory compatibility calls through Beads memory commands, and adds a thin typed memory API for category/provenance enforcement.

## Value
Users and future agents can inspect and tune planning behavior through the same `forge options` surface as other runtime graph primitives. Durable memory now follows the project Beads authority and avoids another repo-local datastore.

## Beads
Closes forge-besw.19
Closes forge-besw.22
Refs forge-besw.24

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 34 targeted tests passing
- Scenarios covered: planning template defaults/config/failure modes, Beads memory write/read/search/list routing, typed category/provenance validation, and migrate dry-run runtime graph output.

### Security Review
- OWASP Top 10: avoids shell interpolation by using command argument arrays for Beads calls; invalid config and malformed Beads JSON fail closed.
- Automated scan: `bun audit` reported no vulnerabilities.

### Design Doc
See: `docs/work/2026-05-16-0-0-17-planning-memory/design.md`

### Key Decisions
- Runtime graph/config remains the planning template authority; no planner-only config file was added.
- `lib/project-memory.js` remains as a compatibility adapter, but no longer writes local JSONL memory.
- Typed memory API was added because it prevents ad hoc category prefixes and provenance payloads.
- Non-scope: upgrade dry-run, lockfile/trust policy, rollback, and patch intent implementation were not touched.

### Documentation Updated
- `.claude/commands/plan.md`
- `.codex/skills/plan/SKILL.md`
- `docs/reference/TEMPLATES.md`
- `docs/reference/TOOLCHAIN.md`
- `docs/work/2026-05-16-0-0-17-planning-memory/*`

### Memory Behavior
- `write` -> `bd remember <payload> --key <key>`
- `read` -> `bd recall <key> --json`
- `search`/`list` -> `bd memories [query] --json`
- Typed writes require `actor`, `reason`, and `source` provenance fields.

### Validation
- [x] Type check passing: `bun run typecheck`
- [x] Lint passing: `bun run lint`
- [x] Targeted tests passing: `bun test --timeout 30000 test/runtime-graph-config.test.js test/project-memory.test.js test/typed-memory-api.test.js test/migrate-dry-run.test.js`
- [x] Security review completed: `bun audit`
- [ ] Full `bun run check`: typecheck, lint, and audit passed; full-suite test phase hit unrelated local broad-suite blockers including missing `chalk`/`inquirer` for `packages/skills` tests and several timeout-sensitive shell tests. The branch-caused migrate dry-run assertion was fixed and rerun green.

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] Relevant tests pass locally
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Planning templates configurable via .forge/config.yaml (mode, convergence threshold, critic set, partial-invocation)
  * /plan exposes explicit planning sub-steps in dry-run/actions (intent capture, research, critics, synthesis, final lock)
  * Project Memory now Beads-backed with a typed memory API for structured categories

* **Documentation**
  * Added planning-template guide, examples, validation notes, and Project Memory reference with command usage

* **Bug Fixes**
  * Validation/lint rejects invalid planning configs and surfaces memory/backend errors via CLI inspection commands (forge options why/diff/lint)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->