### PR TITLE
feat: add day-one forge init skeleton

### DIFF
--- a/docs/reference/TEMPLATES.md
+++ b/docs/reference/TEMPLATES.md
@@ -16,7 +16,7 @@ Generated files:
 
 - `.forge/config.yaml` records the adoption profile, default classification, Layer 1 rail confirmation, and harness targets.
 - `.forge/patch.md` is an empty patch-intent placeholder for future local overrides.
-- `.forge/protected-paths.yaml` records the protected path manifest scaffold. This PR only scaffolds the manifest; protected-state enforcement belongs to the later protected-state work.
+- `.forge/protected-paths.yaml` records the protected path manifest scaffold. Currently, only the manifest structure is generated; protected-state enforcement is not yet implemented.
 
 When run interactively, `forge init` asks for:
 

--- a/docs/reference/TEMPLATES.md
+++ b/docs/reference/TEMPLATES.md
@@ -5,12 +5,44 @@ Forge templates are adoption scaffolds over runtime graph primitives. They are n
 ## Entry Point
 
 ```bash
-forge init --profile minimal --yes
-forge init --profile standard --yes
-forge init --profile full --yes
+forge init
+forge init --yes
+forge init --profile minimal --classification standard --harness codex --yes
 ```
 
-`forge init --yes` uses `standard`. `forge setup --minimal` is a shortcut for clean repositories that only need the minimal adoption config and do not want Beads or agent files installed yet.
+`forge init` is the day-one entry door for fresh repositories. It creates the local `.forge/` skeleton without assuming a prior v2 install or running the `forge new` onboarding wizard.
+
+Generated files:
+
+- `.forge/config.yaml` records the adoption profile, default classification, Layer 1 rail confirmation, and harness targets.
+- `.forge/patch.md` is an empty patch-intent placeholder for future local overrides.
+- `.forge/protected-paths.yaml` records the protected path manifest scaffold. This PR only scaffolds the manifest; protected-state enforcement belongs to the later protected-state work.
+
+When run interactively, `forge init` asks for:
+
+- default classification: `critical`, `standard`, or `refactor`.
+- Layer 1 rail confirmation.
+- harness targets: `claude`, `cursor`, and/or `codex`.
+
+Harness defaults are detected from filesystem markers:
+
+- `.claude` selects `claude`.
+- `.cursor` selects `cursor`.
+- `.codex` selects `codex`.
+
+`forge init --yes` is deterministic for automation: it uses the `standard` profile, `standard` classification, confirms Layer 1 rails, and selects detected harness targets or `codex` when none are detected.
+
+`forge init` does not overwrite existing generated files. Re-run with `--force` only when replacing `.forge/config.yaml`, `.forge/patch.md`, and `.forge/protected-paths.yaml` is intentional.
+
+Profile shortcuts remain available:
+
+```bash
+forge init --minimal
+forge init --standard
+forge init --full
+```
+
+`forge setup --minimal` remains a separate shortcut for repositories that want setup behavior rather than only the day-one `.forge/` skeleton.
 
 ## Planning Template
 
@@ -53,9 +85,9 @@ Invalid planning modes, thresholds outside `0..1`, blank critics, and unknown pl
 
 | Profile | Purpose | Output |
 |---------|---------|--------|
-| `minimal` | Config-only adoption for a clean repository. | Writes `.forge/config.yaml`, disables workflow gates and adapters, and records template ancestry. |
-| `standard` | Default Forge command flow metadata. | Writes `.forge/config.yaml` with default gates enabled and Beads/GitHub issue adapter metadata. |
-| `full` | Explicit full scaffold. | Writes `.forge/config.yaml` with rails, gates, adapters, and protected paths made explicit. |
+| `minimal` | Smallest adoption skeleton for a clean repository. | Writes the day-one `.forge/` files with workflow gates and issue adapters disabled unless selected later. |
+| `standard` | Default Forge command flow metadata. | Writes the day-one `.forge/` files with default gates enabled and Beads/GitHub issue adapter metadata. |
+| `full` | Explicit full scaffold. | Writes the day-one `.forge/` files with rails, gates, adapters, and protected paths made explicit. |
 
 ## Inspect The Result
 
