### PR TITLE
0.0.18 adapter foundation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -67,6 +67,7 @@ See [work/](work/) for the full list of date-prefixed work folders. Each folder 
 - [TOOLCHAIN.md](reference/TOOLCHAIN.md) — Toolchain conventions (Bun, lefthook, beads, MCP, shell model)
 - [VALIDATION.md](reference/VALIDATION.md) — Validation stage requirements
 - [TEMPLATES.md](reference/TEMPLATES.md) — Adoption templates and `forge init` profiles
+- [ADAPTERS.md](reference/ADAPTERS.md) — Review adapter contract, lifecycle, scaffold, and fixture replay expectations
 - [EXAMPLES.md](reference/EXAMPLES.md) — Worked examples
 - [upgrade-safety.md](reference/upgrade-safety.md) — Lockfile trust policy, upgrade dry-run, and self-heal limitations
 - [INSIGHTS_RECAP.md](reference/INSIGHTS_RECAP.md) — `forge insights` and `forge recap` evidence sources, output, and limitations

--- a/docs/reference/ADAPTERS.md
+++ b/docs/reference/ADAPTERS.md
@@ -1,0 +1,89 @@
+# Forge Review Adapters
+
+Forge review adapters normalize provider-specific review feedback into one contract used by review tooling and offline fixture tests.
+
+## Contract
+
+A review adapter has `kind: "review"` and implements these methods:
+
+- `fetchThreads(context)`: fetch provider review threads. Live adapters may use GitHub, REST, GraphQL, or a provider SDK.
+- `parse(payload, options)`: normalize provider payloads into review thread objects.
+- `reply(context)`: post a reply to a provider review comment.
+- `resolve(context)`: mark a provider review thread resolved.
+- `score(threads, context)`: score or classify parsed threads, usually by checking local commits or fixture data.
+
+Normalized thread shape:
+
+```js
+{
+  id: 'provider-thread-id',
+  commentId: 123,
+  file: 'lib/example.js',
+  line: 42,
+  body: 'review text',
+  author: 'review-bot',
+  isResolved: false,
+  raw: {}
+}
+```
+
+## Lifecycle
+
+1. `fetchThreads` obtains raw provider data for live review runs.
+2. `parse` filters and normalizes the provider data.
+3. `score` decides whether local work appears to address each parsed thread.
+4. `reply` posts the resolution explanation.
+5. `resolve` closes the provider thread after a reply is recorded.
+
+The bundled `GreptileReviewAdapter` is the compatibility reference. Existing Greptile shell commands keep their public command names while the shared matching behavior is routed through the adapter implementation.
+
+## Scaffold
+
+Create a local review adapter starter:
+
+```bash
+forge new adapter coderabbit --kind=review --template=greptile
+```
+
+The scaffold is written to:
+
+```text
+.forge/adapters/review/coderabbit.js
+```
+
+Only review adapters and the Greptile-shaped starter template are supported in this foundation PR.
+
+## Fixture Replay
+
+Run adapter parsing and scoring offline:
+
+```bash
+forge adapter test greptile --fixture=fixtures/greptile-review.json
+```
+
+Fixture shape:
+
+```json
+{
+  "input": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "reviewThreads": {
+            "nodes": []
+          }
+        }
+      }
+    }
+  },
+  "expect": {
+    "threads": 0
+  }
+}
+```
+
+Fixture replay must not make network calls. Live provider calls belong in `fetchThreads`, `reply`, and `resolve`.
+
+## Non-Scope
+
+This adapter foundation does not implement `IssueAdapter`, GitHub issue sync, or the full v3 reference adapter template catalog.

--- a/docs/work/2026-05-18-adapter-foundation/decisions.md
+++ b/docs/work/2026-05-18-adapter-foundation/decisions.md
@@ -1,0 +1,3 @@
+# 0.0.18 Adapter Foundation Decisions
+
+No decision gates have fired yet.

--- a/docs/work/2026-05-18-adapter-foundation/decisions.md
+++ b/docs/work/2026-05-18-adapter-foundation/decisions.md
@@ -1,3 +1,5 @@
 # 0.0.18 Adapter Foundation Decisions
 
 No decision gates have fired yet.
+
+Spec gaps: none identified as of 2026-05-18.

--- a/docs/work/2026-05-18-adapter-foundation/design.md
+++ b/docs/work/2026-05-18-adapter-foundation/design.md
@@ -1,0 +1,56 @@
+# 0.0.18 Adapter Foundation
+
+Date: 2026-05-18
+Branch: codex/0.0.18-adapter-foundation
+Issues: forge-79xh, forge-1c0j, forge-tis9
+
+## Purpose
+
+Create the first review-adapter foundation for Forge v3 by defining a stable ReviewAdapter SPI, moving the existing Greptile review-thread behavior behind that SPI, and giving future adapters a small scaffold plus offline replay path.
+
+## Current Behavior Verified
+
+- `lib/greptile-match.js` currently exports `matchThreadsToCommits(threads, projectRoot, opts)` and marks Greptile threads resolved when recent commits touched the same files.
+- `.claude/scripts/greptile-resolve.sh` currently owns GitHub API operations for listing review threads, replying to comments, resolving threads, resolving all, listing Greptile summary comments, and stats.
+- `package.json` exposes `bun test --timeout 15000`, `bun run lint`, `bun run typecheck`, and `node scripts/validate.js`.
+- `docs/work/2026-04-28-skeleton-pivot/locked-decisions.md` D9 requires review adapter templates later, but this PR is a foundation slice, not the full template library.
+
+## Success Criteria
+
+- A ReviewAdapter SPI exists with documented lifecycle and methods for `fetchThreads`, `parse`, `reply`, `resolve`, and `score`.
+- Greptile behavior remains compatible: existing shell commands continue to work and use the Greptile adapter internally where practical.
+- `forge new adapter <name> --kind=review --template=greptile` or a comparably small scaffold entrypoint can generate a review adapter starter once the SPI shape is stable.
+- `forge adapter test <name> --fixture=<path>` or a narrow fixture replay harness validates adapter parsing/scoring offline without live GitHub calls if it fits cleanly.
+- Adapter contract docs describe inputs, outputs, lifecycle, fixture expectations, and compatibility notes.
+
+## Out Of Scope
+
+- Do not implement `IssueAdapter`.
+- Do not implement GitHub issue sync.
+- Do not ship the full v3 reference adapter template catalog.
+- Do not change the public Greptile review workflow behavior beyond routing through the adapter foundation.
+
+## Design
+
+1. Add `lib/review-adapter.js` as the SPI definition and validation helpers.
+2. Add `lib/adapters/greptile-review-adapter.js` as the reference implementation over the existing Greptile review-thread shape.
+3. Keep `lib/greptile-match.js` backward compatible by delegating scoring/matching to the Greptile adapter without changing its export.
+4. Add a small adapter CLI module and wire it into `bin/forge.js` for:
+   - `forge new adapter <name> --kind=review --template=greptile`
+   - `forge adapter test <name> --fixture=<path>`
+   - lightweight `list`, `enable`, and `disable` commands only if they can be implemented as local config/file operations without inventing broader runtime dispatch.
+5. Add tests around SPI validation, Greptile compatibility, scaffold generation, and fixture replay.
+
+## Compatibility Notes
+
+- Existing `.claude/scripts/greptile-resolve.sh` commands must keep their command names and output intent.
+- Existing `matchThreadsToCommits` callers must keep working.
+- Fixture replay must be offline and deterministic.
+
+## Validation Plan
+
+- Targeted adapter tests during development.
+- `bun run typecheck`.
+- `bun run lint`.
+- `bun test --timeout 15000`.
+- `node scripts/validate.js`.

