### PR TITLE
0.0.18 issue authority

### DIFF
--- a/docs/guides/BEADS_GITHUB_SYNC.md
+++ b/docs/guides/BEADS_GITHUB_SYNC.md
@@ -2,14 +2,17 @@
 
 Automatic synchronization between GitHub Issues and Beads issue tracking.
 
-**GitHub Issues** = human/team/public interface.
-**Beads** = issue engine behind Forge (`forge ready`, `forge close`).
+**GitHub Issues** = human/team/public shared issue state.
+**Forge** = issue authority layer, workflow context owner, and supported command/API surface.
+**Beads** = reference issue adapter and local cache/backend behind Forge (`forge ready`, `forge close`).
 
 Neither side needs to know about the other. Contributors file issues on GitHub; AI agents pick up work via Beads. Status changes propagate automatically.
 
 For human and agent workflows, prefer the Forge wrapper commands (`forge ready`,
-`forge create`, `forge close`, `forge sync`). The workflow automation shown below
-still calls `bd` directly as an internal implementation detail.
+`forge create`, `forge close`, `forge sync`). Forge routes issue operations
+through the `IssueAdapter` SPI, with Beads as the reference adapter. The workflow
+automation shown below still calls `bd` directly as an internal implementation
+detail.
 
 ---
 
@@ -69,7 +72,9 @@ Three guards prevent infinite ping-pong:
 2. **Commit message prefix** -- Phase 2 workflow skips commits starting with `chore(beads):`
 3. **Opt-out label** -- `skip-beads-sync` label on any issue disables sync entirely
 
-### Normalized Core
+### Authority Model
+
+Forge owns the authority decision for every synchronized field:
 
 GitHub-owned shared fields are the only fields that steady-state pull and initial import are allowed to overwrite:
 
@@ -84,7 +89,15 @@ GitHub-owned shared fields are the only fields that steady-state pull and initia
 - `shared.milestone`
 - `sync.remoteUpdatedAt`
 
-Forge-owned workflow context stays local in Beads. That includes workflow stage, dependencies, progress notes, decisions, and other issue-engine metadata.
+Forge-owned workflow context stays local in Forge/Beads. That includes Forge issue ids, workflow stage, dependencies, progress notes, stage transitions, decisions, memory, and other issue-engine metadata.
+
+Beads is the reference adapter and cache backend. It does not own shared team-visible GitHub fields. Cache fields such as materialized GitHub snapshots and legacy link hints are derived and can be rebuilt.
+
+### Conflict Behavior
+
+When GitHub-owned shared fields differ during pull/import, Forge applies the remote value and records drift diagnostics. When Forge-owned fields appear in a remote/import payload, Forge preserves the local value and ignores the remote value. Unknown fields are rejected until the authority model assigns ownership.
+
+### Normalized Core
 
 Both ongoing pull sync and the `forge-ij1` import bootstrap use the same primitive layer:
 
@@ -94,6 +107,10 @@ Both ongoing pull sync and the `forge-ij1` import bootstrap use the same primiti
 - `lib/issue-sync/import-primitives.js` exposes `listRemoteIssues`, `normalizeRemoteIssue`, `resolveSharedLink`, and `materializeLocalIssue` for import backfill.
 
 `forge-ij1` depends on these primitives directly. It does not use a separate import-specific sync contract or an alternate reconciliation path.
+
+### Sync Boundaries
+
+Forge does not own GitHub Projects boards, GitHub discussion/comment history, external provider schemas, or team dashboard UI. Forge only owns the adapter contract, authority decisions, local workflow context, and the reconciliation rules that decide what may be copied between GitHub and the local issue backend.
 
 ---
 