@@ -69,4 +101,4 @@ The generated config includes `template.kind`, `template.version`, `template.pro
 
 ## Non-Scope
 
-This flow does not implement harness translation, adapter marketplace installation, upgrade or rollback, or patch intent.
+This flow does not implement harness translation, adapter marketplace installation, upgrade or rollback, protected-state enforcement, `forge new`, or patch intent execution.

--- a/docs/work/2026-05-21-forge-init-day-one-entry/decisions.md
+++ b/docs/work/2026-05-21-forge-init-day-one-entry/decisions.md
@@ -1,0 +1,3 @@
+# forge init Day-One Entry Door Decisions
+
+No decision gates fired yet.

--- a/docs/work/2026-05-21-forge-init-day-one-entry/decisions.md
+++ b/docs/work/2026-05-21-forge-init-day-one-entry/decisions.md
@@ -1,3 +1,31 @@
 # forge init Day-One Entry Door Decisions
 
-No decision gates fired yet.
+No /dev decision gates fired. The entries below record the architectural and scope choices that shaped the implementation.
+
+## Decision 1: Implementation Location
+
+**Date:** 2026-05-21
+**Decision:** Extend `lib/commands/init.js` for the day-one `forge init` entry door.
+**Rationale:** The command registry already routes `forge init` through this module, and the existing adoption profile rendering path lives next to the command handler.
+**Impact:** The change stays close to current dispatch behavior while keeping parsing, wizard resolution, rendering, and file generation testable from one command module.
+
+## Decision 2: Preserve Dry-Run YAML Output
+
+**Date:** 2026-05-21
+**Decision:** Keep `forge init --dry-run` focused on the generated `.forge/config.yaml` content.
+**Rationale:** Existing scripted usage expects parseable YAML on stdout, so day-one scaffolding should not mix extra file previews into that output path.
+**Impact:** Automation can continue reading dry-run output as config YAML while normal execution still creates `config.yaml`, `patch.md`, and `protected-paths.yaml`.
+
+## Decision 3: L1 Confirmation Recording
+
+**Date:** 2026-05-21
+**Decision:** Record Layer 1 rail confirmation under `layer1Rails.confirmed` instead of adding synthetic entries to the runtime `rails` map.
+**Rationale:** Runtime rail configuration already has named rail keys, and day-one confirmation is adoption metadata rather than a new rail definition.
+**Impact:** The wizard captures explicit L1 confirmation without changing the runtime rail schema used by existing config validation.
+
+## Decision 4: Protected Path Enforcement Scope
+
+**Date:** 2026-05-21
+**Decision:** Scaffold `.forge/protected-paths.yaml` only; protected-state enforcement remains deferred to the later protected-state work.
+**Rationale:** The day-one entry door needs visible protected path intent for fresh repositories, but enforcement belongs to the separate protected-state slice.
+**Impact:** Fresh repos receive a generated manifest with harness-aware defaults, and this PR does not introduce write-blocking protected-state behavior.

--- a/docs/work/2026-05-21-forge-init-day-one-entry/design.md
+++ b/docs/work/2026-05-21-forge-init-day-one-entry/design.md
@@ -33,7 +33,7 @@ Keep the command in `lib/commands/init.js` because registry dispatch already rou
 The generated config will continue to use `renderAdoptionConfigYaml(profile)` as the base. Day-one selections then patch the parsed config before rendering:
 
 - `workflow.classification.default`: `critical`, `standard`, or `refactor`.
-- `rails.layer1.confirmed`: boolean confirmation recorded by the wizard or non-interactive default.
+- `layer1Rails.confirmed`: boolean confirmation recorded by the wizard or non-interactive default.
 - `adapters.harness.targets`: selected harness targets.
 
 Scaffold `.forge/protected-paths.yaml` as a manifest, not enforcement:
@@ -51,7 +51,7 @@ Non-interactive mode (`--yes`, profile shortcuts, or non-TTY stdin) uses:
 - profile: `standard`.
 - classification: `standard`.
 - Layer 1 rails: confirmed.
-- harness targets: detected targets, or `codex` when none are detected.
+- harness targets: explicit `--harness`, explicit profile defaults, detected targets, or `codex` when none are detected.
 
 Interactive mode prompts only when no explicit flag is supplied.
 

--- a/docs/work/2026-05-21-forge-init-day-one-entry/design.md
+++ b/docs/work/2026-05-21-forge-init-day-one-entry/design.md
@@ -1,0 +1,71 @@
+# forge init Day-One Entry Door
+
+Date: 2026-05-21
+Issue: forge-fvh9
+Branch: codex/forge-init-day-one-entry
+Classification: Standard
+Status: Plan locked
+
+## Purpose
+
+`forge init` should be the first command a fresh repository can run. It must create the minimum Forge skeleton without assuming a previous v2 install, while keeping the existing adoption-profile behavior compatible for scripted users.
+
+## Success Criteria
+
+- `forge init` scaffolds `.forge/config.yaml`, `.forge/patch.md`, and `.forge/protected-paths.yaml`.
+- Running in a clean repository produces valid YAML config and protected-path manifests plus an empty patch file.
+- Existing files are not overwritten unless `--force` is supplied, and the user-facing error names the safe repair command.
+- Filesystem harness detection recognizes `.claude`, `.cursor`, and `.codex`.
+- First-time interactive flow asks for classification, confirms Layer 1 rails, and lets the user select harness targets.
+- Non-interactive defaults remain deterministic and testable.
+- Docs describe day-one setup and generated files.
+
+## Out Of Scope
+
+- Protected state enforcement for 0.0.19.
+- `forge new` onboarding wizard.
+- Harness-specific command translation beyond recording selected targets.
+
+## Design
+
+Keep the command in `lib/commands/init.js` because registry dispatch already routes `forge init` through that module. Extend the module with small pure helpers so tests can exercise parsing, detection, generated content, and prompts without spawning the CLI.
+
+The generated config will continue to use `renderAdoptionConfigYaml(profile)` as the base. Day-one selections then patch the parsed config before rendering:
+
+- `workflow.classification.default`: `critical`, `standard`, or `refactor`.
+- `rails.layer1.confirmed`: boolean confirmation recorded by the wizard or non-interactive default.
+- `adapters.harness.targets`: selected harness targets.
+
+Scaffold `.forge/protected-paths.yaml` as a manifest, not enforcement:
+
+- version metadata.
+- protected path entries for the generated Forge files and existing harness instruction files.
+- selected harness targets.
+
+Scaffold `.forge/patch.md` as an intentionally empty patch-intent file with a single heading and short comment. This is a placeholder, not the `forge patch` workflow.
+
+## User-Facing Defaults
+
+Non-interactive mode (`--yes`, profile shortcuts, or non-TTY stdin) uses:
+
+- profile: `standard`.
+- classification: `standard`.
+- Layer 1 rails: confirmed.
+- harness targets: detected targets, or `codex` when none are detected.
+
+Interactive mode prompts only when no explicit flag is supplied.
+
+## Validation
+
+Focused validation first:
+
+- `bun test test/init-command.test.js`
+- `bun test test/adoption-profiles.test.js`
+
+Full validation before ship:
+
+- `/validate` freshness check against default branch.
+- `bun run typecheck`
+- `bun run lint`
+- `bun test`
+- security review: no command execution, path writes stay under `projectRoot/.forge`, no clobber by default.

--- a/docs/work/2026-05-21-forge-init-day-one-entry/design.md
+++ b/docs/work/2026-05-21-forge-init-day-one-entry/design.md
@@ -51,7 +51,7 @@ Non-interactive mode (`--yes`, profile shortcuts, or non-TTY stdin) uses:
 - profile: `standard`.
 - classification: `standard`.
 - Layer 1 rails: confirmed.
-- harness targets: explicit `--harness`, explicit profile defaults, detected targets, or `codex` when none are detected.
+- harness targets: explicit `--harness`, detected targets, explicit profile defaults, or `codex` when none are configured.
 
 Interactive mode prompts only when no explicit flag is supplied.
 

--- a/docs/work/2026-05-21-forge-init-day-one-entry/tasks.md
+++ b/docs/work/2026-05-21-forge-init-day-one-entry/tasks.md
@@ -1,0 +1,70 @@
+# forge init Day-One Entry Door Tasks
+
+Issue: forge-fvh9
+Branch: codex/forge-init-day-one-entry
+
+## Task 1: Init command parsing and day-one helpers
+
+Files: `lib/commands/init.js`, `test/init-command.test.js`
+
+TDD:
+
+1. Add failing tests for classification parsing, harness target parsing, harness filesystem detection, and Layer 1 rail confirmation defaults.
+2. Implement pure helpers in `lib/commands/init.js`.
+3. Re-run the focused test until it passes.
+
+Acceptance:
+
+- Classification accepts only `critical`, `standard`, and `refactor`.
+- Harness targets accept only `claude`, `cursor`, and `codex`.
+- Detection reads `.claude`, `.cursor`, and `.codex` directories from a target root.
+- Non-interactive defaults are deterministic.
+
+## Task 2: Scaffold generated files with no-clobber behavior
+
+Files: `lib/commands/init.js`, `test/init-command.test.js`
+
+TDD:
+
+1. Add failing tests for clean-repo generation of `.forge/config.yaml`, `.forge/patch.md`, and `.forge/protected-paths.yaml`.
+2. Add failing tests proving existing files are not overwritten without `--force`.
+3. Implement atomic-ish generation and no-clobber repair messages.
+4. Re-run the focused test until it passes.
+
+Acceptance:
+
+- Clean repo init writes all three files.
+- Existing generated files remain unchanged when `--force` is absent.
+- Error output tells users to re-run with `--force` or move the existing file.
+
+## Task 3: First-time wizard flow
+
+Files: `lib/commands/init.js`, `test/init-command.test.js`
+
+TDD:
+
+1. Add failing tests using an injected prompt function for classification, Layer 1 confirmation, and harness target selection.
+2. Implement prompt sequencing with default choices.
+3. Re-run the focused test until it passes.
+
+Acceptance:
+
+- Interactive flow asks classification first, Layer 1 confirmation second, and harness target selection third.
+- Empty answers use the displayed defaults.
+- Declining Layer 1 confirmation fails with a repair message.
+
+## Task 4: Day-one setup docs
+
+Files: `docs/reference/TEMPLATES.md`
+
+TDD:
+
+1. Add or update assertions if an existing docs test covers template docs.
+2. Update docs with the day-one command, generated files, harness detection, and no-clobber behavior.
+3. Run focused docs-related tests or the nearest relevant test set.
+
+Acceptance:
+
+- Docs explain `forge init` as the fresh-repo entry door.
+- Docs distinguish `forge init` from `forge new`.
+- Docs state that protected paths are scaffolded, not enforced by this PR.

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -211,15 +211,21 @@ function parseInitFlags(args = [], flags = {}) {
   return parsed;
 }
 
-/** Ask one interactive question using stdin/stdout. */
-function ask(question) {
+/** Create one readline prompt interface for a multi-question wizard. */
+function makePromptInterface() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
+  return {
+    ask(question) {
+      return new Promise((resolve) => {
+        rl.question(question, (answer) => {
+          resolve(answer);
+        });
+      });
+    },
+    close() {
       rl.close();
-      resolve(answer);
-    });
-  });
+    },
+  };
 }
 
 /** Resolve the adoption profile while preserving non-interactive defaults. */
@@ -374,63 +380,70 @@ function formatNoClobberError(projectRoot, files) {
 
 /** Resolve profile, classification, L1 confirmation, and harness targets. */
 async function resolveChoices(parsed, projectRoot, deps = {}) {
-  const prompt = deps.prompt || ask;
   const stdinIsTTY = deps.stdinIsTTY ?? process.stdin.isTTY;
   const interactive = !parsed.yes && stdinIsTTY;
+  const promptInterface = !deps.prompt && interactive ? makePromptInterface() : null;
+  const prompt = deps.prompt || (promptInterface ? promptInterface.ask : null);
   const detectedHarnessTargets = detectHarnessTargets(projectRoot);
   const defaultHarnessTargets = detectedHarnessTargets.length > 0 ? detectedHarnessTargets : ['codex'];
   const profile = await resolveProfile(parsed);
 
-  let classification = parsed.classification;
-  if (!classification) {
-    if (interactive) {
-      const answer = await prompt(`Select default classification (${CLASSIFICATIONS.join('/')}), default standard: `);
-      classification = answer.trim() || 'standard';
-      setClassification(parsed, classification);
-      if (parsed.error) return { error: parsed.error };
-      classification = parsed.classification;
-    } else {
-      classification = 'standard';
+  try {
+    let classification = parsed.classification;
+    if (!classification) {
+      if (interactive) {
+        const answer = await prompt(`Select default classification (${CLASSIFICATIONS.join('/')}), default standard: `);
+        classification = answer.trim() || 'standard';
+        setClassification(parsed, classification);
+        if (parsed.error) return { error: parsed.error };
+        classification = parsed.classification;
+      } else {
+        classification = 'standard';
+      }
     }
-  }
 
-  let railsConfirmed = parsed.railsConfirmed;
-  if (!railsConfirmed) {
-    if (interactive) {
-      const answer = await prompt('Confirm Layer 1 rails are required for this repo? (Y/n): ');
-      const normalized = answer.trim().toLowerCase();
-      railsConfirmed = normalized === '' || normalized === 'y' || normalized === 'yes';
-    } else {
-      railsConfirmed = true;
+    let railsConfirmed = parsed.railsConfirmed;
+    if (!railsConfirmed) {
+      if (interactive) {
+        const answer = await prompt('Confirm Layer 1 rails are required for this repo? (Y/n): ');
+        const normalized = answer.trim().toLowerCase();
+        railsConfirmed = normalized === '' || normalized === 'y' || normalized === 'yes';
+      } else {
+        railsConfirmed = true;
+      }
     }
-  }
 
-  if (!railsConfirmed) {
+    if (!railsConfirmed) {
+      return {
+        error: 'Layer 1 rails must be confirmed before initialization. Re-run forge init and answer yes to continue.',
+      };
+    }
+
+    let harnessTargets = parsed.harnessTargets;
+    if (!harnessTargets) {
+      if (interactive) {
+        const defaultValue = defaultHarnessTargets.join(',');
+        const answer = await prompt(`Select harness targets (${HARNESS_TARGETS.join(',')}), default ${defaultValue}: `);
+        const selected = answer.trim() || defaultValue;
+        setHarnessTargets(parsed, selected);
+        if (parsed.error) return { error: parsed.error };
+        harnessTargets = parsed.harnessTargets;
+      } else {
+        harnessTargets = defaultHarnessTargets;
+      }
+    }
+
     return {
-      error: 'Layer 1 rails must be confirmed before initialization. Re-run forge init and answer yes to continue.',
+      profile,
+      classification,
+      railsConfirmed,
+      harnessTargets,
     };
-  }
-
-  let harnessTargets = parsed.harnessTargets;
-  if (!harnessTargets) {
-    if (interactive) {
-      const defaultValue = defaultHarnessTargets.join(',');
-      const answer = await prompt(`Select harness targets (${HARNESS_TARGETS.join(',')}), default ${defaultValue}: `);
-      const selected = answer.trim() || defaultValue;
-      setHarnessTargets(parsed, selected);
-      if (parsed.error) return { error: parsed.error };
-      harnessTargets = parsed.harnessTargets;
-    } else {
-      harnessTargets = defaultHarnessTargets;
+  } finally {
+    if (promptInterface) {
+      promptInterface.close();
     }
   }
-
-  return {
-    profile,
-    classification,
-    railsConfirmed,
-    harnessTargets,
-  };
 }
 
 /** Execute forge init for the target project root. */
@@ -462,11 +475,12 @@ async function handler(args, flags, projectRoot = process.cwd(), deps = {}) {
   }
 
   if (parsed.dryRun) {
+    const previewFile = files[0];
     return {
       success: true,
       ...choices,
-      files: files.map(file => relativeForgePath(projectRoot, file.path)),
-      output: files[0].content,
+      files: [relativeForgePath(projectRoot, previewFile.path)],
+      output: previewFile.content,
     };
   }
 

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -440,9 +440,9 @@ async function resolveHarnessTargetChoice(parsed, interactive, prompt, projectRo
   const detectedHarnessTargets = detectHarnessTargets(projectRoot);
   const profileHarnessTargets = parsed.profile ? getProfileHarnessTargets(profile) : [];
   const fallbackHarnessTargets = profileHarnessTargets.length > 0 || parsed.profile ? profileHarnessTargets : ['codex'];
-  const defaultHarnessTargets = parsed.profile || detectedHarnessTargets.length === 0
-    ? fallbackHarnessTargets
-    : detectedHarnessTargets;
+  const defaultHarnessTargets = detectedHarnessTargets.length > 0
+    ? detectedHarnessTargets
+    : fallbackHarnessTargets;
   if (!interactive) {
     return { harnessTargets: defaultHarnessTargets };
   }

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -11,19 +11,20 @@ const {
 
 const PROFILE_REQUIRED_ERROR = '--profile requires a non-empty value: minimal, standard, or full.';
 const CLASSIFICATION_REQUIRED_ERROR = '--classification requires a non-empty value: critical, standard, or refactor.';
-const HARNESS_REQUIRED_ERROR = '--harness requires a non-empty value: claude, cursor, or codex.';
 const PROFILE_SHORTCUTS = Object.freeze({
   '--minimal': 'minimal',
   '--standard': 'standard',
   '--full': 'full',
 });
 const CLASSIFICATIONS = Object.freeze(['critical', 'standard', 'refactor']);
-const HARNESS_TARGETS = Object.freeze(['claude', 'cursor', 'codex']);
+const DETECTABLE_HARNESS_TARGETS = Object.freeze(['claude', 'cursor', 'codex']);
+const HARNESS_TARGETS = Object.freeze(['claude', 'cursor', 'codex', 'opencode', 'copilot']);
+const HARNESS_REQUIRED_ERROR = `--harness requires a non-empty value: ${HARNESS_TARGETS.join(', ')}.`;
 
 /** Return the command help text shown by the registry. */
 function usage() {
   return [
-    'Usage: forge init [--profile minimal|standard|full] [--classification critical|standard|refactor] [--harness claude,cursor,codex] [--yes] [--force] [--dry-run]',
+    'Usage: forge init [--profile minimal|standard|full] [--classification critical|standard|refactor] [--harness claude,cursor,codex,opencode,copilot] [--yes] [--force] [--dry-run]',
     '',
     'Initialize the day-one .forge skeleton for a fresh repository.',
   ].join('\n');
@@ -256,7 +257,7 @@ function isDirectory(filePath) {
 
 /** Detect active harnesses from day-one filesystem marker directories. */
 function detectHarnessTargets(projectRoot = process.cwd()) {
-  return HARNESS_TARGETS.filter(target => isDirectory(path.join(projectRoot, `.${target}`)));
+  return DETECTABLE_HARNESS_TARGETS.filter(target => isDirectory(path.join(projectRoot, `.${target}`)));
 }
 
 /** Read profile-defined harness targets for explicit profile selections. */

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -375,7 +375,8 @@ function existingGeneratedFiles(files) {
 /** Build a no-clobber repair message for existing generated files. */
 function formatNoClobberError(projectRoot, files) {
   const names = files.map(file => relativeForgePath(projectRoot, file.path)).join(', ');
-  return `${names} already exists. Re-run with --force to overwrite it, or move the existing file and run forge init again.`;
+  const plural = files.length !== 1;
+  return `${names} already ${plural ? 'exist' : 'exists'}. Re-run with --force to overwrite ${plural ? 'them' : 'it'}, or move the existing ${plural ? 'files' : 'file'} and run forge init again.`;
 }
 
 /** Resolve profile, classification, L1 confirmation, and harness targets. */

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -5,6 +5,7 @@ const YAML = require('yaml');
 
 const {
   ADOPTION_PROFILE_NAMES,
+  buildAdoptionConfig,
   renderAdoptionConfigYaml,
 } = require('../adoption-profiles');
 
@@ -258,6 +259,12 @@ function detectHarnessTargets(projectRoot = process.cwd()) {
   return HARNESS_TARGETS.filter(target => isDirectory(path.join(projectRoot, `.${target}`)));
 }
 
+/** Read profile-defined harness targets for explicit profile selections. */
+function getProfileHarnessTargets(profile) {
+  const targets = buildAdoptionConfig(profile).adapters?.harness?.targets;
+  return Array.isArray(targets) ? targets : [];
+}
+
 /** Render the empty patch intent scaffold. */
 function renderPatchMd() {
   return [
@@ -425,20 +432,26 @@ async function resolveRailsConfirmation(parsed, interactive, prompt) {
 }
 
 /** Resolve harness targets from flags, filesystem detection, wizard input, or defaults. */
-async function resolveHarnessTargetChoice(parsed, interactive, prompt, projectRoot) {
+async function resolveHarnessTargetChoice(parsed, interactive, prompt, projectRoot, profile) {
   if (parsed.harnessTargets) {
     return { harnessTargets: parsed.harnessTargets };
   }
 
   const detectedHarnessTargets = detectHarnessTargets(projectRoot);
-  const defaultHarnessTargets = detectedHarnessTargets.length > 0 ? detectedHarnessTargets : ['codex'];
+  const profileHarnessTargets = parsed.profile ? getProfileHarnessTargets(profile) : [];
+  const fallbackHarnessTargets = profileHarnessTargets.length > 0 || parsed.profile ? profileHarnessTargets : ['codex'];
+  const defaultHarnessTargets = detectedHarnessTargets.length > 0 ? detectedHarnessTargets : fallbackHarnessTargets;
   if (!interactive) {
     return { harnessTargets: defaultHarnessTargets };
   }
 
   const defaultValue = defaultHarnessTargets.join(',');
   const answer = await prompt(`Select harness targets (${HARNESS_TARGETS.join(',')}), default ${defaultValue}: `);
-  setHarnessTargets(parsed, answer.trim() || defaultValue);
+  if (answer.trim().length === 0) {
+    return { harnessTargets: defaultHarnessTargets };
+  }
+
+  setHarnessTargets(parsed, answer.trim());
   if (parsed.error) {
     return { error: parsed.error };
   }
@@ -464,7 +477,7 @@ async function resolveChoices(parsed, projectRoot, deps = {}, profile = null) {
       return { error: railsChoice.error };
     }
 
-    const harnessChoice = await resolveHarnessTargetChoice(parsed, interactive, prompt, projectRoot);
+    const harnessChoice = await resolveHarnessTargetChoice(parsed, interactive, prompt, projectRoot, resolvedProfile);
     if (harnessChoice.error) {
       return { error: harnessChoice.error };
     }

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -440,7 +440,9 @@ async function resolveHarnessTargetChoice(parsed, interactive, prompt, projectRo
   const detectedHarnessTargets = detectHarnessTargets(projectRoot);
   const profileHarnessTargets = parsed.profile ? getProfileHarnessTargets(profile) : [];
   const fallbackHarnessTargets = profileHarnessTargets.length > 0 || parsed.profile ? profileHarnessTargets : ['codex'];
-  const defaultHarnessTargets = detectedHarnessTargets.length > 0 ? detectedHarnessTargets : fallbackHarnessTargets;
+  const defaultHarnessTargets = parsed.profile || detectedHarnessTargets.length === 0
+    ? fallbackHarnessTargets
+    : detectedHarnessTargets;
   if (!interactive) {
     return { harnessTargets: defaultHarnessTargets };
   }

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -502,14 +502,6 @@ async function handler(args, flags, projectRoot = process.cwd(), deps = {}) {
   }
   const forgeDir = path.join(projectRoot, '.forge');
   const files = buildGeneratedFiles(projectRoot, choices);
-  const existingFiles = existingGeneratedFiles(files);
-
-  if (existingFiles.length > 0 && !parsed.force) {
-    return {
-      success: false,
-      error: formatNoClobberError(projectRoot, existingFiles),
-    };
-  }
 
   if (parsed.dryRun) {
     const previewFile = files[0];
@@ -518,6 +510,14 @@ async function handler(args, flags, projectRoot = process.cwd(), deps = {}) {
       ...choices,
       files: [relativeForgePath(projectRoot, previewFile.path)],
       output: previewFile.content,
+    };
+  }
+
+  const existingFiles = existingGeneratedFiles(files);
+  if (existingFiles.length > 0 && !parsed.force) {
+    return {
+      success: false,
+      error: formatNoClobberError(projectRoot, existingFiles),
     };
   }
 

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,6 +1,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const readline = require('node:readline');
+const YAML = require('yaml');
 
 const {
   ADOPTION_PROFILE_NAMES,
@@ -8,17 +9,21 @@ const {
 } = require('../adoption-profiles');
 
 const PROFILE_REQUIRED_ERROR = '--profile requires a non-empty value: minimal, standard, or full.';
+const CLASSIFICATION_REQUIRED_ERROR = '--classification requires a non-empty value: critical, standard, or refactor.';
+const HARNESS_REQUIRED_ERROR = '--harness requires a non-empty value: claude, cursor, or codex.';
 const PROFILE_SHORTCUTS = Object.freeze({
   '--minimal': 'minimal',
   '--standard': 'standard',
   '--full': 'full',
 });
+const CLASSIFICATIONS = Object.freeze(['critical', 'standard', 'refactor']);
+const HARNESS_TARGETS = Object.freeze(['claude', 'cursor', 'codex']);
 
 function usage() {
   return [
-    'Usage: forge init [--profile minimal|standard|full] [--yes] [--force] [--dry-run]',
+    'Usage: forge init [--profile minimal|standard|full] [--classification critical|standard|refactor] [--harness claude,cursor,codex] [--yes] [--force] [--dry-run]',
     '',
-    'Initialize .forge/config.yaml for a fresh repository.',
+    'Initialize the day-one .forge skeleton for a fresh repository.',
   ].join('\n');
 }
 
@@ -38,6 +43,54 @@ function setProfile(parsed, value) {
   parsed.profile = profile;
 }
 
+function normalizeClassification(value) {
+  if (typeof value !== 'string') return value ?? null;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : '';
+}
+
+function setClassification(parsed, value) {
+  const classification = normalizeClassification(value);
+  if (classification === '') {
+    parsed.error = CLASSIFICATION_REQUIRED_ERROR;
+    parsed.classification = null;
+    return;
+  }
+  if (!CLASSIFICATIONS.includes(classification)) {
+    parsed.error = `Unknown classification '${classification}'. Choose one of: ${CLASSIFICATIONS.join(', ')}.`;
+    parsed.classification = null;
+    return;
+  }
+  parsed.classification = classification;
+}
+
+function normalizeHarnessTargets(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap(item => normalizeHarnessTargets(item));
+  }
+  if (typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map(item => item.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function setHarnessTargets(parsed, value) {
+  const targets = [...new Set(normalizeHarnessTargets(value))];
+  if (targets.length === 0) {
+    parsed.error = HARNESS_REQUIRED_ERROR;
+    parsed.harnessTargets = null;
+    return;
+  }
+  const unknown = targets.find(target => !HARNESS_TARGETS.includes(target));
+  if (unknown) {
+    parsed.error = `Unknown harness target '${unknown}'. Choose from: ${HARNESS_TARGETS.join(', ')}.`;
+    parsed.harnessTargets = null;
+    return;
+  }
+  parsed.harnessTargets = targets;
+}
+
 function consumeProfileArg(args, index, parsed) {
   const arg = args[index];
   if (arg === '--profile') {
@@ -51,6 +104,38 @@ function consumeProfileArg(args, index, parsed) {
   }
 
   setProfile(parsed, arg.slice('--profile='.length));
+  return index;
+}
+
+function consumeClassificationArg(args, index, parsed) {
+  const arg = args[index];
+  if (arg === '--classification') {
+    const value = args[index + 1];
+    if (typeof value === 'string' && !value.startsWith('--')) {
+      setClassification(parsed, value);
+      return index + 1;
+    }
+    parsed.error = CLASSIFICATION_REQUIRED_ERROR;
+    return index;
+  }
+
+  setClassification(parsed, arg.slice('--classification='.length));
+  return index;
+}
+
+function consumeHarnessArg(args, index, parsed) {
+  const arg = args[index];
+  if (arg === '--harness') {
+    const value = args[index + 1];
+    if (typeof value === 'string' && !value.startsWith('--')) {
+      setHarnessTargets(parsed, value);
+      return index + 1;
+    }
+    parsed.error = HARNESS_REQUIRED_ERROR;
+    return index;
+  }
+
+  setHarnessTargets(parsed, arg.slice('--harness='.length));
   return index;
 }
 
@@ -70,10 +155,19 @@ function parseInitFlags(args = [], flags = {}) {
     yes: Boolean(flags.yes || flags.nonInteractive),
     force: Boolean(flags.force),
     dryRun: Boolean(flags.dryRun),
+    classification: null,
+    harnessTargets: null,
+    railsConfirmed: Boolean(flags.yes || flags.nonInteractive),
   };
 
   if (Object.hasOwn(flags, 'profile')) {
     setProfile(parsed, flags.profile);
+  }
+  if (Object.hasOwn(flags, 'classification')) {
+    setClassification(parsed, flags.classification);
+  }
+  if (Object.hasOwn(flags, 'harness')) {
+    setHarnessTargets(parsed, flags.harness);
   }
 
   let index = 0;
@@ -82,11 +176,18 @@ function parseInitFlags(args = [], flags = {}) {
     if (arg === '--profile' || arg.startsWith('--profile=')) {
       index = consumeProfileArg(args, index, parsed) + 1;
       continue;
+    } else if (arg === '--classification' || arg.startsWith('--classification=')) {
+      index = consumeClassificationArg(args, index, parsed) + 1;
+      continue;
+    } else if (arg === '--harness' || arg.startsWith('--harness=')) {
+      index = consumeHarnessArg(args, index, parsed) + 1;
+      continue;
     } else if (applyProfileShortcut(arg, parsed)) {
       index += 1;
       continue;
     } else if (arg === '--yes' || arg === '-y') {
       parsed.yes = true;
+      parsed.railsConfirmed = true;
     } else if (arg === '--force') {
       parsed.force = true;
     } else if (arg === '--dry-run') {
@@ -112,48 +213,251 @@ async function resolveProfile(parsed) {
   if (parsed.profile) {
     return parsed.profile;
   }
-  if (parsed.yes || !process.stdin.isTTY) {
-    return 'standard';
-  }
-
-  const answer = await ask(`Select Forge adoption profile (${ADOPTION_PROFILE_NAMES.join('/')}): `);
-  return answer.trim() || 'standard';
+  return 'standard';
 }
 
-async function handler(args, flags, projectRoot = process.cwd()) {
+function isDirectory(filePath) {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch (_err) {
+    return false;
+  }
+}
+
+function detectHarnessTargets(projectRoot = process.cwd()) {
+  return HARNESS_TARGETS.filter(target => isDirectory(path.join(projectRoot, `.${target}`)));
+}
+
+function renderPatchMd() {
+  return [
+    '# Forge Patch Intent',
+    '',
+    '<!--',
+    'This file is intentionally empty for day-one setup.',
+    'Use it later to document local Forge overrides before applying them.',
+    '-->',
+    '',
+  ].join('\n');
+}
+
+function addExistingPath(entries, projectRoot, protectedPath, reason) {
+  const absolutePath = projectRoot ? path.join(projectRoot, protectedPath) : null;
+  if (!absolutePath || !fs.existsSync(absolutePath)) {
+    return;
+  }
+  const manifestPath = isDirectory(absolutePath) ? `${protectedPath}/**` : protectedPath;
+  entries.push({ path: manifestPath.replace(/\\/g, '/'), reason });
+}
+
+function addSelectedHarnessPaths(entries, { projectRoot, harnessTargets }) {
+  if (!projectRoot) return;
+  if (fs.existsSync(path.join(projectRoot, 'AGENTS.md'))) {
+    entries.push({ path: 'AGENTS.md', reason: 'Agent workflow instructions' });
+  }
+
+  if (harnessTargets.includes('claude')) {
+    addExistingPath(entries, projectRoot, 'CLAUDE.md', 'Claude harness instructions');
+    addExistingPath(entries, projectRoot, '.claude', 'Claude harness directory');
+  }
+  if (harnessTargets.includes('cursor')) {
+    addExistingPath(entries, projectRoot, '.cursor', 'Cursor harness directory');
+  }
+  if (harnessTargets.includes('codex')) {
+    addExistingPath(entries, projectRoot, '.codex', 'Codex harness directory');
+  }
+}
+
+function renderProtectedPathsYaml({ classification, harnessTargets, projectRoot = null }) {
+  const paths = [
+    { path: '.forge/config.yaml', reason: 'Forge runtime configuration' },
+    { path: '.forge/patch.md', reason: 'Local patch intent scaffold' },
+    { path: '.forge/protected-paths.yaml', reason: 'Protected path manifest scaffold' },
+  ];
+  addSelectedHarnessPaths(paths, { projectRoot, harnessTargets });
+
+  return YAML.stringify({
+    kind: 'forge.protectedPaths',
+    version: 1,
+    classification,
+    harness: {
+      targets: harnessTargets,
+    },
+    paths,
+  });
+}
+
+function renderDayOneConfigYaml({ profile, classification, harnessTargets, railsConfirmed }) {
+  const config = YAML.parse(renderAdoptionConfigYaml(profile));
+  config.workflow = config.workflow || {};
+  config.workflow.classification = { default: classification };
+  config.layer1Rails = {
+    confirmed: railsConfirmed,
+    rails: [
+      'tdd_intent',
+      'secret_scan',
+      'branch_protection',
+      'signed_commits',
+      'schema_integrity',
+    ],
+  };
+  config.adapters = config.adapters || {};
+  config.adapters.harness = {
+    enabled: harnessTargets.length > 0,
+    targets: harnessTargets,
+  };
+  config.protectedPaths = [
+    ...new Set([
+      ...(Array.isArray(config.protectedPaths) ? config.protectedPaths : []),
+      '.forge/config.yaml',
+      '.forge/patch.md',
+      '.forge/protected-paths.yaml',
+    ]),
+  ];
+  return YAML.stringify(config);
+}
+
+function relativeForgePath(projectRoot, filePath) {
+  return path.relative(projectRoot, filePath).replace(/\\/g, '/');
+}
+
+function buildGeneratedFiles(projectRoot, choices) {
+  const forgeDir = path.join(projectRoot, '.forge');
+  return [
+    {
+      path: path.join(forgeDir, 'config.yaml'),
+      content: renderDayOneConfigYaml(choices),
+    },
+    {
+      path: path.join(forgeDir, 'patch.md'),
+      content: renderPatchMd(),
+    },
+    {
+      path: path.join(forgeDir, 'protected-paths.yaml'),
+      content: renderProtectedPathsYaml({ ...choices, projectRoot }),
+    },
+  ];
+}
+
+function existingGeneratedFiles(files) {
+  return files.filter(file => fs.existsSync(file.path));
+}
+
+function formatNoClobberError(projectRoot, files) {
+  const names = files.map(file => relativeForgePath(projectRoot, file.path)).join(', ');
+  return `${names} already exists. Re-run with --force to overwrite it, or move the existing file and run forge init again.`;
+}
+
+async function resolveChoices(parsed, projectRoot, deps = {}) {
+  const prompt = deps.prompt || ask;
+  const stdinIsTTY = deps.stdinIsTTY ?? process.stdin.isTTY;
+  const interactive = !parsed.yes && stdinIsTTY;
+  const detectedHarnessTargets = detectHarnessTargets(projectRoot);
+  const defaultHarnessTargets = detectedHarnessTargets.length > 0 ? detectedHarnessTargets : ['codex'];
+  const profile = await resolveProfile(parsed);
+
+  let classification = parsed.classification;
+  if (!classification) {
+    if (interactive) {
+      const answer = await prompt(`Select default classification (${CLASSIFICATIONS.join('/')}), default standard: `);
+      classification = answer.trim() || 'standard';
+      setClassification(parsed, classification);
+      if (parsed.error) return { error: parsed.error };
+      classification = parsed.classification;
+    } else {
+      classification = 'standard';
+    }
+  }
+
+  let railsConfirmed = parsed.railsConfirmed;
+  if (!railsConfirmed) {
+    if (interactive) {
+      const answer = await prompt('Confirm Layer 1 rails are required for this repo? (Y/n): ');
+      const normalized = answer.trim().toLowerCase();
+      railsConfirmed = normalized === '' || normalized === 'y' || normalized === 'yes';
+    } else {
+      railsConfirmed = true;
+    }
+  }
+
+  if (!railsConfirmed) {
+    return {
+      error: 'Layer 1 rails must be confirmed before initialization. Re-run forge init and answer yes to continue.',
+    };
+  }
+
+  let harnessTargets = parsed.harnessTargets;
+  if (!harnessTargets) {
+    if (interactive) {
+      const defaultValue = defaultHarnessTargets.join(',');
+      const answer = await prompt(`Select harness targets (${HARNESS_TARGETS.join(',')}), default ${defaultValue}: `);
+      const selected = answer.trim() || defaultValue;
+      setHarnessTargets(parsed, selected);
+      if (parsed.error) return { error: parsed.error };
+      harnessTargets = parsed.harnessTargets;
+    } else {
+      harnessTargets = defaultHarnessTargets;
+    }
+  }
+
+  return {
+    profile,
+    classification,
+    railsConfirmed,
+    harnessTargets,
+  };
+}
+
+async function handler(args, flags, projectRoot = process.cwd(), deps = {}) {
   const parsed = parseInitFlags(args, flags);
   if (parsed.error) {
     return { success: false, error: parsed.error };
   }
-  const profile = await resolveProfile(parsed);
+  const choices = await resolveChoices(parsed, projectRoot, deps);
+  if (choices.error) {
+    return { success: false, error: choices.error };
+  }
+  const { profile } = choices;
   if (!ADOPTION_PROFILE_NAMES.includes(profile)) {
     return {
       success: false,
       error: `Unknown adoption profile '${profile}'. Available profiles: ${ADOPTION_PROFILE_NAMES.join(', ')}`,
     };
   }
-  const configYaml = renderAdoptionConfigYaml(profile);
   const forgeDir = path.join(projectRoot, '.forge');
-  const configPath = path.join(forgeDir, 'config.yaml');
+  const files = buildGeneratedFiles(projectRoot, choices);
+  const existingFiles = existingGeneratedFiles(files);
 
-  if (fs.existsSync(configPath) && !parsed.force) {
+  if (existingFiles.length > 0 && !parsed.force) {
     return {
       success: false,
-      error: `.forge/config.yaml already exists. Re-run with --force to overwrite it.`,
+      error: formatNoClobberError(projectRoot, existingFiles),
     };
   }
 
   if (parsed.dryRun) {
-    return { success: true, profile, configPath, output: configYaml };
+    return {
+      success: true,
+      ...choices,
+      files: files.map(file => relativeForgePath(projectRoot, file.path)),
+      output: files[0].content,
+    };
   }
 
   fs.mkdirSync(forgeDir, { recursive: true });
-  fs.writeFileSync(configPath, configYaml, 'utf8');
+  for (const file of files) {
+    fs.writeFileSync(file.path, file.content, 'utf8');
+  }
 
-  console.log(`Initialized Forge adoption profile '${profile}' at .forge/config.yaml`);
+  console.log(`Initialized Forge adoption profile '${profile}' at .forge/`);
+  console.log(`Classification: ${choices.classification}`);
+  console.log(`Harness targets: ${choices.harnessTargets.join(', ')}`);
   console.log('Inspect with: forge options lint && forge options diff');
 
-  return { success: true, profile, configPath };
+  return {
+    success: true,
+    ...choices,
+    files: files.map(file => relativeForgePath(projectRoot, file.path)),
+  };
 }
 
 module.exports = {
@@ -165,10 +469,16 @@ module.exports = {
     '--minimal': 'Shortcut for --profile minimal --yes',
     '--standard': 'Shortcut for --profile standard --yes',
     '--full': 'Shortcut for --profile full --yes',
+    '--classification <name>': 'Default workflow classification: critical, standard, or refactor',
+    '--harness <targets>': 'Comma-separated harness targets: claude, cursor, codex',
     '--yes': 'Use the standard profile when no profile is provided',
-    '--force': 'Overwrite an existing .forge/config.yaml',
+    '--force': 'Overwrite existing day-one .forge files',
     '--dry-run': 'Print the generated config YAML without writing files',
   },
   handler,
+  detectHarnessTargets,
   parseInitFlags,
+  renderDayOneConfigYaml,
+  renderPatchMd,
+  renderProtectedPathsYaml,
 };

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -236,6 +236,14 @@ async function resolveProfile(parsed) {
   return 'standard';
 }
 
+/** Validate a resolved adoption profile name before prompting the user. */
+function validateProfile(profile) {
+  if (ADOPTION_PROFILE_NAMES.includes(profile)) {
+    return null;
+  }
+  return `Unknown adoption profile '${profile}'. Available profiles: ${ADOPTION_PROFILE_NAMES.join(', ')}`;
+}
+
 /** Return true only when a path exists and is a directory. */
 function isDirectory(filePath) {
   try {
@@ -379,66 +387,93 @@ function formatNoClobberError(projectRoot, files) {
   return `${names} already ${plural ? 'exist' : 'exists'}. Re-run with --force to overwrite ${plural ? 'them' : 'it'}, or move the existing ${plural ? 'files' : 'file'} and run forge init again.`;
 }
 
+/** Resolve the workflow classification from flags, wizard input, or defaults. */
+async function resolveClassificationChoice(parsed, interactive, prompt) {
+  if (parsed.classification) {
+    return { classification: parsed.classification };
+  }
+  if (!interactive) {
+    return { classification: 'standard' };
+  }
+
+  const answer = await prompt(`Select default classification (${CLASSIFICATIONS.join('/')}), default standard: `);
+  setClassification(parsed, answer.trim() || 'standard');
+  if (parsed.error) {
+    return { error: parsed.error };
+  }
+  return { classification: parsed.classification };
+}
+
+/** Resolve Layer 1 rail confirmation from flags, wizard input, or defaults. */
+async function resolveRailsConfirmation(parsed, interactive, prompt) {
+  if (parsed.railsConfirmed) {
+    return { railsConfirmed: true };
+  }
+  if (!interactive) {
+    return { railsConfirmed: true };
+  }
+
+  const answer = await prompt('Confirm Layer 1 rails are required for this repo? (Y/n): ');
+  const normalized = answer.trim().toLowerCase();
+  const railsConfirmed = normalized === '' || normalized === 'y' || normalized === 'yes';
+  if (railsConfirmed) {
+    return { railsConfirmed: true };
+  }
+  return {
+    error: 'Layer 1 rails must be confirmed before initialization. Re-run forge init and answer yes to continue.',
+  };
+}
+
+/** Resolve harness targets from flags, filesystem detection, wizard input, or defaults. */
+async function resolveHarnessTargetChoice(parsed, interactive, prompt, projectRoot) {
+  if (parsed.harnessTargets) {
+    return { harnessTargets: parsed.harnessTargets };
+  }
+
+  const detectedHarnessTargets = detectHarnessTargets(projectRoot);
+  const defaultHarnessTargets = detectedHarnessTargets.length > 0 ? detectedHarnessTargets : ['codex'];
+  if (!interactive) {
+    return { harnessTargets: defaultHarnessTargets };
+  }
+
+  const defaultValue = defaultHarnessTargets.join(',');
+  const answer = await prompt(`Select harness targets (${HARNESS_TARGETS.join(',')}), default ${defaultValue}: `);
+  setHarnessTargets(parsed, answer.trim() || defaultValue);
+  if (parsed.error) {
+    return { error: parsed.error };
+  }
+  return { harnessTargets: parsed.harnessTargets };
+}
+
 /** Resolve profile, classification, L1 confirmation, and harness targets. */
-async function resolveChoices(parsed, projectRoot, deps = {}) {
+async function resolveChoices(parsed, projectRoot, deps = {}, profile = null) {
   const stdinIsTTY = deps.stdinIsTTY ?? process.stdin.isTTY;
   const interactive = !parsed.yes && stdinIsTTY;
   const promptInterface = !deps.prompt && interactive ? makePromptInterface() : null;
   const prompt = deps.prompt || (promptInterface ? promptInterface.ask : null);
-  const detectedHarnessTargets = detectHarnessTargets(projectRoot);
-  const defaultHarnessTargets = detectedHarnessTargets.length > 0 ? detectedHarnessTargets : ['codex'];
-  const profile = await resolveProfile(parsed);
+  const resolvedProfile = profile || await resolveProfile(parsed);
 
   try {
-    let classification = parsed.classification;
-    if (!classification) {
-      if (interactive) {
-        const answer = await prompt(`Select default classification (${CLASSIFICATIONS.join('/')}), default standard: `);
-        classification = answer.trim() || 'standard';
-        setClassification(parsed, classification);
-        if (parsed.error) return { error: parsed.error };
-        classification = parsed.classification;
-      } else {
-        classification = 'standard';
-      }
+    const classificationChoice = await resolveClassificationChoice(parsed, interactive, prompt);
+    if (classificationChoice.error) {
+      return { error: classificationChoice.error };
     }
 
-    let railsConfirmed = parsed.railsConfirmed;
-    if (!railsConfirmed) {
-      if (interactive) {
-        const answer = await prompt('Confirm Layer 1 rails are required for this repo? (Y/n): ');
-        const normalized = answer.trim().toLowerCase();
-        railsConfirmed = normalized === '' || normalized === 'y' || normalized === 'yes';
-      } else {
-        railsConfirmed = true;
-      }
+    const railsChoice = await resolveRailsConfirmation(parsed, interactive, prompt);
+    if (railsChoice.error) {
+      return { error: railsChoice.error };
     }
 
-    if (!railsConfirmed) {
-      return {
-        error: 'Layer 1 rails must be confirmed before initialization. Re-run forge init and answer yes to continue.',
-      };
-    }
-
-    let harnessTargets = parsed.harnessTargets;
-    if (!harnessTargets) {
-      if (interactive) {
-        const defaultValue = defaultHarnessTargets.join(',');
-        const answer = await prompt(`Select harness targets (${HARNESS_TARGETS.join(',')}), default ${defaultValue}: `);
-        const selected = answer.trim() || defaultValue;
-        setHarnessTargets(parsed, selected);
-        if (parsed.error) return { error: parsed.error };
-        harnessTargets = parsed.harnessTargets;
-      } else {
-        harnessTargets = defaultHarnessTargets;
-      }
+    const harnessChoice = await resolveHarnessTargetChoice(parsed, interactive, prompt, projectRoot);
+    if (harnessChoice.error) {
+      return { error: harnessChoice.error };
     }
 
     return {
-      profile,
-      classification,
-      railsConfirmed,
-      harnessTargets,
+      profile: resolvedProfile,
+      classification: classificationChoice.classification,
+      railsConfirmed: railsChoice.railsConfirmed,
+      harnessTargets: harnessChoice.harnessTargets,
     };
   } finally {
     if (promptInterface) {
@@ -453,16 +488,17 @@ async function handler(args, flags, projectRoot = process.cwd(), deps = {}) {
   if (parsed.error) {
     return { success: false, error: parsed.error };
   }
-  const choices = await resolveChoices(parsed, projectRoot, deps);
-  if (choices.error) {
-    return { success: false, error: choices.error };
-  }
-  const { profile } = choices;
-  if (!ADOPTION_PROFILE_NAMES.includes(profile)) {
+  const profile = await resolveProfile(parsed);
+  const profileError = validateProfile(profile);
+  if (profileError) {
     return {
       success: false,
-      error: `Unknown adoption profile '${profile}'. Available profiles: ${ADOPTION_PROFILE_NAMES.join(', ')}`,
+      error: profileError,
     };
+  }
+  const choices = await resolveChoices(parsed, projectRoot, deps, profile);
+  if (choices.error) {
+    return { success: false, error: choices.error };
   }
   const forgeDir = path.join(projectRoot, '.forge');
   const files = buildGeneratedFiles(projectRoot, choices);

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -19,6 +19,7 @@ const PROFILE_SHORTCUTS = Object.freeze({
 const CLASSIFICATIONS = Object.freeze(['critical', 'standard', 'refactor']);
 const HARNESS_TARGETS = Object.freeze(['claude', 'cursor', 'codex']);
 
+/** Return the command help text shown by the registry. */
 function usage() {
   return [
     'Usage: forge init [--profile minimal|standard|full] [--classification critical|standard|refactor] [--harness claude,cursor,codex] [--yes] [--force] [--dry-run]',
@@ -27,12 +28,14 @@ function usage() {
   ].join('\n');
 }
 
+/** Normalize a profile flag value while preserving empty-string validation. */
 function normalizeProfile(value) {
   if (typeof value !== 'string') return value ?? null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : '';
 }
 
+/** Apply a parsed adoption profile value to the mutable parse result. */
 function setProfile(parsed, value) {
   const profile = normalizeProfile(value);
   if (profile === '') {
@@ -43,12 +46,14 @@ function setProfile(parsed, value) {
   parsed.profile = profile;
 }
 
+/** Normalize a classification flag or wizard answer. */
 function normalizeClassification(value) {
   if (typeof value !== 'string') return value ?? null;
   const trimmed = value.trim().toLowerCase();
   return trimmed.length > 0 ? trimmed : '';
 }
 
+/** Validate and apply a default workflow classification. */
 function setClassification(parsed, value) {
   const classification = normalizeClassification(value);
   if (classification === '') {
@@ -64,6 +69,7 @@ function setClassification(parsed, value) {
   parsed.classification = classification;
 }
 
+/** Convert comma-separated or array harness input into normalized target names. */
 function normalizeHarnessTargets(value) {
   if (Array.isArray(value)) {
     return value.flatMap(item => normalizeHarnessTargets(item));
@@ -75,6 +81,7 @@ function normalizeHarnessTargets(value) {
     .filter(Boolean);
 }
 
+/** Validate and apply selected harness targets. */
 function setHarnessTargets(parsed, value) {
   const targets = [...new Set(normalizeHarnessTargets(value))];
   if (targets.length === 0) {
@@ -91,6 +98,7 @@ function setHarnessTargets(parsed, value) {
   parsed.harnessTargets = targets;
 }
 
+/** Consume --profile syntax from argv and return the consumed index. */
 function consumeProfileArg(args, index, parsed) {
   const arg = args[index];
   if (arg === '--profile') {
@@ -107,6 +115,7 @@ function consumeProfileArg(args, index, parsed) {
   return index;
 }
 
+/** Consume --classification syntax from argv and return the consumed index. */
 function consumeClassificationArg(args, index, parsed) {
   const arg = args[index];
   if (arg === '--classification') {
@@ -123,6 +132,7 @@ function consumeClassificationArg(args, index, parsed) {
   return index;
 }
 
+/** Consume --harness syntax from argv and return the consumed index. */
 function consumeHarnessArg(args, index, parsed) {
   const arg = args[index];
   if (arg === '--harness') {
@@ -139,6 +149,7 @@ function consumeHarnessArg(args, index, parsed) {
   return index;
 }
 
+/** Apply profile shortcut flags such as --minimal and --full. */
 function applyProfileShortcut(arg, parsed) {
   const profile = PROFILE_SHORTCUTS[arg];
   if (profile) {
@@ -148,6 +159,7 @@ function applyProfileShortcut(arg, parsed) {
   return Boolean(profile);
 }
 
+/** Parse init-specific flags after global CLI flag handling. */
 function parseInitFlags(args = [], flags = {}) {
   const parsed = {
     profile: null,
@@ -199,6 +211,7 @@ function parseInitFlags(args = [], flags = {}) {
   return parsed;
 }
 
+/** Ask one interactive question using stdin/stdout. */
 function ask(question) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
@@ -209,6 +222,7 @@ function ask(question) {
   });
 }
 
+/** Resolve the adoption profile while preserving non-interactive defaults. */
 async function resolveProfile(parsed) {
   if (parsed.profile) {
     return parsed.profile;
@@ -216,6 +230,7 @@ async function resolveProfile(parsed) {
   return 'standard';
 }
 
+/** Return true only when a path exists and is a directory. */
 function isDirectory(filePath) {
   try {
     return fs.statSync(filePath).isDirectory();
@@ -224,10 +239,12 @@ function isDirectory(filePath) {
   }
 }
 
+/** Detect active harnesses from day-one filesystem marker directories. */
 function detectHarnessTargets(projectRoot = process.cwd()) {
   return HARNESS_TARGETS.filter(target => isDirectory(path.join(projectRoot, `.${target}`)));
 }
 
+/** Render the empty patch intent scaffold. */
 function renderPatchMd() {
   return [
     '# Forge Patch Intent',
@@ -240,6 +257,7 @@ function renderPatchMd() {
   ].join('\n');
 }
 
+/** Append an existing file or directory glob to the protected-path manifest. */
 function addExistingPath(entries, projectRoot, protectedPath, reason) {
   const absolutePath = projectRoot ? path.join(projectRoot, protectedPath) : null;
   if (!absolutePath || !fs.existsSync(absolutePath)) {
@@ -249,6 +267,7 @@ function addExistingPath(entries, projectRoot, protectedPath, reason) {
   entries.push({ path: manifestPath.replace(/\\/g, '/'), reason });
 }
 
+/** Add only selected and existing harness paths to the manifest. */
 function addSelectedHarnessPaths(entries, { projectRoot, harnessTargets }) {
   if (!projectRoot) return;
   if (fs.existsSync(path.join(projectRoot, 'AGENTS.md'))) {
@@ -267,6 +286,7 @@ function addSelectedHarnessPaths(entries, { projectRoot, harnessTargets }) {
   }
 }
 
+/** Render the protected-path manifest scaffold without enforcing it. */
 function renderProtectedPathsYaml({ classification, harnessTargets, projectRoot = null }) {
   const paths = [
     { path: '.forge/config.yaml', reason: 'Forge runtime configuration' },
@@ -286,6 +306,7 @@ function renderProtectedPathsYaml({ classification, harnessTargets, projectRoot 
   });
 }
 
+/** Render config.yaml by layering day-one choices over an adoption profile. */
 function renderDayOneConfigYaml({ profile, classification, harnessTargets, railsConfirmed }) {
   const config = YAML.parse(renderAdoptionConfigYaml(profile));
   config.workflow = config.workflow || {};
@@ -316,10 +337,12 @@ function renderDayOneConfigYaml({ profile, classification, harnessTargets, rails
   return YAML.stringify(config);
 }
 
+/** Format generated file paths relative to the target project root. */
 function relativeForgePath(projectRoot, filePath) {
   return path.relative(projectRoot, filePath).replace(/\\/g, '/');
 }
 
+/** Build the complete set of day-one generated files. */
 function buildGeneratedFiles(projectRoot, choices) {
   const forgeDir = path.join(projectRoot, '.forge');
   return [
@@ -338,15 +361,18 @@ function buildGeneratedFiles(projectRoot, choices) {
   ];
 }
 
+/** Filter generated files down to paths that already exist. */
 function existingGeneratedFiles(files) {
   return files.filter(file => fs.existsSync(file.path));
 }
 
+/** Build a no-clobber repair message for existing generated files. */
 function formatNoClobberError(projectRoot, files) {
   const names = files.map(file => relativeForgePath(projectRoot, file.path)).join(', ');
   return `${names} already exists. Re-run with --force to overwrite it, or move the existing file and run forge init again.`;
 }
 
+/** Resolve profile, classification, L1 confirmation, and harness targets. */
 async function resolveChoices(parsed, projectRoot, deps = {}) {
   const prompt = deps.prompt || ask;
   const stdinIsTTY = deps.stdinIsTTY ?? process.stdin.isTTY;
@@ -407,6 +433,7 @@ async function resolveChoices(parsed, projectRoot, deps = {}) {
   };
 }
 
+/** Execute forge init for the target project root. */
 async function handler(args, flags, projectRoot = process.cwd(), deps = {}) {
   const parsed = parseInitFlags(args, flags);
   if (parsed.error) {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -306,6 +306,13 @@ function addSelectedHarnessPaths(entries, { projectRoot, harnessTargets }) {
   if (harnessTargets.includes('codex')) {
     addExistingPath(entries, projectRoot, '.codex', 'Codex harness directory');
   }
+  if (harnessTargets.includes('opencode')) {
+    addExistingPath(entries, projectRoot, 'opencode.json', 'OpenCode root configuration');
+    addExistingPath(entries, projectRoot, '.opencode', 'OpenCode harness directory');
+  }
+  if (harnessTargets.includes('copilot')) {
+    addExistingPath(entries, projectRoot, '.github/copilot-instructions.md', 'GitHub Copilot instructions');
+  }
 }
 
 /** Render the protected-path manifest scaffold without enforcing it. */

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -118,16 +118,17 @@ describe('forge init command', () => {
     expect(config.adapters.harness.targets).toEqual(['codex', 'claude', 'cursor', 'opencode', 'copilot']);
   });
 
-  test('preserves explicit profile harness defaults over detected markers', async () => {
+  test('uses detected harness markers before explicit profile defaults', async () => {
     const root = makeProject();
-    fs.mkdirSync(path.join(root, '.codex'));
+    fs.mkdirSync(path.join(root, '.claude'));
+    fs.mkdirSync(path.join(root, '.cursor'));
 
     const result = await handler(['--full', '--yes'], {}, root);
 
     expect(result.success).toBe(true);
     const config = readYaml(path.join(root, '.forge', 'config.yaml'));
     expect(config.template.profile).toBe('full');
-    expect(config.adapters.harness.targets).toEqual(['codex', 'claude', 'cursor', 'opencode', 'copilot']);
+    expect(config.adapters.harness.targets).toEqual(['claude', 'cursor']);
   });
 
   test('does not clobber existing generated files without force', async () => {

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -123,6 +123,22 @@ describe('forge init command', () => {
     expect(fs.existsSync(path.join(root, '.forge', 'config.yaml'))).toBe(false);
   });
 
+  test('dry-run previews config when generated files already exist', async () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.forge', 'patch.md'), 'user patch\n');
+    fs.writeFileSync(path.join(root, '.forge', 'protected-paths.yaml'), 'user manifest\n');
+
+    const result = await handler(['--yes', '--dry-run'], {}, root);
+
+    expect(result.success).toBe(true);
+    expect(result.files).toEqual(['.forge/config.yaml']);
+    expect(result.output).toContain('workflow:');
+    expect(fs.readFileSync(path.join(root, '.forge', 'patch.md'), 'utf8')).toBe('user patch\n');
+    expect(fs.readFileSync(path.join(root, '.forge', 'protected-paths.yaml'), 'utf8')).toBe('user manifest\n');
+    expect(fs.existsSync(path.join(root, '.forge', 'config.yaml'))).toBe(false);
+  });
+
   test('first-time wizard asks classification, L1 confirmation, and harness targets in order', async () => {
     const root = makeProject();
     fs.mkdirSync(path.join(root, '.claude'));

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -83,16 +83,21 @@ describe('forge init command', () => {
   test('renders protected path and patch scaffolds', () => {
     const root = makeProject();
     fs.mkdirSync(path.join(root, '.cursor'));
+    fs.mkdirSync(path.join(root, '.github'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'opencode.json'), '{}\n');
+    fs.writeFileSync(path.join(root, '.github', 'copilot-instructions.md'), '# Copilot\n');
     const protectedYaml = readYamlFromString(renderProtectedPathsYaml({
       classification: 'standard',
-      harnessTargets: ['cursor'],
+      harnessTargets: ['cursor', 'opencode', 'copilot'],
       projectRoot: root,
     }));
 
     expect(protectedYaml.kind).toBe('forge.protectedPaths');
-    expect(protectedYaml.harness.targets).toEqual(['cursor']);
+    expect(protectedYaml.harness.targets).toEqual(['cursor', 'opencode', 'copilot']);
     expect(protectedYaml.paths.map(entry => entry.path)).toContain('.forge/config.yaml');
     expect(protectedYaml.paths.map(entry => entry.path)).toContain('.cursor/**');
+    expect(protectedYaml.paths.map(entry => entry.path)).toContain('opencode.json');
+    expect(protectedYaml.paths.map(entry => entry.path)).toContain('.github/copilot-instructions.md');
     expect(protectedYaml.paths.map(entry => entry.path)).not.toContain('.codex/**');
     expect(renderPatchMd()).toContain('# Forge Patch Intent');
   });

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -1,0 +1,164 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const YAML = require('yaml');
+const { afterEach, describe, expect, test } = require('bun:test');
+
+const {
+  detectHarnessTargets,
+  handler,
+  parseInitFlags,
+  renderPatchMd,
+  renderProtectedPathsYaml,
+} = require('../lib/commands/init');
+
+const tempRoots = [];
+
+function makeProject() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-init-command-'));
+  tempRoots.push(root);
+  return root;
+}
+
+function readYaml(filePath) {
+  return YAML.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('forge init command', () => {
+  test('parses day-one classification, rail, and harness flags', () => {
+    const parsed = parseInitFlags([
+      '--profile',
+      'minimal',
+      '--classification',
+      'critical',
+      '--harness',
+      'claude,codex',
+      '--yes',
+    ]);
+
+    expect(parsed.profile).toBe('minimal');
+    expect(parsed.classification).toBe('critical');
+    expect(parsed.harnessTargets).toEqual(['claude', 'codex']);
+    expect(parsed.railsConfirmed).toBe(true);
+    expect(parsed.error).toBeNull();
+  });
+
+  test('rejects unknown classifications and harness targets with repair text', () => {
+    expect(parseInitFlags(['--classification', 'minor']).error)
+      .toContain('Choose one of: critical, standard, refactor');
+    expect(parseInitFlags(['--harness', 'vscode']).error)
+      .toContain('Choose from: claude, cursor, codex');
+  });
+
+  test('detects active harness targets from filesystem markers', () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, '.claude'));
+    fs.mkdirSync(path.join(root, '.cursor'));
+    fs.mkdirSync(path.join(root, '.codex'));
+    fs.writeFileSync(path.join(root, '.cursor-file'), '');
+
+    expect(detectHarnessTargets(root)).toEqual(['claude', 'cursor', 'codex']);
+  });
+
+  test('does not detect harness markers that are plain files', () => {
+    const root = makeProject();
+    fs.writeFileSync(path.join(root, '.cursor'), '');
+
+    expect(detectHarnessTargets(root)).toEqual([]);
+  });
+
+  test('renders protected path and patch scaffolds', () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, '.cursor'));
+    const protectedYaml = readYamlFromString(renderProtectedPathsYaml({
+      classification: 'standard',
+      harnessTargets: ['cursor'],
+      projectRoot: root,
+    }));
+
+    expect(protectedYaml.kind).toBe('forge.protectedPaths');
+    expect(protectedYaml.harness.targets).toEqual(['cursor']);
+    expect(protectedYaml.paths.map(entry => entry.path)).toContain('.forge/config.yaml');
+    expect(protectedYaml.paths.map(entry => entry.path)).toContain('.cursor/**');
+    expect(protectedYaml.paths.map(entry => entry.path)).not.toContain('.codex/**');
+    expect(renderPatchMd()).toContain('# Forge Patch Intent');
+  });
+
+  test('initializes clean repo with config, patch, and protected paths files', async () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, '.codex'));
+
+    const result = await handler(['--yes'], {}, root);
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(path.join(root, '.forge', 'config.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(root, '.forge', 'patch.md'))).toBe(true);
+    expect(fs.existsSync(path.join(root, '.forge', 'protected-paths.yaml'))).toBe(true);
+
+    const config = readYaml(path.join(root, '.forge', 'config.yaml'));
+    expect(config.workflow.classification.default).toBe('standard');
+    expect(config.layer1Rails.confirmed).toBe(true);
+    expect(config.adapters.harness.targets).toEqual(['codex']);
+  });
+
+  test('does not clobber existing generated files without force', async () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.forge', 'patch.md'), 'user patch\n');
+
+    const result = await handler(['--yes'], {}, root);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('.forge/patch.md already exists');
+    expect(result.error).toContain('Re-run with --force');
+    expect(fs.readFileSync(path.join(root, '.forge', 'patch.md'), 'utf8')).toBe('user patch\n');
+    expect(fs.existsSync(path.join(root, '.forge', 'config.yaml'))).toBe(false);
+  });
+
+  test('first-time wizard asks classification, L1 confirmation, and harness targets in order', async () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, '.claude'));
+    const prompts = [];
+    const answers = ['refactor', 'y', 'claude,codex'];
+
+    const result = await handler([], {}, root, {
+      stdinIsTTY: true,
+      prompt: async (question) => {
+        prompts.push(question);
+        return answers.shift();
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(prompts[0]).toContain('classification');
+    expect(prompts[1]).toContain('Layer 1');
+    expect(prompts[2]).toContain('harness');
+
+    const config = readYaml(path.join(root, '.forge', 'config.yaml'));
+    expect(config.workflow.classification.default).toBe('refactor');
+    expect(config.adapters.harness.targets).toEqual(['claude', 'codex']);
+  });
+
+  test('wizard fails closed when Layer 1 rails are declined', async () => {
+    const root = makeProject();
+    const result = await handler([], {}, root, {
+      stdinIsTTY: true,
+      prompt: async (question) => question.includes('Layer 1') ? 'n' : '',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Layer 1 rails must be confirmed');
+    expect(result.error).toContain('Re-run forge init');
+    expect(fs.existsSync(path.join(root, '.forge'))).toBe(false);
+  });
+});
+
+function readYamlFromString(value) {
+  return YAML.parse(value);
+}

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -107,6 +107,17 @@ describe('forge init command', () => {
     expect(config.adapters.harness.targets).toEqual(['codex']);
   });
 
+  test('preserves explicit profile harness defaults when no harness markers exist', async () => {
+    const root = makeProject();
+
+    const result = await handler(['--full', '--yes'], {}, root);
+
+    expect(result.success).toBe(true);
+    const config = readYaml(path.join(root, '.forge', 'config.yaml'));
+    expect(config.template.profile).toBe('full');
+    expect(config.adapters.harness.targets).toEqual(['codex', 'claude', 'cursor', 'opencode', 'copilot']);
+  });
+
   test('does not clobber existing generated files without force', async () => {
     const root = makeProject();
     fs.mkdirSync(path.join(root, '.forge'), { recursive: true });

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -111,13 +111,15 @@ describe('forge init command', () => {
     const root = makeProject();
     fs.mkdirSync(path.join(root, '.forge'), { recursive: true });
     fs.writeFileSync(path.join(root, '.forge', 'patch.md'), 'user patch\n');
+    fs.writeFileSync(path.join(root, '.forge', 'protected-paths.yaml'), 'user manifest\n');
 
     const result = await handler(['--yes'], {}, root);
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('.forge/patch.md already exists');
+    expect(result.error).toContain('.forge/patch.md, .forge/protected-paths.yaml already exist');
     expect(result.error).toContain('Re-run with --force');
     expect(fs.readFileSync(path.join(root, '.forge', 'patch.md'), 'utf8')).toBe('user patch\n');
+    expect(fs.readFileSync(path.join(root, '.forge', 'protected-paths.yaml'), 'utf8')).toBe('user manifest\n');
     expect(fs.existsSync(path.join(root, '.forge', 'config.yaml'))).toBe(false);
   });
 

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -159,6 +159,24 @@ describe('forge init command', () => {
     expect(result.error).toContain('Re-run forge init');
     expect(fs.existsSync(path.join(root, '.forge'))).toBe(false);
   });
+
+  test('validates unknown profile before interactive wizard prompts', async () => {
+    const root = makeProject();
+    const prompts = [];
+
+    const result = await handler(['--profile', 'unknown'], {}, root, {
+      stdinIsTTY: true,
+      prompt: async (question) => {
+        prompts.push(question);
+        return '';
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Unknown adoption profile 'unknown'");
+    expect(prompts).toEqual([]);
+    expect(fs.existsSync(path.join(root, '.forge'))).toBe(false);
+  });
 });
 
 function readYamlFromString(value) {

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -53,7 +53,14 @@ describe('forge init command', () => {
     expect(parseInitFlags(['--classification', 'minor']).error)
       .toContain('Choose one of: critical, standard, refactor');
     expect(parseInitFlags(['--harness', 'vscode']).error)
-      .toContain('Choose from: claude, cursor, codex');
+      .toContain('Choose from: claude, cursor, codex, opencode, copilot');
+  });
+
+  test('accepts full-profile harness targets in explicit input', () => {
+    const parsed = parseInitFlags(['--harness', 'opencode,copilot']);
+
+    expect(parsed.error).toBeNull();
+    expect(parsed.harnessTargets).toEqual(['opencode', 'copilot']);
   });
 
   test('detects active harness targets from filesystem markers', () => {

--- a/test/init-command.test.js
+++ b/test/init-command.test.js
@@ -118,6 +118,18 @@ describe('forge init command', () => {
     expect(config.adapters.harness.targets).toEqual(['codex', 'claude', 'cursor', 'opencode', 'copilot']);
   });
 
+  test('preserves explicit profile harness defaults over detected markers', async () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, '.codex'));
+
+    const result = await handler(['--full', '--yes'], {}, root);
+
+    expect(result.success).toBe(true);
+    const config = readYaml(path.join(root, '.forge', 'config.yaml'));
+    expect(config.template.profile).toBe('full');
+    expect(config.adapters.harness.targets).toEqual(['codex', 'claude', 'cursor', 'opencode', 'copilot']);
+  });
+
   test('does not clobber existing generated files without force', async () => {
     const root = makeProject();
     fs.mkdirSync(path.join(root, '.forge'), { recursive: true });


### PR DESCRIPTION
## Problem
Fresh repositories needed a `forge init` day-one entry door that does not assume a previous v2 install or route users into `forge new` onboarding.

## Root Cause
The existing `forge init` only generated `.forge/config.yaml` from adoption profiles, so it did not scaffold the full skeleton, detect harnesses, or capture first-time classification/L1/harness choices.

## Fix
Adds the day-one init flow: config, patch intent placeholder, protected path manifest scaffold, harness filesystem detection, wizard choices, no-clobber repair messages, and docs.

## Value
New repos get a deterministic Forge skeleton with safe defaults, while scripted users keep parseable dry-run config output and existing profile shortcuts.

## Beads
Closes forge-fvh9

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 3417 full-suite tests passing; 24 focused init/adoption tests passing; pre-push targeted tests passing.
- Scenarios covered: clean repo init, existing file no-clobber, `.claude`/`.cursor`/`.codex` directory detection, plain-file non-detection, generated files, wizard prompts, rail-decline error, dry-run CLI compatibility, minimal profile lint compatibility.

### Security Review
- OWASP Top 10: no command execution added; enum inputs validated; writes are fixed `.forge/*` files under the target project root; existing files are preserved unless `--force` is explicit.
- Automated scan: `bun run lint` passed with 0 errors; full `bun test` passed.

### Design Doc
See: `docs/work/2026-05-21-forge-init-day-one-entry/design.md`

### Key Decisions
- Keep implementation in `lib/commands/init.js` because registry dispatch already owns `forge init`.
- Preserve dry-run stdout as config YAML only for existing CLI consumers.
- Record L1 confirmation outside runtime `rails` so `forge options lint` stays compatible.
- Scaffold protected paths only; enforcement remains out of scope.

### Documentation Updated
- `docs/reference/TEMPLATES.md`
- `docs/work/2026-05-21-forge-init-day-one-entry/design.md`
- `docs/work/2026-05-21-forge-init-day-one-entry/tasks.md`
- `docs/work/2026-05-21-forge-init-day-one-entry/decisions.md`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Day‑one init now scaffolds a local .forge skeleton (config, empty patch intent, protected‑paths), adds --classification/--harness flags, harness auto‑detection (.claude/.cursor/.codex), profile shortcuts (--minimal/--standard/--full) and setup shortcut, deterministic non‑interactive defaults (--yes), Layer‑1 confirmation, non‑clobber by default (--force to overwrite), and dry‑run config preview.

* **Documentation**
  * Clarified init vs new, generated artifacts, profiles, prompts, harness detection, and that protected‑state enforcement is not implemented.

* **Tests**
  * Added unit and end‑to‑end coverage for init flows, prompts, detection, previews, and non‑overwrite behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->