--- a/docs/work/2026-05-18-adapter-foundation/tasks.md
+++ b/docs/work/2026-05-18-adapter-foundation/tasks.md
@@ -1,0 +1,46 @@
+# 0.0.18 Adapter Foundation Tasks
+
+## Task 1: ReviewAdapter SPI
+
+TDD:
+- Add failing tests for ReviewAdapter method contract validation and lifecycle expectations.
+- Implement `lib/review-adapter.js`.
+- Document method inputs, outputs, and required adapter metadata.
+
+Acceptance:
+- Missing required methods fail validation.
+- Valid review adapters pass validation.
+- Contract docs are precise enough for user-authored adapters.
+
+## Task 2: Greptile Adapter Compatibility
+
+TDD:
+- Add failing tests proving Greptile fixture parsing and scoring match existing `matchThreadsToCommits` behavior.
+- Implement `lib/adapters/greptile-review-adapter.js`.
+- Refactor `lib/greptile-match.js` to delegate while preserving its current public export.
+
+Acceptance:
+- Existing `matchThreadsToCommits` API is unchanged.
+- Greptile unresolved-thread filtering and commit matching remain behaviorally compatible.
+
+## Task 3: Adapter Scaffold And Fixture Replay CLI
+
+TDD:
+- Add failing CLI tests for `forge new adapter <name> --kind=review --template=greptile`.
+- Add failing fixture replay tests for `forge adapter test <name> --fixture=<path>`.
+- Implement the smallest CLI surface needed for scaffold generation and offline replay.
+
+Acceptance:
+- Scaffold command writes a review adapter starter in the expected local extension location.
+- Fixture replay runs without GitHub network access.
+- Any enable/disable/list support is local and minimal; defer if it would require runtime dispatch not in this PR.
+
+## Task 4: Documentation And Workflow Artifacts
+
+TDD:
+- Add or update tests that check documented CLI examples if an existing docs test pattern exists.
+
+Acceptance:
+- Adapter contract, lifecycle, fixture expectations, compatibility notes, and non-scope are documented.
+- `docs/work/2026-05-18-adapter-foundation/decisions.md` records any spec gaps.
+- Covered issues and validation commands are ready for the PR body.

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -162,7 +162,7 @@ function listAdapters(projectRoot) {
   const local = fs.existsSync(adapterDir)
     ? fs.readdirSync(adapterDir).filter((file) => file.endsWith('.js')).map((file) => file.replace(/\.js$/, ''))
     : [];
-  return ['greptile', ...local].sort();
+  return ['greptile', ...local].sort((left, right) => left.localeCompare(right));
 }
 
 function setAdapterEnabled(args, projectRoot, enabled) {

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -186,11 +186,17 @@ async function runFixtureReplay(args, projectRoot) {
   try {
     fixture = JSON.parse(fs.readFileSync(absoluteFixturePath, 'utf8'));
     parsed = adapter.parse(fixture.input || fixture);
+    if (!Array.isArray(parsed)) {
+      throw new Error('Adapter parse must return an array');
+    }
     scores = await adapter.score(parsed, {
       projectRoot,
       sinceCommit: fixture.sinceCommit || null,
       _exec: fixture.gitOutput ? () => fixture.gitOutput : () => '',
     });
+    if (!Array.isArray(scores)) {
+      throw new Error('Adapter score must return an array');
+    }
   } catch (error) {
     return { success: false, error: `Fixture replay failed: ${error.message}` };
   }

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -246,15 +246,25 @@ function setAdapterEnabled(args, projectRoot, enabled) {
   if (nameError) {
     return { success: false, error: nameError };
   }
-  const configDir = path.join(projectRoot, '.forge');
-  const configPath = path.join(configDir, 'adapters.json');
-  fs.mkdirSync(configDir, { recursive: true });
-  const config = fs.existsSync(configPath)
-    ? JSON.parse(fs.readFileSync(configPath, 'utf8'))
-    : { review: {} };
-  config.review = config.review || {};
-  config.review[name] = { ...(config.review[name] || {}), enabled };
-  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  let config;
+  try {
+    const configDir = path.join(projectRoot, '.forge');
+    const configPath = path.join(configDir, 'adapters.json');
+    fs.mkdirSync(configDir, { recursive: true });
+    const parsedConfig = fs.existsSync(configPath)
+      ? JSON.parse(fs.readFileSync(configPath, 'utf8'))
+      : null;
+    config = parsedConfig && typeof parsedConfig === 'object' && !Array.isArray(parsedConfig)
+      ? parsedConfig
+      : { review: {} };
+    config.review = config.review && typeof config.review === 'object' && !Array.isArray(config.review)
+      ? config.review
+      : {};
+    config.review[name] = { ...(config.review[name] || {}), enabled };
+    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  } catch (error) {
+    return { success: false, error: `Failed to update adapter config: ${error.message}` };
+  }
   return {
     success: true,
     output: `${enabled ? 'Enabled' : 'Disabled'} review adapter: ${name}`,

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { GreptileReviewAdapter } = require('./adapters/greptile-review-adapter');
+const { validateReviewAdapter } = require('./review-adapter');
+
+function parseOption(args, name, fallback = undefined) {
+  const prefix = `--${name}=`;
+  const inline = args.find((arg) => arg.startsWith(prefix));
+  if (inline) {
+    return inline.slice(prefix.length);
+  }
+  const index = args.indexOf(`--${name}`);
+  if (index !== -1 && args[index + 1]) {
+    return args[index + 1];
+  }
+  return fallback;
+}
+
+function adapterNameToClassName(name) {
+  return `${name
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')}ReviewAdapter`;
+}
+
+function getReviewAdapterDir(projectRoot) {
+  return path.join(projectRoot, '.forge', 'adapters', 'review');
+}
+
+function getAdapterPath(projectRoot, name, kind = 'review') {
+  return path.join(projectRoot, '.forge', 'adapters', kind, `${name}.js`);
+}
+
+function renderReviewAdapterScaffold(name, template) {
+  const className = adapterNameToClassName(name);
+  return `'use strict';
+
+const { ReviewAdapter } = require('forge-workflow/lib/review-adapter');
+
+class ${className} extends ReviewAdapter {
+  constructor(options = {}) {
+    super({ id: '${name}', kind: 'review', name: '${className}', ...options });
+  }
+
+  async fetchThreads(context) {
+    throw new Error('${name}.fetchThreads must connect to the review provider');
+  }
+
+  parse(payload) {
+    // Start from the ${template} template and normalize provider payloads into:
+    // { id, commentId, file, line, body, author, isResolved, raw }
+    return Array.isArray(payload) ? payload : [];
+  }
+
+  async reply(context) {
+    throw new Error('${name}.reply must post a review-thread reply');
+  }
+
+  async resolve(context) {
+    throw new Error('${name}.resolve must mark a review thread resolved');
+  }
+
+  score(threads) {
+    return threads.map((thread) => ({ ...thread, resolved: false, reason: 'not scored' }));
+  }
+}
+
+module.exports = { ${className} };
+`;
+}
+
+function scaffoldAdapter(args, projectRoot) {
+  const subcommand = args[0];
+  const name = args[1];
+  const kind = parseOption(args, 'kind', 'review');
+  const template = parseOption(args, 'template', 'greptile');
+
+  if (subcommand !== 'adapter' || !name) {
+    return { success: false, error: 'Usage: forge new adapter <name> --kind=review --template=greptile' };
+  }
+  if (kind !== 'review') {
+    return { success: false, error: 'Only --kind=review is supported in this foundation PR' };
+  }
+  if (template !== 'greptile') {
+    return { success: false, error: 'Only --template=greptile is supported in this foundation PR' };
+  }
+
+  const adapterDir = getReviewAdapterDir(projectRoot);
+  const adapterPath = getAdapterPath(projectRoot, name, kind);
+  fs.mkdirSync(adapterDir, { recursive: true });
+
+  if (fs.existsSync(adapterPath)) {
+    return { success: false, error: `Adapter already exists: ${path.relative(projectRoot, adapterPath)}` };
+  }
+
+  fs.writeFileSync(adapterPath, renderReviewAdapterScaffold(name, template));
+
+  return {
+    success: true,
+    output: `Created review adapter scaffold: ${path.relative(projectRoot, adapterPath).split(path.sep).join('/')}`,
+  };
+}
+
+function loadAdapter(name, projectRoot) {
+  if (name === 'greptile') {
+    return new GreptileReviewAdapter();
+  }
+
+  const adapterPath = getAdapterPath(projectRoot, name);
+  if (!fs.existsSync(adapterPath)) {
+    throw new Error(`Adapter not found: ${name}`);
+  }
+
+  const mod = require(adapterPath);
+  const exported = mod.default || mod[adapterNameToClassName(name)] || mod.adapter || mod;
+  return typeof exported === 'function' ? new exported() : exported;
+}
+
+function runFixtureReplay(args, projectRoot) {
+  const name = args[1];
+  const fixturePath = parseOption(args, 'fixture');
+
+  if (!name || !fixturePath) {
+    return { success: false, error: 'Usage: forge adapter test <name> --fixture=<path>' };
+  }
+
+  const adapter = loadAdapter(name, projectRoot);
+  const validation = validateReviewAdapter(adapter);
+  if (!validation.valid) {
+    return { success: false, error: validation.errors.join('; ') };
+  }
+
+  const absoluteFixturePath = path.isAbsolute(fixturePath)
+    ? fixturePath
+    : path.join(projectRoot, fixturePath);
+  const fixture = JSON.parse(fs.readFileSync(absoluteFixturePath, 'utf8'));
+  const parsed = adapter.parse(fixture.input || fixture);
+  const scores = adapter.score(parsed, {
+    projectRoot,
+    sinceCommit: fixture.sinceCommit || null,
+    _exec: fixture.gitOutput ? () => fixture.gitOutput : () => '',
+  });
+
+  if (fixture.expect?.threads !== undefined && parsed.length !== fixture.expect.threads) {
+    return {
+      success: false,
+      error: `Expected ${fixture.expect.threads} parsed threads, got ${parsed.length}`,
+    };
+  }
+
+  return {
+    success: true,
+    output: `Adapter ${name} fixture replay passed: ${parsed.length} parsed thread${parsed.length === 1 ? '' : 's'}, ${scores.length} scored result${scores.length === 1 ? '' : 's'}`,
+  };
+}
+
+function listAdapters(projectRoot) {
+  const adapterDir = getReviewAdapterDir(projectRoot);
+  const local = fs.existsSync(adapterDir)
+    ? fs.readdirSync(adapterDir).filter((file) => file.endsWith('.js')).map((file) => file.replace(/\.js$/, ''))
+    : [];
+  return ['greptile', ...local].sort();
+}
+
+function setAdapterEnabled(args, projectRoot, enabled) {
+  const name = args[1];
+  if (!name) {
+    return { success: false, error: `Usage: forge adapter ${enabled ? 'enable' : 'disable'} <name>` };
+  }
+  const configDir = path.join(projectRoot, '.forge');
+  const configPath = path.join(configDir, 'adapters.json');
+  fs.mkdirSync(configDir, { recursive: true });
+  const config = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, 'utf8'))
+    : { review: {} };
+  config.review = config.review || {};
+  config.review[name] = { enabled };
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return {
+    success: true,
+    output: `${enabled ? 'Enabled' : 'Disabled'} review adapter: ${name}`,
+  };
+}
+
+function handleAdapterCommand(args, projectRoot) {
+  const action = args[0];
+
+  if (action === 'test') {
+    return runFixtureReplay(args, projectRoot);
+  }
+  if (action === 'list') {
+    return { success: true, output: listAdapters(projectRoot).join('\n') };
+  }
+  if (action === 'enable') {
+    return setAdapterEnabled(args, projectRoot, true);
+  }
+  if (action === 'disable') {
+    return setAdapterEnabled(args, projectRoot, false);
+  }
+
+  return {
+    success: false,
+    error: 'Usage: forge adapter <test|list|enable|disable> ...',
+  };
+}
+
+module.exports = {
+  adapterNameToClassName,
+  getAdapterPath,
+  handleAdapterCommand,
+  listAdapters,
+  runFixtureReplay,
+  scaffoldAdapter,
+  setAdapterEnabled,
+};

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -158,7 +158,7 @@ function loadAdapter(name, projectRoot) {
   return typeof exported === 'function' ? new exported() : exported;
 }
 
-function runFixtureReplay(args, projectRoot) {
+async function runFixtureReplay(args, projectRoot) {
   const name = args[1];
   const fixturePath = parseOption(args, 'fixture');
 
@@ -186,7 +186,7 @@ function runFixtureReplay(args, projectRoot) {
   try {
     fixture = JSON.parse(fs.readFileSync(absoluteFixturePath, 'utf8'));
     parsed = adapter.parse(fixture.input || fixture);
-    scores = adapter.score(parsed, {
+    scores = await adapter.score(parsed, {
       projectRoot,
       sinceCommit: fixture.sinceCommit || null,
       _exec: fixture.gitOutput ? () => fixture.gitOutput : () => '',
@@ -224,6 +224,10 @@ function setAdapterEnabled(args, projectRoot, enabled) {
   if (!name) {
     return { success: false, error: `Usage: forge adapter ${enabled ? 'enable' : 'disable'} <name>` };
   }
+  const nameError = validateAdapterName(name);
+  if (nameError) {
+    return { success: false, error: nameError };
+  }
   const configDir = path.join(projectRoot, '.forge');
   const configPath = path.join(configDir, 'adapters.json');
   fs.mkdirSync(configDir, { recursive: true });
@@ -239,7 +243,7 @@ function setAdapterEnabled(args, projectRoot, enabled) {
   };
 }
 
-function handleAdapterCommand(args, projectRoot) {
+async function handleAdapterCommand(args, projectRoot) {
   const action = args[0];
 
   if (action === 'test') {

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -5,6 +5,8 @@ const path = require('node:path');
 const { GreptileReviewAdapter } = require('./adapters/greptile-review-adapter');
 const { validateReviewAdapter } = require('./review-adapter');
 
+const RESERVED_ADAPTER_NAMES = new Set(['greptile']);
+
 function parseOption(args, name, fallback = undefined) {
   const prefix = `--${name}=`;
   const inline = args.find((arg) => arg.startsWith(prefix));
@@ -36,6 +38,10 @@ function assertValidAdapterName(name) {
   if (error) {
     throw new Error(error);
   }
+}
+
+function isReservedAdapterName(name) {
+  return RESERVED_ADAPTER_NAMES.has(name);
 }
 
 function adapterNameToClassName(name) {
@@ -111,6 +117,9 @@ function scaffoldAdapter(args, projectRoot) {
   if (nameError) {
     return { success: false, error: nameError };
   }
+  if (isReservedAdapterName(name)) {
+    return { success: false, error: `Adapter name is reserved: ${name}` };
+  }
   if (kind !== 'review') {
     return { success: false, error: 'Only --kind=review is supported in this foundation PR' };
   }
@@ -171,13 +180,20 @@ function runFixtureReplay(args, projectRoot) {
   const absoluteFixturePath = path.isAbsolute(fixturePath)
     ? fixturePath
     : path.join(projectRoot, fixturePath);
-  const fixture = JSON.parse(fs.readFileSync(absoluteFixturePath, 'utf8'));
-  const parsed = adapter.parse(fixture.input || fixture);
-  const scores = adapter.score(parsed, {
-    projectRoot,
-    sinceCommit: fixture.sinceCommit || null,
-    _exec: fixture.gitOutput ? () => fixture.gitOutput : () => '',
-  });
+  let fixture;
+  let parsed;
+  let scores;
+  try {
+    fixture = JSON.parse(fs.readFileSync(absoluteFixturePath, 'utf8'));
+    parsed = adapter.parse(fixture.input || fixture);
+    scores = adapter.score(parsed, {
+      projectRoot,
+      sinceCommit: fixture.sinceCommit || null,
+      _exec: fixture.gitOutput ? () => fixture.gitOutput : () => '',
+    });
+  } catch (error) {
+    return { success: false, error: `Fixture replay failed: ${error.message}` };
+  }
 
   if (fixture.expect?.threads !== undefined && parsed.length !== fixture.expect.threads) {
     return {
@@ -195,7 +211,10 @@ function runFixtureReplay(args, projectRoot) {
 function listAdapters(projectRoot) {
   const adapterDir = getReviewAdapterDir(projectRoot);
   const local = fs.existsSync(adapterDir)
-    ? fs.readdirSync(adapterDir).filter((file) => file.endsWith('.js')).map((file) => file.replace(/\.js$/, ''))
+    ? fs.readdirSync(adapterDir)
+      .filter((file) => file.endsWith('.js'))
+      .map((file) => file.replace(/\.js$/, ''))
+      .filter((name) => !isReservedAdapterName(name))
     : [];
   return ['greptile', ...local].sort((left, right) => left.localeCompare(right));
 }
@@ -212,7 +231,7 @@ function setAdapterEnabled(args, projectRoot, enabled) {
     ? JSON.parse(fs.readFileSync(configPath, 'utf8'))
     : { review: {} };
   config.review = config.review || {};
-  config.review[name] = { enabled };
+  config.review[name] = { ...(config.review[name] || {}), enabled };
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
   return {
     success: true,
@@ -246,6 +265,7 @@ module.exports = {
   adapterNameToClassName,
   getAdapterPath,
   handleAdapterCommand,
+  isReservedAdapterName,
   listAdapters,
   runFixtureReplay,
   scaffoldAdapter,

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -191,7 +191,10 @@ async function runFixtureReplay(args, projectRoot) {
   let scores;
   try {
     fixture = JSON.parse(fs.readFileSync(absoluteFixturePath, 'utf8'));
-    parsed = adapter.parse(fixture.input || fixture);
+    const fixtureInput = Object.prototype.hasOwnProperty.call(fixture, 'input')
+      ? fixture.input
+      : fixture;
+    parsed = adapter.parse(fixtureInput);
     if (!Array.isArray(parsed)) {
       throw new Error('Adapter parse must return an array');
     }

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -6,6 +6,7 @@ const { GreptileReviewAdapter } = require('./adapters/greptile-review-adapter');
 const { validateReviewAdapter } = require('./review-adapter');
 
 const RESERVED_ADAPTER_NAMES = new Set(['greptile']);
+const REQUIRED_NORMALIZED_THREAD_KEYS = ['id', 'commentId', 'file', 'line', 'body', 'author', 'isResolved', 'raw'];
 
 function parseOption(args, name, fallback = undefined) {
   const prefix = `--${name}=`;
@@ -81,10 +82,10 @@ class ${className} {
     throw new Error('${name}.fetchThreads must connect to the review provider');
   }
 
-  parse(payload) {
+  parse(_payload) {
     // Start from the ${template} template and normalize provider payloads into:
     // { id, commentId, file, line, body, author, isResolved, raw }
-    return Array.isArray(payload) ? payload : [];
+    throw new Error('${name}.parse must normalize provider payloads before use');
   }
 
   async reply(_context) {
@@ -158,6 +159,11 @@ function loadAdapter(name, projectRoot) {
   return typeof exported === 'function' ? new exported() : exported;
 }
 
+function hasNormalizedReviewThreadShape(thread) {
+  return Boolean(thread)
+    && REQUIRED_NORMALIZED_THREAD_KEYS.every((key) => Object.prototype.hasOwnProperty.call(thread, key));
+}
+
 async function runFixtureReplay(args, projectRoot) {
   const name = args[1];
   const fixturePath = parseOption(args, 'fixture');
@@ -188,6 +194,9 @@ async function runFixtureReplay(args, projectRoot) {
     parsed = adapter.parse(fixture.input || fixture);
     if (!Array.isArray(parsed)) {
       throw new Error('Adapter parse must return an array');
+    }
+    if (!parsed.every(hasNormalizedReviewThreadShape)) {
+      throw new Error('Adapter parse must return normalized review threads');
     }
     scores = await adapter.score(parsed, {
       projectRoot,
@@ -275,6 +284,7 @@ module.exports = {
   adapterNameToClassName,
   getAdapterPath,
   handleAdapterCommand,
+  hasNormalizedReviewThreadShape,
   isReservedAdapterName,
   listAdapters,
   runFixtureReplay,

--- a/lib/adapter-cli.js
+++ b/lib/adapter-cli.js
@@ -12,10 +12,30 @@ function parseOption(args, name, fallback = undefined) {
     return inline.slice(prefix.length);
   }
   const index = args.indexOf(`--${name}`);
-  if (index !== -1 && args[index + 1]) {
+  if (index !== -1 && args[index + 1] && !args[index + 1].startsWith('--')) {
     return args[index + 1];
   }
+  if (index !== -1) {
+    return '';
+  }
   return fallback;
+}
+
+function validateAdapterName(name) {
+  if (!name || typeof name !== 'string') {
+    return 'Adapter name is required';
+  }
+  if (!/^[a-z][a-z0-9-]*$/.test(name)) {
+    return 'Adapter name must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens';
+  }
+  return null;
+}
+
+function assertValidAdapterName(name) {
+  const error = validateAdapterName(name);
+  if (error) {
+    throw new Error(error);
+  }
 }
 
 function adapterNameToClassName(name) {
@@ -31,21 +51,27 @@ function getReviewAdapterDir(projectRoot) {
 }
 
 function getAdapterPath(projectRoot, name, kind = 'review') {
-  return path.join(projectRoot, '.forge', 'adapters', kind, `${name}.js`);
+  assertValidAdapterName(name);
+  const adapterDir = path.resolve(projectRoot, '.forge', 'adapters', kind);
+  const adapterPath = path.resolve(adapterDir, `${name}.js`);
+  if (!adapterPath.startsWith(`${adapterDir}${path.sep}`)) {
+    throw new Error('Adapter path must stay under .forge/adapters');
+  }
+  return adapterPath;
 }
 
 function renderReviewAdapterScaffold(name, template) {
   const className = adapterNameToClassName(name);
   return `'use strict';
 
-const { ReviewAdapter } = require('forge-workflow/lib/review-adapter');
-
-class ${className} extends ReviewAdapter {
+class ${className} {
   constructor(options = {}) {
-    super({ id: '${name}', kind: 'review', name: '${className}', ...options });
+    this.id = options.id || '${name}';
+    this.kind = 'review';
+    this.name = options.name || '${className}';
   }
 
-  async fetchThreads(context) {
+  async fetchThreads(_context) {
     throw new Error('${name}.fetchThreads must connect to the review provider');
   }
 
@@ -55,11 +81,11 @@ class ${className} extends ReviewAdapter {
     return Array.isArray(payload) ? payload : [];
   }
 
-  async reply(context) {
+  async reply(_context) {
     throw new Error('${name}.reply must post a review-thread reply');
   }
 
-  async resolve(context) {
+  async resolve(_context) {
     throw new Error('${name}.resolve must mark a review thread resolved');
   }
 
@@ -80,6 +106,10 @@ function scaffoldAdapter(args, projectRoot) {
 
   if (subcommand !== 'adapter' || !name) {
     return { success: false, error: 'Usage: forge new adapter <name> --kind=review --template=greptile' };
+  }
+  const nameError = validateAdapterName(name);
+  if (nameError) {
+    return { success: false, error: nameError };
   }
   if (kind !== 'review') {
     return { success: false, error: 'Only --kind=review is supported in this foundation PR' };
@@ -127,7 +157,12 @@ function runFixtureReplay(args, projectRoot) {
     return { success: false, error: 'Usage: forge adapter test <name> --fixture=<path>' };
   }
 
-  const adapter = loadAdapter(name, projectRoot);
+  let adapter;
+  try {
+    adapter = loadAdapter(name, projectRoot);
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
   const validation = validateReviewAdapter(adapter);
   if (!validation.valid) {
     return { success: false, error: validation.errors.join('; ') };
@@ -215,4 +250,5 @@ module.exports = {
   runFixtureReplay,
   scaffoldAdapter,
   setAdapterEnabled,
+  validateAdapterName,
 };

--- a/lib/adapters/greptile-review-adapter.js
+++ b/lib/adapters/greptile-review-adapter.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const { ReviewAdapter } = require('../review-adapter');
+
+function getReviewThreadNodes(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  return payload?.data?.repository?.pullRequest?.reviewThreads?.nodes
+    || payload?.repository?.pullRequest?.reviewThreads?.nodes
+    || payload?.reviewThreads?.nodes
+    || payload?.nodes
+    || [];
+}
+
+function getFirstComment(thread) {
+  return thread?.comments?.nodes?.[0] || {};
+}
+
+class GreptileReviewAdapter extends ReviewAdapter {
+  constructor(options = {}) {
+    super({
+      id: options.id || 'greptile',
+      kind: 'review',
+      name: options.name || 'Greptile Review Adapter',
+      version: options.version,
+    });
+    this.authorPrefix = options.authorPrefix || 'greptile-apps';
+    this.github = options.github;
+  }
+
+  async fetchThreads(context = {}) {
+    if (this.github && typeof this.github.fetchThreads === 'function') {
+      return this.github.fetchThreads(context);
+    }
+    throw new Error('greptile.fetchThreads requires a GitHub client');
+  }
+
+  parse(payload, options = {}) {
+    const includeResolved = options.includeResolved === true;
+    const authorPrefix = options.authorPrefix || this.authorPrefix;
+
+    return getReviewThreadNodes(payload)
+      .filter((thread) => includeResolved || thread?.isResolved === false)
+      .map((thread) => {
+        const comment = getFirstComment(thread);
+        return {
+          id: thread.id,
+          commentId: comment.databaseId || comment.id,
+          file: comment.path,
+          line: comment.line || 0,
+          body: comment.body || '',
+          author: comment.author?.login || 'unknown',
+          isResolved: Boolean(thread.isResolved),
+          raw: thread,
+        };
+      })
+      .filter((thread) => thread.author.startsWith(authorPrefix))
+      .filter((thread) => Boolean(thread.file));
+  }
+
+  async reply(context = {}) {
+    if (this.github && typeof this.github.reply === 'function') {
+      return this.github.reply(context);
+    }
+    throw new Error('greptile.reply requires a GitHub client');
+  }
+
+  async resolve(context = {}) {
+    if (this.github && typeof this.github.resolve === 'function') {
+      return this.github.resolve(context);
+    }
+    throw new Error('greptile.resolve requires a GitHub client');
+  }
+
+  score(threads, context = {}) {
+    return matchThreadsToCommitsWithGit(threads, context.projectRoot || process.cwd(), context);
+  }
+}
+
+function matchThreadsToCommitsWithGit(threads, projectRoot, opts = {}) {
+  if (!threads || threads.length === 0) {
+    return [];
+  }
+
+  const exec = opts._exec || ((cmd, args) => {
+    return execFileSync(cmd, args, { encoding: 'utf8' });
+  });
+
+  let sinceCommit = opts.sinceCommit;
+  if (!sinceCommit) {
+    try {
+      sinceCommit = exec('git', ['-C', projectRoot, 'merge-base', 'HEAD', 'main']).trim();
+    } catch (_e) { // NOSONAR S2486
+      try {
+        sinceCommit = exec('git', ['-C', projectRoot, 'merge-base', 'HEAD', 'master']).trim();
+      } catch (_e2) { // NOSONAR S2486
+        sinceCommit = null;
+      }
+    }
+  }
+
+  return threads.map((thread) => {
+    const { file, line } = thread;
+
+    try {
+      const logArgs = [
+        '-C', projectRoot,
+        'log',
+        '--oneline',
+        '--follow',
+      ];
+      if (sinceCommit) {
+        logArgs.push(`${sinceCommit}..HEAD`);
+      }
+      logArgs.push('--', file);
+
+      const output = exec('git', logArgs);
+      const trimmed = (output || '').trim();
+
+      if (!trimmed) {
+        return { file, line, resolved: false, reason: 'no matching commit' };
+      }
+
+      const firstLine = trimmed.split('\n')[0];
+      const sha = firstLine.split(' ')[0];
+
+      return { file, line, resolved: true, sha };
+    } catch (_err) { // NOSONAR S2486
+      return { file, line, resolved: false, reason: 'no matching commit' };
+    }
+  });
+}
+
+module.exports = {
+  GreptileReviewAdapter,
+  getReviewThreadNodes,
+  matchThreadsToCommitsWithGit,
+};

--- a/lib/adapters/greptile-review-adapter.js
+++ b/lib/adapters/greptile-review-adapter.js
@@ -27,7 +27,7 @@ class GreptileReviewAdapter extends ReviewAdapter {
       name: options.name || 'Greptile Review Adapter',
       version: options.version,
     });
-    this.authorPrefix = options.authorPrefix || 'greptile-apps';
+    this.authorPrefix = options.authorPrefix ?? 'greptile-apps';
     this.github = options.github;
   }
 
@@ -40,7 +40,7 @@ class GreptileReviewAdapter extends ReviewAdapter {
 
   parse(payload, options = {}) {
     const includeResolved = options.includeResolved === true;
-    const authorPrefix = options.authorPrefix || this.authorPrefix;
+    const authorPrefix = options.authorPrefix ?? this.authorPrefix;
 
     return getReviewThreadNodes(payload)
       .filter((thread) => includeResolved || thread?.isResolved === false)

--- a/lib/commands/adapter.js
+++ b/lib/commands/adapter.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { handleAdapterCommand } = require('../adapter-cli');
+
+module.exports = {
+  name: 'adapter',
+  description: 'Manage and test review adapters',
+  usage: 'forge adapter <test|list|enable|disable> ...',
+  async handler(args, _flags, projectRoot) {
+    return handleAdapterCommand(args, projectRoot);
+  },
+};

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { scaffoldAdapter } = require('../adapter-cli');
+
+module.exports = {
+  name: 'new',
+  description: 'Create Forge extension scaffolds',
+  usage: 'forge new adapter <name> --kind=review --template=greptile',
+  async handler(args, _flags, projectRoot) {
+    return scaffoldAdapter(args, projectRoot);
+  },
+};

--- a/lib/greptile-match.js
+++ b/lib/greptile-match.js
@@ -1,80 +1,24 @@
 'use strict';
 
-const { execFileSync } = require('node:child_process');
+const { GreptileReviewAdapter } = require('./adapters/greptile-review-adapter');
 
 /**
  * Match unresolved review threads to recent commits that touched the same files.
  *
- * For each thread, runs `git log --oneline --follow -- <file>` to find
- * recent commits. If a commit exists, the thread is considered resolved
- * (the file was modified after the review comment).
- *
- * Uses execFileSync (not exec) to prevent shell injection (OWASP A03).
+ * This backward-compatible export now delegates to the Greptile review adapter
+ * so existing Greptile scripts keep working while new review integrations use
+ * the ReviewAdapter SPI.
  *
  * @param {Array<{file: string, line: number}>} threads - Review threads with file paths
  * @param {string} projectRoot - Absolute path to the project root (used with git -C)
  * @param {object} [opts] - Options
- * @param {Function} [opts._exec] - Injected exec function for testing (defaults to execFileSync)
+ * @param {Function} [opts._exec] - Injected exec function for testing
  * @param {string} [opts.sinceCommit] - Merge-base SHA to restrict log to PR commits only
  * @returns {Array<{file: string, line: number, resolved: boolean, sha?: string, reason?: string}>}
  */
 function matchThreadsToCommits(threads, projectRoot, opts = {}) {
-  if (!threads || threads.length === 0) {
-    return [];
-  }
-
-  const exec = opts._exec || ((cmd, args) => {
-    return execFileSync(cmd, args, { encoding: 'utf8' });
-  });
-
-  // Determine commit range — restrict to PR commits when sinceCommit provided
-  let sinceCommit = opts.sinceCommit;
-  if (!sinceCommit) {
-    try {
-      sinceCommit = exec('git', ['-C', projectRoot, 'merge-base', 'HEAD', 'main']).trim();
-    } catch (_e) { // NOSONAR S2486
-      /* intentional: main branch not found, try master instead */
-      try {
-        sinceCommit = exec('git', ['-C', projectRoot, 'merge-base', 'HEAD', 'master']).trim();
-      } catch (_e2) { /* intentional: no merge-base available, fall back to unbounded log */ // NOSONAR S2486
-        sinceCommit = null;
-      }
-    }
-  }
-
-  return threads.map((thread) => {
-    const { file, line } = thread;
-
-    try {
-      const logArgs = [
-        '-C', projectRoot,
-        'log',
-        '--oneline',
-        '--follow',
-      ];
-      if (sinceCommit) {
-        logArgs.push(`${sinceCommit}..HEAD`);
-      }
-      logArgs.push('--', file);
-
-      const output = exec('git', logArgs);
-
-      const trimmed = (output || '').trim();
-
-      if (!trimmed) {
-        return { file, line, resolved: false, reason: 'no matching commit' };
-      }
-
-      // git log --oneline format: "<sha> <message>"
-      // Take the first (most recent) line
-      const firstLine = trimmed.split('\n')[0];
-      const sha = firstLine.split(' ')[0];
-
-      return { file, line, resolved: true, sha };
-    } catch (_err) { /* intentional: git log failed (file missing or git unavailable), mark unresolved */ // NOSONAR S2486
-      return { file, line, resolved: false, reason: 'no matching commit' };
-    }
-  });
+  const adapter = new GreptileReviewAdapter();
+  return adapter.score(threads, { ...opts, projectRoot });
 }
 
 module.exports = { matchThreadsToCommits };

--- a/lib/review-adapter.js
+++ b/lib/review-adapter.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const REQUIRED_REVIEW_ADAPTER_METHODS = [
+  'fetchThreads',
+  'parse',
+  'reply',
+  'resolve',
+  'score',
+];
+
+class ReviewAdapter {
+  constructor(options = {}) {
+    this.id = options.id || 'review-adapter';
+    this.kind = options.kind || 'review';
+    this.name = options.name || this.id;
+    this.version = options.version || '0.1.0';
+  }
+
+  async fetchThreads() {
+    throw new Error(`${this.id}.fetchThreads is not implemented`);
+  }
+
+  parse() {
+    throw new Error(`${this.id}.parse is not implemented`);
+  }
+
+  async reply() {
+    throw new Error(`${this.id}.reply is not implemented`);
+  }
+
+  async resolve() {
+    throw new Error(`${this.id}.resolve is not implemented`);
+  }
+
+  score() {
+    throw new Error(`${this.id}.score is not implemented`);
+  }
+}
+
+function validateReviewAdapter(adapter) {
+  const errors = [];
+
+  if (!adapter || typeof adapter !== 'object') {
+    return { valid: false, errors: ['adapter must be an object'] };
+  }
+
+  if (!adapter.id || typeof adapter.id !== 'string') {
+    errors.push('id must be a non-empty string');
+  }
+
+  if (adapter.kind !== 'review') {
+    errors.push('kind must be "review"');
+  }
+
+  for (const method of REQUIRED_REVIEW_ADAPTER_METHODS) {
+    if (typeof adapter[method] !== 'function') {
+      errors.push(`${method} must be a function`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = {
+  ReviewAdapter,
+  REQUIRED_REVIEW_ADAPTER_METHODS,
+  validateReviewAdapter,
+};

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -365,6 +365,29 @@ module.exports = {
     expect(config.review.coderabbit).toEqual({ provider: 'api', enabled: true });
   });
 
+  test('forge adapter enable returns structured errors for invalid config JSON', async () => {
+    const configDir = path.join(projectRoot, '.forge');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'adapters.json'), '{not-json');
+
+    const result = await adapterCommand.handler(['enable', 'coderabbit'], {}, projectRoot);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Failed to update adapter config');
+  });
+
+  test('forge adapter enable replaces non-object config roots', async () => {
+    const configDir = path.join(projectRoot, '.forge');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'adapters.json'), '[]');
+
+    const result = await adapterCommand.handler(['enable', 'coderabbit'], {}, projectRoot);
+    const config = JSON.parse(fs.readFileSync(path.join(configDir, 'adapters.json'), 'utf8'));
+
+    expect(result.success).toBe(true);
+    expect(config).toEqual({ review: { coderabbit: { enabled: true } } });
+  });
+
   test('forge adapter enable rejects invalid adapter names before writing config', async () => {
     const result = await adapterCommand.handler(['enable', '__proto__'], {}, projectRoot);
 

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -202,6 +202,47 @@ module.exports = {
     expect(result.output).toContain('1 scored result');
   });
 
+  test('forge adapter test preserves explicit falsy fixture input', async () => {
+    const adapterDir = path.join(projectRoot, '.forge', 'adapters', 'review');
+    fs.mkdirSync(adapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(adapterDir, 'falsy-input.js'),
+      `'use strict';
+module.exports = {
+  id: 'falsy-input',
+  kind: 'review',
+  async fetchThreads() {},
+  parse(payload) {
+    return [{
+      id: 'thread-1',
+      commentId: 'comment-1',
+      file: 'README.md',
+      line: 1,
+      body: String(payload),
+      author: 'fixture',
+      isResolved: false,
+      raw: payload,
+    }];
+  },
+  async reply() {},
+  async resolve() {},
+  score(threads) { return threads; },
+};
+`
+    );
+    const fixturePath = path.join(projectRoot, 'falsy-input-fixture.json');
+    fs.writeFileSync(fixturePath, JSON.stringify({ input: false, expect: { threads: 1 } }));
+
+    const result = await adapterCommand.handler(
+      ['test', 'falsy-input', `--fixture=${fixturePath}`],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('1 parsed thread');
+  });
+
   test('forge adapter test rejects non-array parse output', async () => {
     const adapterDir = path.join(projectRoot, '.forge', 'adapters', 'review');
     fs.mkdirSync(adapterDir, { recursive: true });

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -1,0 +1,85 @@
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const newCommand = require('../lib/commands/new');
+const adapterCommand = require('../lib/commands/adapter');
+
+function makeProjectRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-adapter-cli-'));
+  fs.writeFileSync(path.join(root, 'AGENTS.md'), '# Test project\n');
+  return root;
+}
+
+describe('adapter CLI commands', () => {
+  let projectRoot;
+
+  beforeEach(() => {
+    projectRoot = makeProjectRoot();
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  test('forge new adapter scaffolds a review adapter starter', async () => {
+    const result = await newCommand.handler(
+      ['adapter', 'coderabbit', '--kind=review', '--template=greptile'],
+      {},
+      projectRoot
+    );
+
+    const adapterPath = path.join(projectRoot, '.forge', 'adapters', 'review', 'coderabbit.js');
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('.forge/adapters/review/coderabbit.js');
+    expect(fs.existsSync(adapterPath)).toBe(true);
+    expect(fs.readFileSync(adapterPath, 'utf8')).toContain('class CoderabbitReviewAdapter');
+  });
+
+  test('forge adapter test replays a Greptile fixture offline', async () => {
+    const fixturePath = path.join(projectRoot, 'greptile-fixture.json');
+    fs.writeFileSync(
+      fixturePath,
+      JSON.stringify({
+        input: {
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: 'thread-1',
+                      isResolved: false,
+                      comments: {
+                        nodes: [
+                          {
+                            databaseId: 55,
+                            path: 'README.md',
+                            line: 3,
+                            author: { login: 'greptile-apps[bot]' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        expect: { threads: 1 },
+      })
+    );
+
+    const result = await adapterCommand.handler(
+      ['test', 'greptile', `--fixture=${fixturePath}`],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Adapter greptile fixture replay passed');
+    expect(result.output).toContain('1 parsed thread');
+  });
+});

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -82,4 +82,22 @@ describe('adapter CLI commands', () => {
     expect(result.output).toContain('Adapter greptile fixture replay passed');
     expect(result.output).toContain('1 parsed thread');
   });
+
+  test('forge adapter list returns deterministic adapter order', async () => {
+    await newCommand.handler(
+      ['adapter', 'zeta', '--kind=review', '--template=greptile'],
+      {},
+      projectRoot
+    );
+    await newCommand.handler(
+      ['adapter', 'alpha', '--kind=review', '--template=greptile'],
+      {},
+      projectRoot
+    );
+
+    const result = await adapterCommand.handler(['list'], {}, projectRoot);
+
+    expect(result.success).toBe(true);
+    expect(result.output.split('\n')).toEqual(['alpha', 'greptile', 'zeta']);
+  });
 });

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -190,6 +190,58 @@ module.exports = {
     expect(result.output).toContain('1 scored result');
   });
 
+  test('forge adapter test rejects non-array parse output', async () => {
+    const adapterDir = path.join(projectRoot, '.forge', 'adapters', 'review');
+    fs.mkdirSync(adapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(adapterDir, 'bad-parse.js'),
+      `'use strict';
+module.exports = {
+  id: 'bad-parse',
+  kind: 'review',
+  async fetchThreads() {},
+  parse() { return { file: 'README.md' }; },
+  async reply() {},
+  async resolve() {},
+  score() { return []; },
+};
+`
+    );
+    const fixturePath = path.join(projectRoot, 'bad-parse-fixture.json');
+    fs.writeFileSync(fixturePath, JSON.stringify({ input: [] }));
+
+    const result = await adapterCommand.handler(['test', 'bad-parse', `--fixture=${fixturePath}`], {}, projectRoot);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('parse must return an array');
+  });
+
+  test('forge adapter test rejects non-array score output', async () => {
+    const adapterDir = path.join(projectRoot, '.forge', 'adapters', 'review');
+    fs.mkdirSync(adapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(adapterDir, 'bad-score.js'),
+      `'use strict';
+module.exports = {
+  id: 'bad-score',
+  kind: 'review',
+  async fetchThreads() {},
+  parse(payload) { return payload; },
+  async reply() {},
+  async resolve() {},
+  score() { return { resolved: true }; },
+};
+`
+    );
+    const fixturePath = path.join(projectRoot, 'bad-score-fixture.json');
+    fs.writeFileSync(fixturePath, JSON.stringify({ input: [{ file: 'README.md', line: 1 }] }));
+
+    const result = await adapterCommand.handler(['test', 'bad-score', `--fixture=${fixturePath}`], {}, projectRoot);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('score must return an array');
+  });
+
   test('forge adapter list returns deterministic adapter order', async () => {
     await newCommand.handler(
       ['adapter', 'zeta', '--kind=review', '--template=greptile'],

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -160,6 +160,36 @@ describe('adapter CLI commands', () => {
     expect(result.error).toContain('Fixture replay failed');
   });
 
+  test('forge adapter test awaits async adapter scoring', async () => {
+    const adapterDir = path.join(projectRoot, '.forge', 'adapters', 'review');
+    fs.mkdirSync(adapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(adapterDir, 'async-score.js'),
+      `'use strict';
+module.exports = {
+  id: 'async-score',
+  kind: 'review',
+  async fetchThreads() {},
+  parse(payload) { return payload; },
+  async reply() {},
+  async resolve() {},
+  async score(threads) { return threads.map((thread) => ({ ...thread, resolved: true })); },
+};
+`
+    );
+    const fixturePath = path.join(projectRoot, 'async-fixture.json');
+    fs.writeFileSync(fixturePath, JSON.stringify({ input: [{ file: 'README.md', line: 1 }], expect: { threads: 1 } }));
+
+    const result = await adapterCommand.handler(
+      ['test', 'async-score', `--fixture=${fixturePath}`],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('1 scored result');
+  });
+
   test('forge adapter list returns deterministic adapter order', async () => {
     await newCommand.handler(
       ['adapter', 'zeta', '--kind=review', '--template=greptile'],
@@ -191,5 +221,13 @@ describe('adapter CLI commands', () => {
 
     expect(result.success).toBe(true);
     expect(config.review.coderabbit).toEqual({ provider: 'api', enabled: true });
+  });
+
+  test('forge adapter enable rejects invalid adapter names before writing config', async () => {
+    const result = await adapterCommand.handler(['enable', '__proto__'], {}, projectRoot);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Adapter name must start');
+    expect(fs.existsSync(path.join(projectRoot, '.forge', 'adapters.json'))).toBe(false);
   });
 });

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -78,6 +78,17 @@ describe('adapter CLI commands', () => {
     expect(result.error).toContain('Adapter name must start');
   });
 
+  test('rejects local adapters that collide with the built-in Greptile adapter', async () => {
+    const result = await newCommand.handler(
+      ['adapter', 'greptile', '--kind=review', '--template=greptile'],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('reserved');
+  });
+
   test('does not treat the next flag as a missing option value', async () => {
     const result = await newCommand.handler(
       ['adapter', 'coderabbit', '--kind', '--template=greptile'],
@@ -135,6 +146,20 @@ describe('adapter CLI commands', () => {
     expect(result.output).toContain('1 parsed thread');
   });
 
+  test('forge adapter test returns structured errors for invalid fixtures', async () => {
+    const fixturePath = path.join(projectRoot, 'invalid-fixture.json');
+    fs.writeFileSync(fixturePath, '{not-json');
+
+    const result = await adapterCommand.handler(
+      ['test', 'greptile', `--fixture=${fixturePath}`],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Fixture replay failed');
+  });
+
   test('forge adapter list returns deterministic adapter order', async () => {
     await newCommand.handler(
       ['adapter', 'zeta', '--kind=review', '--template=greptile'],
@@ -151,5 +176,20 @@ describe('adapter CLI commands', () => {
 
     expect(result.success).toBe(true);
     expect(result.output.trim().split('\n')).toEqual(['alpha', 'greptile', 'zeta']);
+  });
+
+  test('forge adapter enable preserves existing adapter settings', async () => {
+    const configDir = path.join(projectRoot, '.forge');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'adapters.json'),
+      JSON.stringify({ review: { coderabbit: { provider: 'api', enabled: false } } })
+    );
+
+    const result = await adapterCommand.handler(['enable', 'coderabbit'], {}, projectRoot);
+    const config = JSON.parse(fs.readFileSync(path.join(configDir, 'adapters.json'), 'utf8'));
+
+    expect(result.success).toBe(true);
+    expect(config.review.coderabbit).toEqual({ provider: 'api', enabled: true });
   });
 });

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -37,7 +37,7 @@ describe('adapter CLI commands', () => {
     expect(fs.readFileSync(adapterPath, 'utf8')).toContain('class CoderabbitReviewAdapter');
   });
 
-  test('generated review adapter can be loaded by fixture replay without package dependencies', async () => {
+  test('generated review adapter loads and fails closed until parse is implemented', async () => {
     await newCommand.handler(
       ['adapter', 'coderabbit', '--kind=review', '--template=greptile'],
       {},
@@ -52,7 +52,8 @@ describe('adapter CLI commands', () => {
       projectRoot
     );
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('parse must normalize provider payloads');
   });
 
   test('rejects unsafe adapter names before composing paths', async () => {
@@ -170,7 +171,18 @@ module.exports = {
   id: 'async-score',
   kind: 'review',
   async fetchThreads() {},
-  parse(payload) { return payload; },
+  parse(payload) {
+    return payload.map((thread, index) => ({
+      id: String(index),
+      commentId: index,
+      file: thread.file,
+      line: thread.line,
+      body: '',
+      author: 'fixture',
+      isResolved: false,
+      raw: thread,
+    }));
+  },
   async reply() {},
   async resolve() {},
   async score(threads) { return threads.map((thread) => ({ ...thread, resolved: true })); },
@@ -226,7 +238,18 @@ module.exports = {
   id: 'bad-score',
   kind: 'review',
   async fetchThreads() {},
-  parse(payload) { return payload; },
+  parse(payload) {
+    return payload.map((thread, index) => ({
+      id: String(index),
+      commentId: index,
+      file: thread.file,
+      line: thread.line,
+      body: '',
+      author: 'fixture',
+      isResolved: false,
+      raw: thread,
+    }));
+  },
   async reply() {},
   async resolve() {},
   score() { return { resolved: true }; },
@@ -240,6 +263,32 @@ module.exports = {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('score must return an array');
+  });
+
+  test('forge adapter test rejects non-normalized parse output', async () => {
+    const adapterDir = path.join(projectRoot, '.forge', 'adapters', 'review');
+    fs.mkdirSync(adapterDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(adapterDir, 'raw-parse.js'),
+      `'use strict';
+module.exports = {
+  id: 'raw-parse',
+  kind: 'review',
+  async fetchThreads() {},
+  parse(payload) { return payload; },
+  async reply() {},
+  async resolve() {},
+  score(threads) { return threads; },
+};
+`
+    );
+    const fixturePath = path.join(projectRoot, 'raw-parse-fixture.json');
+    fs.writeFileSync(fixturePath, JSON.stringify({ input: [{ file: 'README.md', line: 1 }] }));
+
+    const result = await adapterCommand.handler(['test', 'raw-parse', `--fixture=${fixturePath}`], {}, projectRoot);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('normalized review threads');
   });
 
   test('forge adapter list returns deterministic adapter order', async () => {

--- a/test/adapter-cli.test.js
+++ b/test/adapter-cli.test.js
@@ -37,6 +37,58 @@ describe('adapter CLI commands', () => {
     expect(fs.readFileSync(adapterPath, 'utf8')).toContain('class CoderabbitReviewAdapter');
   });
 
+  test('generated review adapter can be loaded by fixture replay without package dependencies', async () => {
+    await newCommand.handler(
+      ['adapter', 'coderabbit', '--kind=review', '--template=greptile'],
+      {},
+      projectRoot
+    );
+    const fixturePath = path.join(projectRoot, 'empty-fixture.json');
+    fs.writeFileSync(fixturePath, JSON.stringify({ input: [], expect: { threads: 0 } }));
+
+    const result = await adapterCommand.handler(
+      ['test', 'coderabbit', `--fixture=${fixturePath}`],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects unsafe adapter names before composing paths', async () => {
+    const result = await newCommand.handler(
+      ['adapter', '../escape', '--kind=review', '--template=greptile'],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Adapter name must start');
+    expect(fs.existsSync(path.join(projectRoot, '.forge', 'adapters', 'escape.js'))).toBe(false);
+  });
+
+  test('rejects adapter names that cannot produce valid class names', async () => {
+    const result = await newCommand.handler(
+      ['adapter', '123', '--kind=review', '--template=greptile'],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Adapter name must start');
+  });
+
+  test('does not treat the next flag as a missing option value', async () => {
+    const result = await newCommand.handler(
+      ['adapter', 'coderabbit', '--kind', '--template=greptile'],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Only --kind=review');
+  });
+
   test('forge adapter test replays a Greptile fixture offline', async () => {
     const fixturePath = path.join(projectRoot, 'greptile-fixture.json');
     fs.writeFileSync(
@@ -98,6 +150,6 @@ describe('adapter CLI commands', () => {
     const result = await adapterCommand.handler(['list'], {}, projectRoot);
 
     expect(result.success).toBe(true);
-    expect(result.output.split('\n')).toEqual(['alpha', 'greptile', 'zeta']);
+    expect(result.output.trim().split('\n')).toEqual(['alpha', 'greptile', 'zeta']);
   });
 });

--- a/test/review-adapter.test.js
+++ b/test/review-adapter.test.js
@@ -119,6 +119,15 @@ describe('GreptileReviewAdapter', () => {
     ]);
   });
 
+  test('allows author filtering to be explicitly disabled', () => {
+    const adapter = new GreptileReviewAdapter({ authorPrefix: '' });
+
+    expect(adapter.parse(reviewThreadsResponse).map((thread) => thread.author)).toEqual([
+      'greptile-apps[bot]',
+      'human-reviewer',
+    ]);
+  });
+
   test('keeps matchThreadsToCommits public API behavior compatible', () => {
     const execCalls = [];
     const threads = [{ file: 'lib/example.js', line: 12 }];

--- a/test/review-adapter.test.js
+++ b/test/review-adapter.test.js
@@ -1,0 +1,141 @@
+const { describe, test, expect } = require('bun:test');
+
+const {
+  ReviewAdapter,
+  REQUIRED_REVIEW_ADAPTER_METHODS,
+  validateReviewAdapter,
+} = require('../lib/review-adapter');
+const { GreptileReviewAdapter } = require('../lib/adapters/greptile-review-adapter');
+const { matchThreadsToCommits } = require('../lib/greptile-match');
+
+describe('ReviewAdapter SPI', () => {
+  test('base adapter documents the required review lifecycle methods', () => {
+    expect(REQUIRED_REVIEW_ADAPTER_METHODS).toEqual([
+      'fetchThreads',
+      'parse',
+      'reply',
+      'resolve',
+      'score',
+    ]);
+  });
+
+  test('validates a complete review adapter implementation', () => {
+    const adapter = {
+      id: 'review-test',
+      kind: 'review',
+      fetchThreads() {},
+      parse() {},
+      reply() {},
+      resolve() {},
+      score() {},
+    };
+
+    expect(validateReviewAdapter(adapter)).toEqual({ valid: true, errors: [] });
+  });
+
+  test('reports every missing required method', () => {
+    const adapter = { id: 'broken', kind: 'review', parse() {} };
+
+    expect(validateReviewAdapter(adapter)).toEqual({
+      valid: false,
+      errors: [
+        'fetchThreads must be a function',
+        'reply must be a function',
+        'resolve must be a function',
+        'score must be a function',
+      ],
+    });
+  });
+
+  test('base class throws for lifecycle methods that subclasses do not implement', async () => {
+    const adapter = new ReviewAdapter({ id: 'base', kind: 'review' });
+
+    await expect(adapter.fetchThreads()).rejects.toThrow(/fetchThreads/);
+    expect(() => adapter.parse()).toThrow(/parse/);
+    await expect(adapter.reply()).rejects.toThrow(/reply/);
+    await expect(adapter.resolve()).rejects.toThrow(/resolve/);
+    expect(() => adapter.score()).toThrow(/score/);
+  });
+});
+
+describe('GreptileReviewAdapter', () => {
+  const reviewThreadsResponse = {
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [
+              {
+                id: 'thread-1',
+                isResolved: false,
+                comments: {
+                  nodes: [
+                    {
+                      id: 'comment-node-1',
+                      databaseId: 101,
+                      path: 'lib/example.js',
+                      line: 12,
+                      body: 'please fix this',
+                      author: { login: 'greptile-apps[bot]' },
+                    },
+                  ],
+                },
+              },
+              {
+                id: 'thread-2',
+                isResolved: false,
+                comments: {
+                  nodes: [
+                    {
+                      databaseId: 102,
+                      path: 'lib/other.js',
+                      line: 7,
+                      author: { login: 'human-reviewer' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+
+  test('parses unresolved Greptile review threads from GitHub GraphQL shape', () => {
+    const adapter = new GreptileReviewAdapter();
+
+    expect(adapter.parse(reviewThreadsResponse)).toEqual([
+      {
+        id: 'thread-1',
+        commentId: 101,
+        file: 'lib/example.js',
+        line: 12,
+        body: 'please fix this',
+        author: 'greptile-apps[bot]',
+        isResolved: false,
+        raw: reviewThreadsResponse.data.repository.pullRequest.reviewThreads.nodes[0],
+      },
+    ]);
+  });
+
+  test('keeps matchThreadsToCommits public API behavior compatible', () => {
+    const execCalls = [];
+    const threads = [{ file: 'lib/example.js', line: 12 }];
+    const result = matchThreadsToCommits(threads, '/repo', {
+      _exec: (cmd, args) => {
+        execCalls.push([cmd, args]);
+        if (args.includes('merge-base')) {
+          return 'base123\n';
+        }
+        return 'abc1234 fix adapter\n';
+      },
+    });
+
+    expect(execCalls).toEqual([
+      ['git', ['-C', '/repo', 'merge-base', 'HEAD', 'main']],
+      ['git', ['-C', '/repo', 'log', '--oneline', '--follow', 'base123..HEAD', '--', 'lib/example.js']],
+    ]);
+    expect(result).toEqual([{ file: 'lib/example.js', line: 12, resolved: true, sha: 'abc1234' }]);
+  });
+});


### PR DESCRIPTION
## Problem
Forge v3 needs a stable review-adapter foundation so provider-specific review systems can be normalized without coupling future adapters to the current Greptile helper.

## Root Cause
The current review integration exposes Greptile-specific matching through `lib/greptile-match.js`, but there was no ReviewAdapter SPI, scaffold entrypoint, fixture replay harness, or adapter contract documentation for user-authored review adapters.

## Fix
This PR defines the ReviewAdapter SPI, adds `GreptileReviewAdapter` as the compatibility reference, keeps `matchThreadsToCommits` backward compatible by delegating through the Greptile adapter, adds `forge new adapter ...` and `forge adapter test ...` foundation commands, and documents the adapter contract/lifecycle/test expectations.

Issues covered:
- forge-79xh: ReviewAdapter SPI + Greptile refactor
- forge-1c0j: `forge new adapter` scaffold + adapter CLI foundation
- forge-tis9: offline fixture replay harness foundation

Adapter contract summary:
- Review adapters implement `fetchThreads`, `parse`, `reply`, `resolve`, and `score`.
- `parse` normalizes provider review payloads to `{ id, commentId, file, line, body, author, isResolved, raw }`.
- Fixture replay is offline and deterministic through `forge adapter test <name> --fixture=<path>`.

Compatibility notes:
- Existing `matchThreadsToCommits(threads, projectRoot, opts)` export remains intact.
- Existing Greptile shell workflow keeps using the same matcher path and behavior.
- New scaffold support is intentionally local to `.forge/adapters/review/<name>.js`.

Non-scope:
- No IssueAdapter implementation.
- No GitHub issue sync changes.
- No full v3 reference adapter template catalog.

## Value
Future review providers can be introduced behind a documented SPI while current Greptile review resolution behavior remains compatible. Adapter authors also get a starter scaffold and offline replay path before live API integration.

## Beads
Closes forge-79xh
Closes forge-1c0j
Closes forge-tis9

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 266 passing via `node scripts/validate.js`; 8 focused adapter tests passing.
- Scenarios covered: SPI validation, base lifecycle errors, Greptile GraphQL parsing, `matchThreadsToCommits` compatibility, adapter scaffold generation, fixture replay.

### Security Review
- OWASP Top 10: no new network/auth/data exposure paths; scaffold writes local files only; fixture replay reads local JSON only.
- Automated scan: `bun audit` passed with no vulnerabilities.

### Design Doc
See: `docs/work/2026-05-18-adapter-foundation/design.md`

### Key Decisions
- Keep `lib/greptile-match.js` public API stable and delegate to `GreptileReviewAdapter` internally.
- Limit scaffold support to review adapters and the Greptile-shaped starter in this foundation PR.
- Keep fixture replay offline; live provider operations stay in adapter lifecycle methods.
- Explicitly exclude IssueAdapter and GitHub issue sync from this PR.

### Documentation Updated
- `docs/reference/ADAPTERS.md`
- `docs/INDEX.md`
- `docs/work/2026-05-18-adapter-foundation/design.md`
- `docs/work/2026-05-18-adapter-foundation/tasks.md`
- `docs/work/2026-05-18-adapter-foundation/decisions.md`

### Validation
- [x] Type check passing: `bun run typecheck`
- [x] Lint passing (0 errors, 0 warnings): `bun run lint`
- [x] All selected validation tests passing: `node scripts/validate.js` (266 pass, 0 fail)
- [x] Security review completed: `bun audit` (no vulnerabilities)

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] Local validation passes (`node scripts/validate.js`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (compatibility notes included)
- [x] TDD compliance: Source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review adapter system for creating, scaffolding, testing, enabling, disabling, and listing custom review adapters
  * Built-in Greptile-compatible adapter and deterministic offline fixture replay for testing without network access

* **Documentation**
  * New adapter reference, design, tasks, and decision docs detailing contract, lifecycle, scaffold, and replay expectations

* **Tests**
  * Expanded tests covering CLI flows, adapter validation, parsing, scoring, and fixture replay behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->