--- a/docs/reference/ADAPTERS.md
+++ b/docs/reference/ADAPTERS.md
@@ -1,8 +1,45 @@
-# Forge Review Adapters
+# Forge Adapters
+
+Forge adapters normalize provider-specific surfaces behind Forge-owned contracts. The bundled adapters are reference implementations; Forge owns the contract and authority rules.
+
+## Issue Adapters
+
+Issue adapters expose issue tracking operations without making Beads, GitHub, Linear, Jira, or another provider the Forge API. The bundled reference adapter is `BeadsIssueAdapter`.
+
+### Issue Contract
+
+An issue adapter has `kind: "issue"` and implements these methods:
+
+- `list(args, context)`: list issues from the provider/backend.
+- `read(args, context)`: read a single issue. The Beads adapter maps this to `bd show`.
+- `create(args, context)`: create an issue.
+- `update(args, context)`: update issue fields.
+- `close(args, context)`: close an issue.
+- `comment(args, context)`: add an issue comment. The Beads adapter maps this to `bd comments add`.
+- `mapStatus(status, context)`: map provider status into the requested target state.
+- `decideAuthority(change, context)`: return the Forge authority decision for a field change.
+
+### Issue Authority
+
+GitHub owns shared team-visible fields: GitHub identity, URL, title, body, state, assignees, labels, milestone, and remote update timestamps.
+
+Forge owns workflow and project context: Forge issue id, dependencies, parent/child links, workflow stages, acceptance criteria, progress notes, stage transitions, decisions, memory, outbound projection bookkeeping, and drift diagnostics.
+
+Beads is the local/reference issue adapter and cache backend. Cache fields are derived and may be rebuilt. Unknown field paths are rejected until the authority model explicitly assigns ownership.
+
+### Conflict Behavior
+
+During pull/import, GitHub-owned remote fields overwrite local materialized shared fields and differences are recorded as drift diagnostics. Forge-owned fields are preserved locally and are not overwritten by GitHub import. Cache fields are rebuilt from the authoritative inputs.
+
+### Issue Non-Scope
+
+Issue adapters do not implement team dashboard UI, ReviewAdapter internals, GitHub Projects board automation, or full comment/discussion import. GitHub issue import must use the existing `lib/issue-sync/import-primitives.js` reconciliation path rather than a separate import contract.
+
+## Review Adapters
 
 Forge review adapters normalize provider-specific review feedback into one contract used by review tooling and offline fixture tests.
 
-## Contract
+### Review Contract
 
 A review adapter has `kind: "review"` and implements these methods:
 
