### PR TITLE
0.0.16 upgrade safety foundation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -68,6 +68,7 @@ See [work/](work/) for the full list of date-prefixed work folders. Each folder 
 - [VALIDATION.md](reference/VALIDATION.md) — Validation stage requirements
 - [TEMPLATES.md](reference/TEMPLATES.md) — Adoption templates and `forge init` profiles
 - [EXAMPLES.md](reference/EXAMPLES.md) — Worked examples
+- [upgrade-safety.md](reference/upgrade-safety.md) — Lockfile trust policy, upgrade dry-run, and self-heal limitations
 - [RESEARCH_TEMPLATE.md](reference/RESEARCH_TEMPLATE.md) — Template for research docs (formerly docs/research/TEMPLATE.md)
 
 ## Guides

--- a/docs/reference/upgrade-safety.md
+++ b/docs/reference/upgrade-safety.md
@@ -1,0 +1,59 @@
+# Upgrade Safety
+
+Forge 0.0.16 upgrade safety is a foundation layer. It makes upgrade inputs reviewable and checks recoverable metadata before later releases add full install, rollback, and restore flows.
+
+## Lockfile
+
+`forge add <source> [--name <id>]` records extension source metadata in `forge.lock`.
+
+Trusted local files inside the project root are hashed with SHA-512 SRI and can be rechecked:
+
+```bash
+forge add ./extensions/local.plugin.json --name local
+forge audit verify
+```
+
+Remote and package locator strings such as `https:`, `gh:`, `gist:`, and `npm:` are untrusted by default. They are recorded only when the caller explicitly uses `--allow-untrusted`:
+
+```bash
+forge add gh:owner/repo/plugin --name plugin --allow-untrusted
+```
+
+Those entries are visible in `forge.lock` as explicit trust-policy records. This foundation does not fetch remote bytes for SRI verification.
+
+## Audit Log
+
+`forge add` appends a JSONL audit event to `.forge/log.jsonl`. The log is best-effort local evidence for reviewing lockfile changes. Beads remains the durable issue-state authority.
+
+## Verification
+
+`forge audit verify` rechecks all local lockfile integrity hashes:
+
+- matching local content passes;
+- missing or tampered local content fails;
+- untrusted remote/package locators warn because this PR does not implement resolver-backed byte materialization.
+
+## Upgrade Dry-Run
+
+`forge upgrade --dry-run` is report-only. It reads:
+
+- resolved runtime config health;
+- patch intent record/orphan status;
+- lock/trust state and integrity verification;
+- recoverable self-heal candidates.
+
+The dry-run does not write files.
+
+## Self-Heal
+
+`forge upgrade --self-heal` applies only safe metadata repairs:
+
+- create missing `.forge/`;
+- create missing `.forge/log.jsonl`.
+
+It is idempotent and refuses unrecoverable integrity failures. It does not edit managed workflow files, apply patch intent diffs, install extensions, create rollback snapshots, or restore backups.
+
+## Non-Scope
+
+This PR intentionally does not implement rollback snapshots, full restore, marketplace allowlists, name-collision policy, resolver-backed downloads, or automatic patch application.
+

--- a/docs/work/2026-05-16-0.0.16-upgrade-safety/decisions.md
+++ b/docs/work/2026-05-16-0.0.16-upgrade-safety/decisions.md
@@ -1,0 +1,4 @@
+# Decisions: 0.0.16 Upgrade Safety Foundation
+
+No `/dev` decision gates recorded yet.
+

--- a/docs/work/2026-05-16-0.0.16-upgrade-safety/design.md
+++ b/docs/work/2026-05-16-0.0.16-upgrade-safety/design.md
@@ -37,7 +37,7 @@ Implement a small local trust foundation rather than a full installer:
 2. Add registry commands:
    - `forge add <source> [--name <id>] [--allow-untrusted]`
    - `forge audit verify`
-   - `forge upgrade --dry-run [--self-heal]`
+   - `forge upgrade [--dry-run] [--self-heal]`
 3. Keep source resolution conservative:
    - local filesystem paths are trusted and integrity-verifiable;
    - remote/package locator strings are untrusted and require explicit opt-in;
@@ -64,4 +64,3 @@ Implement a small local trust foundation rather than a full installer:
   - `bun run lint`
   - `bun test`
   - `bun run check`
-

--- a/docs/work/2026-05-16-0.0.16-upgrade-safety/design.md
+++ b/docs/work/2026-05-16-0.0.16-upgrade-safety/design.md
@@ -1,0 +1,67 @@
+# 0.0.16 Upgrade Safety Foundation
+
+**Date**: 2026-05-16  
+**Status**: planned  
+**Branch**: `codex/0.0.16-upgrade-safety`  
+**Issues**: `forge-besw.8`, `forge-besw.11`
+
+## Purpose
+
+Add the minimum lockfile, trust, upgrade dry-run, and self-heal foundation needed for safe 0.0.16 upgrades. The work must make extension/source integrity reviewable before upgrade planning consumes it.
+
+## Success Criteria
+
+- `forge add` writes a reviewable `forge.lock` entry and `.forge/log.jsonl` audit entry.
+- Untrusted sources are refused by default and accepted only with `--allow-untrusted`.
+- Lock entries contain integrity metadata that `forge audit verify` can re-check.
+- Tampered local source content with mismatched SRI is refused by verification.
+- `forge upgrade --dry-run` consumes resolved runtime config, patch intent status, and lock/trust state, then renders a non-mutating upgrade plan.
+- Upgrade dry-run reports recoverable failures with a self-heal hint.
+- `forge upgrade --self-heal` performs only safe, recoverable repair steps and stays idempotent.
+
+## Out Of Scope
+
+- Rollback snapshots, backup retention, and full restore flow.
+- Marketplace allowlists and name-collision policy.
+- Real package installation from npm, GitHub, gist, or HTTPS.
+- Applying patch intent diffs to managed files.
+- Overwriting user-managed surfaces during upgrade.
+
+If rollback snapshots become necessary for self-heal, stop and report scope expansion instead of implementing them.
+
+## Approach Selected
+
+Implement a small local trust foundation rather than a full installer:
+
+1. Add `lib/forge-lock.js` for `forge.lock` parsing/writing, source trust classification, SRI calculation, audit-log append, and verification.
+2. Add registry commands:
+   - `forge add <source> [--name <id>] [--allow-untrusted]`
+   - `forge audit verify`
+   - `forge upgrade --dry-run [--self-heal]`
+3. Keep source resolution conservative:
+   - local filesystem paths are trusted and integrity-verifiable;
+   - remote/package locator strings are untrusted and require explicit opt-in;
+   - unsupported remote verification remains a clear limitation in dry-run output.
+4. Reuse current `options` graph lint/diff and `patch` status behavior indirectly through library functions where possible.
+5. Make self-heal repair only missing safe metadata directories/files such as `.forge/` and `.forge/log.jsonl`; do not snapshot or restore.
+
+## Constraints
+
+- `forge-besw.8` must be usable before `forge-besw.11` implementation relies on it.
+- All dry-run behavior must be report-only unless `--self-heal` is explicitly present.
+- `--allow-untrusted` must never become the default.
+- Audit entries must be JSONL and reviewable.
+- Tests must cover trusted/untrusted sources, lockfile behavior, upgrade dry-run output, and self-heal recovery.
+
+## Validation Plan
+
+- Targeted tests during TDD:
+  - `bun test test/forge-lock.test.js`
+  - `bun test test/commands/add.test.js test/commands/audit.test.js`
+  - `bun test test/commands/upgrade.test.js`
+- Full validation:
+  - `bun run typecheck`
+  - `bun run lint`
+  - `bun test`
+  - `bun run check`
+

--- a/docs/work/2026-05-16-0.0.16-upgrade-safety/tasks.md
+++ b/docs/work/2026-05-16-0.0.16-upgrade-safety/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: 0.0.16 Upgrade Safety Foundation
+
+## Task 1: Lockfile And Trust Policy (`forge-besw.8`)
+
+TDD red:
+- Add tests for trusted local sources, refused untrusted sources, `--allow-untrusted`, lockfile SRI metadata, and audit JSONL entries.
+- Add tests for tampered local content causing `forge audit verify` failure.
+
+Implementation:
+- Add `lib/forge-lock.js`.
+- Add `lib/commands/add.js`.
+- Add `lib/commands/audit.js`.
+- Keep remote/package sources opt-in only and document unsupported verification.
+
+Done when:
+- Targeted lock/add/audit tests pass.
+- `forge add` and `forge audit verify` operate through the existing registry.
+
+## Task 2: Upgrade Dry-Run Plan (`forge-besw.11`)
+
+TDD red:
+- Add tests proving `forge upgrade --dry-run` reports config state, patch intent state, lock/trust state, non-scope limitations, and planned self-heal candidates without mutation.
+
+Implementation:
+- Add `lib/upgrade-safety.js`.
+- Add `lib/commands/upgrade.js`.
+- Consume runtime graph config lint/diff, patch intent records, and lock verification.
+
+Done when:
+- Targeted upgrade dry-run tests pass.
+- Dry-run output is deterministic and reviewable.
+
+## Task 3: Safe Self-Heal Flow (`forge-besw.11`)
+
+TDD red:
+- Add tests for a recoverable missing `.forge/log.jsonl` path repaired by `forge upgrade --self-heal`.
+- Add tests that unrecoverable integrity failures are reported but not repaired.
+- Add idempotency test for running self-heal twice.
+
+Implementation:
+- Restrict self-heal to metadata scaffolding that does not overwrite user files.
+- Refuse rollback/snapshot behavior in this PR.
+
+Done when:
+- Targeted self-heal tests pass.
+- No rollback snapshot or restore files/commands are introduced.
+
+## Task 4: Docs And Validation
+
+TDD red:
+- Add docs consistency coverage if an existing docs test requires it.
+
+Implementation:
+- Add docs/reference/upgrade-safety.md.
+- Link from docs/INDEX.md if appropriate.
+- Run targeted and full validation commands.
+
+Done when:
+- Docs explain trust policy, dry-run behavior, self-heal limits, and non-scope.
+- Full validation passes before `/ship`.
+