@@ -27,7 +64,7 @@ Normalized thread shape:
 }
 ```
 
-## Lifecycle
+### Review Lifecycle
 
 1. `fetchThreads` obtains raw provider data for live review runs.
 2. `parse` filters and normalizes the provider data.
@@ -37,7 +74,7 @@ Normalized thread shape:
 
 The bundled `GreptileReviewAdapter` is the compatibility reference. Existing Greptile shell commands keep their public command names while the shared matching behavior is routed through the adapter implementation.
 
-## Scaffold
+### Review Scaffold
 
 Create a local review adapter starter:
 
@@ -53,7 +90,7 @@ The scaffold is written to:
 
 Only review adapters and the Greptile-shaped starter template are supported in this foundation PR.
 
-## Fixture Replay
+### Review Fixture Replay
 
 Run adapter parsing and scoring offline:
 
@@ -84,6 +121,6 @@ Fixture shape:
 
 Fixture replay must not make network calls. Live provider calls belong in `fetchThreads`, `reply`, and `resolve`.
 
-## Non-Scope
+### Review Non-Scope
 
-This adapter foundation does not implement `IssueAdapter`, GitHub issue sync, or the full v3 reference adapter template catalog.
+Review adapters do not implement issue tracking, GitHub issue sync, or the full v3 reference adapter template catalog.

--- a/docs/work/2026-05-18-issue-authority/decisions.md
+++ b/docs/work/2026-05-18-issue-authority/decisions.md
@@ -1,0 +1,13 @@
+# 0.0.18 Issue Authority Decisions
+
+## D1: Stack on PR #168
+
+PR #168 is open, but this branch consumes the adapter foundation by stacking on `codex/0.0.18-adapter-foundation` at `a03f8cf`. The PR #168 SPI shape is stable enough for this slice because the review adapter foundation files and docs are present, tests exist, and IssueAdapter is explicitly documented there as non-scope.
+
+## D2: Beads is the reference adapter, not the authority model
+
+The Beads adapter delegates local issue operations, but authority decisions live in Forge and reuse `lib/issue-sync/authority.js`. This keeps Beads replaceable behind the SPI.
+
+## D3: No separate GitHub import stack
+
+Existing import primitives already normalize and reconcile GitHub issue payloads. This slice documents and tests the boundary instead of introducing a new `forge team sync --pull` implementation path.

--- a/docs/work/2026-05-18-issue-authority/design.md
+++ b/docs/work/2026-05-18-issue-authority/design.md
@@ -1,0 +1,54 @@
+# 0.0.18 Issue Authority
+
+## Issues Covered
+
+- `forge-3yrz`: IssueAdapter SPI with Beads reference adapter.
+- `forge-f3lx`: Forge issue authority and GitHub-backed coordination.
+- `forge-ij1`: only primitive-level support if it stays inside the existing issue-sync import boundary.
+
+## Current State
+
+PR #168 (`0.0.18 adapter foundation`) is open, not merged. This branch is stacked on `codex/0.0.18-adapter-foundation` at `a03f8cf` because that branch already exposes the adapter foundation shape in `lib/review-adapter.js` and documents that IssueAdapter is non-scope for that PR.
+
+The repo already has issue authority primitives:
+
+- `lib/issue-sync/authority.js` defines GitHub-, Forge-, and cache-owned field paths.
+- `lib/issue-sync/reconcile.js` applies GitHub-owned fields and records drift diagnostics.
+- `lib/issue-sync/import-primitives.js` materializes GitHub issue payloads through the same reconciliation path.
+- `lib/forge-issues.js` wraps Beads operations behind a service/backend boundary.
+
+## Design
+
+Add a first-class `IssueAdapter` SPI that mirrors the review adapter foundation style but stays issue-specific:
+
+- `list(args, context)`
+- `read(args, context)`
+- `create(args, context)`
+- `update(args, context)`
+- `close(args, context)`
+- `comment(args, context)`
+- `mapStatus(status, context)`
+- `decideAuthority(change, context)`
+
+Implement `BeadsIssueAdapter` as the reference adapter. It delegates to the existing Beads operation runner, maps Beads `show` to `read`, maps `comment` to `bd comments add`, and exposes Forge-owned authority decisions through the existing issue-sync authority tables.
+
+Keep GitHub-backed coordination on the existing primitive layer. This slice should not build a team dashboard UI, ReviewAdapter internals, or a separate GitHub issue client. If import behavior is touched, it must reuse `lib/issue-sync/import-primitives.js` and not create a second reconciliation contract.
+
+## Authority Model
+
+- GitHub owns shared team-visible identity and state fields: GitHub issue id, URL, title, body, state, assignees, labels, milestone, and remote update timestamps.
+- Forge owns workflow and project context: issue id, dependencies, parent/child links, workflow stages, acceptance criteria, progress notes, stage transitions, decisions, memory, outbound projection bookkeeping, and drift diagnostics.
+- Beads is the local/reference issue adapter and cache backend. It can store Forge-owned state and materialized GitHub snapshots, but it is not the cross-team source of truth for shared GitHub fields.
+- Cache fields are derived and may be rebuilt.
+
+## Conflict Behavior
+
+GitHub-owned remote changes overwrite local materialized shared fields during pull/import. Differences are retained as drift diagnostics rather than silently discarded. Forge-owned fields are not overwritten by GitHub pull/import. Unknown fields are rejected by the authority decision helper so callers cannot accidentally claim ownership without updating the model.
+
+## Non-Scope
+
+- Team dashboard UI.
+- ReviewAdapter internals beyond consuming the foundation shape.
+- Full GitHub issue write client.
+- GitHub Projects migration or board automation.
+- Importing all comments/discussions.

--- a/docs/work/2026-05-18-issue-authority/tasks.md
+++ b/docs/work/2026-05-18-issue-authority/tasks.md
@@ -1,0 +1,37 @@
+# 0.0.18 Issue Authority Tasks
+
+## Task 1: IssueAdapter SPI
+
+RED: Add tests for required issue adapter methods, status mapping, and authority decisions.
+
+GREEN: Add `lib/issue-adapter.js` with validation helpers and default throwing methods.
+
+REFACTOR: Keep the API parallel to the review adapter foundation without sharing review-specific logic.
+
+## Task 2: Beads Reference Adapter
+
+RED: Add tests proving Beads delegates create/list/read/update/close/comment through the existing operation runner.
+
+GREEN: Add `lib/adapters/beads-issue-adapter.js` and route `lib/forge-issues.js` through the adapter.
+
+REFACTOR: Preserve existing `createBeadsIssueBackend` and `runIssueOperation` compatibility.
+
+## Task 3: Authority and Conflict Contract
+
+RED: Add tests for GitHub-owned, Forge-owned, cache, and unknown field decisions plus status mapping.
+
+GREEN: Expose `decideIssueAuthority` and conflict decision helpers through the SPI.
+
+REFACTOR: Reuse `lib/issue-sync/authority.js` instead of duplicating field tables.
+
+## Task 4: Documentation
+
+RED: Confirm docs mention IssueAdapter, authority model, conflict behavior, sync boundaries, and non-scope.
+
+GREEN: Update `docs/reference/ADAPTERS.md` and `docs/guides/BEADS_GITHUB_SYNC.md`.
+
+REFACTOR: Keep PR #168 review adapter docs intact and add issue-specific sections.
+
+## Task 5: Validation and Ship
+
+Run targeted tests first, then lint and broader validation. Ship as PR `0.0.18 issue authority` with issues covered, validation commands, authority model, conflict behavior, and non-scope.

--- a/lib/adapters/beads-issue-adapter.js
+++ b/lib/adapters/beads-issue-adapter.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const {
+  IssueAdapter,
+  decideIssueAuthority,
+  normalizeIssueStatus,
+} = require('../issue-adapter.js');
+
+class BeadsIssueAdapter extends IssueAdapter {
+  constructor(options = {}) {
+    super({
+      id: options.id || 'beads',
+      kind: 'issue',
+      name: options.name || 'Beads Issue Adapter',
+      version: options.version || '0.1.0',
+    });
+    this.runBeadsOperation = options.runBeadsOperation;
+  }
+
+  run(operation, args = [], context = {}) {
+    if (typeof this.runBeadsOperation !== 'function') {
+      throw new TypeError('runBeadsOperation is not configured on this adapter');
+    }
+
+    return this.runBeadsOperation(operation, args, context, context.deps || {});
+  }
+
+  list(args = [], context = {}) {
+    return this.run('list', args, context);
+  }
+
+  read(args = [], context = {}) {
+    return this.run('show', args, context);
+  }
+
+  show(args = [], context = {}) {
+    return this.read(args, context);
+  }
+
+  create(args = [], context = {}) {
+    return this.run('create', args, context);
+  }
+
+  update(args = [], context = {}) {
+    return this.run('update', args, context);
+  }
+
+  close(args = [], context = {}) {
+    return this.run('close', args, context);
+  }
+
+  comment(args = [], context = {}) {
+    return this.run('comment', args, context);
+  }
+
+  mapStatus(status, context = {}) {
+    return normalizeIssueStatus(status, context);
+  }
+
+  decideAuthority(change = {}, context = {}) {
+    return decideIssueAuthority(change, context);
+  }
+}
+
+module.exports = {
+  BeadsIssueAdapter,
+};

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -4,6 +4,7 @@ const { spawn } = require('node:child_process');
 const { existsSync } = require('node:fs');
 const path = require('node:path');
 const { isBeadsInitialized } = require('./beads-setup');
+const { BeadsIssueAdapter } = require('./adapters/beads-issue-adapter');
 const { createGitHubProjectionPlan } = require('./issue-sync/project-github');
 
 const OPERATION_TO_BD = {
@@ -12,6 +13,7 @@ const OPERATION_TO_BD = {
   show: 'show',
   close: 'close',
   update: 'update',
+  comment: 'comments',
 };
 
 function getSpawnOptions(projectRoot) {
@@ -117,6 +119,10 @@ function getCommandErrorMessage(result) {
 }
 
 function buildBdArgs(operation, args) {
+  if (operation === 'comment') {
+    return ['comments', 'add', ...args];
+  }
+
   const bdCommand = OPERATION_TO_BD[operation];
   if (!bdCommand) {
     return null;
@@ -243,13 +249,13 @@ async function runBeadsOperation(operation, args, context, deps) {
 }
 
 function createBeadsIssueBackend(deps = {}) {
-  return {
-    create: async (args, context) => runBeadsOperation('create', args, context, deps),
-    list: async (args, context) => runBeadsOperation('list', args, context, deps),
-    show: async (args, context) => runBeadsOperation('show', args, context, deps),
-    close: async (args, context) => runBeadsOperation('close', args, context, deps),
-    update: async (args, context) => runBeadsOperation('update', args, context, deps),
-  };
+  return new BeadsIssueAdapter({
+    runBeadsOperation: (operation, args, context, contextDeps = {}) =>
+      runBeadsOperation(operation, args, context, {
+        ...deps,
+        ...contextDeps,
+      }),
+  });
 }
 
 function createIssueService({ backend } = {}) {
@@ -257,7 +263,10 @@ function createIssueService({ backend } = {}) {
 
   return {
     async run(operation, args = [], context = {}) {
-      const method = resolvedBackend?.[operation];
+      const methodName = operation === 'show' && typeof resolvedBackend?.show !== 'function'
+        ? 'read'
+        : operation;
+      const method = resolvedBackend?.[methodName];
       if (typeof method !== 'function') {
         return {
           success: false,
@@ -310,6 +319,7 @@ async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
 module.exports = {
   createIssueService,
   createBeadsIssueBackend,
+  runBeadsOperation,
   runIssueOperation,
   buildBdArgs,
   extractErrorMessage,

--- a/lib/issue-adapter.js
+++ b/lib/issue-adapter.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const { getFieldAuthority } = require('./issue-sync/authority.js');
+
+const REQUIRED_ISSUE_ADAPTER_METHODS = [
+  'list',
+  'read',
+  'create',
+  'update',
+  'close',
+  'comment',
+  'mapStatus',
+  'decideAuthority',
+];
+
+const ABSTRACT_ISSUE_ADAPTER_METHODS = new Set([
+  'list',
+  'read',
+  'create',
+  'update',
+  'close',
+  'comment',
+]);
+
+const GITHUB_OPEN_STATUSES = new Set(['open', 'in_progress', 'blocked', 'todo', 'ready']);
+const GITHUB_CLOSED_STATUSES = new Set(['closed', 'done', 'resolved', 'complete', 'completed']);
+
+class IssueAdapter {
+  constructor(options = {}) {
+    this.id = options.id || 'issue-adapter';
+    this.kind = options.kind || 'issue';
+    this.name = options.name || this.id;
+    this.version = options.version || '0.1.0';
+  }
+
+  async list() {
+    throw new Error(`${this.id}.list is not implemented`);
+  }
+
+  async read() {
+    throw new Error(`${this.id}.read is not implemented`);
+  }
+
+  async create() {
+    throw new Error(`${this.id}.create is not implemented`);
+  }
+
+  async update() {
+    throw new Error(`${this.id}.update is not implemented`);
+  }
+
+  async close() {
+    throw new Error(`${this.id}.close is not implemented`);
+  }
+
+  async comment() {
+    throw new Error(`${this.id}.comment is not implemented`);
+  }
+
+  mapStatus(status, context) {
+    return normalizeIssueStatus(status, context);
+  }
+
+  decideAuthority(change, context) {
+    return decideIssueAuthority(change, context);
+  }
+}
+
+function validateIssueAdapter(adapter) {
+  const errors = [];
+
+  if (!adapter || typeof adapter !== 'object') {
+    return { valid: false, errors: ['adapter must be an object'] };
+  }
+
+  if (!adapter.id || typeof adapter.id !== 'string') {
+    errors.push('id must be a non-empty string');
+  }
+
+  if (adapter.kind !== 'issue') {
+    errors.push('kind must be "issue"');
+  }
+
+  for (const method of REQUIRED_ISSUE_ADAPTER_METHODS) {
+    if (typeof adapter[method] !== 'function') {
+      errors.push(`${method} must be a function`);
+    } else if (
+      ABSTRACT_ISSUE_ADAPTER_METHODS.has(method)
+      && adapter[method] === IssueAdapter.prototype[method]
+    ) {
+      errors.push(`${method} must be implemented by the adapter`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+function normalizeIssueStatus(status, options = {}) {
+  const normalized = typeof status === 'string'
+    ? status.trim().toLowerCase().replace(/[-\s]+/g, '_')
+    : '';
+
+  if (options.target === 'github') {
+    if (GITHUB_CLOSED_STATUSES.has(normalized)) {
+      return 'closed';
+    }
+    if (GITHUB_OPEN_STATUSES.has(normalized)) {
+      return 'open';
+    }
+    return 'open';
+  }
+
+  return normalized || 'open';
+}
+
+function decideIssueAuthority(change = {}, _context = {}) {
+  const authority = getFieldAuthority(change.fieldPath);
+
+  if (authority === 'github') {
+    return {
+      authority,
+      action: change.direction === 'push' ? 'project-to-github' : 'apply-remote',
+      conflict: change.direction === 'push' ? 'remote-wins-on-pull' : 'record-drift',
+    };
+  }
+
+  if (authority === 'forge') {
+    return {
+      authority,
+      action: change.direction === 'push' ? 'keep-local' : 'preserve-local',
+      conflict: change.direction === 'push' ? 'not-shared-to-github' : 'ignore-remote',
+    };
+  }
+
+  if (authority === 'cache') {
+    return {
+      authority,
+      action: 'rebuild-cache',
+      conflict: 'derived',
+    };
+  }
+
+  return {
+    authority: null,
+    action: 'reject',
+    conflict: 'unknown-field',
+  };
+}
+
+module.exports = {
+  IssueAdapter,
+  REQUIRED_ISSUE_ADAPTER_METHODS,
+  decideIssueAuthority,
+  normalizeIssueStatus,
+  validateIssueAdapter,
+};

--- a/test/beads-issue-adapter.test.js
+++ b/test/beads-issue-adapter.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+
+describe('BeadsIssueAdapter', () => {
+  test('implements the IssueAdapter contract', () => {
+    const { validateIssueAdapter } = require('../lib/issue-adapter');
+    const { BeadsIssueAdapter } = require('../lib/adapters/beads-issue-adapter');
+
+    const adapter = new BeadsIssueAdapter();
+    expect(adapter.id).toBe('beads');
+    expect(adapter.kind).toBe('issue');
+    expect(validateIssueAdapter(adapter)).toEqual({ valid: true, errors: [] });
+  });
+
+  test('delegates issue operations to the Beads command surface', async () => {
+    const { BeadsIssueAdapter } = require('../lib/adapters/beads-issue-adapter');
+    const calls = [];
+    const adapter = new BeadsIssueAdapter({
+      runBeadsOperation: async (operation, args, context, deps) => {
+        calls.push({ operation, args, context, deps });
+        return { success: true, operation, output: `${operation}:ok` };
+      },
+    });
+    const context = { projectRoot: '/repo', deps: { marker: 'test' } };
+
+    await expect(adapter.create(['Issue title'], context)).resolves.toMatchObject({ operation: 'create' });
+    await expect(adapter.list(['--json'], context)).resolves.toMatchObject({ operation: 'list' });
+    await expect(adapter.read(['forge-1'], context)).resolves.toMatchObject({ operation: 'show' });
+    await expect(adapter.update(['forge-1', '--title', 'Renamed'], context)).resolves.toMatchObject({ operation: 'update' });
+    await expect(adapter.close(['forge-1'], context)).resolves.toMatchObject({ operation: 'close' });
+    await expect(adapter.comment(['forge-1', 'note'], context)).resolves.toMatchObject({ operation: 'comment' });
+
+    expect(calls.map(call => [call.operation, call.args])).toEqual([
+      ['create', ['Issue title']],
+      ['list', ['--json']],
+      ['show', ['forge-1']],
+      ['update', ['forge-1', '--title', 'Renamed']],
+      ['close', ['forge-1']],
+      ['comment', ['forge-1', 'note']],
+    ]);
+    expect(calls[0].context).toBe(context);
+    expect(calls[0].deps).toEqual({ marker: 'test' });
+  });
+
+  test('requires a configured Beads operation runner', () => {
+    const { BeadsIssueAdapter } = require('../lib/adapters/beads-issue-adapter');
+    const adapter = new BeadsIssueAdapter();
+
+    expect(() => adapter.run('list')).toThrow(TypeError);
+    expect(() => adapter.run('list')).toThrow('runBeadsOperation is not configured on this adapter');
+  });
+
+  test('maps comments to bd comments add arguments in the default Beads backend', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+    const calls = [];
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      runBdCommand: async (args, projectRoot) => {
+        calls.push({ args, projectRoot });
+        return { code: 0, stdout: 'comment added', stderr: '' };
+      },
+    });
+
+    await expect(backend.comment(['forge-1', 'handoff note'], { projectRoot: '/repo' })).resolves.toEqual({
+      success: true,
+      operation: 'comment',
+      output: 'comment added',
+      stderr: '',
+    });
+    expect(calls).toEqual([{
+      args: ['comments', 'add', 'forge-1', 'handoff note'],
+      projectRoot: '/repo',
+    }]);
+  });
+
+  test('top-level issue service uses BeadsIssueAdapter by default', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+    const calls = [];
+
+    const result = await runIssueOperation('show', ['forge-1'], '/repo', {
+      isBeadsInitialized: () => true,
+      runBdCommand: async (args, projectRoot) => {
+        calls.push({ args, projectRoot });
+        return { code: 0, stdout: '{"id":"forge-1"}', stderr: '' };
+      },
+    });
+
+    expect(result).toEqual({
+      success: true,
+      operation: 'show',
+      output: '{"id":"forge-1"}',
+      stderr: '',
+    });
+    expect(calls).toEqual([{ args: ['show', 'forge-1'], projectRoot: '/repo' }]);
+  });
+});

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -108,6 +108,30 @@ describe('forge issue service contract', () => {
     });
   });
 
+  test('maps legacy show dispatch to the IssueAdapter read contract', async () => {
+    const { createIssueService } = require('../lib/forge-issues');
+    const calls = [];
+    const adapter = {
+      async read(args, context) {
+        calls.push({ args, context, thisRef: this });
+        return { success: true, output: `read:${args[0]}` };
+      },
+    };
+
+    const context = { projectRoot: '/repo' };
+    const service = createIssueService({ backend: adapter });
+
+    await expect(service.run('show', ['forge-123'], context)).resolves.toEqual({
+      success: true,
+      output: 'read:forge-123',
+    });
+    expect(calls).toEqual([{
+      args: ['forge-123'],
+      context,
+      thisRef: adapter,
+    }]);
+  });
+
   test('uses dependency injection in the top-level operation runner', async () => {
     const { runIssueOperation } = require('../lib/forge-issues');
     const calls = [];
@@ -246,6 +270,32 @@ describe('forge issue service contract', () => {
         projectRoot: '/repo',
       },
     ]);
+  });
+
+  test('default beads backend lets per-call deps override construction deps', async () => {
+    const { createBeadsIssueBackend } = require('../lib/forge-issues');
+    const calls = [];
+
+    const backend = createBeadsIssueBackend({
+      isBeadsInitialized: () => true,
+      runBdCommand: async () => ({ code: 1, stdout: '', stderr: 'construction deps used' }),
+    });
+
+    await expect(backend.show(['forge-1'], {
+      projectRoot: '/repo',
+      deps: {
+        runBdCommand: async (args, projectRoot) => {
+          calls.push({ args, projectRoot });
+          return { code: 0, stdout: '{"id":"forge-1"}', stderr: '' };
+        },
+      },
+    })).resolves.toEqual({
+      success: true,
+      operation: 'show',
+      output: '{"id":"forge-1"}',
+      stderr: '',
+    });
+    expect(calls).toEqual([{ args: ['show', 'forge-1'], projectRoot: '/repo' }]);
   });
 
   test('default beads backend translates missing bd binary into a forge-level error', async () => {

--- a/test/issue-adapter.test.js
+++ b/test/issue-adapter.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+
+describe('IssueAdapter SPI', () => {
+  test('exports the required issue adapter contract', () => {
+    const {
+      IssueAdapter,
+      REQUIRED_ISSUE_ADAPTER_METHODS,
+      validateIssueAdapter,
+    } = require('../lib/issue-adapter');
+
+    expect(REQUIRED_ISSUE_ADAPTER_METHODS).toEqual([
+      'list',
+      'read',
+      'create',
+      'update',
+      'close',
+      'comment',
+      'mapStatus',
+      'decideAuthority',
+    ]);
+
+    const adapter = new IssueAdapter({ id: 'test-issues', name: 'Test Issues' });
+    expect(adapter.kind).toBe('issue');
+    expect(typeof adapter.list).toBe('function');
+    expect(validateIssueAdapter(adapter)).toEqual({
+      valid: false,
+      errors: [
+        'list must be implemented by the adapter',
+        'read must be implemented by the adapter',
+        'create must be implemented by the adapter',
+        'update must be implemented by the adapter',
+        'close must be implemented by the adapter',
+        'comment must be implemented by the adapter',
+      ],
+    });
+  });
+
+  test('rejects incomplete issue adapters', () => {
+    const { validateIssueAdapter } = require('../lib/issue-adapter');
+
+    expect(validateIssueAdapter({ id: 'bad', kind: 'issue', list() {} })).toEqual({
+      valid: false,
+      errors: [
+        'read must be a function',
+        'create must be a function',
+        'update must be a function',
+        'close must be a function',
+        'comment must be a function',
+        'mapStatus must be a function',
+        'decideAuthority must be a function',
+      ],
+    });
+  });
+
+  test('rejects subclasses that inherit abstract operation methods', () => {
+    const { IssueAdapter, validateIssueAdapter } = require('../lib/issue-adapter');
+
+    class PartialIssueAdapter extends IssueAdapter {
+      constructor() {
+        super({ id: 'partial' });
+      }
+
+      list() {
+        return [];
+      }
+
+      read() {
+        return null;
+      }
+    }
+
+    expect(validateIssueAdapter(new PartialIssueAdapter())).toEqual({
+      valid: false,
+      errors: [
+        'create must be implemented by the adapter',
+        'update must be implemented by the adapter',
+        'close must be implemented by the adapter',
+        'comment must be implemented by the adapter',
+      ],
+    });
+  });
+
+  test('maps issue statuses for GitHub shared state', () => {
+    const { normalizeIssueStatus } = require('../lib/issue-adapter');
+
+    expect(normalizeIssueStatus('open', { target: 'github' })).toBe('open');
+    expect(normalizeIssueStatus('in_progress', { target: 'github' })).toBe('open');
+    expect(normalizeIssueStatus('blocked', { target: 'github' })).toBe('open');
+    expect(normalizeIssueStatus('in_review', { target: 'github' })).toBe('open');
+    expect(normalizeIssueStatus('closed', { target: 'github' })).toBe('closed');
+    expect(normalizeIssueStatus('done', { target: 'github' })).toBe('closed');
+  });
+
+  test('returns explicit authority decisions for shared, forge, cache, and unknown fields', () => {
+    const { decideIssueAuthority } = require('../lib/issue-adapter');
+
+    expect(decideIssueAuthority({ fieldPath: 'shared.title', direction: 'pull' })).toEqual({
+      authority: 'github',
+      action: 'apply-remote',
+      conflict: 'record-drift',
+    });
+    expect(decideIssueAuthority({ fieldPath: 'forge.workflowStage', direction: 'pull' })).toEqual({
+      authority: 'forge',
+      action: 'preserve-local',
+      conflict: 'ignore-remote',
+    });
+    expect(decideIssueAuthority({ fieldPath: 'cache.githubSnapshot', direction: 'pull' })).toEqual({
+      authority: 'cache',
+      action: 'rebuild-cache',
+      conflict: 'derived',
+    });
+    expect(decideIssueAuthority({ fieldPath: 'custom.field', direction: 'pull' })).toEqual({
+      authority: null,
+      action: 'reject',
+      conflict: 'unknown-field',
+    });
+  });
+});


### PR DESCRIPTION
## Issues covered
- forge-3yrz: IssueAdapter SPI with Beads reference adapter
- forge-f3lx: Forge issue authority and GitHub-backed coordination
- forge-ij1: Kept to existing import primitive boundaries; no new team sync --pull command surface in this slice

## Validation commands
- bun test test/issue-adapter.test.js test/beads-issue-adapter.test.js test/forge-issues.test.js test/issue-sync/authority.test.js test/issue-sync/reconcile.test.js test/issue-sync/github-pull.test.js test/issue-sync/import-primitives.test.js
- bun run lint
- bun run typecheck
- bun run check

Note: direct `bun test` and `bun run test` were attempted on the Windows worktree and timed out after 6 minutes without returning a summary; `bun run check` completed the repo validation path successfully.

## Authority model
- GitHub owns shared team-visible issue identity/state: GitHub id/url, title, body, state, assignees, labels, milestone, and remote update timestamps.
- Forge owns workflow/project context: Forge issue id, dependencies, parent/child links, stages, acceptance criteria, progress notes, transitions, decisions, memory, outbound projection bookkeeping, and drift diagnostics.
- Beads is the reference IssueAdapter and local cache/backend, not the cross-team source of truth for shared GitHub fields.

## Conflict behavior
- Pull/import applies GitHub-owned remote fields and records drift diagnostics when local materialized fields differ.
- Forge-owned fields are preserved locally and ignored from remote payloads.
- Cache fields are derived and may be rebuilt.
- Unknown field paths are rejected until ownership is explicitly added to the authority model.

## Non-scope
- Team dashboard UI
- ReviewAdapter internals
- Full GitHub issue write client
- GitHub Projects/board automation
- Importing all GitHub comments or discussions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified sync guide terminology, authority model, conflict behavior, and explicit sync boundaries; added adapter reference docs, design/decision records, tasks, and guide updates.

* **New Features**
  * Introduced an Issue Adapter SPI and base adapter with status normalization and field-authority decision logic; added a Beads-backed reference adapter and Beads-backed comment support.

* **Tests**
  * Added contract and unit tests for adapter validation, adapter operations, authority/conflict rules, and backend integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->