--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -15,6 +15,25 @@ function argValue(args, name) {
   return match ? match.slice(prefix.length) : null;
 }
 
+function positionalArgs(args) {
+  const positionals = [];
+  const flagsWithValues = new Set(['--name']);
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg.startsWith('--') && arg.includes('=')) {
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      if (flagsWithValues.has(arg) && index + 1 < args.length && !args[index + 1].startsWith('-')) {
+        index++;
+      }
+      continue;
+    }
+    positionals.push(arg);
+  }
+  return positionals;
+}
+
 function stripKnownExtension(base) {
   const lowerBase = base.toLowerCase();
   for (const suffix of ['.plugin.json', '.tar.gz', '.json', '.tgz']) {
@@ -59,7 +78,7 @@ function usage() {
 }
 
 async function handler(args, _flags, projectRoot) {
-  const source = args.find(arg => !arg.startsWith('-'));
+  const [source] = positionalArgs(args);
   if (!source) {
     return { success: false, error: usage() };
   }

--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -15,10 +15,43 @@ function argValue(args, name) {
   return match ? match.slice(prefix.length) : null;
 }
 
+function stripKnownExtension(base) {
+  const lowerBase = base.toLowerCase();
+  for (const suffix of ['.plugin.json', '.tar.gz', '.json', '.tgz']) {
+    if (lowerBase.endsWith(suffix)) {
+      return base.slice(0, base.length - suffix.length);
+    }
+  }
+  return base;
+}
+
+function normalizeNameSegment(value) {
+  let normalized = '';
+  let previousWasSeparator = true;
+  for (const character of value) {
+    const isAllowed = (
+      (character >= 'A' && character <= 'Z')
+      || (character >= 'a' && character <= 'z')
+      || (character >= '0' && character <= '9')
+      || character === '.'
+      || character === '_'
+      || character === '-'
+    );
+    if (isAllowed) {
+      normalized += character;
+      previousWasSeparator = false;
+    } else if (!previousWasSeparator) {
+      normalized += '-';
+      previousWasSeparator = true;
+    }
+  }
+  return normalized.endsWith('-') ? normalized.slice(0, -1) : normalized;
+}
+
 function deriveName(source) {
-  const base = path.basename(String(source || '').replace(/\/$/, ''));
-  const withoutExt = base.replace(/\.(?:plugin\.json|json|tgz|tar\.gz)$/i, '');
-  return withoutExt.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'extension';
+  const sourceText = String(source || '');
+  const base = path.basename(sourceText.endsWith('/') ? sourceText.slice(0, -1) : sourceText);
+  return normalizeNameSegment(stripKnownExtension(base)) || 'extension';
 }
 
 function usage() {
@@ -62,4 +95,3 @@ module.exports = {
   },
   handler,
 };
-

--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -9,7 +9,9 @@ function hasArg(args, name) {
 
 function argValue(args, name) {
   const index = args.indexOf(name);
-  if (index >= 0 && index + 1 < args.length) return args[index + 1];
+  if (index >= 0 && index + 1 < args.length && !args[index + 1].startsWith('-')) {
+    return args[index + 1];
+  }
   const prefix = `${name}=`;
   const match = args.find(arg => arg.startsWith(prefix));
   return match ? match.slice(prefix.length) : null;

--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const path = require('node:path');
+const { addLockEntry } = require('../forge-lock');
+
+function hasArg(args, name) {
+  return Array.isArray(args) && args.includes(name);
+}
+
+function argValue(args, name) {
+  const index = args.indexOf(name);
+  if (index >= 0 && index + 1 < args.length) return args[index + 1];
+  const prefix = `${name}=`;
+  const match = args.find(arg => arg.startsWith(prefix));
+  return match ? match.slice(prefix.length) : null;
+}
+
+function deriveName(source) {
+  const base = path.basename(String(source || '').replace(/\/$/, ''));
+  const withoutExt = base.replace(/\.(?:plugin\.json|json|tgz|tar\.gz)$/i, '');
+  return withoutExt.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'extension';
+}
+
+function usage() {
+  return 'Usage: forge add <source> [--name <id>] [--allow-untrusted]';
+}
+
+async function handler(args, _flags, projectRoot) {
+  const source = args.find(arg => !arg.startsWith('-'));
+  if (!source) {
+    return { success: false, error: usage() };
+  }
+
+  try {
+    const result = addLockEntry(projectRoot, {
+      name: argValue(args, '--name') || deriveName(source),
+      source,
+      allowUntrusted: hasArg(args, '--allow-untrusted'),
+    });
+    const trustNote = result.entry.trust.trusted
+      ? 'trusted source verified'
+      : 'untrusted source accepted by explicit policy';
+    return {
+      success: true,
+      output: `Added ${result.entry.name} to forge.lock (${trustNote}).`,
+    };
+  } catch (error) {
+    const message = error.message.includes('Untrusted source')
+      ? `${error.message}\nUse --allow-untrusted only for sources you intentionally trust for this project.`
+      : error.message;
+    return { success: false, error: message };
+  }
+}
+
+module.exports = {
+  name: 'add',
+  description: 'Record an extension source in forge.lock',
+  usage: usage(),
+  flags: {
+    '--name': 'Lockfile extension id to record',
+    '--allow-untrusted': 'Explicitly record an untrusted remote/package source',
+  },
+  handler,
+};
+

--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -19,7 +19,7 @@ function argValue(args, name) {
 
 function positionalArgs(args) {
   const positionals = [];
-  const flagsWithValues = new Set(['--name']);
+  const flagsWithValues = new Set(['--name', '--path', '-p']);
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
     if (arg.startsWith('--') && arg.includes('=')) {

--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { verifyForgeLock } = require('../forge-lock');
+
+const usage = 'Usage: forge audit verify';
+
+function renderVerifyReport(report) {
+  const lines = [
+    'Forge lock audit verify',
+    `Result: ${report.ok ? 'PASS' : 'FAIL'}`,
+  ];
+
+  if (report.results.length === 0) {
+    lines.push('[PASS] forge.lock: no extensions recorded');
+  } else {
+    for (const result of report.results) {
+      lines.push(`[${result.status.toUpperCase()}] ${result.name}: ${result.reason}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+async function handler(args, _flags, projectRoot) {
+  if (args[0] !== 'verify') {
+    return { success: false, error: usage };
+  }
+  const report = verifyForgeLock(projectRoot);
+  const output = renderVerifyReport(report);
+  return {
+    success: report.ok,
+    output,
+    error: report.ok ? undefined : output,
+  };
+}
+
+module.exports = {
+  name: 'audit',
+  description: 'Verify Forge lockfile and audit state',
+  usage,
+  handler,
+  renderVerifyReport,
+};
+

--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -25,13 +25,20 @@ async function handler(args, _flags, projectRoot) {
   if (args[0] !== 'verify') {
     return { success: false, error: usage };
   }
-  const report = verifyForgeLock(projectRoot);
-  const output = renderVerifyReport(report);
-  return {
-    success: report.ok,
-    output,
-    error: report.ok ? undefined : output,
-  };
+  try {
+    const report = verifyForgeLock(projectRoot);
+    const output = renderVerifyReport(report);
+    return {
+      success: report.ok,
+      output,
+      error: report.ok ? undefined : output,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message || String(error),
+    };
+  }
 }
 
 module.exports = {
@@ -41,4 +48,3 @@ module.exports = {
   handler,
   renderVerifyReport,
 };
-

--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -4,6 +4,25 @@ const { verifyForgeLock } = require('../forge-lock');
 
 const usage = 'Usage: forge audit verify';
 
+function positionalArgs(args) {
+  const positionals = [];
+  const flagsWithValues = new Set(['--path', '-p']);
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg.startsWith('--') && arg.includes('=')) {
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      if (flagsWithValues.has(arg) && index + 1 < args.length && !args[index + 1].startsWith('-')) {
+        index++;
+      }
+      continue;
+    }
+    positionals.push(arg);
+  }
+  return positionals;
+}
+
 function renderVerifyReport(report) {
   const lines = [
     'Forge lock audit verify',
@@ -22,7 +41,8 @@ function renderVerifyReport(report) {
 }
 
 async function handler(args, _flags, projectRoot) {
-  if (args[0] !== 'verify') {
+  const [subcommand] = positionalArgs(args);
+  if (subcommand !== 'verify') {
     return { success: false, error: usage };
   }
   try {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -27,6 +27,12 @@ const LOCKFILE_MAP = [
 
 const DEFAULT_TIMEOUT = 120000;
 const BEADS_CHECK_TIMEOUT = 3000;
+const DIRECT_TEST_CANDIDATES = Object.freeze({
+	'lib/lefthook-check.js': ['test/lefthook-check.test.js', 'test/runtime-health.test.js'],
+	'lib/runtime-health.js': ['test/runtime-health.test.js'],
+	'lib/upgrade-safety.js': ['test/commands/upgrade.test.js'],
+	'scripts/test.js': ['test/scripts/test-runner.test.js'],
+});
 
 /**
  * Detect the package manager by checking which lockfile exists.
@@ -152,20 +158,17 @@ function getAffectedTestFiles(projectRoot, execFileSync, fs = defaultFs, options
 function getTestCandidatesForChangedFile(file) {
 	if (!file) return [];
 
-	if (file === 'lib/lefthook-check.js') {
-		return ['test/lefthook-check.test.js', 'test/runtime-health.test.js'];
-	}
-
-	if (file === 'lib/runtime-health.js') {
-		return ['test/runtime-health.test.js'];
-	}
-
-	if (file === 'scripts/test.js') {
-		return ['test/scripts/test-runner.test.js'];
+	const directCandidates = DIRECT_TEST_CANDIDATES[file];
+	if (directCandidates) {
+		return directCandidates;
 	}
 
 	if (file.startsWith('test/') && file.endsWith('.test.js')) {
 		return [file];
+	}
+
+	if (file === 'docs/INDEX.md' || file.startsWith('docs/reference/')) {
+		return ['test/docs-consistency.test.js'];
 	}
 
 	if (file.startsWith('lib/') && file.endsWith('.js')) {

--- a/lib/commands/upgrade.js
+++ b/lib/commands/upgrade.js
@@ -26,7 +26,7 @@ async function handler(args, flags, projectRoot) {
   const report = buildUpgradeDryRunReport(projectRoot);
   const selfHealResult = selfHeal ? applySelfHeal(projectRoot, report) : null;
   const output = renderUpgradeDryRunReport(report, selfHealResult);
-  const success = report.ok && !(selfHealResult && selfHealResult.refused);
+  const success = report.ok && !selfHealResult?.refused;
 
   return {
     success,
@@ -45,4 +45,3 @@ module.exports = {
   },
   handler,
 };
-

--- a/lib/commands/upgrade.js
+++ b/lib/commands/upgrade.js
@@ -10,11 +10,11 @@ function hasArg(args, name) {
   return Array.isArray(args) && args.includes(name);
 }
 
-const usage = 'Usage: forge upgrade --dry-run [--self-heal]';
+const usage = 'Usage: forge upgrade [--dry-run] [--self-heal]';
 
 async function handler(args, flags, projectRoot) {
   const dryRun = flags?.dryRun === true || hasArg(args, '--dry-run');
-  const selfHeal = hasArg(args, '--self-heal');
+  const selfHeal = flags?.selfHeal === true || flags?.['self-heal'] === true || hasArg(args, '--self-heal');
 
   if (!dryRun && !selfHeal) {
     return {
@@ -24,7 +24,7 @@ async function handler(args, flags, projectRoot) {
   }
 
   const report = buildUpgradeDryRunReport(projectRoot);
-  const selfHealResult = selfHeal ? applySelfHeal(projectRoot, report) : null;
+  const selfHealResult = selfHeal ? applySelfHeal(report.projectRoot, report) : null;
   const output = renderUpgradeDryRunReport(report, selfHealResult);
   const success = report.ok && !selfHealResult?.refused;
 

--- a/lib/commands/upgrade.js
+++ b/lib/commands/upgrade.js
@@ -13,7 +13,7 @@ function hasArg(args, name) {
 const usage = 'Usage: forge upgrade [--dry-run] [--self-heal]';
 
 async function handler(args, flags, projectRoot) {
-  const dryRun = flags?.dryRun === true || hasArg(args, '--dry-run');
+  const dryRun = flags?.dryRun === true || flags?.['dry-run'] === true || hasArg(args, '--dry-run');
   const selfHeal = flags?.selfHeal === true || flags?.['self-heal'] === true || hasArg(args, '--self-heal');
 
   if (!dryRun && !selfHeal) {

--- a/lib/commands/upgrade.js
+++ b/lib/commands/upgrade.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const {
+  applySelfHeal,
+  buildUpgradeDryRunReport,
+  renderUpgradeDryRunReport,
+} = require('../upgrade-safety');
+
+function hasArg(args, name) {
+  return Array.isArray(args) && args.includes(name);
+}
+
+const usage = 'Usage: forge upgrade --dry-run [--self-heal]';
+
+async function handler(args, flags, projectRoot) {
+  const dryRun = flags?.dryRun === true || hasArg(args, '--dry-run');
+  const selfHeal = hasArg(args, '--self-heal');
+
+  if (!dryRun && !selfHeal) {
+    return {
+      success: false,
+      error: usage,
+    };
+  }
+
+  const report = buildUpgradeDryRunReport(projectRoot);
+  const selfHealResult = selfHeal ? applySelfHeal(projectRoot, report) : null;
+  const output = renderUpgradeDryRunReport(report, selfHealResult);
+  const success = report.ok && !(selfHealResult && selfHealResult.refused);
+
+  return {
+    success,
+    output,
+    error: success ? undefined : output,
+  };
+}
+
+module.exports = {
+  name: 'upgrade',
+  description: 'Preview and self-heal safe Forge upgrade readiness',
+  usage,
+  flags: {
+    '--dry-run': 'Preview upgrade readiness without writing files',
+    '--self-heal': 'Apply safe metadata repairs only; does not snapshot or restore',
+  },
+  handler,
+};
+

--- a/lib/forge-lock.js
+++ b/lib/forge-lock.js
@@ -129,6 +129,7 @@ function upsertExtension(extensions, entry) {
 
 function addLockEntry(projectRoot, options) {
   const root = path.resolve(projectRoot);
+  const realRoot = fs.realpathSync(root);
   const sourceInfo = classifySource(root, options.source, {
     allowUntrusted: Boolean(options.allowUntrusted),
   });
@@ -136,7 +137,7 @@ function addLockEntry(projectRoot, options) {
   const entry = {
     name: options.name,
     source: options.source,
-    resolvedPath: sourceInfo.resolvedPath ? normalizeRelativePath(root, sourceInfo.resolvedPath) : null,
+    resolvedPath: sourceInfo.resolvedPath ? normalizeRelativePath(realRoot, sourceInfo.resolvedPath) : null,
     integrity: sourceInfo.integrity,
     verification: sourceInfo.verification,
     trust: {
@@ -172,8 +173,9 @@ function verifyEntry(projectRoot, entry) {
 
   const relativePath = entry.resolvedPath || entry.source;
   const root = path.resolve(projectRoot);
-  const fullPath = path.resolve(root, relativePath);
-  if (!isInsideRoot(root, fullPath)) {
+  const realRoot = fs.realpathSync(root);
+  const fullPath = path.resolve(realRoot, relativePath);
+  if (!isInsideRoot(realRoot, fullPath)) {
     return {
       name: entry.name,
       status: 'fail',
@@ -187,7 +189,6 @@ function verifyEntry(projectRoot, entry) {
       reason: `source missing: ${relativePath}`,
     };
   }
-  const realRoot = fs.realpathSync(root);
   const realFullPath = fs.realpathSync(fullPath);
   if (!isInsideRoot(realRoot, realFullPath)) {
     return {

--- a/lib/forge-lock.js
+++ b/lib/forge-lock.js
@@ -16,6 +16,11 @@ function normalizeRelativePath(projectRoot, fullPath) {
   return toPosixPath(path.relative(projectRoot, fullPath));
 }
 
+function isInsideRoot(projectRoot, fullPath) {
+  const relative = path.relative(projectRoot, fullPath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
 function lockPath(projectRoot) {
   return path.join(projectRoot, LOCKFILE_NAME);
 }
@@ -59,16 +64,23 @@ function isRemoteSource(source) {
 }
 
 function resolveLocalSource(projectRoot, source) {
-  const resolved = path.resolve(projectRoot, source);
   const root = path.resolve(projectRoot);
-  const relative = path.relative(root, resolved);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+  const resolved = path.resolve(root, source);
+  if (!isInsideRoot(root, resolved)) {
     throw new Error(`Source must stay inside project root: ${source}`);
   }
   if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
     throw new Error(`Local source does not exist: ${source}`);
   }
-  return resolved;
+  const realRoot = fs.realpathSync(root);
+  const realResolved = fs.realpathSync(resolved);
+  if (!isInsideRoot(realRoot, realResolved)) {
+    throw new Error(`Source must stay inside project root: ${source}`);
+  }
+  if (!fs.statSync(realResolved).isFile()) {
+    throw new Error(`Local source does not exist: ${source}`);
+  }
+  return realResolved;
 }
 
 function sourceIntegrity(filePath) {
@@ -159,7 +171,15 @@ function verifyEntry(projectRoot, entry) {
   }
 
   const relativePath = entry.resolvedPath || entry.source;
-  const fullPath = path.resolve(projectRoot, relativePath);
+  const root = path.resolve(projectRoot);
+  const fullPath = path.resolve(root, relativePath);
+  if (!isInsideRoot(root, fullPath)) {
+    return {
+      name: entry.name,
+      status: 'fail',
+      reason: `source escapes project root: ${relativePath}`,
+    };
+  }
   if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isFile()) {
     return {
       name: entry.name,
@@ -167,8 +187,17 @@ function verifyEntry(projectRoot, entry) {
       reason: `source missing: ${relativePath}`,
     };
   }
+  const realRoot = fs.realpathSync(root);
+  const realFullPath = fs.realpathSync(fullPath);
+  if (!isInsideRoot(realRoot, realFullPath)) {
+    return {
+      name: entry.name,
+      status: 'fail',
+      reason: `source escapes project root: ${relativePath}`,
+    };
+  }
 
-  const actual = sourceIntegrity(fullPath);
+  const actual = sourceIntegrity(realFullPath);
   if (actual !== entry.integrity) {
     return {
       name: entry.name,
@@ -205,4 +234,3 @@ module.exports = {
   verifyForgeLock,
   writeForgeLock,
 };
-

--- a/lib/forge-lock.js
+++ b/lib/forge-lock.js
@@ -1,0 +1,208 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LOCKFILE_NAME = 'forge.lock';
+const AUDIT_LOG_PATH = path.join('.forge', 'log.jsonl');
+const REMOTE_SOURCE_PATTERN = /^(?:https?:|gh:|gist:|npm:)/i;
+
+function toPosixPath(value) {
+  return String(value || '').replaceAll('\\', '/');
+}
+
+function normalizeRelativePath(projectRoot, fullPath) {
+  return toPosixPath(path.relative(projectRoot, fullPath));
+}
+
+function lockPath(projectRoot) {
+  return path.join(projectRoot, LOCKFILE_NAME);
+}
+
+function defaultLock() {
+  return {
+    version: 1,
+    generatedBy: 'forge',
+    extensions: [],
+  };
+}
+
+function readForgeLock(projectRoot) {
+  const filePath = lockPath(projectRoot);
+  if (!fs.existsSync(filePath)) return defaultLock();
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  return {
+    ...defaultLock(),
+    ...parsed,
+    extensions: Array.isArray(parsed.extensions) ? parsed.extensions : [],
+  };
+}
+
+function writeForgeLock(projectRoot, lock) {
+  fs.writeFileSync(lockPath(projectRoot), `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
+}
+
+function appendAuditEvent(projectRoot, event) {
+  const logPath = path.join(projectRoot, AUDIT_LOG_PATH);
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  fs.appendFileSync(logPath, `${JSON.stringify({
+    kind: 'forge.lock',
+    schemaVersion: 1,
+    recordedAt: new Date().toISOString(),
+    ...event,
+  })}\n`, 'utf8');
+}
+
+function isRemoteSource(source) {
+  return REMOTE_SOURCE_PATTERN.test(String(source || ''));
+}
+
+function resolveLocalSource(projectRoot, source) {
+  const resolved = path.resolve(projectRoot, source);
+  const root = path.resolve(projectRoot);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Source must stay inside project root: ${source}`);
+  }
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+    throw new Error(`Local source does not exist: ${source}`);
+  }
+  return resolved;
+}
+
+function sourceIntegrity(filePath) {
+  const digest = crypto
+    .createHash('sha512')
+    .update(fs.readFileSync(filePath))
+    .digest('base64');
+  return `sha512-${digest}`;
+}
+
+function classifySource(projectRoot, source, options = {}) {
+  if (!source) {
+    throw new Error('Source is required');
+  }
+
+  if (isRemoteSource(source)) {
+    if (!options.allowUntrusted) {
+      throw new Error(`Untrusted source refused: ${source}. Re-run with --allow-untrusted to record it explicitly.`);
+    }
+    return {
+      trusted: false,
+      allowUntrusted: true,
+      resolvedPath: null,
+      integrity: null,
+      verification: 'unsupported-remote',
+      reason: 'remote locator requires explicit --allow-untrusted',
+    };
+  }
+
+  const resolvedPath = resolveLocalSource(projectRoot, source);
+  return {
+    trusted: true,
+    allowUntrusted: false,
+    resolvedPath,
+    integrity: sourceIntegrity(resolvedPath),
+    verification: 'sri',
+    reason: 'local file inside project root',
+  };
+}
+
+function upsertExtension(extensions, entry) {
+  const next = extensions.filter(existing => existing.name !== entry.name);
+  next.push(entry);
+  return next.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function addLockEntry(projectRoot, options) {
+  const root = path.resolve(projectRoot);
+  const sourceInfo = classifySource(root, options.source, {
+    allowUntrusted: Boolean(options.allowUntrusted),
+  });
+  const lock = readForgeLock(root);
+  const entry = {
+    name: options.name,
+    source: options.source,
+    resolvedPath: sourceInfo.resolvedPath ? normalizeRelativePath(root, sourceInfo.resolvedPath) : null,
+    integrity: sourceInfo.integrity,
+    verification: sourceInfo.verification,
+    trust: {
+      trusted: sourceInfo.trusted,
+      allowUntrusted: sourceInfo.allowUntrusted,
+      reason: sourceInfo.reason,
+    },
+    lockedAt: new Date().toISOString(),
+  };
+
+  lock.extensions = upsertExtension(lock.extensions, entry);
+  writeForgeLock(root, lock);
+  appendAuditEvent(root, {
+    action: 'add',
+    name: entry.name,
+    source: entry.source,
+    trusted: entry.trust.trusted,
+    verification: entry.verification,
+    integrity: entry.integrity,
+  });
+
+  return { lock, entry };
+}
+
+function verifyEntry(projectRoot, entry) {
+  if (entry.verification === 'unsupported-remote') {
+    return {
+      name: entry.name,
+      status: 'warn',
+      reason: 'remote source integrity cannot be rechecked by this foundation',
+    };
+  }
+
+  const relativePath = entry.resolvedPath || entry.source;
+  const fullPath = path.resolve(projectRoot, relativePath);
+  if (!fs.existsSync(fullPath) || !fs.statSync(fullPath).isFile()) {
+    return {
+      name: entry.name,
+      status: 'fail',
+      reason: `source missing: ${relativePath}`,
+    };
+  }
+
+  const actual = sourceIntegrity(fullPath);
+  if (actual !== entry.integrity) {
+    return {
+      name: entry.name,
+      status: 'fail',
+      reason: `integrity mismatch: expected ${entry.integrity}, got ${actual}`,
+    };
+  }
+
+  return {
+    name: entry.name,
+    status: 'pass',
+    reason: 'integrity verified',
+  };
+}
+
+function verifyForgeLock(projectRoot) {
+  const lock = readForgeLock(projectRoot);
+  const results = lock.extensions.map(entry => verifyEntry(projectRoot, entry));
+  return {
+    ok: results.every(result => result.status !== 'fail'),
+    path: LOCKFILE_NAME,
+    results,
+    lock,
+  };
+}
+
+module.exports = {
+  LOCKFILE_NAME,
+  AUDIT_LOG_PATH,
+  addLockEntry,
+  classifySource,
+  readForgeLock,
+  sourceIntegrity,
+  verifyForgeLock,
+  writeForgeLock,
+};
+

--- a/lib/forge-lock.js
+++ b/lib/forge-lock.js
@@ -91,6 +91,28 @@ function sourceIntegrity(filePath) {
   return `sha512-${digest}`;
 }
 
+function verifyUnsupportedRemoteEntry(entry) {
+  if (!isRemoteSource(entry.source)) {
+    return {
+      name: entry.name,
+      status: 'fail',
+      reason: 'unsupported remote verification requires a remote source locator',
+    };
+  }
+  if (entry.resolvedPath || entry.integrity || entry.trust?.allowUntrusted !== true) {
+    return {
+      name: entry.name,
+      status: 'fail',
+      reason: 'unsupported remote entry has inconsistent lock metadata',
+    };
+  }
+  return {
+    name: entry.name,
+    status: 'warn',
+    reason: 'remote source integrity cannot be rechecked by this foundation',
+  };
+}
+
 function classifySource(projectRoot, source, options = {}) {
   if (!source) {
     throw new Error('Source is required');
@@ -164,11 +186,7 @@ function addLockEntry(projectRoot, options) {
 
 function verifyEntry(projectRoot, entry) {
   if (entry.verification === 'unsupported-remote') {
-    return {
-      name: entry.name,
-      status: 'warn',
-      reason: 'remote source integrity cannot be rechecked by this foundation',
-    };
+    return verifyUnsupportedRemoteEntry(entry);
   }
 
   const relativePath = entry.resolvedPath || entry.source;

--- a/lib/forge-lock.js
+++ b/lib/forge-lock.js
@@ -188,6 +188,13 @@ function verifyEntry(projectRoot, entry) {
   if (entry.verification === 'unsupported-remote') {
     return verifyUnsupportedRemoteEntry(entry);
   }
+  if (isRemoteSource(entry.source) || isRemoteSource(entry.resolvedPath)) {
+    return {
+      name: entry.name,
+      status: 'fail',
+      reason: 'remote source locator requires unsupported-remote verification policy',
+    };
+  }
 
   const relativePath = entry.resolvedPath || entry.source;
   const root = path.resolve(projectRoot);

--- a/lib/upgrade-safety.js
+++ b/lib/upgrade-safety.js
@@ -64,14 +64,17 @@ function buildUpgradeDryRunReport(projectRoot = process.cwd()) {
   const lock = readForgeLock(root);
   const selfHealCandidates = buildSelfHealCandidates(root);
   const failedLockEntries = lockReport.results.filter(result => result.status === 'fail');
+  const untrustedOptIns = countUntrustedOptIns(lock);
+  const lockTrustOk = lockReport.ok && untrustedOptIns === 0;
 
   return {
-    ok: runtime.ok && patchIntent.ok && lockReport.ok,
+    ok: runtime.ok && patchIntent.ok && lockTrustOk,
     projectRoot: root,
     runtime,
     patchIntent,
     lock,
     lockReport,
+    lockTrustOk,
     selfHealCandidates,
     failedLockEntries,
   };
@@ -95,7 +98,7 @@ function patchIntentDetail(patchIntent) {
 
 function readinessLines(report) {
   const untrustedOptIns = countUntrustedOptIns(report.lock);
-  const lockStatus = report.lockReport.ok && untrustedOptIns === 0 ? 'pass' : 'fail';
+  const lockStatus = report.lockTrustOk ? 'pass' : 'fail';
   return [
     formatCheck(checkStatus(report.runtime.ok), 'Runtime config', runtimeDetail(report.runtime)),
     formatCheck(checkStatus(report.patchIntent.ok), 'Patch intent', patchIntentDetail(report.patchIntent)),

--- a/lib/upgrade-safety.js
+++ b/lib/upgrade-safety.js
@@ -81,59 +81,72 @@ function formatCheck(status, label, detail) {
   return `[${status.toUpperCase()}] ${label}: ${detail}`;
 }
 
-function renderUpgradeDryRunReport(report, selfHealResult = null) {
+function runtimeDetail(runtime) {
+  return runtime.ok
+    ? 'resolved runtime graph config'
+    : runtime.errors.map(error => error.message).join('; ');
+}
+
+function patchIntentDetail(patchIntent) {
+  return patchIntent.error
+    ? patchIntent.error
+    : `${patchIntent.records} record(s), ${patchIntent.orphans} orphan(s)`;
+}
+
+function readinessLines(report) {
   const untrustedOptIns = countUntrustedOptIns(report.lock);
+  return [
+    formatCheck(checkStatus(report.runtime.ok), 'Runtime config', runtimeDetail(report.runtime)),
+    formatCheck(checkStatus(report.patchIntent.ok), 'Patch intent', patchIntentDetail(report.patchIntent)),
+    formatCheck(
+      'pass',
+      'Lock trust',
+      `${report.lock.extensions.length} extension(s), ${untrustedOptIns} untrusted opt-in${untrustedOptIns === 1 ? '' : 's'}`
+    ),
+    ...report.lockReport.results.map(result => formatCheck(result.status, result.name, result.reason)),
+  ];
+}
+
+function appendPlannedSelfHeal(lines, candidates) {
+  lines.push('', 'Planned self-heal');
+  if (candidates.length === 0) {
+    lines.push('No self-heal actions needed.');
+    return;
+  }
+  for (const candidate of candidates) {
+    lines.push(`- ${candidate.path}: ${candidate.description}`);
+  }
+}
+
+function appendSelfHealResult(lines, selfHealResult) {
+  if (!selfHealResult) return;
+  lines.push('', 'Self-heal result');
+  if (selfHealResult.refused) {
+    lines.push('Self-heal refused unrecoverable lock integrity failure.');
+    return;
+  }
+  if (selfHealResult.applied.length === 0) {
+    lines.push('No self-heal actions needed.');
+    return;
+  }
+  lines.push(`Self-heal applied ${selfHealResult.applied.length} action(s).`);
+  for (const action of selfHealResult.applied) {
+    lines.push(`- ${action.path}`);
+  }
+}
+
+function renderUpgradeDryRunReport(report, selfHealResult = null) {
   const lines = [
     'Forge upgrade dry-run',
     `Target: ${report.projectRoot}`,
     `Result: ${report.ok ? 'PASS' : 'FAIL'}`,
     '',
     'Readiness',
-    formatCheck(
-      checkStatus(report.runtime.ok),
-      'Runtime config',
-      report.runtime.ok ? 'resolved runtime graph config' : report.runtime.errors.map(error => error.message).join('; ')
-    ),
-    formatCheck(
-      checkStatus(report.patchIntent.ok),
-      'Patch intent',
-      report.patchIntent.error
-        ? report.patchIntent.error
-        : `${report.patchIntent.records} record(s), ${report.patchIntent.orphans} orphan(s)`
-    ),
-    formatCheck(
-      'pass',
-      'Lock trust',
-      `${report.lock.extensions.length} extension(s), ${untrustedOptIns} untrusted opt-in${untrustedOptIns === 1 ? '' : 's'}`
-    ),
+    ...readinessLines(report),
   ];
 
-  for (const result of report.lockReport.results) {
-    lines.push(formatCheck(result.status, result.name, result.reason));
-  }
-
-  lines.push('', 'Planned self-heal');
-  if (report.selfHealCandidates.length === 0) {
-    lines.push('No self-heal actions needed.');
-  } else {
-    for (const candidate of report.selfHealCandidates) {
-      lines.push(`- ${candidate.path}: ${candidate.description}`);
-    }
-  }
-
-  if (selfHealResult) {
-    lines.push('', 'Self-heal result');
-    if (selfHealResult.refused) {
-      lines.push('Self-heal refused unrecoverable lock integrity failure.');
-    } else if (selfHealResult.applied.length === 0) {
-      lines.push('No self-heal actions needed.');
-    } else {
-      lines.push(`Self-heal applied ${selfHealResult.applied.length} action(s).`);
-      for (const action of selfHealResult.applied) {
-        lines.push(`- ${action.path}`);
-      }
-    }
-  }
+  appendPlannedSelfHeal(lines, report.selfHealCandidates);
+  appendSelfHealResult(lines, selfHealResult);
 
   lines.push(
     '',
@@ -180,4 +193,3 @@ module.exports = {
   buildSelfHealCandidates,
   renderUpgradeDryRunReport,
 };
-

--- a/lib/upgrade-safety.js
+++ b/lib/upgrade-safety.js
@@ -95,11 +95,12 @@ function patchIntentDetail(patchIntent) {
 
 function readinessLines(report) {
   const untrustedOptIns = countUntrustedOptIns(report.lock);
+  const lockStatus = report.lockReport.ok && untrustedOptIns === 0 ? 'pass' : 'fail';
   return [
     formatCheck(checkStatus(report.runtime.ok), 'Runtime config', runtimeDetail(report.runtime)),
     formatCheck(checkStatus(report.patchIntent.ok), 'Patch intent', patchIntentDetail(report.patchIntent)),
     formatCheck(
-      'pass',
+      lockStatus,
       'Lock trust',
       `${report.lock.extensions.length} extension(s), ${untrustedOptIns} untrusted opt-in${untrustedOptIns === 1 ? '' : 's'}`
     ),

--- a/lib/upgrade-safety.js
+++ b/lib/upgrade-safety.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { lintRuntimeGraphConfig } = require('./core/runtime-graph');
+const { resolvePatchIntentRecords } = require('./patch-intent');
+const { verifyForgeLock, readForgeLock } = require('./forge-lock');
+
+function checkStatus(ok) {
+  return ok ? 'pass' : 'fail';
+}
+
+function countUntrustedOptIns(lock) {
+  return lock.extensions.filter(entry => entry.trust?.allowUntrusted === true).length;
+}
+
+function buildPatchIntentSummary(projectRoot) {
+  try {
+    const status = resolvePatchIntentRecords(projectRoot);
+    return {
+      ok: status.orphans.length === 0,
+      path: status.path,
+      records: status.records.length,
+      orphans: status.orphans.length,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      path: '.forge/patch.md',
+      records: 0,
+      orphans: 0,
+      error: error.message,
+    };
+  }
+}
+
+function buildSelfHealCandidates(projectRoot) {
+  const forgeDir = path.join(projectRoot, '.forge');
+  const logPath = path.join(forgeDir, 'log.jsonl');
+  const candidates = [];
+  if (!fs.existsSync(forgeDir)) {
+    candidates.push({
+      id: 'forge-dir',
+      path: '.forge/',
+      description: 'Create missing Forge metadata directory',
+    });
+  }
+  if (!fs.existsSync(logPath)) {
+    candidates.push({
+      id: 'audit-log',
+      path: '.forge/log.jsonl',
+      description: 'Create missing Forge audit log file',
+    });
+  }
+  return candidates;
+}
+
+function buildUpgradeDryRunReport(projectRoot = process.cwd()) {
+  const root = path.resolve(projectRoot);
+  const runtime = lintRuntimeGraphConfig({ projectRoot: root });
+  const patchIntent = buildPatchIntentSummary(root);
+  const lockReport = verifyForgeLock(root);
+  const lock = readForgeLock(root);
+  const selfHealCandidates = buildSelfHealCandidates(root);
+  const failedLockEntries = lockReport.results.filter(result => result.status === 'fail');
+
+  return {
+    ok: runtime.ok && patchIntent.ok && lockReport.ok,
+    projectRoot: root,
+    runtime,
+    patchIntent,
+    lock,
+    lockReport,
+    selfHealCandidates,
+    failedLockEntries,
+  };
+}
+
+function formatCheck(status, label, detail) {
+  return `[${status.toUpperCase()}] ${label}: ${detail}`;
+}
+
+function renderUpgradeDryRunReport(report, selfHealResult = null) {
+  const untrustedOptIns = countUntrustedOptIns(report.lock);
+  const lines = [
+    'Forge upgrade dry-run',
+    `Target: ${report.projectRoot}`,
+    `Result: ${report.ok ? 'PASS' : 'FAIL'}`,
+    '',
+    'Readiness',
+    formatCheck(
+      checkStatus(report.runtime.ok),
+      'Runtime config',
+      report.runtime.ok ? 'resolved runtime graph config' : report.runtime.errors.map(error => error.message).join('; ')
+    ),
+    formatCheck(
+      checkStatus(report.patchIntent.ok),
+      'Patch intent',
+      report.patchIntent.error
+        ? report.patchIntent.error
+        : `${report.patchIntent.records} record(s), ${report.patchIntent.orphans} orphan(s)`
+    ),
+    formatCheck(
+      'pass',
+      'Lock trust',
+      `${report.lock.extensions.length} extension(s), ${untrustedOptIns} untrusted opt-in${untrustedOptIns === 1 ? '' : 's'}`
+    ),
+  ];
+
+  for (const result of report.lockReport.results) {
+    lines.push(formatCheck(result.status, result.name, result.reason));
+  }
+
+  lines.push('', 'Planned self-heal');
+  if (report.selfHealCandidates.length === 0) {
+    lines.push('No self-heal actions needed.');
+  } else {
+    for (const candidate of report.selfHealCandidates) {
+      lines.push(`- ${candidate.path}: ${candidate.description}`);
+    }
+  }
+
+  if (selfHealResult) {
+    lines.push('', 'Self-heal result');
+    if (selfHealResult.refused) {
+      lines.push('Self-heal refused unrecoverable lock integrity failure.');
+    } else if (selfHealResult.applied.length === 0) {
+      lines.push('No self-heal actions needed.');
+    } else {
+      lines.push(`Self-heal applied ${selfHealResult.applied.length} action(s).`);
+      for (const action of selfHealResult.applied) {
+        lines.push(`- ${action.path}`);
+      }
+    }
+  }
+
+  lines.push(
+    '',
+    'Limitations',
+    'Non-scope: rollback snapshots and full restore are not implemented in this PR.',
+    'Remote/package source integrity is recorded as explicit trust policy only until a resolver can materialize bytes for SRI verification.'
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function applySelfHeal(projectRoot, report) {
+  if (report.failedLockEntries.length > 0) {
+    return {
+      refused: true,
+      applied: [],
+      reason: 'unrecoverable lock integrity failure',
+    };
+  }
+
+  const applied = [];
+  const forgeDir = path.join(projectRoot, '.forge');
+  const logPath = path.join(forgeDir, 'log.jsonl');
+
+  if (!fs.existsSync(forgeDir)) {
+    fs.mkdirSync(forgeDir, { recursive: true });
+    applied.push({ path: '.forge/' });
+  }
+
+  if (!fs.existsSync(logPath)) {
+    fs.writeFileSync(logPath, '', 'utf8');
+    applied.push({ path: '.forge/log.jsonl' });
+  }
+
+  return {
+    refused: false,
+    applied,
+  };
+}
+
+module.exports = {
+  applySelfHeal,
+  buildUpgradeDryRunReport,
+  buildSelfHealCandidates,
+  renderUpgradeDryRunReport,
+};
+

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -101,7 +101,10 @@ function isKnownTargetablePath(file) {
     return true;
   }
 
-  if (file.startsWith('docs/plans/') || file.startsWith('docs/work/')) {
+  if (file === 'docs/INDEX.md'
+    || file.startsWith('docs/plans/')
+    || file.startsWith('docs/reference/')
+    || file.startsWith('docs/work/')) {
     return true;
   }
 

--- a/test/commands/add.test.js
+++ b/test/commands/add.test.js
@@ -1,0 +1,51 @@
+const { describe, expect, test, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const addCommand = require('../../lib/commands/add');
+
+const tempRoots = [];
+
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-add-command-'));
+  tempRoots.push(root);
+  fs.writeFileSync(path.join(root, 'plugin.json'), '{"id":"local"}\n', 'utf8');
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('forge add command', () => {
+  test('adds trusted local sources to forge.lock', async () => {
+    const root = makeRepo();
+
+    const result = await addCommand.handler(['./plugin.json', '--name', 'local'], {}, root);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Added local');
+    expect(fs.readFileSync(path.join(root, 'forge.lock'), 'utf8')).toContain('"name": "local"');
+  });
+
+  test('requires --allow-untrusted for remote locators', async () => {
+    const root = makeRepo();
+
+    const refused = await addCommand.handler(['https://example.com/plugin.tgz', '--name', 'remote'], {}, root);
+    expect(refused.success).toBe(false);
+    expect(refused.error).toContain('--allow-untrusted');
+
+    const allowed = await addCommand.handler([
+      'https://example.com/plugin.tgz',
+      '--name',
+      'remote',
+      '--allow-untrusted',
+    ], {}, root);
+    expect(allowed.success).toBe(true);
+    expect(allowed.output).toContain('untrusted source accepted');
+  });
+});
+

--- a/test/commands/add.test.js
+++ b/test/commands/add.test.js
@@ -67,4 +67,13 @@ describe('forge add command', () => {
     expect(result.output).toContain('Added plugin');
     expect(fs.readFileSync(path.join(root, 'forge.lock'), 'utf8')).toContain('"name": "plugin"');
   });
+
+  test('skips global path flag values when selecting source', async () => {
+    const root = makeRepo();
+
+    const result = await addCommand.handler(['--path', root, './plugin.json', '--name', 'local'], {}, root);
+
+    expect(result.success).toBe(true);
+    expect(fs.readFileSync(path.join(root, 'forge.lock'), 'utf8')).toContain('"source": "./plugin.json"');
+  });
 });

--- a/test/commands/add.test.js
+++ b/test/commands/add.test.js
@@ -47,5 +47,14 @@ describe('forge add command', () => {
     expect(allowed.success).toBe(true);
     expect(allowed.output).toContain('untrusted source accepted');
   });
-});
 
+  test('parses flag values without treating them as the source', async () => {
+    const root = makeRepo();
+
+    const result = await addCommand.handler(['--name', 'local', './plugin.json'], {}, root);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Added local');
+    expect(fs.readFileSync(path.join(root, 'forge.lock'), 'utf8')).toContain('"source": "./plugin.json"');
+  });
+});

--- a/test/commands/add.test.js
+++ b/test/commands/add.test.js
@@ -57,4 +57,14 @@ describe('forge add command', () => {
     expect(result.output).toContain('Added local');
     expect(fs.readFileSync(path.join(root, 'forge.lock'), 'utf8')).toContain('"source": "./plugin.json"');
   });
+
+  test('does not treat another flag as a --name value', async () => {
+    const root = makeRepo();
+
+    const result = await addCommand.handler(['./plugin.json', '--name', '--allow-untrusted'], {}, root);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Added plugin');
+    expect(fs.readFileSync(path.join(root, 'forge.lock'), 'utf8')).toContain('"name": "plugin"');
+  });
 });

--- a/test/commands/audit.test.js
+++ b/test/commands/audit.test.js
@@ -37,6 +37,16 @@ describe('forge audit command', () => {
     expect(tampered.error).toBe(tampered.output);
   });
 
+  test('accepts verify after global path flags', async () => {
+    const root = makeRepo();
+    await addCommand.handler(['./plugin.json', '--name', 'local'], {}, root);
+
+    const result = await auditCommand.handler(['--path', root, 'verify'], {}, root);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('[PASS] local');
+  });
+
   test('reports malformed lockfiles as structured failures', async () => {
     const root = makeRepo();
     fs.writeFileSync(path.join(root, 'forge.lock'), '{not json', 'utf8');

--- a/test/commands/audit.test.js
+++ b/test/commands/audit.test.js
@@ -36,5 +36,15 @@ describe('forge audit command', () => {
     expect(tampered.output).toContain('[FAIL] local');
     expect(tampered.error).toBe(tampered.output);
   });
-});
 
+  test('reports malformed lockfiles as structured failures', async () => {
+    const root = makeRepo();
+    fs.writeFileSync(path.join(root, 'forge.lock'), '{not json', 'utf8');
+
+    const result = await auditCommand.handler(['verify'], {}, root);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('JSON');
+    expect(result.output).toBeUndefined();
+  });
+});

--- a/test/commands/audit.test.js
+++ b/test/commands/audit.test.js
@@ -1,0 +1,40 @@
+const { describe, expect, test, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const addCommand = require('../../lib/commands/add');
+const auditCommand = require('../../lib/commands/audit');
+
+const tempRoots = [];
+
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-audit-command-'));
+  tempRoots.push(root);
+  fs.writeFileSync(path.join(root, 'plugin.json'), '{"id":"local"}\n', 'utf8');
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('forge audit command', () => {
+  test('verifies lockfile integrity hashes', async () => {
+    const root = makeRepo();
+    await addCommand.handler(['./plugin.json', '--name', 'local'], {}, root);
+
+    const clean = await auditCommand.handler(['verify'], {}, root);
+    expect(clean.success).toBe(true);
+    expect(clean.output).toContain('[PASS] local');
+
+    fs.writeFileSync(path.join(root, 'plugin.json'), '{"id":"tampered"}\n', 'utf8');
+    const tampered = await auditCommand.handler(['verify'], {}, root);
+    expect(tampered.success).toBe(false);
+    expect(tampered.output).toContain('[FAIL] local');
+    expect(tampered.error).toBe(tampered.output);
+  });
+});
+

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -274,6 +274,35 @@ describe('forge test command', () => {
 			expect(call.args).toContain('test/bar.test.js');
 		});
 
+		test('maps upgrade safety support files to targeted tests', async () => {
+			const spawnSpy = makeSpawnSync();
+			await testCommand.handler([], { affected: true }, '/fake/root', {
+				fs: makeFsStub({
+					existingPaths: [
+						'/fake/root/test/commands/upgrade.test.js',
+						'/fake/root/test/docs-consistency.test.js',
+					],
+				}),
+				execFileSync: makeExecFileSync({
+					mergeBaseOutput: 'abc123',
+					gitDiffOutput: [
+						'docs/INDEX.md',
+						'docs/reference/upgrade-safety.md',
+						'lib/upgrade-safety.js',
+						'lib/commands/upgrade.js',
+					].join('\n'),
+				}),
+				spawnSync: spawnSpy,
+			});
+
+			expect(spawnSpy.calls[0].args).toEqual([
+				'run',
+				'test',
+				'test/commands/upgrade.test.js',
+				'test/docs-consistency.test.js',
+			]);
+		});
+
 		test('uses merge-base for diff by default', async () => {
 			const execCalls = [];
 			const execStub = (cmd, args, _opts) => {

--- a/test/commands/upgrade.test.js
+++ b/test/commands/upgrade.test.js
@@ -62,6 +62,15 @@ describe('forge upgrade command', () => {
     expect(second.output).toContain('No self-heal actions needed');
   });
 
+  test('honors parsed kebab-case dry-run flags', async () => {
+    const root = makeRepo();
+
+    const result = await upgradeCommand.handler([], { 'dry-run': true }, root);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Forge upgrade dry-run');
+  });
+
   test('self-heal reports integrity failures without repairing them', async () => {
     const root = makeRepo();
     await addCommand.handler(['./plugin.json', '--name', 'local'], {}, root);

--- a/test/commands/upgrade.test.js
+++ b/test/commands/upgrade.test.js
@@ -36,8 +36,9 @@ describe('forge upgrade command', () => {
 
     const result = await upgradeCommand.handler(['--dry-run'], { dryRun: true }, root);
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
     expect(result.output).toContain('Forge upgrade dry-run');
+    expect(result.error).toBe(result.output);
     expect(result.output).toContain('[PASS] Runtime config');
     expect(result.output).toContain('[PASS] Patch intent: 0 record(s), 0 orphan(s)');
     expect(result.output).toContain('[FAIL] Lock trust: 2 extension(s), 1 untrusted opt-in');

--- a/test/commands/upgrade.test.js
+++ b/test/commands/upgrade.test.js
@@ -40,7 +40,7 @@ describe('forge upgrade command', () => {
     expect(result.output).toContain('Forge upgrade dry-run');
     expect(result.output).toContain('[PASS] Runtime config');
     expect(result.output).toContain('[PASS] Patch intent: 0 record(s), 0 orphan(s)');
-    expect(result.output).toContain('[PASS] Lock trust: 2 extension(s), 1 untrusted opt-in');
+    expect(result.output).toContain('[FAIL] Lock trust: 2 extension(s), 1 untrusted opt-in');
     expect(result.output).toContain('[WARN] remote: remote source integrity cannot be rechecked');
     expect(result.output).toContain('Non-scope: rollback snapshots and full restore are not implemented');
     expect(fs.readFileSync(path.join(root, '.forge', 'log.jsonl'), 'utf8')).toBe(beforeLog);
@@ -75,4 +75,3 @@ describe('forge upgrade command', () => {
     expect(fs.readFileSync(path.join(root, 'plugin.json'), 'utf8')).toContain('tampered');
   });
 });
-

--- a/test/commands/upgrade.test.js
+++ b/test/commands/upgrade.test.js
@@ -1,0 +1,78 @@
+const { describe, expect, test, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const addCommand = require('../../lib/commands/add');
+const upgradeCommand = require('../../lib/commands/upgrade');
+
+const tempRoots = [];
+
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-upgrade-command-'));
+  tempRoots.push(root);
+  fs.writeFileSync(path.join(root, 'AGENTS.md'), [
+    '# Agents',
+    '<!-- forge-anchor:stage.plan -->',
+    'Plan instructions.',
+    '',
+  ].join('\n'), 'utf8');
+  fs.writeFileSync(path.join(root, 'plugin.json'), '{"id":"local"}\n', 'utf8');
+  return root;
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('forge upgrade command', () => {
+  test('dry-run consumes config, patch intent, and lock trust state without mutation', async () => {
+    const root = makeRepo();
+    await addCommand.handler(['./plugin.json', '--name', 'local'], {}, root);
+    await addCommand.handler(['gh:owner/repo/plugin', '--name', 'remote', '--allow-untrusted'], {}, root);
+    const beforeLog = fs.readFileSync(path.join(root, '.forge', 'log.jsonl'), 'utf8');
+
+    const result = await upgradeCommand.handler(['--dry-run'], { dryRun: true }, root);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Forge upgrade dry-run');
+    expect(result.output).toContain('[PASS] Runtime config');
+    expect(result.output).toContain('[PASS] Patch intent: 0 record(s), 0 orphan(s)');
+    expect(result.output).toContain('[PASS] Lock trust: 2 extension(s), 1 untrusted opt-in');
+    expect(result.output).toContain('[WARN] remote: remote source integrity cannot be rechecked');
+    expect(result.output).toContain('Non-scope: rollback snapshots and full restore are not implemented');
+    expect(fs.readFileSync(path.join(root, '.forge', 'log.jsonl'), 'utf8')).toBe(beforeLog);
+  });
+
+  test('self-heal creates only missing safe metadata and is idempotent', async () => {
+    const root = makeRepo();
+    fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
+    fs.rmSync(path.join(root, '.forge'), { recursive: true, force: true });
+
+    const first = await upgradeCommand.handler(['--self-heal'], {}, root);
+
+    expect(first.success).toBe(true);
+    expect(first.output).toContain('Self-heal applied');
+    expect(fs.existsSync(path.join(root, '.forge', 'log.jsonl'))).toBe(true);
+
+    const second = await upgradeCommand.handler(['--self-heal'], {}, root);
+    expect(second.success).toBe(true);
+    expect(second.output).toContain('No self-heal actions needed');
+  });
+
+  test('self-heal reports integrity failures without repairing them', async () => {
+    const root = makeRepo();
+    await addCommand.handler(['./plugin.json', '--name', 'local'], {}, root);
+    fs.writeFileSync(path.join(root, 'plugin.json'), '{"id":"tampered"}\n', 'utf8');
+
+    const result = await upgradeCommand.handler(['--self-heal'], {}, root);
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain('[FAIL] local: integrity mismatch');
+    expect(result.output).toContain('Self-heal refused unrecoverable lock integrity failure');
+    expect(fs.readFileSync(path.join(root, 'plugin.json'), 'utf8')).toContain('tampered');
+  });
+});
+

--- a/test/forge-lock.test.js
+++ b/test/forge-lock.test.js
@@ -136,4 +136,31 @@ describe('forge lock trust policy', () => {
     expect(report.results[0].status).toBe('fail');
     expect(report.results[0].reason).toContain('project root');
   });
+
+  test('fails verification when local paths spoof unsupported remote entries', () => {
+    const root = makeRepo();
+    writeForgeLock(root, {
+      version: 1,
+      generatedBy: 'forge',
+      extensions: [{
+        name: 'spoofed',
+        source: './extensions/local.plugin.json',
+        resolvedPath: null,
+        integrity: null,
+        verification: 'unsupported-remote',
+        trust: {
+          trusted: false,
+          allowUntrusted: true,
+          reason: 'crafted test entry',
+        },
+        lockedAt: new Date().toISOString(),
+      }],
+    });
+
+    const report = verifyForgeLock(root);
+
+    expect(report.ok).toBe(false);
+    expect(report.results[0].status).toBe('fail');
+    expect(report.results[0].reason).toContain('remote source locator');
+  });
 });

--- a/test/forge-lock.test.js
+++ b/test/forge-lock.test.js
@@ -1,0 +1,92 @@
+const { describe, expect, test, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  addLockEntry,
+  readForgeLock,
+  verifyForgeLock,
+} = require('../lib/forge-lock');
+
+const tempRoots = [];
+
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-lock-'));
+  tempRoots.push(root);
+  fs.mkdirSync(path.join(root, 'extensions'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'extensions', 'local.plugin.json'), '{"name":"local"}\n', 'utf8');
+  return root;
+}
+
+beforeEach(() => {
+  tempRoots.length = 0;
+});
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('forge lock trust policy', () => {
+  test('writes a reviewable lock entry and audit event for trusted local sources', () => {
+    const root = makeRepo();
+
+    const result = addLockEntry(root, {
+      name: 'local',
+      source: './extensions/local.plugin.json',
+    });
+
+    expect(result.entry.name).toBe('local');
+    expect(result.entry.trust.trusted).toBe(true);
+    expect(result.entry.integrity).toMatch(/^sha512-/);
+
+    const lock = readForgeLock(root);
+    expect(lock.version).toBe(1);
+    expect(lock.extensions).toHaveLength(1);
+    expect(lock.extensions[0].source).toBe('./extensions/local.plugin.json');
+
+    const auditLog = fs.readFileSync(path.join(root, '.forge', 'log.jsonl'), 'utf8').trim();
+    const event = JSON.parse(auditLog);
+    expect(event.kind).toBe('forge.lock');
+    expect(event.action).toBe('add');
+    expect(event.name).toBe('local');
+  });
+
+  test('refuses untrusted locator strings unless explicitly allowed', () => {
+    const root = makeRepo();
+
+    expect(() => addLockEntry(root, {
+      name: 'remote',
+      source: 'gh:owner/repo/plugin',
+    })).toThrow(/Untrusted source/);
+
+    const result = addLockEntry(root, {
+      name: 'remote',
+      source: 'gh:owner/repo/plugin',
+      allowUntrusted: true,
+    });
+
+    expect(result.entry.trust.trusted).toBe(false);
+    expect(result.entry.trust.allowUntrusted).toBe(true);
+    expect(result.entry.integrity).toBe(null);
+    expect(result.entry.verification).toBe('unsupported-remote');
+  });
+
+  test('reports tampered local source integrity mismatches', () => {
+    const root = makeRepo();
+    addLockEntry(root, {
+      name: 'local',
+      source: './extensions/local.plugin.json',
+    });
+
+    fs.writeFileSync(path.join(root, 'extensions', 'local.plugin.json'), '{"name":"tampered"}\n', 'utf8');
+
+    const report = verifyForgeLock(root);
+    expect(report.ok).toBe(false);
+    expect(report.results[0].status).toBe('fail');
+    expect(report.results[0].reason).toContain('integrity mismatch');
+  });
+});
+

--- a/test/forge-lock.test.js
+++ b/test/forge-lock.test.js
@@ -7,6 +7,7 @@ const {
   addLockEntry,
   readForgeLock,
   verifyForgeLock,
+  writeForgeLock,
 } = require('../lib/forge-lock');
 
 const tempRoots = [];
@@ -88,5 +89,51 @@ describe('forge lock trust policy', () => {
     expect(report.results[0].status).toBe('fail');
     expect(report.results[0].reason).toContain('integrity mismatch');
   });
-});
 
+  test('refuses symlinked local sources that resolve outside the project root', () => {
+    const root = makeRepo();
+    const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-lock-outside-'));
+    tempRoots.push(outsideRoot);
+    const outsideFile = path.join(outsideRoot, 'external.plugin.json');
+    const linkPath = path.join(root, 'extensions', 'external.plugin.json');
+    fs.writeFileSync(outsideFile, '{"name":"external"}\n', 'utf8');
+    try {
+      fs.symlinkSync(outsideFile, linkPath);
+    } catch (error) {
+      expect(['EACCES', 'EPERM']).toContain(error.code);
+      return;
+    }
+
+    expect(() => addLockEntry(root, {
+      name: 'external',
+      source: './extensions/external.plugin.json',
+    })).toThrow(/project root/);
+  });
+
+  test('fails verification when a crafted lock entry escapes the project root', () => {
+    const root = makeRepo();
+    writeForgeLock(root, {
+      version: 1,
+      generatedBy: 'forge',
+      extensions: [{
+        name: 'escape',
+        source: '../outside.plugin.json',
+        resolvedPath: '../outside.plugin.json',
+        integrity: 'sha512-invalid',
+        verification: 'sri',
+        trust: {
+          trusted: true,
+          allowUntrusted: false,
+          reason: 'crafted test entry',
+        },
+        lockedAt: new Date().toISOString(),
+      }],
+    });
+
+    const report = verifyForgeLock(root);
+
+    expect(report.ok).toBe(false);
+    expect(report.results[0].status).toBe('fail');
+    expect(report.results[0].reason).toContain('project root');
+  });
+});

--- a/test/forge-lock.test.js
+++ b/test/forge-lock.test.js
@@ -163,4 +163,31 @@ describe('forge lock trust policy', () => {
     expect(report.results[0].status).toBe('fail');
     expect(report.results[0].reason).toContain('remote source locator');
   });
+
+  test('fails verification when remote sources spoof trusted local integrity', () => {
+    const root = makeRepo();
+    writeForgeLock(root, {
+      version: 1,
+      generatedBy: 'forge',
+      extensions: [{
+        name: 'remote-spoof',
+        source: 'gh:owner/repo/plugin',
+        resolvedPath: './extensions/local.plugin.json',
+        integrity: 'sha512-invalid',
+        verification: 'sri',
+        trust: {
+          trusted: true,
+          allowUntrusted: false,
+          reason: 'crafted test entry',
+        },
+        lockedAt: new Date().toISOString(),
+      }],
+    });
+
+    const report = verifyForgeLock(root);
+
+    expect(report.ok).toBe(false);
+    expect(report.results[0].status).toBe('fail');
+    expect(report.results[0].reason).toContain('unsupported-remote verification policy');
+  });
 });

--- a/test/scripts/test-runner.test.js
+++ b/test/scripts/test-runner.test.js
@@ -152,6 +152,25 @@ describe('scripts/test pre-push runner', () => {
     ]);
   });
 
+  test('classifyPushTests maps upgrade safety docs and support modules without forcing a full suite', () => {
+    const plan = classifyPushTests(repoRoot, makeExecFileSync({
+      changedFiles: [
+        'docs/INDEX.md',
+        'docs/reference/upgrade-safety.md',
+        'lib/upgrade-safety.js',
+        'lib/commands/upgrade.js',
+      ].join('\n'),
+    }));
+
+    expect(plan.runFullSuite).toBe(false);
+    expect(plan.hasUnmappedFiles).toBe(false);
+    expect(plan.testTargets).toEqual([
+      'test/commands/upgrade.test.js',
+      'test/docs-consistency.test.js',
+      ...riskTargets,
+    ]);
+  });
+
   test('buildTestExecutionPlan always includes curated risk tests in targeted mode', () => {
     const plan = buildTestExecutionPlan(repoRoot, makeExecFileSync({
       changedFiles: 'scripts/behavioral-judge.sh\n',


### PR DESCRIPTION
## Problem
0.0.16 needs a safety foundation before upgrade flows can consume extension/source state. `forge-besw.8` requires reviewable lock/trust policy and audit verification, and `forge-besw.11` depends on that policy for upgrade dry-run and self-heal readiness.

## Root Cause
Upgrade planning had patch intent and runtime config primitives, but no usable lockfile/trust state to distinguish trusted local sources from explicit untrusted opt-ins. Validation also treated the new upgrade safety files as unmapped, forcing unrelated full-suite lanes.

## Fix
Implements dependency order explicitly:
1. `forge-besw.8`: `forge.lock`, `forge add`, `forge audit verify`, SRI verification for local sources, audit JSONL entries, and `--allow-untrusted` policy for remote/package locators.
2. `forge-besw.11`: `forge upgrade --dry-run` consuming runtime config, patch intent, and lock/trust state; `forge upgrade --self-heal` limited to safe metadata scaffolding.
3. Validation mapping for the new upgrade safety files so PR checks target relevant tests.

## Value
Upgrade readiness becomes reviewable and safer: local source tampering is refused, untrusted sources require explicit opt-in, dry-run explains planned state without mutation, and self-heal handles only recoverable metadata gaps.

## Beads
Covers `forge-besw.8` and `forge-besw.11`.
Closes forge-besw.8
Closes forge-besw.11

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: `bun run check` passed; targeted lane ran 103 PR tests plus 266 affected edge-case tests.
- Scenarios covered: trusted local lock entries, untrusted refusal/`--allow-untrusted`, SRI tamper detection, audit verify, upgrade dry-run output, self-heal idempotency, unrecoverable integrity refusal, validation mapping.

### Security Review
- OWASP Top 10: A08 software/data integrity addressed through lockfile SRI and explicit trust policy; A09 logging/monitoring addressed through JSONL audit entries.
- Automated scan: `bun audit` passed with no vulnerabilities found.

### Design Doc
See: `docs/work/2026-05-16-0.0.16-upgrade-safety/design.md`

### Key Decisions
- Implemented `forge-besw.8` before `forge-besw.11` so upgrade dry-run consumes usable lock/trust state.
- Local project files are trusted and SRI-verifiable; remote/package locators are untrusted and require `--allow-untrusted`.
- Self-heal is limited to `.forge/` and `.forge/log.jsonl` metadata scaffolding.
- Remote resolver downloads, marketplace allowlists, rollback snapshots, and full restore remain non-scope.

### Documentation Updated
- `docs/reference/upgrade-safety.md`
- `docs/INDEX.md`
- `docs/work/2026-05-16-0.0.16-upgrade-safety/*`

### Validation
- [x] Type check passing (`bun run typecheck` / included in `bun run check`; no TypeScript, skipped by project policy)
- [x] Lint passing (0 errors, 0 warnings)
- [x] All relevant tests passing (`bun run check`)
- [x] Security review completed (`bun audit` passed)

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff locally
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint` via `bun run check`)
- [x] Relevant tests pass locally (`bun run check`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (new commands are additive)
- [x] TDD compliance: Source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added add, audit verify, and upgrade commands. Upgrade supports --dry-run (readiness & lock-trust report) and --self-heal (idempotent creation of missing metadata; refuses integrity repairs).

* **Documentation**
  * New upgrade-safety reference and work docs covering lockfile trust policy, SRI integrity for local files, audit logging, dry-run reporting, self-heal limits, and explicit out-of-scope items.

* **Tests**
  * Added/expanded tests for add, audit, upgrade, lockfile trust/integrity, self-heal idempotency, and targeted test-selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->