### PR TITLE
feat: add harness capability parity contract

### DIFF
--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -79,7 +79,7 @@ The full Forge extension parity model must cover more than skills:
 | Hooks | Forge hook manifest | Claude hook adapter if supported | unsupported unless verified | Codex hook adapter if supported | supported/unsupported matrix |
 | Commands | Forge command shim manifest | `.claude/commands` thin shims | native command surface if supported | CLI docs or skill fallback | shim points to canonical skill |
 | Agents/subagents | Forge agent role spec | Claude subagents | Cursor agent/subagent config if supported | Codex skill/agent fallback | role mapping or known issue |
-| Marketplace/extensions | `extension.yaml` plus lock metadata | plugin/skills/commands/hooks | skills/rules/MCP config | skills/MCP/hooks | lockfile, SHA, trust, generated targets |
+| Marketplace/extensions | `extension.yaml` plus lock metadata | plugin/skills/commands/hooks | skills/rules/`.cursor/mcp.json` config | skills/MCP/hooks | lockfile, SHA, trust, generated targets |
 
 The machine-readable matrix intentionally separates similar-looking surfaces:
 

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -22,6 +22,19 @@ Cursor rules are included here because `forge-2si5` explicitly asked for `.curso
 
 Tracked as `forge-wj36`.
 
+This follow-up now has a machine-readable contract in `lib/harness-capability-matrix.js`.
+Generate the current evidence artifact with:
+
+```bash
+node scripts/spikes/harness-capability-matrix.js
+```
+
+The output is JSON with three top-level contracts:
+
+- `harnesses[]`: Claude, Cursor, and Codex capability support across instructions, skills, rules, MCP, hooks, commands, agents/subagents, stages, Beads, typed memory, patch overrides, marketplace trust, and extension packs.
+- `stageGraph`: default Forge stages as skills-first super skills with addressable subskills.
+- `rendererContract`: the evidence a renderer must provide before Forge emits broad harness files.
+
 Forge stage parity should become skills-first across Claude, Cursor, and Codex:
 
 | Forge stage | Canonical surface | Claude render | Cursor render | Codex render |
@@ -65,11 +78,31 @@ The full Forge extension parity model must cover more than skills:
 | Agents/subagents | Forge agent role spec | Claude subagents | Cursor agent/subagent config if supported | Codex skill/agent fallback | role mapping or known issue |
 | Marketplace/extensions | `extension.yaml` plus lock metadata | plugin/skills/commands/hooks | skills/rules/MCP config | skills/MCP/hooks | lockfile, SHA, trust, generated targets |
 
-The next implementation should start with a machine-readable harness capability matrix and renderer contract before adding more generated files.
+The machine-readable matrix intentionally separates similar-looking surfaces:
+
+- Skills are on-demand workflows: `.claude/skills/<skill>/SKILL.md`, `.cursor/skills/<skill>/SKILL.md`, and `.codex/skills/<skill>/SKILL.md`.
+- Rules are policy/context projections: Cursor uses `.cursor/rules/<rule>.mdc`; Claude and Codex receive policy through instruction projections unless a native rule surface is verified.
+- Commands are shims: Claude command files remain useful for compatibility, but the command body must point to the canonical stage skill instead of duplicating the workflow.
+- MCP is config plumbing: each harness gets native MCP config only when the matrix records a target path and probe evidence.
+- Hooks are lifecycle adapters: Claude and Codex have native hook targets; Cursor remains a known issue until a hook surface is proven.
+- Distribution is not a skill directory dump: Codex can use plugins and marketplaces; Forge extension packs must carry lock/trust metadata before installation.
+
+No broad renderer should be added until its capability has a matrix entry, target path contract, activation metadata contract, machine-readable evidence, and a known-issue record for any unproven harness.
+
+## External Compatibility Pattern
+
+The current ecosystem pattern is a canonical payload with native harness renderers:
+
+- Claude Code documents skills as `SKILL.md` files whose `description` controls automatic loading, and notes that commands and skills can both expose slash affordances.
+- Cursor documents `.cursor/rules/*.mdc` as persistent scoped context with `description`, `globs`, and `alwaysApply`; Cursor skills are treated by Forge as the on-demand workflow target, while rules remain the policy target.
+- Codex documents skills as reusable workflow packages, uses description-based implicit invocation, and uses plugins/marketplaces to distribute reusable skills, MCP servers, hooks, and apps.
+- AGENTS.md remains the shared instruction projection for agents that read repository instructions directly.
+
+Forge adopts that pattern by keeping one canonical Forge capability and rendering the smallest verified native wrapper per harness. It does not duplicate every feature blindly into every directory.
 
 ## Evidence Command
 
-Run the parity fixture from the repository root:
+Run the W0 parity fixture from the repository root:
 
 ```bash
 node scripts/spikes/skill-auto-invoke-parity.js --json
@@ -84,6 +117,20 @@ The JSON output includes:
 - `proofBoundary`
 - `knownIssues[]`
 
+Run the broader capability matrix evidence from the repository root:
+
+```bash
+node scripts/spikes/harness-capability-matrix.js
+```
+
+The JSON output includes:
+
+- `harnesses[].capabilities`
+- `stageGraph.stages[].subskills`
+- `stageGraph.stages[].renderTargets`
+- `rendererContract.rendererFamilies`
+- `sources[]`
+
 ## Proof Boundary
 
 This fixture proves deterministic metadata-surface parity. It does not launch closed-source agent sessions or claim that a live model selected a skill in a proprietary runtime. For Codex specifically, it validates the Forge packaging source for Codex skills, not direct runtime discovery.
@@ -96,6 +143,7 @@ No harness-specific metadata issue is known for this fixture. Live proprietary-a
 
 Known gaps intentionally left for follow-up:
 
-- Cursor Agent Skills are not proven in this W0 fixture; Cursor rules were the requested target for `forge-2si5`.
-- Claude still has command-first stage distribution in the current Forge setup; this must move to skills-first with commands as shims.
-- MCPs, hooks, stage/gate renderers, Beads wiring, typed memory, patch overrides, marketplace trust, and extension packs are not covered by this fixture.
+- Cursor Agent Skills are not proven in the W0 fixture; the capability matrix records `.cursor/skills` as the intended on-demand target and `.cursor/rules` as the policy target.
+- Claude still has command-first stage distribution in the current Forge setup; the skills-first graph records commands as shims over `.claude/skills`.
+- Cursor hooks remain unsupported until a verified hook surface exists; use Forge-owned hooks or file-watcher fallback for protected-path enforcement.
+- MCPs, hooks, stage/gate renderers, Beads wiring, typed memory, patch overrides, marketplace trust, and extension packs are covered by the capability matrix contract, but broad renderer implementation remains future work.

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -75,7 +75,7 @@ The full Forge extension parity model must cover more than skills:
 | Project instructions | structured `AGENTS.md` sections | `CLAUDE.md` shim or generated file | `.cursor/rules/*.mdc` for scoped policy | `AGENTS.md` | semantic section comparison |
 | Skills/playbooks | agentskills.io-compatible `SKILL.md` | `.claude/skills` | `.cursor/skills` | `.codex/skills` packaging source; `.agents/skills` after generator migration | generated file and trigger metadata |
 | Rules/policies | Forge rule manifest | `CLAUDE.md` or `.claude/rules` if supported | `.cursor/rules/*.mdc` | `AGENTS.md` section | rule target and unsupported-surface notes |
-| MCP tools/resources | Forge MCP manifest | Claude MCP config | Cursor MCP config | Codex MCP config | config render and server probe |
+| MCP tools/resources | Forge MCP manifest | Claude MCP config | `.cursor/mcp.json` | Codex MCP config | config render and server probe |
 | Hooks | Forge hook manifest | Claude hook adapter if supported | unsupported unless verified | Codex hook adapter if supported | supported/unsupported matrix |
 | Commands | Forge command shim manifest | `.claude/commands` thin shims | native command surface if supported | CLI docs or skill fallback | shim points to canonical skill |
 | Agents/subagents | Forge agent role spec | Claude subagents | Cursor agent/subagent config if supported | Codex skill/agent fallback | role mapping or known issue |

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -34,14 +34,13 @@ node scripts/spikes/harness-capability-matrix.js
 The output is JSON with three top-level contracts:
 
 - `harnesses[]`: Claude, Cursor, and Codex capability support across instructions, skills, rules, MCP, hooks, commands, agents/subagents, stages, Beads, typed memory, patch overrides, marketplace trust, and extension packs.
-- `stageGraph`: default Forge stages as skills-first super skills with addressable subskills.
+- `stageGraph`: canonical Forge workflow stages as skills-first super skills with addressable subskills, plus utility skills such as `status` outside workflow transitions.
 - `rendererContract`: the evidence a renderer must provide before Forge emits broad harness files.
 
 Forge stage parity should become skills-first across Claude, Cursor, and Codex:
 
 | Forge stage | Canonical surface | Claude render | Cursor render | Codex render |
 | --- | --- | --- | --- | --- |
-| `status` | super skill with subskills | `.claude/skills/status/SKILL.md` plus command shim | `.cursor/skills/status/SKILL.md` (unproven) | `.codex/skills/status/SKILL.md` |
 | `plan` | super skill with phases | `.claude/skills/plan/SKILL.md` plus command shim | `.cursor/skills/plan/SKILL.md` (unproven) | `.codex/skills/plan/SKILL.md` |
 | `dev` | super skill with TDD subskills | `.claude/skills/dev/SKILL.md` plus command shim | `.cursor/skills/dev/SKILL.md` (unproven) | `.codex/skills/dev/SKILL.md` |
 | `validate` | super skill with check subskills | `.claude/skills/validate/SKILL.md` plus command shim | `.cursor/skills/validate/SKILL.md` (unproven) | `.codex/skills/validate/SKILL.md` |
@@ -49,6 +48,8 @@ Forge stage parity should become skills-first across Claude, Cursor, and Codex:
 | `review` | super skill with feedback subskills | `.claude/skills/review/SKILL.md` plus command shim | `.cursor/skills/review/SKILL.md` (unproven) | `.codex/skills/review/SKILL.md` |
 | `premerge` | super skill with readiness subskills | `.claude/skills/premerge/SKILL.md` plus command shim | `.cursor/skills/premerge/SKILL.md` (unproven) | `.codex/skills/premerge/SKILL.md` |
 | `verify` | super skill with post-merge subskills | `.claude/skills/verify/SKILL.md` plus command shim | `.cursor/skills/verify/SKILL.md` (unproven) | `.codex/skills/verify/SKILL.md` |
+
+`status` remains a utility skill, not a workflow stage. The stage graph exposes it in `utilitySkills[]` so renderers can still generate status affordances without adding invalid workflow transitions.
 
 Claude commands should become compatibility shims, not the workflow authority. The canonical workflow should live in stage skills and subskills.
 

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -12,11 +12,11 @@ For Week 3 planning, see [Week 3 Runtime Capability Packs](../work/2026-04-28-sk
 | --- | --- | --- | --- |
 | Claude Code | `.claude/skills/<name>/SKILL.md` | `description` in `SKILL.md` frontmatter | Proven by metadata fixture |
 | Cursor | `.cursor/rules/<name>.mdc` | `description`, blank `globs`, `alwaysApply: false` | Proven by metadata fixture |
-| Codex CLI | `.codex/skills/<name>/SKILL.md` | `name` and `description` in `SKILL.md` frontmatter | Proven by metadata fixture and Forge packaging helper |
+| Codex CLI | `.agents/skills/<name>/SKILL.md` | `name` and `description` in `SKILL.md` frontmatter | Proven by metadata fixture and current Codex repo-scoped skill discovery docs |
 
 The shared rule is: keep the skill name, description, and task body canonical, then generate the smallest native wrapper each harness needs.
 
-For Codex, this W0 fixture validates Forge's repository packaging surface (`.codex/skills`) plus the metadata needed for installed Codex skills. It does not prove direct Codex runtime discovery from a repo-local skill directory.
+For Codex, this W0 fixture validates Forge's repository skill surface (`.agents/skills`) plus the metadata needed for installed Codex skills. It does not launch Codex to prove live auto-invocation.
 
 Cursor rules are included here because `forge-2si5` explicitly asked for `.cursor/rules/*.mdc` evidence. They are not the final Cursor skill target. The broader parity model must treat Cursor Agent Skills as the primary on-demand workflow surface and Cursor rules as the always-on or scoped-policy surface.
 
@@ -41,14 +41,14 @@ Forge stage parity should become skills-first across Claude, Cursor, and Codex:
 
 | Forge stage | Canonical surface | Claude render | Cursor render | Codex render |
 | --- | --- | --- | --- | --- |
-| `status` | super skill with subskills | `.claude/skills/status/SKILL.md` plus command shim | `.cursor/skills/status/SKILL.md` | `.codex/skills/status/SKILL.md` |
-| `plan` | super skill with phases | `.claude/skills/plan/SKILL.md` plus command shim | `.cursor/skills/plan/SKILL.md` | `.codex/skills/plan/SKILL.md` |
-| `dev` | super skill with TDD subskills | `.claude/skills/dev/SKILL.md` plus command shim | `.cursor/skills/dev/SKILL.md` | `.codex/skills/dev/SKILL.md` |
-| `validate` | super skill with check subskills | `.claude/skills/validate/SKILL.md` plus command shim | `.cursor/skills/validate/SKILL.md` | `.codex/skills/validate/SKILL.md` |
-| `ship` | super skill with PR subskills | `.claude/skills/ship/SKILL.md` plus command shim | `.cursor/skills/ship/SKILL.md` | `.codex/skills/ship/SKILL.md` |
-| `review` | super skill with feedback subskills | `.claude/skills/review/SKILL.md` plus command shim | `.cursor/skills/review/SKILL.md` | `.codex/skills/review/SKILL.md` |
-| `premerge` | super skill with readiness subskills | `.claude/skills/premerge/SKILL.md` plus command shim | `.cursor/skills/premerge/SKILL.md` | `.codex/skills/premerge/SKILL.md` |
-| `verify` | super skill with post-merge subskills | `.claude/skills/verify/SKILL.md` plus command shim | `.cursor/skills/verify/SKILL.md` | `.codex/skills/verify/SKILL.md` |
+| `status` | super skill with subskills | `.claude/skills/status/SKILL.md` plus command shim | `.cursor/skills/status/SKILL.md` | `.agents/skills/status/SKILL.md` |
+| `plan` | super skill with phases | `.claude/skills/plan/SKILL.md` plus command shim | `.cursor/skills/plan/SKILL.md` | `.agents/skills/plan/SKILL.md` |
+| `dev` | super skill with TDD subskills | `.claude/skills/dev/SKILL.md` plus command shim | `.cursor/skills/dev/SKILL.md` | `.agents/skills/dev/SKILL.md` |
+| `validate` | super skill with check subskills | `.claude/skills/validate/SKILL.md` plus command shim | `.cursor/skills/validate/SKILL.md` | `.agents/skills/validate/SKILL.md` |
+| `ship` | super skill with PR subskills | `.claude/skills/ship/SKILL.md` plus command shim | `.cursor/skills/ship/SKILL.md` | `.agents/skills/ship/SKILL.md` |
+| `review` | super skill with feedback subskills | `.claude/skills/review/SKILL.md` plus command shim | `.cursor/skills/review/SKILL.md` | `.agents/skills/review/SKILL.md` |
+| `premerge` | super skill with readiness subskills | `.claude/skills/premerge/SKILL.md` plus command shim | `.cursor/skills/premerge/SKILL.md` | `.agents/skills/premerge/SKILL.md` |
+| `verify` | super skill with post-merge subskills | `.claude/skills/verify/SKILL.md` plus command shim | `.cursor/skills/verify/SKILL.md` | `.agents/skills/verify/SKILL.md` |
 
 Claude commands should become compatibility shims, not the workflow authority. The canonical workflow should live in stage skills and subskills.
 
@@ -72,7 +72,7 @@ The full Forge extension parity model must cover more than skills:
 | Capability | Canonical Forge source | Claude | Cursor | Codex | Required evidence |
 | --- | --- | --- | --- | --- | --- |
 | Project instructions | structured `AGENTS.md` sections | `CLAUDE.md` shim or generated file | `.cursor/rules/*.mdc` for scoped policy | `AGENTS.md` | semantic section comparison |
-| Skills/playbooks | agentskills.io-compatible `SKILL.md` | `.claude/skills` | `.cursor/skills` | `.codex/skills` | generated file and trigger metadata |
+| Skills/playbooks | agentskills.io-compatible `SKILL.md` | `.claude/skills` | `.cursor/skills` | `.agents/skills` | generated file and trigger metadata |
 | Rules/policies | Forge rule manifest | `CLAUDE.md` or `.claude/rules` if supported | `.cursor/rules/*.mdc` | `AGENTS.md` section | rule target and unsupported-surface notes |
 | MCP tools/resources | Forge MCP manifest | Claude MCP config | Cursor MCP config | Codex MCP config | config render and server probe |
 | Hooks | Forge hook manifest | Claude hook adapter if supported | unsupported unless verified | Codex hook adapter if supported | supported/unsupported matrix |
@@ -82,7 +82,7 @@ The full Forge extension parity model must cover more than skills:
 
 The machine-readable matrix intentionally separates similar-looking surfaces:
 
-- Skills are on-demand workflows: `.claude/skills/<skill>/SKILL.md`, `.cursor/skills/<skill>/SKILL.md`, and `.codex/skills/<skill>/SKILL.md`.
+- Skills are on-demand workflows: `.claude/skills/<skill>/SKILL.md`, `.cursor/skills/<skill>/SKILL.md`, and `.agents/skills/<skill>/SKILL.md` for Codex repository-scoped skills.
 - Rules are policy/context projections: Cursor uses `.cursor/rules/<rule>.mdc`; Claude and Codex receive policy through instruction projections unless a native rule surface is verified.
 - Commands are shims: Claude command files remain useful for compatibility, but the command body must point to the canonical stage skill instead of duplicating the workflow.
 - MCP is config plumbing: each harness gets native MCP config only when the matrix records a target path and probe evidence.
@@ -97,7 +97,7 @@ The current ecosystem pattern is a canonical payload with native harness rendere
 
 - Claude Code documents skills as `SKILL.md` files whose `description` controls automatic loading, and notes that commands and skills can both expose slash affordances.
 - Cursor documents `.cursor/rules/*.mdc` as persistent scoped context with `description`, `globs`, and `alwaysApply`; Cursor skills are treated by Forge as the on-demand workflow target, while rules remain the policy target.
-- Codex documents skills as reusable workflow packages, uses description-based implicit invocation, and uses plugins/marketplaces to distribute reusable skills, MCP servers, hooks, and apps.
+- Codex documents skills as reusable workflow packages under `.agents/skills` for repository scope, uses description-based implicit invocation, and uses plugins/marketplaces to distribute reusable skills, MCP servers, hooks, and apps.
 - AGENTS.md remains the shared instruction projection for agents that read repository instructions directly.
 
 Forge adopts that pattern by keeping one canonical Forge capability and rendering the smallest verified native wrapper per harness. It does not duplicate every feature blindly into every directory.
@@ -141,7 +141,7 @@ The JSON output includes:
 
 ## Proof Boundary
 
-This fixture proves deterministic metadata-surface parity. It does not launch closed-source agent sessions or claim that a live model selected a skill in a proprietary runtime. For Codex specifically, it validates the Forge packaging source for Codex skills, not direct runtime discovery.
+This fixture proves deterministic metadata-surface parity. It does not launch closed-source agent sessions or claim that a live model selected a skill in a proprietary runtime. For Codex specifically, it validates the documented repo-scoped skill path and metadata, not live auto-invocation.
 
 If a future release needs live invocation proof, add a separate transcript-producing eval for Claude Code, Cursor, and Codex and keep this fixture as the fast CI gate.
 

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -12,11 +12,11 @@ For Week 3 planning, see [Week 3 Runtime Capability Packs](../work/2026-04-28-sk
 | --- | --- | --- | --- |
 | Claude Code | `.claude/skills/<name>/SKILL.md` | `description` in `SKILL.md` frontmatter | Proven by metadata fixture |
 | Cursor | `.cursor/rules/<name>.mdc` | `description`, blank `globs`, `alwaysApply: false` | Proven by metadata fixture |
-| Codex CLI | `.agents/skills/<name>/SKILL.md` | `name` and `description` in `SKILL.md` frontmatter | Proven by metadata fixture and current Codex repo-scoped skill discovery docs |
+| Codex CLI | `.codex/skills/<name>/SKILL.md` | `name` and `description` in `SKILL.md` frontmatter | Proven by metadata fixture and Forge packaging helper |
 
 The shared rule is: keep the skill name, description, and task body canonical, then generate the smallest native wrapper each harness needs.
 
-For Codex, this W0 fixture validates Forge's repository skill surface (`.agents/skills`) plus the metadata needed for installed Codex skills. It does not launch Codex to prove live auto-invocation.
+For Codex, this W0 fixture validates Forge's current repository packaging surface (`.codex/skills`) plus the metadata needed for installed Codex skills. Current Codex docs use `.agents/skills` for direct repo discovery; Forge should migrate the generator before treating that as the renderer target.
 
 Cursor rules are included here because `forge-2si5` explicitly asked for `.cursor/rules/*.mdc` evidence. They are not the final Cursor skill target. The broader parity model must treat Cursor Agent Skills as the primary on-demand workflow surface and Cursor rules as the always-on or scoped-policy surface.
 
@@ -41,14 +41,14 @@ Forge stage parity should become skills-first across Claude, Cursor, and Codex:
 
 | Forge stage | Canonical surface | Claude render | Cursor render | Codex render |
 | --- | --- | --- | --- | --- |
-| `status` | super skill with subskills | `.claude/skills/status/SKILL.md` plus command shim | `.cursor/skills/status/SKILL.md` | `.agents/skills/status/SKILL.md` |
-| `plan` | super skill with phases | `.claude/skills/plan/SKILL.md` plus command shim | `.cursor/skills/plan/SKILL.md` | `.agents/skills/plan/SKILL.md` |
-| `dev` | super skill with TDD subskills | `.claude/skills/dev/SKILL.md` plus command shim | `.cursor/skills/dev/SKILL.md` | `.agents/skills/dev/SKILL.md` |
-| `validate` | super skill with check subskills | `.claude/skills/validate/SKILL.md` plus command shim | `.cursor/skills/validate/SKILL.md` | `.agents/skills/validate/SKILL.md` |
-| `ship` | super skill with PR subskills | `.claude/skills/ship/SKILL.md` plus command shim | `.cursor/skills/ship/SKILL.md` | `.agents/skills/ship/SKILL.md` |
-| `review` | super skill with feedback subskills | `.claude/skills/review/SKILL.md` plus command shim | `.cursor/skills/review/SKILL.md` | `.agents/skills/review/SKILL.md` |
-| `premerge` | super skill with readiness subskills | `.claude/skills/premerge/SKILL.md` plus command shim | `.cursor/skills/premerge/SKILL.md` | `.agents/skills/premerge/SKILL.md` |
-| `verify` | super skill with post-merge subskills | `.claude/skills/verify/SKILL.md` plus command shim | `.cursor/skills/verify/SKILL.md` | `.agents/skills/verify/SKILL.md` |
+| `status` | super skill with subskills | `.claude/skills/status/SKILL.md` plus command shim | `.cursor/skills/status/SKILL.md` (unproven) | `.codex/skills/status/SKILL.md` |
+| `plan` | super skill with phases | `.claude/skills/plan/SKILL.md` plus command shim | `.cursor/skills/plan/SKILL.md` (unproven) | `.codex/skills/plan/SKILL.md` |
+| `dev` | super skill with TDD subskills | `.claude/skills/dev/SKILL.md` plus command shim | `.cursor/skills/dev/SKILL.md` (unproven) | `.codex/skills/dev/SKILL.md` |
+| `validate` | super skill with check subskills | `.claude/skills/validate/SKILL.md` plus command shim | `.cursor/skills/validate/SKILL.md` (unproven) | `.codex/skills/validate/SKILL.md` |
+| `ship` | super skill with PR subskills | `.claude/skills/ship/SKILL.md` plus command shim | `.cursor/skills/ship/SKILL.md` (unproven) | `.codex/skills/ship/SKILL.md` |
+| `review` | super skill with feedback subskills | `.claude/skills/review/SKILL.md` plus command shim | `.cursor/skills/review/SKILL.md` (unproven) | `.codex/skills/review/SKILL.md` |
+| `premerge` | super skill with readiness subskills | `.claude/skills/premerge/SKILL.md` plus command shim | `.cursor/skills/premerge/SKILL.md` (unproven) | `.codex/skills/premerge/SKILL.md` |
+| `verify` | super skill with post-merge subskills | `.claude/skills/verify/SKILL.md` plus command shim | `.cursor/skills/verify/SKILL.md` (unproven) | `.codex/skills/verify/SKILL.md` |
 
 Claude commands should become compatibility shims, not the workflow authority. The canonical workflow should live in stage skills and subskills.
 
@@ -72,7 +72,7 @@ The full Forge extension parity model must cover more than skills:
 | Capability | Canonical Forge source | Claude | Cursor | Codex | Required evidence |
 | --- | --- | --- | --- | --- | --- |
 | Project instructions | structured `AGENTS.md` sections | `CLAUDE.md` shim or generated file | `.cursor/rules/*.mdc` for scoped policy | `AGENTS.md` | semantic section comparison |
-| Skills/playbooks | agentskills.io-compatible `SKILL.md` | `.claude/skills` | `.cursor/skills` | `.agents/skills` | generated file and trigger metadata |
+| Skills/playbooks | agentskills.io-compatible `SKILL.md` | `.claude/skills` | `.cursor/skills` | `.codex/skills` packaging source; `.agents/skills` after generator migration | generated file and trigger metadata |
 | Rules/policies | Forge rule manifest | `CLAUDE.md` or `.claude/rules` if supported | `.cursor/rules/*.mdc` | `AGENTS.md` section | rule target and unsupported-surface notes |
 | MCP tools/resources | Forge MCP manifest | Claude MCP config | Cursor MCP config | Codex MCP config | config render and server probe |
 | Hooks | Forge hook manifest | Claude hook adapter if supported | unsupported unless verified | Codex hook adapter if supported | supported/unsupported matrix |
@@ -82,7 +82,7 @@ The full Forge extension parity model must cover more than skills:
 
 The machine-readable matrix intentionally separates similar-looking surfaces:
 
-- Skills are on-demand workflows: `.claude/skills/<skill>/SKILL.md`, `.cursor/skills/<skill>/SKILL.md`, and `.agents/skills/<skill>/SKILL.md` for Codex repository-scoped skills.
+- Skills are on-demand workflows: `.claude/skills/<skill>/SKILL.md`, `.cursor/skills/<skill>/SKILL.md`, and Forge's current `.codex/skills/<skill>/SKILL.md` packaging source for Codex. Direct Codex repo discovery should use `.agents/skills/<skill>/SKILL.md` after the Forge generator migrates.
 - Rules are policy/context projections: Cursor uses `.cursor/rules/<rule>.mdc`; Claude and Codex receive policy through instruction projections unless a native rule surface is verified.
 - Commands are shims: Claude command files remain useful for compatibility, but the command body must point to the canonical stage skill instead of duplicating the workflow.
 - MCP is config plumbing: each harness gets native MCP config only when the matrix records a target path and probe evidence.
@@ -97,7 +97,7 @@ The current ecosystem pattern is a canonical payload with native harness rendere
 
 - Claude Code documents skills as `SKILL.md` files whose `description` controls automatic loading, and notes that commands and skills can both expose slash affordances.
 - Cursor documents `.cursor/rules/*.mdc` as persistent scoped context with `description`, `globs`, and `alwaysApply`; Cursor skills are treated by Forge as the on-demand workflow target, while rules remain the policy target.
-- Codex documents skills as reusable workflow packages under `.agents/skills` for repository scope, uses description-based implicit invocation, and uses plugins/marketplaces to distribute reusable skills, MCP servers, hooks, and apps.
+- Codex documents skills as reusable workflow packages under `.agents/skills` for repository scope, uses description-based implicit invocation, and uses plugins/marketplaces to distribute reusable skills, MCP servers, hooks, and apps. Forge's current generator still emits `.codex/skills` packages for installation.
 - AGENTS.md remains the shared instruction projection for agents that read repository instructions directly.
 
 Forge adopts that pattern by keeping one canonical Forge capability and rendering the smallest verified native wrapper per harness. It does not duplicate every feature blindly into every directory.
@@ -141,7 +141,7 @@ The JSON output includes:
 
 ## Proof Boundary
 
-This fixture proves deterministic metadata-surface parity. It does not launch closed-source agent sessions or claim that a live model selected a skill in a proprietary runtime. For Codex specifically, it validates the documented repo-scoped skill path and metadata, not live auto-invocation.
+This fixture proves deterministic metadata-surface parity. It does not launch closed-source agent sessions or claim that a live model selected a skill in a proprietary runtime. For Codex specifically, it validates the current Forge packaging source and metadata, not live auto-invocation or direct `.agents/skills` repo discovery.
 
 If a future release needs live invocation proof, add a separate transcript-producing eval for Claude Code, Cursor, and Codex and keep this fixture as the fast CI gate.
 

--- a/docs/work/2026-05-23-harness-capability-parity/decisions.md
+++ b/docs/work/2026-05-23-harness-capability-parity/decisions.md
@@ -1,0 +1,44 @@
+# Harness Capability Parity Decisions
+
+Feature: harness-capability-parity
+Issue: forge-wj36
+
+## Decision 1
+
+Date: 2026-05-23
+Task: Capability matrix contract
+Gap: Cursor now has a skills surface, while the W0 fixture used Cursor rules because `forge-2si5` requested `.cursor/rules/*.mdc`.
+Score: 2/14
+Route: PROCEED
+Choice made: Model `.cursor/skills` as the on-demand workflow target and `.cursor/rules/*.mdc` as the always-on/scoped policy target. Keep the W0 fixture boundary documented instead of pretending rules are the final skill surface.
+Status: RESOLVED
+
+## Decision 2
+
+Date: 2026-05-23
+Task: Skills-first stage graph
+Gap: Current Forge stage docs still use Claude commands as the source surface.
+Score: 3/14
+Route: PROCEED
+Choice made: Record the target architecture as skills-first and keep Claude commands as shim-only in the contract. Do not migrate command files in this PR because that is broad renderer work.
+Status: RESOLVED
+
+## Decision 3
+
+Date: 2026-05-23
+Task: Renderer evidence contract
+Gap: Some surfaces are unverified or unsupported in at least one harness.
+Score: 2/14
+Route: PROCEED
+Choice made: Store unsupported/unproven states in the matrix with `knownIssue` fields. This keeps the renderer contract honest and blocks silent parity claims.
+Status: RESOLVED
+
+## Decision 4
+
+Date: 2026-05-23
+Task: Beads context
+Gap: The isolated worktree could not open the Beads Dolt database.
+Score: 1/14
+Route: PROCEED
+Choice made: Keep implementation in the isolated git worktree and document the local Beads limitation in validation notes. The primary checkout can still read the issue.
+Status: RESOLVED

--- a/docs/work/2026-05-23-harness-capability-parity/design.md
+++ b/docs/work/2026-05-23-harness-capability-parity/design.md
@@ -36,7 +36,7 @@ The pattern is a canonical payload plus native harness renderers, not one univer
 Sources used:
 
 - https://code.claude.com/docs/en/skills
-- https://code.claude.com/docs/en/agent-sdk/skills
+- https://code.claude.com/docs/en/agent-sdk/skills.md
 - https://docs.cursor.com/en/context
 - https://docs.cursor.com/context/model-context-protocol
 - https://developers.openai.com/codex/skills

--- a/docs/work/2026-05-23-harness-capability-parity/design.md
+++ b/docs/work/2026-05-23-harness-capability-parity/design.md
@@ -1,0 +1,75 @@
+# Harness Capability Parity Design
+
+Feature: harness-capability-parity
+Issue: forge-wj36
+Date: 2026-05-23
+Status: implemented
+Branch: codex/harness-capability-parity
+Worktree: .worktrees/codex/harness-capability-parity
+
+## Purpose
+
+Define the parity foundation after the W0 skill metadata fixture. Forge needs one canonical capability model that can render to Claude, Cursor, and Codex without duplicating every feature blindly into every harness directory.
+
+## Success Criteria
+
+1. A machine-readable matrix covers Claude, Cursor, and Codex across instructions, skills, rules, MCP, hooks, commands, agents/subagents, stages/gates, Beads wiring, typed memory, patch overrides, marketplace trust, and extension packs.
+2. Cursor skills and Cursor rules are modeled as separate surfaces: skills for on-demand workflows, rules for always-on or scoped policy.
+3. Claude commands are recorded as compatibility shims over stage skills, not canonical workflow authority.
+4. Default stages are represented as skills-first super skills with addressable subskills.
+5. A renderer contract defines evidence required before any broad renderer is added.
+6. User docs explain the mechanism and link to a machine-readable evidence command.
+
+## Out Of Scope
+
+- Do not implement broad harness renderers in this PR.
+- Do not migrate checked-in Claude commands to skills yet.
+- Do not claim live proprietary-agent invocation proof.
+- Do not overhaul the full docs set.
+
+## Research Summary
+
+Claude Code documents `SKILL.md` files with `description` metadata for automatic loading and treats commands as compatible slash affordances. Codex documents the same core skill pattern, plus plugins and marketplaces for distribution. Cursor rules are `.mdc` policy/context files with `description`, `globs`, and `alwaysApply`; Forge records Cursor skills as the intended on-demand workflow surface and Cursor rules as the policy surface.
+
+The pattern is a canonical payload plus native harness renderers, not one universal folder copied everywhere.
+
+Sources used:
+
+- https://code.claude.com/docs/en/skills
+- https://code.claude.com/docs/en/agent-sdk/skills
+- https://docs.cursor.com/en/context
+- https://docs.cursor.com/context/model-context-protocol
+- https://developers.openai.com/codex/skills
+- https://developers.openai.com/codex/mcp
+- https://developers.openai.com/codex/hooks
+- https://developers.openai.com/codex/plugins/build
+- https://agents.md/
+
+## Approach Selected
+
+Add a small contract module at `lib/harness-capability-matrix.js` and a JSON evidence CLI at `scripts/spikes/harness-capability-matrix.js`.
+
+This keeps the PR bounded: it creates the matrix, stage graph, and renderer contract without generating new harness files. Future renderer PRs must consume this contract and add their own target-path/evidence tests.
+
+## Edge Cases
+
+- Unsupported harness surfaces must be explicit known issues, not silent omissions.
+- Cursor hooks remain unsupported until verified.
+- Cursor Agent Skills are not proven by the W0 rule fixture; the matrix distinguishes intended target from proven fixture target.
+- Codex commands fall back to skills rather than undocumented prompt/slash files.
+
+## Ambiguity Policy
+
+Use the `/dev` 7-dimension rubric. Proceed without user input only for local contract naming or wording that does not affect public APIs, persistent data, security, or broad renderer behavior.
+
+## OWASP Notes
+
+This PR adds static metadata and a read-only JSON evidence CLI. It does not execute untrusted code, process credentials, or open network connections at runtime. Relevant risk is A08 software/data integrity: mitigated by tests requiring known unsupported surfaces and renderer evidence before broad generation.
+
+## TDD Scenarios
+
+1. Happy path: matrix covers all target harnesses and required capability IDs.
+2. Edge path: Cursor skills and rules remain separate surfaces.
+3. Known-issue path: unsupported/unproven surfaces are recorded explicitly.
+4. Stage graph path: each default stage renders as a super skill with subskills and Claude command shim.
+5. Evidence path: CLI prints JSON containing matrix, stage graph, renderer contract, and sources.

--- a/docs/work/2026-05-23-harness-capability-parity/tasks.md
+++ b/docs/work/2026-05-23-harness-capability-parity/tasks.md
@@ -1,0 +1,77 @@
+# Harness Capability Parity Tasks
+
+Feature: harness-capability-parity
+Issue: forge-wj36
+
+## Task 1: Capability Matrix Contract
+
+File(s): `lib/harness-capability-matrix.js`, `test/harness-capability-matrix.test.js`
+OWNS: `lib/harness-capability-matrix.js`, `test/harness-capability-matrix.test.js`
+
+What to implement: Add a machine-readable matrix for Claude, Cursor, and Codex across all parity capabilities requested by `forge-wj36`. Include status, native target, role, activation, renderer family, source evidence, and known issues.
+
+TDD steps:
+1. Write test: assert all harnesses and capability IDs exist.
+2. Run test: confirm it fails because the module is missing.
+3. Implement: add the matrix module and exports.
+4. Run test: confirm it passes.
+5. Commit: `feat: add harness capability matrix contract`
+
+Expected output: focused test reports the matrix is JSON-serializable and covers every required capability.
+
+## Task 2: Skills-First Stage Graph
+
+File(s): `lib/harness-capability-matrix.js`, `test/harness-capability-matrix.test.js`
+OWNS: `lib/harness-capability-matrix.js`, `test/harness-capability-matrix.test.js`
+
+What to implement: Add a stage graph where every default stage is a canonical super skill with subskills. Claude commands must be shims pointing at `.claude/skills`, Cursor uses `.cursor/skills`, and Codex uses `.codex/skills`.
+
+TDD steps:
+1. Write test: assert stage IDs, subskills, and render targets.
+2. Run test: confirm it fails before graph implementation.
+3. Implement: add `getSkillsFirstStageGraph`.
+4. Run test: confirm it passes.
+5. Commit: `feat: add skills-first stage graph`
+
+Expected output: tests prove stages are skill-first and Claude command files are shim-only.
+
+## Task 3: Renderer Evidence Contract
+
+File(s): `lib/harness-capability-matrix.js`, `scripts/spikes/harness-capability-matrix.js`, `test/harness-capability-matrix.test.js`
+OWNS: `lib/harness-capability-matrix.js`, `scripts/spikes/harness-capability-matrix.js`, `test/harness-capability-matrix.test.js`
+
+What to implement: Define renderer families and the evidence required before broad generation. Add a JSON CLI that emits the matrix, stage graph, renderer contract, and sources.
+
+TDD steps:
+1. Write test: assert renderer families and evidence requirements.
+2. Run test: confirm it fails before contract/CLI implementation.
+3. Implement: add `getRendererContract`, `buildHarnessCapabilityEvidence`, and CLI.
+4. Run test: confirm it passes.
+5. Commit: `test: cover harness capability evidence CLI`
+
+Expected output: `node scripts/spikes/harness-capability-matrix.js` prints valid JSON.
+
+## Task 4: User Docs
+
+File(s): `docs/reference/AGENT_SKILL_PARITY.md`, `docs/work/2026-05-23-harness-capability-parity/*`, `test/docs-consistency.test.js`
+OWNS: `docs/reference/AGENT_SKILL_PARITY.md`, `docs/work/2026-05-23-harness-capability-parity/*`, `test/docs-consistency.test.js`
+
+What to implement: Document the end-to-end mechanism and evidence command so the docs overhaul can link to a stable section.
+
+TDD steps:
+1. Write test: assert docs mention the evidence command, contract module, renderer families, and Cursor hook known issue.
+2. Run test: confirm it fails before docs update.
+3. Implement: update docs.
+4. Run test: confirm it passes.
+5. Commit: `docs: explain harness capability parity contract`
+
+Expected output: docs explain canonical Forge source plus per-harness target renderers without implying broad renderers are implemented.
+
+## Focused Validation
+
+Run:
+
+1. `bun test test/harness-capability-matrix.test.js`
+2. `bun test test/docs-consistency.test.js test/harness-capability-matrix.test.js`
+3. `node scripts/spikes/harness-capability-matrix.js`
+4. `bun run check`

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { STAGE_IDS: WORKFLOW_STAGE_IDS } = require('./workflow/stages');
+
 const HARNESS_IDS = ['claude', 'cursor', 'codex'];
 
 const CAPABILITY_IDS = [
@@ -18,16 +20,8 @@ const CAPABILITY_IDS = [
   'extensionPacks',
 ];
 
-const STAGE_IDS = [
-  'status',
-  'plan',
-  'dev',
-  'validate',
-  'ship',
-  'review',
-  'premerge',
-  'verify',
-];
+const STAGE_IDS = [...WORKFLOW_STAGE_IDS];
+const UTILITY_SKILL_IDS = ['status'];
 
 const SOURCE_ROWS = [
   ['S1', 'Claude Code skills', 'https://code.claude.com/docs/en/skills', 'Claude Code skills use SKILL.md frontmatter descriptions for automatic invocation; commands remain compatible but skills are recommended.'],
@@ -185,6 +179,28 @@ const STAGE_SUBSKILLS = {
 };
 
 function buildSkillsFirstStageGraph() {
+  const renderTargetsForSkill = (id) => ({
+    claude: {
+      skill: `.claude/skills/${id}/SKILL.md`,
+      commandShim: {
+        path: `.claude/commands/${id}.md`,
+        pointsTo: `.claude/skills/${id}/SKILL.md`,
+        shimOnly: true,
+      },
+    },
+    cursor: {
+      skill: `.cursor/skills/${id}/SKILL.md`,
+      status: 'unproven',
+      knownIssue: 'Cursor Agent Skills are the intended stage target, but Forge does not yet have matching source evidence or live invocation proof.',
+      rulePolicy: `.cursor/rules/${id}.mdc`,
+    },
+    codex: {
+      skill: `.codex/skills/${id}/SKILL.md`,
+      installTarget: '$CODEX_HOME/skills',
+      directRepoDiscoveryTarget: `.agents/skills/${id}/SKILL.md`,
+    },
+  });
+
   return {
     schemaVersion: '1.0.0',
     kind: 'forge.skillsFirstStageGraph',
@@ -192,32 +208,24 @@ function buildSkillsFirstStageGraph() {
     stages: STAGE_IDS.map(id => ({
       id,
       canonicalSurface: 'skill',
+      workflowStage: true,
       superSkill: id,
       subskills: STAGE_SUBSKILLS[id].map(subskillId => ({
         id: subskillId,
         parent: id,
       })),
-      renderTargets: {
-        claude: {
-          skill: `.claude/skills/${id}/SKILL.md`,
-          commandShim: {
-            path: `.claude/commands/${id}.md`,
-            pointsTo: `.claude/skills/${id}/SKILL.md`,
-            shimOnly: true,
-          },
-        },
-        cursor: {
-          skill: `.cursor/skills/${id}/SKILL.md`,
-          status: 'unproven',
-          knownIssue: 'Cursor Agent Skills are the intended stage target, but Forge does not yet have matching source evidence or live invocation proof.',
-          rulePolicy: `.cursor/rules/${id}.mdc`,
-        },
-        codex: {
-          skill: `.codex/skills/${id}/SKILL.md`,
-          installTarget: '$CODEX_HOME/skills',
-          directRepoDiscoveryTarget: `.agents/skills/${id}/SKILL.md`,
-        },
-      },
+      renderTargets: renderTargetsForSkill(id),
+    })),
+    utilitySkills: UTILITY_SKILL_IDS.map(id => ({
+      id,
+      canonicalSurface: 'skill',
+      workflowStage: false,
+      superSkill: id,
+      subskills: STAGE_SUBSKILLS[id].map(subskillId => ({
+        id: subskillId,
+        parent: id,
+      })),
+      renderTargets: renderTargetsForSkill(id),
     })),
   };
 }
@@ -289,6 +297,7 @@ module.exports = {
   HARNESS_IDS,
   SOURCES,
   STAGE_IDS,
+  UTILITY_SKILL_IDS,
   buildHarnessCapabilityEvidence,
   getHarnessCapabilityMatrix,
   getRendererContract,

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -31,10 +31,10 @@ const STAGE_IDS = [
 
 const SOURCE_ROWS = [
   ['S1', 'Claude Code skills', 'https://code.claude.com/docs/en/skills', 'Claude Code skills use SKILL.md frontmatter descriptions for automatic invocation; commands remain compatible but skills are recommended.'],
-  ['S2', 'Claude Agent SDK skills', 'https://code.claude.com/docs/en/agent-sdk/skills', 'Claude SDK loads project/user/plugin skills and invokes them based on description metadata.'],
+  ['S2', 'Claude Agent SDK skills', 'https://code.claude.com/docs/en/agent-sdk/skills.md', 'Claude SDK loads project/user/plugin skills and invokes them based on description metadata.'],
   ['S3', 'Cursor rules', 'https://docs.cursor.com/en/context', 'Cursor project rules live in .cursor/rules as .mdc files with description, globs, and alwaysApply metadata.'],
   ['S4', 'Cursor MCP', 'https://docs.cursor.com/context/model-context-protocol', 'Cursor connects external tools and data sources through MCP using stdio, SSE, and streamable HTTP transports.'],
-  ['S5', 'Codex skills', 'https://developers.openai.com/codex/skills', 'Codex skills package instructions, resources, and scripts; implicit invocation is based on the skill description.'],
+  ['S5', 'Codex skills', 'https://developers.openai.com/codex/skills', 'Codex skills package instructions, resources, and scripts; repo-scoped skills live under .agents/skills and implicit invocation is based on the skill description.'],
   ['S6', 'Codex MCP', 'https://developers.openai.com/codex/mcp', 'Codex configures MCP servers in config.toml and supports plugin-provided MCP servers.'],
   ['S7', 'Codex hooks', 'https://developers.openai.com/codex/hooks', 'Codex hooks run deterministic scripts during lifecycle events.'],
   ['S8', 'Codex plugins and marketplaces', 'https://developers.openai.com/codex/plugins/build', 'Codex plugins can package skills, apps, MCP servers, hooks, and marketplace metadata.'],
@@ -91,8 +91,8 @@ const CAPABILITY_ROWS = [
   ]),
   row('skills', 'skills', 'on-demand workflow', [
     ['claude', target('native', '.claude/skills/<skill>/SKILL.md', { activation: 'description match or /skill-name', evidence: ['S1', 'S2'] })],
-    ['cursor', target('native', '.cursor/skills/<skill>/SKILL.md', { activation: 'description match or explicit skill invocation', evidence: ['S3'] })],
-    ['codex', target('native', '.codex/skills/<skill>/SKILL.md', { activation: 'description match or explicit $skill mention', evidence: ['S5'] })],
+    ['cursor', target('unproven', '.cursor/skills/<skill>/SKILL.md', { activation: 'description match or explicit skill invocation', knownIssue: 'Cursor Agent Skills are the intended on-demand workflow target, but Forge does not yet have matching source evidence or live invocation proof.' })],
+    ['codex', target('native', '.agents/skills/<skill>/SKILL.md', { activation: 'description match or explicit $skill mention', evidence: ['S5'] })],
   ]),
   row('rules', 'rules', null, [
     ['claude', target('shim', 'CLAUDE.md', { role: 'always-on policy projection', evidence: ['S1'] })],
@@ -112,17 +112,17 @@ const CAPABILITY_ROWS = [
   row('commands', 'commands', null, [
     ['claude', target('shim', '.claude/commands/<stage>.md', { role: 'compatibility shim', activation: 'explicit slash command forwarding to stage skill', evidence: ['S1'] })],
     ['cursor', target('compatibility', '.cursor/commands/<stage>.md', { role: 'optional explicit command affordance', evidence: ['S3'] })],
-    ['codex', target('fallback', '.codex/skills/<stage>/SKILL.md', { role: 'skill fallback instead of command authority', activation: 'explicit $skill or description match', evidence: ['S5'] })],
+    ['codex', target('fallback', '.agents/skills/<stage>/SKILL.md', { role: 'skill fallback instead of command authority', activation: 'explicit $skill or description match', evidence: ['S5'] })],
   ]),
   row('agents', 'agents', 'subagent role mapping', [
     ['claude', target('native', '.claude/agents/<role>.md', { evidence: ['S1'] })],
     ['cursor', target('unproven', '.cursor/agents/<role>.md', { knownIssue: 'Cursor agent/subagent file contract is not proven in Forge tests yet.' })],
-    ['codex', target('skill-backed', '.codex/skills/<role>/SKILL.md', { role: 'subagent role fallback through skill metadata', evidence: ['S5'] })],
+    ['codex', target('skill-backed', '.agents/skills/<role>/SKILL.md', { role: 'subagent role fallback through skill metadata', evidence: ['S5'] })],
   ]),
   row('stages', 'stage-graph', 'super skill with addressable subskills', [
     ['claude', target('skill-first', '.claude/skills/<stage>/SKILL.md', { evidence: ['S1'] })],
     ['cursor', target('skill-first', '.cursor/skills/<stage>/SKILL.md', { evidence: ['S3'] })],
-    ['codex', target('skill-first', '.codex/skills/<stage>/SKILL.md', { evidence: ['S5'] })],
+    ['codex', target('skill-first', '.agents/skills/<stage>/SKILL.md', { evidence: ['S5'] })],
   ]),
   row('beads', 'state-and-memory', 'issue and audit state authority', HARNESS_IDS.map(id => [id, target('forge-owned', 'forge CLI + bd adapter')])),
   row('typedMemory', 'state-and-memory', 'typed memory projection', [
@@ -211,7 +211,7 @@ function buildSkillsFirstStageGraph() {
           rulePolicy: `.cursor/rules/${id}.mdc`,
         },
         codex: {
-          skill: `.codex/skills/${id}/SKILL.md`,
+          skill: `.agents/skills/${id}/SKILL.md`,
         },
       },
     })),
@@ -267,7 +267,7 @@ function buildHarnessCapabilityEvidence() {
   const matrix = getHarnessCapabilityMatrix();
   return {
     schemaVersion: matrix.schemaVersion,
-    kind: matrix.kind,
+    kind: 'forge.harnessCapabilityEvidence',
     scope: matrix.scope,
     harnesses: HARNESS_IDS.map(id => ({
       id,

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -95,7 +95,7 @@ const CAPABILITY_ROWS = [
   ]),
   row('mcp', 'mcp', 'tool and resource plumbing', [
     ['claude', target('native', 'Claude MCP config', { evidence: ['S1'] })],
-    ['cursor', target('native', 'mcp.json', { evidence: ['S4'] })],
+    ['cursor', target('native', '.cursor/mcp.json', { evidence: ['S4'] })],
     ['codex', target('native', '.codex/config.toml', { evidence: ['S6'] })],
   ]),
   row('hooks', 'hooks', 'lifecycle enforcement', [

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -1,0 +1,469 @@
+'use strict';
+
+const HARNESS_IDS = ['claude', 'cursor', 'codex'];
+
+const CAPABILITY_IDS = [
+  'instructions',
+  'skills',
+  'rules',
+  'mcp',
+  'hooks',
+  'commands',
+  'agents',
+  'stages',
+  'beads',
+  'typedMemory',
+  'patchOverrides',
+  'marketplaceTrust',
+  'extensionPacks',
+];
+
+const STAGE_IDS = [
+  'status',
+  'plan',
+  'dev',
+  'validate',
+  'ship',
+  'review',
+  'premerge',
+  'verify',
+];
+
+const SOURCES = [
+  {
+    label: 'S1',
+    title: 'Claude Code skills',
+    url: 'https://code.claude.com/docs/en/skills',
+    summary: 'Claude Code skills use SKILL.md frontmatter descriptions for automatic invocation; commands remain compatible but skills are recommended.',
+  },
+  {
+    label: 'S2',
+    title: 'Claude Agent SDK skills',
+    url: 'https://code.claude.com/docs/en/agent-sdk/skills',
+    summary: 'Claude SDK loads project/user/plugin skills and invokes them based on description metadata.',
+  },
+  {
+    label: 'S3',
+    title: 'Cursor rules',
+    url: 'https://docs.cursor.com/en/context',
+    summary: 'Cursor project rules live in .cursor/rules as .mdc files with description, globs, and alwaysApply metadata.',
+  },
+  {
+    label: 'S4',
+    title: 'Cursor MCP',
+    url: 'https://docs.cursor.com/context/model-context-protocol',
+    summary: 'Cursor connects external tools and data sources through MCP using stdio, SSE, and streamable HTTP transports.',
+  },
+  {
+    label: 'S5',
+    title: 'Codex skills',
+    url: 'https://developers.openai.com/codex/skills',
+    summary: 'Codex skills package instructions, resources, and scripts; implicit invocation is based on the skill description.',
+  },
+  {
+    label: 'S6',
+    title: 'Codex MCP',
+    url: 'https://developers.openai.com/codex/mcp',
+    summary: 'Codex configures MCP servers in config.toml and supports plugin-provided MCP servers.',
+  },
+  {
+    label: 'S7',
+    title: 'Codex hooks',
+    url: 'https://developers.openai.com/codex/hooks',
+    summary: 'Codex hooks run deterministic scripts during lifecycle events.',
+  },
+  {
+    label: 'S8',
+    title: 'Codex plugins and marketplaces',
+    url: 'https://developers.openai.com/codex/plugins/build',
+    summary: 'Codex plugins can package skills, apps, MCP servers, hooks, and marketplace metadata.',
+  },
+  {
+    label: 'S9',
+    title: 'AGENTS.md standard',
+    url: 'https://agents.md/',
+    summary: 'AGENTS.md provides repository instructions for coding agents.',
+  },
+];
+
+function capability(status, primarySurface, options = {}) {
+  return {
+    status,
+    primarySurface,
+    role: options.role || 'native surface',
+    activation: options.activation || 'explicit or harness-defined',
+    renderer: options.renderer || null,
+    evidence: options.evidence || [],
+    knownIssue: options.knownIssue || null,
+  };
+}
+
+function buildHarnessCapabilityMatrix() {
+  return {
+    schemaVersion: '1.0.0',
+    kind: 'forge.harnessCapabilityMatrix',
+    scope: 'v3.0-mvp',
+    harnesses: {
+      claude: {
+        id: 'claude',
+        name: 'Claude Code',
+        capabilities: {
+          instructions: capability('shim', 'CLAUDE.md', {
+            role: 'project instruction projection',
+            renderer: 'instructions',
+            evidence: ['S1', 'S9'],
+          }),
+          skills: capability('native', '.claude/skills/<skill>/SKILL.md', {
+            role: 'on-demand workflow',
+            activation: 'description match or /skill-name',
+            renderer: 'skills',
+            evidence: ['S1', 'S2'],
+          }),
+          rules: capability('shim', 'CLAUDE.md', {
+            role: 'always-on policy projection',
+            renderer: 'rules',
+            evidence: ['S1'],
+          }),
+          mcp: capability('native', 'Claude MCP config', {
+            role: 'tool and resource plumbing',
+            renderer: 'mcp',
+            evidence: ['S1'],
+          }),
+          hooks: capability('native', 'Claude settings hooks', {
+            role: 'lifecycle enforcement',
+            renderer: 'hooks',
+            evidence: ['S1'],
+          }),
+          commands: capability('shim', '.claude/commands/<stage>.md', {
+            role: 'compatibility shim',
+            activation: 'explicit slash command forwarding to stage skill',
+            renderer: 'commands',
+            evidence: ['S1'],
+          }),
+          agents: capability('native', '.claude/agents/<role>.md', {
+            role: 'subagent role mapping',
+            renderer: 'agents',
+            evidence: ['S1'],
+          }),
+          stages: capability('skill-first', '.claude/skills/<stage>/SKILL.md', {
+            role: 'super skill with addressable subskills',
+            renderer: 'stage-graph',
+            evidence: ['S1'],
+          }),
+          beads: capability('forge-owned', 'forge CLI + bd adapter', {
+            role: 'issue and audit state authority',
+            renderer: 'state-and-memory',
+          }),
+          typedMemory: capability('projection', 'CLAUDE.md plus generated memory sections', {
+            role: 'typed memory projection',
+            renderer: 'state-and-memory',
+          }),
+          patchOverrides: capability('forge-owned', '.forge/patch.md', {
+            role: 'project override source',
+            renderer: 'state-and-memory',
+          }),
+          marketplaceTrust: capability('plugin-aware', 'Claude plugin or Forge lock metadata', {
+            role: 'trusted distribution metadata',
+            renderer: 'distribution',
+            evidence: ['S1'],
+          }),
+          extensionPacks: capability('plugin-aware', 'plugin skills/commands/hooks', {
+            role: 'installable Forge extension pack',
+            renderer: 'distribution',
+            evidence: ['S1'],
+          }),
+        },
+      },
+      cursor: {
+        id: 'cursor',
+        name: 'Cursor',
+        capabilities: {
+          instructions: capability('native', 'AGENTS.md', {
+            role: 'project instruction projection',
+            renderer: 'instructions',
+            evidence: ['S3', 'S9'],
+          }),
+          skills: capability('native', '.cursor/skills/<skill>/SKILL.md', {
+            role: 'on-demand workflow',
+            activation: 'description match or explicit skill invocation',
+            renderer: 'skills',
+            evidence: ['S3'],
+          }),
+          rules: capability('native', '.cursor/rules/<rule>.mdc', {
+            role: 'always-on or scoped policy',
+            activation: 'description, globs, alwaysApply, or manual rule mention',
+            renderer: 'rules',
+            evidence: ['S3'],
+          }),
+          mcp: capability('native', 'mcp.json', {
+            role: 'tool and resource plumbing',
+            renderer: 'mcp',
+            evidence: ['S4'],
+          }),
+          hooks: capability('unsupported', null, {
+            role: 'lifecycle enforcement',
+            renderer: 'hooks',
+            knownIssue: 'No verified Cursor hook surface; use Forge CLI hooks or file-watcher fallback until Cursor hook support is proven.',
+          }),
+          commands: capability('compatibility', '.cursor/commands/<stage>.md', {
+            role: 'optional explicit command affordance',
+            renderer: 'commands',
+            evidence: ['S3'],
+          }),
+          agents: capability('unproven', '.cursor/agents/<role>.md', {
+            role: 'subagent role mapping',
+            renderer: 'agents',
+            knownIssue: 'Cursor agent/subagent file contract is not proven in Forge tests yet.',
+          }),
+          stages: capability('skill-first', '.cursor/skills/<stage>/SKILL.md', {
+            role: 'super skill with addressable subskills',
+            renderer: 'stage-graph',
+            evidence: ['S3'],
+          }),
+          beads: capability('forge-owned', 'forge CLI + bd adapter', {
+            role: 'issue and audit state authority',
+            renderer: 'state-and-memory',
+          }),
+          typedMemory: capability('projection', 'AGENTS.md and .cursor/rules memory projections', {
+            role: 'typed memory projection',
+            renderer: 'state-and-memory',
+          }),
+          patchOverrides: capability('forge-owned', '.forge/patch.md', {
+            role: 'project override source',
+            renderer: 'state-and-memory',
+          }),
+          marketplaceTrust: capability('forge-owned', 'extension lock metadata', {
+            role: 'trusted distribution metadata',
+            renderer: 'distribution',
+          }),
+          extensionPacks: capability('generated', '.cursor/skills + .cursor/rules + mcp.json', {
+            role: 'installable Forge extension pack projection',
+            renderer: 'distribution',
+          }),
+        },
+      },
+      codex: {
+        id: 'codex',
+        name: 'OpenAI Codex',
+        capabilities: {
+          instructions: capability('native', 'AGENTS.md', {
+            role: 'project instruction projection',
+            renderer: 'instructions',
+            evidence: ['S9'],
+          }),
+          skills: capability('native', '.codex/skills/<skill>/SKILL.md', {
+            role: 'on-demand workflow',
+            activation: 'description match or explicit $skill mention',
+            renderer: 'skills',
+            evidence: ['S5'],
+          }),
+          rules: capability('projection', 'AGENTS.md', {
+            role: 'always-on policy projection',
+            renderer: 'rules',
+            evidence: ['S9'],
+          }),
+          mcp: capability('native', '.codex/config.toml', {
+            role: 'tool and resource plumbing',
+            renderer: 'mcp',
+            evidence: ['S6'],
+          }),
+          hooks: capability('native', 'Codex hooks config', {
+            role: 'lifecycle enforcement',
+            renderer: 'hooks',
+            evidence: ['S7'],
+          }),
+          commands: capability('fallback', '.codex/skills/<stage>/SKILL.md', {
+            role: 'skill fallback instead of command authority',
+            activation: 'explicit $skill or description match',
+            renderer: 'commands',
+            evidence: ['S5'],
+          }),
+          agents: capability('skill-backed', '.codex/skills/<role>/SKILL.md', {
+            role: 'subagent role fallback through skill metadata',
+            renderer: 'agents',
+            evidence: ['S5'],
+          }),
+          stages: capability('skill-first', '.codex/skills/<stage>/SKILL.md', {
+            role: 'super skill with addressable subskills',
+            renderer: 'stage-graph',
+            evidence: ['S5'],
+          }),
+          beads: capability('forge-owned', 'forge CLI + bd adapter', {
+            role: 'issue and audit state authority',
+            renderer: 'state-and-memory',
+          }),
+          typedMemory: capability('projection', 'AGENTS.md plus Codex skill references', {
+            role: 'typed memory projection',
+            renderer: 'state-and-memory',
+          }),
+          patchOverrides: capability('forge-owned', '.forge/patch.md', {
+            role: 'project override source',
+            renderer: 'state-and-memory',
+          }),
+          marketplaceTrust: capability('native', '.agents/plugins/marketplace.json plus plugin lock metadata', {
+            role: 'trusted distribution metadata',
+            renderer: 'distribution',
+            evidence: ['S8'],
+          }),
+          extensionPacks: capability('native', 'Codex plugin with skills, MCP servers, hooks, and apps', {
+            role: 'installable Forge extension pack',
+            renderer: 'distribution',
+            evidence: ['S8'],
+          }),
+        },
+      },
+    },
+  };
+}
+
+const STAGE_SUBSKILLS = {
+  status: ['status.context_scan', 'status.issue_scan', 'status.git_scan'],
+  plan: ['plan.intent_capture', 'plan.parallel_research', 'plan.parallel_critics', 'plan.synthesis', 'plan.final_lock'],
+  dev: ['dev.red', 'dev.green', 'dev.refactor', 'dev.spec_review', 'dev.quality_review'],
+  validate: ['validate.typecheck', 'validate.lint', 'validate.tests', 'validate.security', 'validate.context'],
+  ship: ['ship.freshness', 'ship.push', 'ship.pr_body', 'ship.pr_create'],
+  review: ['review.collect_feedback', 'review.classify', 'review.fix', 'review.resolve_threads'],
+  premerge: ['premerge.docs', 'premerge.ci', 'premerge.handoff'],
+  verify: ['verify.merge_state', 'verify.default_branch_ci', 'verify.cleanup', 'verify.issue_close'],
+};
+
+function buildSkillsFirstStageGraph() {
+  return {
+    schemaVersion: '1.0.0',
+    kind: 'forge.skillsFirstStageGraph',
+    rule: 'Stages are canonical super skills; commands are compatibility shims only.',
+    stages: STAGE_IDS.map(id => ({
+      id,
+      canonicalSurface: 'skill',
+      superSkill: id,
+      subskills: STAGE_SUBSKILLS[id].map(subskillId => ({
+        id: subskillId,
+        parent: id,
+      })),
+      renderTargets: {
+        claude: {
+          skill: `.claude/skills/${id}/SKILL.md`,
+          commandShim: {
+            path: `.claude/commands/${id}.md`,
+            pointsTo: `.claude/skills/${id}/SKILL.md`,
+            shimOnly: true,
+          },
+        },
+        cursor: {
+          skill: `.cursor/skills/${id}/SKILL.md`,
+          rulePolicy: `.cursor/rules/${id}.mdc`,
+        },
+        codex: {
+          skill: `.codex/skills/${id}/SKILL.md`,
+        },
+      },
+    })),
+  };
+}
+
+function buildRendererContract() {
+  return {
+    schemaVersion: '1.0.0',
+    kind: 'forge.harnessRendererContract',
+    scope: 'contract-only',
+    beforeAddingRenderer: [
+      'capability-matrix-entry',
+      'target-path-contract',
+      'activation-metadata-contract',
+      'machine-readable-evidence',
+      'known-issue-if-unproven',
+    ],
+    rendererFamilies: [
+      {
+        id: 'instructions',
+        canonicalInput: 'Forge typed instruction sections',
+        requiredEvidence: ['semantic section comparison', 'target path exists'],
+      },
+      {
+        id: 'skills',
+        canonicalInput: 'agentskills.io-compatible SKILL.md',
+        requiredEvidence: ['frontmatter name/description', 'description-match fixture'],
+      },
+      {
+        id: 'rules',
+        canonicalInput: 'Forge rule manifest',
+        requiredEvidence: ['policy scope', 'activation metadata', 'unsupported target note'],
+      },
+      {
+        id: 'mcp',
+        canonicalInput: 'Forge MCP manifest',
+        requiredEvidence: ['config render', 'server probe or known issue'],
+      },
+      {
+        id: 'hooks',
+        canonicalInput: 'Forge hook manifest',
+        requiredEvidence: ['lifecycle event mapping', 'deny/allow behavior proof'],
+      },
+      {
+        id: 'commands',
+        canonicalInput: 'Forge command shim manifest',
+        requiredEvidence: ['shim points to canonical skill', 'no duplicated stage body'],
+      },
+      {
+        id: 'agents',
+        canonicalInput: 'Forge agent role spec',
+        requiredEvidence: ['role mapping', 'parallelism or fallback policy'],
+      },
+      {
+        id: 'stage-graph',
+        canonicalInput: 'Forge skills-first stage graph',
+        requiredEvidence: ['super skill target', 'subskill target list', 'gate mapping'],
+      },
+      {
+        id: 'state-and-memory',
+        canonicalInput: 'Beads, typed memory, and patch override manifests',
+        requiredEvidence: ['state authority', 'projection provenance', 'protected path policy'],
+      },
+      {
+        id: 'distribution',
+        canonicalInput: 'Forge extension manifest and lock metadata',
+        requiredEvidence: ['lock hash', 'trusted source', 'generated target inventory'],
+      },
+    ],
+  };
+}
+
+function getHarnessCapabilityMatrix() {
+  return buildHarnessCapabilityMatrix();
+}
+
+function getSkillsFirstStageGraph() {
+  return buildSkillsFirstStageGraph();
+}
+
+function getRendererContract() {
+  return buildRendererContract();
+}
+
+function buildHarnessCapabilityEvidence() {
+  const matrix = getHarnessCapabilityMatrix();
+  return {
+    schemaVersion: matrix.schemaVersion,
+    kind: matrix.kind,
+    scope: matrix.scope,
+    harnesses: HARNESS_IDS.map(id => ({
+      id,
+      name: matrix.harnesses[id].name,
+      capabilities: matrix.harnesses[id].capabilities,
+    })),
+    stageGraph: getSkillsFirstStageGraph(),
+    rendererContract: getRendererContract(),
+    sources: SOURCES,
+  };
+}
+
+module.exports = {
+  CAPABILITY_IDS,
+  HARNESS_IDS,
+  SOURCES,
+  STAGE_IDS,
+  buildHarnessCapabilityEvidence,
+  getHarnessCapabilityMatrix,
+  getRendererContract,
+  getSkillsFirstStageGraph,
+};

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -98,221 +98,165 @@ function capability(status, primarySurface, options = {}) {
   };
 }
 
+const HARNESS_NAMES = {
+  claude: 'Claude Code',
+  cursor: 'Cursor',
+  codex: 'OpenAI Codex',
+};
+
+const CAPABILITY_ROWS = [
+  {
+    id: 'instructions',
+    renderer: 'instructions',
+    role: 'project instruction projection',
+    harnesses: {
+      claude: { status: 'shim', surface: 'CLAUDE.md', evidence: ['S1', 'S9'] },
+      cursor: { status: 'native', surface: 'AGENTS.md', evidence: ['S3', 'S9'] },
+      codex: { status: 'native', surface: 'AGENTS.md', evidence: ['S9'] },
+    },
+  },
+  {
+    id: 'skills',
+    renderer: 'skills',
+    role: 'on-demand workflow',
+    harnesses: {
+      claude: { status: 'native', surface: '.claude/skills/<skill>/SKILL.md', activation: 'description match or /skill-name', evidence: ['S1', 'S2'] },
+      cursor: { status: 'native', surface: '.cursor/skills/<skill>/SKILL.md', activation: 'description match or explicit skill invocation', evidence: ['S3'] },
+      codex: { status: 'native', surface: '.codex/skills/<skill>/SKILL.md', activation: 'description match or explicit $skill mention', evidence: ['S5'] },
+    },
+  },
+  {
+    id: 'rules',
+    renderer: 'rules',
+    harnesses: {
+      claude: { status: 'shim', surface: 'CLAUDE.md', role: 'always-on policy projection', evidence: ['S1'] },
+      cursor: { status: 'native', surface: '.cursor/rules/<rule>.mdc', role: 'always-on or scoped policy', activation: 'description, globs, alwaysApply, or manual rule mention', evidence: ['S3'] },
+      codex: { status: 'projection', surface: 'AGENTS.md', role: 'always-on policy projection', evidence: ['S9'] },
+    },
+  },
+  {
+    id: 'mcp',
+    renderer: 'mcp',
+    role: 'tool and resource plumbing',
+    harnesses: {
+      claude: { status: 'native', surface: 'Claude MCP config', evidence: ['S1'] },
+      cursor: { status: 'native', surface: 'mcp.json', evidence: ['S4'] },
+      codex: { status: 'native', surface: '.codex/config.toml', evidence: ['S6'] },
+    },
+  },
+  {
+    id: 'hooks',
+    renderer: 'hooks',
+    role: 'lifecycle enforcement',
+    harnesses: {
+      claude: { status: 'native', surface: 'Claude settings hooks', evidence: ['S1'] },
+      cursor: {
+        status: 'unsupported',
+        surface: null,
+        knownIssue: 'No verified Cursor hook surface; use Forge CLI hooks or file-watcher fallback until Cursor hook support is proven.',
+      },
+      codex: { status: 'native', surface: 'Codex hooks config', evidence: ['S7'] },
+    },
+  },
+  {
+    id: 'commands',
+    renderer: 'commands',
+    harnesses: {
+      claude: { status: 'shim', surface: '.claude/commands/<stage>.md', role: 'compatibility shim', activation: 'explicit slash command forwarding to stage skill', evidence: ['S1'] },
+      cursor: { status: 'compatibility', surface: '.cursor/commands/<stage>.md', role: 'optional explicit command affordance', evidence: ['S3'] },
+      codex: { status: 'fallback', surface: '.codex/skills/<stage>/SKILL.md', role: 'skill fallback instead of command authority', activation: 'explicit $skill or description match', evidence: ['S5'] },
+    },
+  },
+  {
+    id: 'agents',
+    renderer: 'agents',
+    role: 'subagent role mapping',
+    harnesses: {
+      claude: { status: 'native', surface: '.claude/agents/<role>.md', evidence: ['S1'] },
+      cursor: { status: 'unproven', surface: '.cursor/agents/<role>.md', knownIssue: 'Cursor agent/subagent file contract is not proven in Forge tests yet.' },
+      codex: { status: 'skill-backed', surface: '.codex/skills/<role>/SKILL.md', role: 'subagent role fallback through skill metadata', evidence: ['S5'] },
+    },
+  },
+  {
+    id: 'stages',
+    renderer: 'stage-graph',
+    role: 'super skill with addressable subskills',
+    harnesses: {
+      claude: { status: 'skill-first', surface: '.claude/skills/<stage>/SKILL.md', evidence: ['S1'] },
+      cursor: { status: 'skill-first', surface: '.cursor/skills/<stage>/SKILL.md', evidence: ['S3'] },
+      codex: { status: 'skill-first', surface: '.codex/skills/<stage>/SKILL.md', evidence: ['S5'] },
+    },
+  },
+  {
+    id: 'beads',
+    renderer: 'state-and-memory',
+    role: 'issue and audit state authority',
+    harnesses: Object.fromEntries(HARNESS_IDS.map(id => [id, { status: 'forge-owned', surface: 'forge CLI + bd adapter' }])),
+  },
+  {
+    id: 'typedMemory',
+    renderer: 'state-and-memory',
+    role: 'typed memory projection',
+    harnesses: {
+      claude: { status: 'projection', surface: 'CLAUDE.md plus generated memory sections' },
+      cursor: { status: 'projection', surface: 'AGENTS.md and .cursor/rules memory projections' },
+      codex: { status: 'projection', surface: 'AGENTS.md plus Codex skill references' },
+    },
+  },
+  {
+    id: 'patchOverrides',
+    renderer: 'state-and-memory',
+    role: 'project override source',
+    harnesses: Object.fromEntries(HARNESS_IDS.map(id => [id, { status: 'forge-owned', surface: '.forge/patch.md' }])),
+  },
+  {
+    id: 'marketplaceTrust',
+    renderer: 'distribution',
+    role: 'trusted distribution metadata',
+    harnesses: {
+      claude: { status: 'plugin-aware', surface: 'Claude plugin or Forge lock metadata', evidence: ['S1'] },
+      cursor: { status: 'forge-owned', surface: 'extension lock metadata' },
+      codex: { status: 'native', surface: '.agents/plugins/marketplace.json plus plugin lock metadata', evidence: ['S8'] },
+    },
+  },
+  {
+    id: 'extensionPacks',
+    renderer: 'distribution',
+    harnesses: {
+      claude: { status: 'plugin-aware', surface: 'plugin skills/commands/hooks', role: 'installable Forge extension pack', evidence: ['S1'] },
+      cursor: { status: 'generated', surface: '.cursor/skills + .cursor/rules + mcp.json', role: 'installable Forge extension pack projection' },
+      codex: { status: 'native', surface: 'Codex plugin with skills, MCP servers, hooks, and apps', role: 'installable Forge extension pack', evidence: ['S8'] },
+    },
+  },
+];
+
+function rowCapability(row, harnessId) {
+  const target = row.harnesses[harnessId];
+  return capability(target.status, target.surface, {
+    role: target.role || row.role,
+    activation: target.activation || row.activation,
+    renderer: row.renderer,
+    evidence: target.evidence,
+    knownIssue: target.knownIssue,
+  });
+}
+
+function buildHarnessCapabilities(harnessId) {
+  return Object.fromEntries(
+    CAPABILITY_ROWS.map(row => [row.id, rowCapability(row, harnessId)]),
+  );
+}
+
 function buildHarnessCapabilityMatrix() {
   return {
     schemaVersion: '1.0.0',
     kind: 'forge.harnessCapabilityMatrix',
     scope: 'v3.0-mvp',
-    harnesses: {
-      claude: {
-        id: 'claude',
-        name: 'Claude Code',
-        capabilities: {
-          instructions: capability('shim', 'CLAUDE.md', {
-            role: 'project instruction projection',
-            renderer: 'instructions',
-            evidence: ['S1', 'S9'],
-          }),
-          skills: capability('native', '.claude/skills/<skill>/SKILL.md', {
-            role: 'on-demand workflow',
-            activation: 'description match or /skill-name',
-            renderer: 'skills',
-            evidence: ['S1', 'S2'],
-          }),
-          rules: capability('shim', 'CLAUDE.md', {
-            role: 'always-on policy projection',
-            renderer: 'rules',
-            evidence: ['S1'],
-          }),
-          mcp: capability('native', 'Claude MCP config', {
-            role: 'tool and resource plumbing',
-            renderer: 'mcp',
-            evidence: ['S1'],
-          }),
-          hooks: capability('native', 'Claude settings hooks', {
-            role: 'lifecycle enforcement',
-            renderer: 'hooks',
-            evidence: ['S1'],
-          }),
-          commands: capability('shim', '.claude/commands/<stage>.md', {
-            role: 'compatibility shim',
-            activation: 'explicit slash command forwarding to stage skill',
-            renderer: 'commands',
-            evidence: ['S1'],
-          }),
-          agents: capability('native', '.claude/agents/<role>.md', {
-            role: 'subagent role mapping',
-            renderer: 'agents',
-            evidence: ['S1'],
-          }),
-          stages: capability('skill-first', '.claude/skills/<stage>/SKILL.md', {
-            role: 'super skill with addressable subskills',
-            renderer: 'stage-graph',
-            evidence: ['S1'],
-          }),
-          beads: capability('forge-owned', 'forge CLI + bd adapter', {
-            role: 'issue and audit state authority',
-            renderer: 'state-and-memory',
-          }),
-          typedMemory: capability('projection', 'CLAUDE.md plus generated memory sections', {
-            role: 'typed memory projection',
-            renderer: 'state-and-memory',
-          }),
-          patchOverrides: capability('forge-owned', '.forge/patch.md', {
-            role: 'project override source',
-            renderer: 'state-and-memory',
-          }),
-          marketplaceTrust: capability('plugin-aware', 'Claude plugin or Forge lock metadata', {
-            role: 'trusted distribution metadata',
-            renderer: 'distribution',
-            evidence: ['S1'],
-          }),
-          extensionPacks: capability('plugin-aware', 'plugin skills/commands/hooks', {
-            role: 'installable Forge extension pack',
-            renderer: 'distribution',
-            evidence: ['S1'],
-          }),
-        },
-      },
-      cursor: {
-        id: 'cursor',
-        name: 'Cursor',
-        capabilities: {
-          instructions: capability('native', 'AGENTS.md', {
-            role: 'project instruction projection',
-            renderer: 'instructions',
-            evidence: ['S3', 'S9'],
-          }),
-          skills: capability('native', '.cursor/skills/<skill>/SKILL.md', {
-            role: 'on-demand workflow',
-            activation: 'description match or explicit skill invocation',
-            renderer: 'skills',
-            evidence: ['S3'],
-          }),
-          rules: capability('native', '.cursor/rules/<rule>.mdc', {
-            role: 'always-on or scoped policy',
-            activation: 'description, globs, alwaysApply, or manual rule mention',
-            renderer: 'rules',
-            evidence: ['S3'],
-          }),
-          mcp: capability('native', 'mcp.json', {
-            role: 'tool and resource plumbing',
-            renderer: 'mcp',
-            evidence: ['S4'],
-          }),
-          hooks: capability('unsupported', null, {
-            role: 'lifecycle enforcement',
-            renderer: 'hooks',
-            knownIssue: 'No verified Cursor hook surface; use Forge CLI hooks or file-watcher fallback until Cursor hook support is proven.',
-          }),
-          commands: capability('compatibility', '.cursor/commands/<stage>.md', {
-            role: 'optional explicit command affordance',
-            renderer: 'commands',
-            evidence: ['S3'],
-          }),
-          agents: capability('unproven', '.cursor/agents/<role>.md', {
-            role: 'subagent role mapping',
-            renderer: 'agents',
-            knownIssue: 'Cursor agent/subagent file contract is not proven in Forge tests yet.',
-          }),
-          stages: capability('skill-first', '.cursor/skills/<stage>/SKILL.md', {
-            role: 'super skill with addressable subskills',
-            renderer: 'stage-graph',
-            evidence: ['S3'],
-          }),
-          beads: capability('forge-owned', 'forge CLI + bd adapter', {
-            role: 'issue and audit state authority',
-            renderer: 'state-and-memory',
-          }),
-          typedMemory: capability('projection', 'AGENTS.md and .cursor/rules memory projections', {
-            role: 'typed memory projection',
-            renderer: 'state-and-memory',
-          }),
-          patchOverrides: capability('forge-owned', '.forge/patch.md', {
-            role: 'project override source',
-            renderer: 'state-and-memory',
-          }),
-          marketplaceTrust: capability('forge-owned', 'extension lock metadata', {
-            role: 'trusted distribution metadata',
-            renderer: 'distribution',
-          }),
-          extensionPacks: capability('generated', '.cursor/skills + .cursor/rules + mcp.json', {
-            role: 'installable Forge extension pack projection',
-            renderer: 'distribution',
-          }),
-        },
-      },
-      codex: {
-        id: 'codex',
-        name: 'OpenAI Codex',
-        capabilities: {
-          instructions: capability('native', 'AGENTS.md', {
-            role: 'project instruction projection',
-            renderer: 'instructions',
-            evidence: ['S9'],
-          }),
-          skills: capability('native', '.codex/skills/<skill>/SKILL.md', {
-            role: 'on-demand workflow',
-            activation: 'description match or explicit $skill mention',
-            renderer: 'skills',
-            evidence: ['S5'],
-          }),
-          rules: capability('projection', 'AGENTS.md', {
-            role: 'always-on policy projection',
-            renderer: 'rules',
-            evidence: ['S9'],
-          }),
-          mcp: capability('native', '.codex/config.toml', {
-            role: 'tool and resource plumbing',
-            renderer: 'mcp',
-            evidence: ['S6'],
-          }),
-          hooks: capability('native', 'Codex hooks config', {
-            role: 'lifecycle enforcement',
-            renderer: 'hooks',
-            evidence: ['S7'],
-          }),
-          commands: capability('fallback', '.codex/skills/<stage>/SKILL.md', {
-            role: 'skill fallback instead of command authority',
-            activation: 'explicit $skill or description match',
-            renderer: 'commands',
-            evidence: ['S5'],
-          }),
-          agents: capability('skill-backed', '.codex/skills/<role>/SKILL.md', {
-            role: 'subagent role fallback through skill metadata',
-            renderer: 'agents',
-            evidence: ['S5'],
-          }),
-          stages: capability('skill-first', '.codex/skills/<stage>/SKILL.md', {
-            role: 'super skill with addressable subskills',
-            renderer: 'stage-graph',
-            evidence: ['S5'],
-          }),
-          beads: capability('forge-owned', 'forge CLI + bd adapter', {
-            role: 'issue and audit state authority',
-            renderer: 'state-and-memory',
-          }),
-          typedMemory: capability('projection', 'AGENTS.md plus Codex skill references', {
-            role: 'typed memory projection',
-            renderer: 'state-and-memory',
-          }),
-          patchOverrides: capability('forge-owned', '.forge/patch.md', {
-            role: 'project override source',
-            renderer: 'state-and-memory',
-          }),
-          marketplaceTrust: capability('native', '.agents/plugins/marketplace.json plus plugin lock metadata', {
-            role: 'trusted distribution metadata',
-            renderer: 'distribution',
-            evidence: ['S8'],
-          }),
-          extensionPacks: capability('native', 'Codex plugin with skills, MCP servers, hooks, and apps', {
-            role: 'installable Forge extension pack',
-            renderer: 'distribution',
-            evidence: ['S8'],
-          }),
-        },
-      },
-    },
+    harnesses: Object.fromEntries(HARNESS_IDS.map(id => [id, {
+      id,
+      name: HARNESS_NAMES[id],
+      capabilities: buildHarnessCapabilities(id),
+    }])),
   };
 }
 
@@ -361,6 +305,19 @@ function buildSkillsFirstStageGraph() {
   };
 }
 
+const RENDERER_FAMILIES = [
+  ['instructions', 'Forge typed instruction sections', ['semantic section comparison', 'target path exists']],
+  ['skills', 'agentskills.io-compatible SKILL.md', ['frontmatter name/description', 'description-match fixture']],
+  ['rules', 'Forge rule manifest', ['policy scope', 'activation metadata', 'unsupported target note']],
+  ['mcp', 'Forge MCP manifest', ['config render', 'server probe or known issue']],
+  ['hooks', 'Forge hook manifest', ['lifecycle event mapping', 'deny/allow behavior proof']],
+  ['commands', 'Forge command shim manifest', ['shim points to canonical skill', 'no duplicated stage body']],
+  ['agents', 'Forge agent role spec', ['role mapping', 'parallelism or fallback policy']],
+  ['stage-graph', 'Forge skills-first stage graph', ['super skill target', 'subskill target list', 'gate mapping']],
+  ['state-and-memory', 'Beads, typed memory, and patch override manifests', ['state authority', 'projection provenance', 'protected path policy']],
+  ['distribution', 'Forge extension manifest and lock metadata', ['lock hash', 'trusted source', 'generated target inventory']],
+];
+
 function buildRendererContract() {
   return {
     schemaVersion: '1.0.0',
@@ -373,58 +330,11 @@ function buildRendererContract() {
       'machine-readable-evidence',
       'known-issue-if-unproven',
     ],
-    rendererFamilies: [
-      {
-        id: 'instructions',
-        canonicalInput: 'Forge typed instruction sections',
-        requiredEvidence: ['semantic section comparison', 'target path exists'],
-      },
-      {
-        id: 'skills',
-        canonicalInput: 'agentskills.io-compatible SKILL.md',
-        requiredEvidence: ['frontmatter name/description', 'description-match fixture'],
-      },
-      {
-        id: 'rules',
-        canonicalInput: 'Forge rule manifest',
-        requiredEvidence: ['policy scope', 'activation metadata', 'unsupported target note'],
-      },
-      {
-        id: 'mcp',
-        canonicalInput: 'Forge MCP manifest',
-        requiredEvidence: ['config render', 'server probe or known issue'],
-      },
-      {
-        id: 'hooks',
-        canonicalInput: 'Forge hook manifest',
-        requiredEvidence: ['lifecycle event mapping', 'deny/allow behavior proof'],
-      },
-      {
-        id: 'commands',
-        canonicalInput: 'Forge command shim manifest',
-        requiredEvidence: ['shim points to canonical skill', 'no duplicated stage body'],
-      },
-      {
-        id: 'agents',
-        canonicalInput: 'Forge agent role spec',
-        requiredEvidence: ['role mapping', 'parallelism or fallback policy'],
-      },
-      {
-        id: 'stage-graph',
-        canonicalInput: 'Forge skills-first stage graph',
-        requiredEvidence: ['super skill target', 'subskill target list', 'gate mapping'],
-      },
-      {
-        id: 'state-and-memory',
-        canonicalInput: 'Beads, typed memory, and patch override manifests',
-        requiredEvidence: ['state authority', 'projection provenance', 'protected path policy'],
-      },
-      {
-        id: 'distribution',
-        canonicalInput: 'Forge extension manifest and lock metadata',
-        requiredEvidence: ['lock hash', 'trusted source', 'generated target inventory'],
-      },
-    ],
+    rendererFamilies: RENDERER_FAMILIES.map(([id, canonicalInput, requiredEvidence]) => ({
+      id,
+      canonicalInput,
+      requiredEvidence,
+    })),
   };
 }
 

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -132,7 +132,7 @@ const CAPABILITY_ROWS = [
   ]),
   row('extensionPacks', 'distribution', null, [
     ['claude', target('plugin-aware', 'plugin skills/commands/hooks', { role: 'installable Forge extension pack', evidence: ['S1'] })],
-    ['cursor', target('generated', '.cursor/skills + .cursor/rules + mcp.json', { role: 'installable Forge extension pack projection' })],
+    ['cursor', target('generated', '.cursor/skills + .cursor/rules + .cursor/mcp.json', { role: 'installable Forge extension pack projection' })],
     ['codex', target('native', 'Codex plugin with skills, MCP servers, hooks, and apps', { role: 'installable Forge extension pack', evidence: ['S8'] })],
   ]),
 ];

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -29,62 +29,24 @@ const STAGE_IDS = [
   'verify',
 ];
 
-const SOURCES = [
-  {
-    label: 'S1',
-    title: 'Claude Code skills',
-    url: 'https://code.claude.com/docs/en/skills',
-    summary: 'Claude Code skills use SKILL.md frontmatter descriptions for automatic invocation; commands remain compatible but skills are recommended.',
-  },
-  {
-    label: 'S2',
-    title: 'Claude Agent SDK skills',
-    url: 'https://code.claude.com/docs/en/agent-sdk/skills',
-    summary: 'Claude SDK loads project/user/plugin skills and invokes them based on description metadata.',
-  },
-  {
-    label: 'S3',
-    title: 'Cursor rules',
-    url: 'https://docs.cursor.com/en/context',
-    summary: 'Cursor project rules live in .cursor/rules as .mdc files with description, globs, and alwaysApply metadata.',
-  },
-  {
-    label: 'S4',
-    title: 'Cursor MCP',
-    url: 'https://docs.cursor.com/context/model-context-protocol',
-    summary: 'Cursor connects external tools and data sources through MCP using stdio, SSE, and streamable HTTP transports.',
-  },
-  {
-    label: 'S5',
-    title: 'Codex skills',
-    url: 'https://developers.openai.com/codex/skills',
-    summary: 'Codex skills package instructions, resources, and scripts; implicit invocation is based on the skill description.',
-  },
-  {
-    label: 'S6',
-    title: 'Codex MCP',
-    url: 'https://developers.openai.com/codex/mcp',
-    summary: 'Codex configures MCP servers in config.toml and supports plugin-provided MCP servers.',
-  },
-  {
-    label: 'S7',
-    title: 'Codex hooks',
-    url: 'https://developers.openai.com/codex/hooks',
-    summary: 'Codex hooks run deterministic scripts during lifecycle events.',
-  },
-  {
-    label: 'S8',
-    title: 'Codex plugins and marketplaces',
-    url: 'https://developers.openai.com/codex/plugins/build',
-    summary: 'Codex plugins can package skills, apps, MCP servers, hooks, and marketplace metadata.',
-  },
-  {
-    label: 'S9',
-    title: 'AGENTS.md standard',
-    url: 'https://agents.md/',
-    summary: 'AGENTS.md provides repository instructions for coding agents.',
-  },
+const SOURCE_ROWS = [
+  ['S1', 'Claude Code skills', 'https://code.claude.com/docs/en/skills', 'Claude Code skills use SKILL.md frontmatter descriptions for automatic invocation; commands remain compatible but skills are recommended.'],
+  ['S2', 'Claude Agent SDK skills', 'https://code.claude.com/docs/en/agent-sdk/skills', 'Claude SDK loads project/user/plugin skills and invokes them based on description metadata.'],
+  ['S3', 'Cursor rules', 'https://docs.cursor.com/en/context', 'Cursor project rules live in .cursor/rules as .mdc files with description, globs, and alwaysApply metadata.'],
+  ['S4', 'Cursor MCP', 'https://docs.cursor.com/context/model-context-protocol', 'Cursor connects external tools and data sources through MCP using stdio, SSE, and streamable HTTP transports.'],
+  ['S5', 'Codex skills', 'https://developers.openai.com/codex/skills', 'Codex skills package instructions, resources, and scripts; implicit invocation is based on the skill description.'],
+  ['S6', 'Codex MCP', 'https://developers.openai.com/codex/mcp', 'Codex configures MCP servers in config.toml and supports plugin-provided MCP servers.'],
+  ['S7', 'Codex hooks', 'https://developers.openai.com/codex/hooks', 'Codex hooks run deterministic scripts during lifecycle events.'],
+  ['S8', 'Codex plugins and marketplaces', 'https://developers.openai.com/codex/plugins/build', 'Codex plugins can package skills, apps, MCP servers, hooks, and marketplace metadata.'],
+  ['S9', 'AGENTS.md standard', 'https://agents.md/', 'AGENTS.md provides repository instructions for coding agents.'],
 ];
+
+const SOURCES = SOURCE_ROWS.map(([label, title, url, summary]) => ({
+  label,
+  title,
+  url,
+  summary,
+}));
 
 function capability(status, primarySurface, options = {}) {
   return {
@@ -104,130 +66,81 @@ const HARNESS_NAMES = {
   codex: 'OpenAI Codex',
 };
 
+function harnessTargets(entries) {
+  return Object.fromEntries(entries.map(([id, target]) => [id, target]));
+}
+
+function target(status, surface, overrides = {}) {
+  return { status, surface, ...overrides };
+}
+
+function row(id, renderer, role, entries) {
+  return {
+    id,
+    renderer,
+    role,
+    harnesses: harnessTargets(entries),
+  };
+}
+
 const CAPABILITY_ROWS = [
-  {
-    id: 'instructions',
-    renderer: 'instructions',
-    role: 'project instruction projection',
-    harnesses: {
-      claude: { status: 'shim', surface: 'CLAUDE.md', evidence: ['S1', 'S9'] },
-      cursor: { status: 'native', surface: 'AGENTS.md', evidence: ['S3', 'S9'] },
-      codex: { status: 'native', surface: 'AGENTS.md', evidence: ['S9'] },
-    },
-  },
-  {
-    id: 'skills',
-    renderer: 'skills',
-    role: 'on-demand workflow',
-    harnesses: {
-      claude: { status: 'native', surface: '.claude/skills/<skill>/SKILL.md', activation: 'description match or /skill-name', evidence: ['S1', 'S2'] },
-      cursor: { status: 'native', surface: '.cursor/skills/<skill>/SKILL.md', activation: 'description match or explicit skill invocation', evidence: ['S3'] },
-      codex: { status: 'native', surface: '.codex/skills/<skill>/SKILL.md', activation: 'description match or explicit $skill mention', evidence: ['S5'] },
-    },
-  },
-  {
-    id: 'rules',
-    renderer: 'rules',
-    harnesses: {
-      claude: { status: 'shim', surface: 'CLAUDE.md', role: 'always-on policy projection', evidence: ['S1'] },
-      cursor: { status: 'native', surface: '.cursor/rules/<rule>.mdc', role: 'always-on or scoped policy', activation: 'description, globs, alwaysApply, or manual rule mention', evidence: ['S3'] },
-      codex: { status: 'projection', surface: 'AGENTS.md', role: 'always-on policy projection', evidence: ['S9'] },
-    },
-  },
-  {
-    id: 'mcp',
-    renderer: 'mcp',
-    role: 'tool and resource plumbing',
-    harnesses: {
-      claude: { status: 'native', surface: 'Claude MCP config', evidence: ['S1'] },
-      cursor: { status: 'native', surface: 'mcp.json', evidence: ['S4'] },
-      codex: { status: 'native', surface: '.codex/config.toml', evidence: ['S6'] },
-    },
-  },
-  {
-    id: 'hooks',
-    renderer: 'hooks',
-    role: 'lifecycle enforcement',
-    harnesses: {
-      claude: { status: 'native', surface: 'Claude settings hooks', evidence: ['S1'] },
-      cursor: {
-        status: 'unsupported',
-        surface: null,
-        knownIssue: 'No verified Cursor hook surface; use Forge CLI hooks or file-watcher fallback until Cursor hook support is proven.',
-      },
-      codex: { status: 'native', surface: 'Codex hooks config', evidence: ['S7'] },
-    },
-  },
-  {
-    id: 'commands',
-    renderer: 'commands',
-    harnesses: {
-      claude: { status: 'shim', surface: '.claude/commands/<stage>.md', role: 'compatibility shim', activation: 'explicit slash command forwarding to stage skill', evidence: ['S1'] },
-      cursor: { status: 'compatibility', surface: '.cursor/commands/<stage>.md', role: 'optional explicit command affordance', evidence: ['S3'] },
-      codex: { status: 'fallback', surface: '.codex/skills/<stage>/SKILL.md', role: 'skill fallback instead of command authority', activation: 'explicit $skill or description match', evidence: ['S5'] },
-    },
-  },
-  {
-    id: 'agents',
-    renderer: 'agents',
-    role: 'subagent role mapping',
-    harnesses: {
-      claude: { status: 'native', surface: '.claude/agents/<role>.md', evidence: ['S1'] },
-      cursor: { status: 'unproven', surface: '.cursor/agents/<role>.md', knownIssue: 'Cursor agent/subagent file contract is not proven in Forge tests yet.' },
-      codex: { status: 'skill-backed', surface: '.codex/skills/<role>/SKILL.md', role: 'subagent role fallback through skill metadata', evidence: ['S5'] },
-    },
-  },
-  {
-    id: 'stages',
-    renderer: 'stage-graph',
-    role: 'super skill with addressable subskills',
-    harnesses: {
-      claude: { status: 'skill-first', surface: '.claude/skills/<stage>/SKILL.md', evidence: ['S1'] },
-      cursor: { status: 'skill-first', surface: '.cursor/skills/<stage>/SKILL.md', evidence: ['S3'] },
-      codex: { status: 'skill-first', surface: '.codex/skills/<stage>/SKILL.md', evidence: ['S5'] },
-    },
-  },
-  {
-    id: 'beads',
-    renderer: 'state-and-memory',
-    role: 'issue and audit state authority',
-    harnesses: Object.fromEntries(HARNESS_IDS.map(id => [id, { status: 'forge-owned', surface: 'forge CLI + bd adapter' }])),
-  },
-  {
-    id: 'typedMemory',
-    renderer: 'state-and-memory',
-    role: 'typed memory projection',
-    harnesses: {
-      claude: { status: 'projection', surface: 'CLAUDE.md plus generated memory sections' },
-      cursor: { status: 'projection', surface: 'AGENTS.md and .cursor/rules memory projections' },
-      codex: { status: 'projection', surface: 'AGENTS.md plus Codex skill references' },
-    },
-  },
-  {
-    id: 'patchOverrides',
-    renderer: 'state-and-memory',
-    role: 'project override source',
-    harnesses: Object.fromEntries(HARNESS_IDS.map(id => [id, { status: 'forge-owned', surface: '.forge/patch.md' }])),
-  },
-  {
-    id: 'marketplaceTrust',
-    renderer: 'distribution',
-    role: 'trusted distribution metadata',
-    harnesses: {
-      claude: { status: 'plugin-aware', surface: 'Claude plugin or Forge lock metadata', evidence: ['S1'] },
-      cursor: { status: 'forge-owned', surface: 'extension lock metadata' },
-      codex: { status: 'native', surface: '.agents/plugins/marketplace.json plus plugin lock metadata', evidence: ['S8'] },
-    },
-  },
-  {
-    id: 'extensionPacks',
-    renderer: 'distribution',
-    harnesses: {
-      claude: { status: 'plugin-aware', surface: 'plugin skills/commands/hooks', role: 'installable Forge extension pack', evidence: ['S1'] },
-      cursor: { status: 'generated', surface: '.cursor/skills + .cursor/rules + mcp.json', role: 'installable Forge extension pack projection' },
-      codex: { status: 'native', surface: 'Codex plugin with skills, MCP servers, hooks, and apps', role: 'installable Forge extension pack', evidence: ['S8'] },
-    },
-  },
+  row('instructions', 'instructions', 'project instruction projection', [
+    ['claude', target('shim', 'CLAUDE.md', { evidence: ['S1', 'S9'] })],
+    ['cursor', target('native', 'AGENTS.md', { evidence: ['S3', 'S9'] })],
+    ['codex', target('native', 'AGENTS.md', { evidence: ['S9'] })],
+  ]),
+  row('skills', 'skills', 'on-demand workflow', [
+    ['claude', target('native', '.claude/skills/<skill>/SKILL.md', { activation: 'description match or /skill-name', evidence: ['S1', 'S2'] })],
+    ['cursor', target('native', '.cursor/skills/<skill>/SKILL.md', { activation: 'description match or explicit skill invocation', evidence: ['S3'] })],
+    ['codex', target('native', '.codex/skills/<skill>/SKILL.md', { activation: 'description match or explicit $skill mention', evidence: ['S5'] })],
+  ]),
+  row('rules', 'rules', null, [
+    ['claude', target('shim', 'CLAUDE.md', { role: 'always-on policy projection', evidence: ['S1'] })],
+    ['cursor', target('native', '.cursor/rules/<rule>.mdc', { role: 'always-on or scoped policy', activation: 'description, globs, alwaysApply, or manual rule mention', evidence: ['S3'] })],
+    ['codex', target('projection', 'AGENTS.md', { role: 'always-on policy projection', evidence: ['S9'] })],
+  ]),
+  row('mcp', 'mcp', 'tool and resource plumbing', [
+    ['claude', target('native', 'Claude MCP config', { evidence: ['S1'] })],
+    ['cursor', target('native', 'mcp.json', { evidence: ['S4'] })],
+    ['codex', target('native', '.codex/config.toml', { evidence: ['S6'] })],
+  ]),
+  row('hooks', 'hooks', 'lifecycle enforcement', [
+    ['claude', target('native', 'Claude settings hooks', { evidence: ['S1'] })],
+    ['cursor', target('unsupported', null, { knownIssue: 'No verified Cursor hook surface; use Forge CLI hooks or file-watcher fallback until Cursor hook support is proven.' })],
+    ['codex', target('native', 'Codex hooks config', { evidence: ['S7'] })],
+  ]),
+  row('commands', 'commands', null, [
+    ['claude', target('shim', '.claude/commands/<stage>.md', { role: 'compatibility shim', activation: 'explicit slash command forwarding to stage skill', evidence: ['S1'] })],
+    ['cursor', target('compatibility', '.cursor/commands/<stage>.md', { role: 'optional explicit command affordance', evidence: ['S3'] })],
+    ['codex', target('fallback', '.codex/skills/<stage>/SKILL.md', { role: 'skill fallback instead of command authority', activation: 'explicit $skill or description match', evidence: ['S5'] })],
+  ]),
+  row('agents', 'agents', 'subagent role mapping', [
+    ['claude', target('native', '.claude/agents/<role>.md', { evidence: ['S1'] })],
+    ['cursor', target('unproven', '.cursor/agents/<role>.md', { knownIssue: 'Cursor agent/subagent file contract is not proven in Forge tests yet.' })],
+    ['codex', target('skill-backed', '.codex/skills/<role>/SKILL.md', { role: 'subagent role fallback through skill metadata', evidence: ['S5'] })],
+  ]),
+  row('stages', 'stage-graph', 'super skill with addressable subskills', [
+    ['claude', target('skill-first', '.claude/skills/<stage>/SKILL.md', { evidence: ['S1'] })],
+    ['cursor', target('skill-first', '.cursor/skills/<stage>/SKILL.md', { evidence: ['S3'] })],
+    ['codex', target('skill-first', '.codex/skills/<stage>/SKILL.md', { evidence: ['S5'] })],
+  ]),
+  row('beads', 'state-and-memory', 'issue and audit state authority', HARNESS_IDS.map(id => [id, target('forge-owned', 'forge CLI + bd adapter')])),
+  row('typedMemory', 'state-and-memory', 'typed memory projection', [
+    ['claude', target('projection', 'CLAUDE.md plus generated memory sections')],
+    ['cursor', target('projection', 'AGENTS.md and .cursor/rules memory projections')],
+    ['codex', target('projection', 'AGENTS.md plus Codex skill references')],
+  ]),
+  row('patchOverrides', 'state-and-memory', 'project override source', HARNESS_IDS.map(id => [id, target('forge-owned', '.forge/patch.md')])),
+  row('marketplaceTrust', 'distribution', 'trusted distribution metadata', [
+    ['claude', target('plugin-aware', 'Claude plugin or Forge lock metadata', { evidence: ['S1'] })],
+    ['cursor', target('forge-owned', 'extension lock metadata')],
+    ['codex', target('native', '.agents/plugins/marketplace.json plus plugin lock metadata', { evidence: ['S8'] })],
+  ]),
+  row('extensionPacks', 'distribution', null, [
+    ['claude', target('plugin-aware', 'plugin skills/commands/hooks', { role: 'installable Forge extension pack', evidence: ['S1'] })],
+    ['cursor', target('generated', '.cursor/skills + .cursor/rules + mcp.json', { role: 'installable Forge extension pack projection' })],
+    ['codex', target('native', 'Codex plugin with skills, MCP servers, hooks, and apps', { role: 'installable Forge extension pack', evidence: ['S8'] })],
+  ]),
 ];
 
 function rowCapability(row, harnessId) {

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -34,7 +34,7 @@ const SOURCE_ROWS = [
   ['S2', 'Claude Agent SDK skills', 'https://code.claude.com/docs/en/agent-sdk/skills.md', 'Claude SDK loads project/user/plugin skills and invokes them based on description metadata.'],
   ['S3', 'Cursor rules', 'https://docs.cursor.com/en/context', 'Cursor project rules live in .cursor/rules as .mdc files with description, globs, and alwaysApply metadata.'],
   ['S4', 'Cursor MCP', 'https://docs.cursor.com/context/model-context-protocol', 'Cursor connects external tools and data sources through MCP using stdio, SSE, and streamable HTTP transports.'],
-  ['S5', 'Codex skills', 'https://developers.openai.com/codex/skills', 'Codex skills package instructions, resources, and scripts; repo-scoped skills live under .agents/skills and implicit invocation is based on the skill description.'],
+  ['S5', 'Codex skills', 'https://developers.openai.com/codex/skills', 'Codex skills package instructions, resources, and scripts; Forge currently generates .codex/skills packages for installation, while direct Codex repo discovery uses .agents/skills.'],
   ['S6', 'Codex MCP', 'https://developers.openai.com/codex/mcp', 'Codex configures MCP servers in config.toml and supports plugin-provided MCP servers.'],
   ['S7', 'Codex hooks', 'https://developers.openai.com/codex/hooks', 'Codex hooks run deterministic scripts during lifecycle events.'],
   ['S8', 'Codex plugins and marketplaces', 'https://developers.openai.com/codex/plugins/build', 'Codex plugins can package skills, apps, MCP servers, hooks, and marketplace metadata.'],
@@ -92,7 +92,7 @@ const CAPABILITY_ROWS = [
   row('skills', 'skills', 'on-demand workflow', [
     ['claude', target('native', '.claude/skills/<skill>/SKILL.md', { activation: 'description match or /skill-name', evidence: ['S1', 'S2'] })],
     ['cursor', target('unproven', '.cursor/skills/<skill>/SKILL.md', { activation: 'description match or explicit skill invocation', knownIssue: 'Cursor Agent Skills are the intended on-demand workflow target, but Forge does not yet have matching source evidence or live invocation proof.' })],
-    ['codex', target('native', '.agents/skills/<skill>/SKILL.md', { activation: 'description match or explicit $skill mention', evidence: ['S5'] })],
+    ['codex', target('packaged', '.codex/skills/<skill>/SKILL.md', { activation: 'description match or explicit $skill mention after install', evidence: ['S5'], knownIssue: 'Direct Codex repo discovery uses .agents/skills; migrate Forge generators before changing this renderer target.' })],
   ]),
   row('rules', 'rules', null, [
     ['claude', target('shim', 'CLAUDE.md', { role: 'always-on policy projection', evidence: ['S1'] })],
@@ -112,17 +112,17 @@ const CAPABILITY_ROWS = [
   row('commands', 'commands', null, [
     ['claude', target('shim', '.claude/commands/<stage>.md', { role: 'compatibility shim', activation: 'explicit slash command forwarding to stage skill', evidence: ['S1'] })],
     ['cursor', target('compatibility', '.cursor/commands/<stage>.md', { role: 'optional explicit command affordance', evidence: ['S3'] })],
-    ['codex', target('fallback', '.agents/skills/<stage>/SKILL.md', { role: 'skill fallback instead of command authority', activation: 'explicit $skill or description match', evidence: ['S5'] })],
+    ['codex', target('fallback', '.codex/skills/<stage>/SKILL.md', { role: 'skill fallback instead of command authority', activation: 'explicit $skill or description match after install', evidence: ['S5'], knownIssue: 'Direct Codex repo discovery uses .agents/skills; migrate Forge generators before changing this renderer target.' })],
   ]),
   row('agents', 'agents', 'subagent role mapping', [
     ['claude', target('native', '.claude/agents/<role>.md', { evidence: ['S1'] })],
     ['cursor', target('unproven', '.cursor/agents/<role>.md', { knownIssue: 'Cursor agent/subagent file contract is not proven in Forge tests yet.' })],
-    ['codex', target('skill-backed', '.agents/skills/<role>/SKILL.md', { role: 'subagent role fallback through skill metadata', evidence: ['S5'] })],
+    ['codex', target('skill-backed', '.codex/skills/<role>/SKILL.md', { role: 'subagent role fallback through skill metadata', evidence: ['S5'], knownIssue: 'Direct Codex repo discovery uses .agents/skills; migrate Forge generators before changing this renderer target.' })],
   ]),
   row('stages', 'stage-graph', 'super skill with addressable subskills', [
     ['claude', target('skill-first', '.claude/skills/<stage>/SKILL.md', { evidence: ['S1'] })],
-    ['cursor', target('skill-first', '.cursor/skills/<stage>/SKILL.md', { evidence: ['S3'] })],
-    ['codex', target('skill-first', '.agents/skills/<stage>/SKILL.md', { evidence: ['S5'] })],
+    ['cursor', target('unproven', '.cursor/skills/<stage>/SKILL.md', { knownIssue: 'Cursor Agent Skills are the intended stage target, but Forge does not yet have matching source evidence or live invocation proof.' })],
+    ['codex', target('skill-first', '.codex/skills/<stage>/SKILL.md', { evidence: ['S5'], knownIssue: 'Direct Codex repo discovery uses .agents/skills; migrate Forge generators before changing this renderer target.' })],
   ]),
   row('beads', 'state-and-memory', 'issue and audit state authority', HARNESS_IDS.map(id => [id, target('forge-owned', 'forge CLI + bd adapter')])),
   row('typedMemory', 'state-and-memory', 'typed memory projection', [
@@ -208,10 +208,14 @@ function buildSkillsFirstStageGraph() {
         },
         cursor: {
           skill: `.cursor/skills/${id}/SKILL.md`,
+          status: 'unproven',
+          knownIssue: 'Cursor Agent Skills are the intended stage target, but Forge does not yet have matching source evidence or live invocation proof.',
           rulePolicy: `.cursor/rules/${id}.mdc`,
         },
         codex: {
-          skill: `.agents/skills/${id}/SKILL.md`,
+          skill: `.codex/skills/${id}/SKILL.md`,
+          installTarget: '$CODEX_HOME/skills',
+          directRepoDiscoveryTarget: `.agents/skills/${id}/SKILL.md`,
         },
       },
     })),

--- a/scripts/spikes/harness-capability-matrix.js
+++ b/scripts/spikes/harness-capability-matrix.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+'use strict';
+
+const { buildHarnessCapabilityEvidence } = require('../../lib/harness-capability-matrix');
+
+function main() {
+  const evidence = buildHarnessCapabilityEvidence();
+  console.log(JSON.stringify(evidence, null, 2));
+}
+
+if (require.main === module) {
+  main();
+}

--- a/test/docs-consistency.test.js
+++ b/test/docs-consistency.test.js
@@ -67,7 +67,14 @@ describe('docs/reference/AGENT_SKILL_PARITY.md follow-up boundary', () => {
     expect(parity).toContain('Required Follow-Up: Skills-First Stage Graph');
     expect(parity).toContain('Tracked as `forge-wj36`');
     expect(parity).toContain('Claude commands should become compatibility shims');
-    expect(parity).toContain('Cursor Agent Skills are not proven in this W0 fixture');
+    expect(parity).toContain('Cursor Agent Skills are not proven in the W0 fixture');
+  });
+
+  it('documents the machine-readable capability matrix evidence command', () => {
+    expect(parity).toContain('node scripts/spikes/harness-capability-matrix.js');
+    expect(parity).toContain('lib/harness-capability-matrix.js');
+    expect(parity).toContain('rendererContract.rendererFamilies');
+    expect(parity).toContain('Cursor hooks remain unsupported');
   });
 });
 

--- a/test/harness-capability-matrix.test.js
+++ b/test/harness-capability-matrix.test.js
@@ -45,6 +45,7 @@ describe('harness capability matrix', () => {
     expect(matrix.harnesses.cursor.capabilities.hooks.knownIssue).toContain('No verified Cursor hook surface');
     expect(matrix.harnesses.cursor.capabilities.agents.status).toBe('unproven');
     expect(matrix.harnesses.claude.capabilities.commands.role).toBe('compatibility shim');
+    expect(matrix.harnesses.cursor.capabilities.mcp.primarySurface).toBe('.cursor/mcp.json');
   });
 
   test('evidence object is machine-readable and source-backed', () => {

--- a/test/harness-capability-matrix.test.js
+++ b/test/harness-capability-matrix.test.js
@@ -27,8 +27,11 @@ describe('harness capability matrix', () => {
   test('models Cursor skills and rules as different surfaces', () => {
     const cursor = getHarnessCapabilityMatrix().harnesses.cursor.capabilities;
 
+    expect(cursor.skills.status).toBe('unproven');
     expect(cursor.skills.primarySurface).toBe('.cursor/skills/<skill>/SKILL.md');
     expect(cursor.skills.role).toBe('on-demand workflow');
+    expect(cursor.skills.evidence).toEqual([]);
+    expect(cursor.skills.knownIssue).toContain('matching source evidence');
     expect(cursor.rules.primarySurface).toBe('.cursor/rules/<rule>.mdc');
     expect(cursor.rules.role).toBe('always-on or scoped policy');
     expect(cursor.rules.activation).toContain('description');
@@ -46,7 +49,7 @@ describe('harness capability matrix', () => {
   test('evidence object is machine-readable and source-backed', () => {
     const evidence = buildHarnessCapabilityEvidence();
 
-    expect(evidence.kind).toBe('forge.harnessCapabilityMatrix');
+    expect(evidence.kind).toBe('forge.harnessCapabilityEvidence');
     expect(evidence.schemaVersion).toBe('1.0.0');
     expect(evidence.harnesses.map(harness => harness.id)).toEqual(HARNESS_IDS);
     expect(evidence.sources.every(source => source.label && source.url)).toBe(true);
@@ -65,7 +68,7 @@ describe('skills-first stage graph', () => {
       expect(stage.subskills.length).toBeGreaterThan(0);
       expect(stage.renderTargets.claude.skill).toBe(`.claude/skills/${stage.id}/SKILL.md`);
       expect(stage.renderTargets.cursor.skill).toBe(`.cursor/skills/${stage.id}/SKILL.md`);
-      expect(stage.renderTargets.codex.skill).toBe(`.codex/skills/${stage.id}/SKILL.md`);
+      expect(stage.renderTargets.codex.skill).toBe(`.agents/skills/${stage.id}/SKILL.md`);
     }
   });
 
@@ -137,7 +140,7 @@ describe('harness capability evidence CLI', () => {
     );
     const parsed = JSON.parse(output);
 
-    expect(parsed.kind).toBe('forge.harnessCapabilityMatrix');
+    expect(parsed.kind).toBe('forge.harnessCapabilityEvidence');
     expect(parsed.stageGraph.kind).toBe('forge.skillsFirstStageGraph');
     expect(parsed.rendererContract.kind).toBe('forge.harnessRendererContract');
   });

--- a/test/harness-capability-matrix.test.js
+++ b/test/harness-capability-matrix.test.js
@@ -46,6 +46,7 @@ describe('harness capability matrix', () => {
     expect(matrix.harnesses.cursor.capabilities.agents.status).toBe('unproven');
     expect(matrix.harnesses.claude.capabilities.commands.role).toBe('compatibility shim');
     expect(matrix.harnesses.cursor.capabilities.mcp.primarySurface).toBe('.cursor/mcp.json');
+    expect(matrix.harnesses.cursor.capabilities.extensionPacks.primarySurface).toContain('.cursor/mcp.json');
   });
 
   test('evidence object is machine-readable and source-backed', () => {

--- a/test/harness-capability-matrix.test.js
+++ b/test/harness-capability-matrix.test.js
@@ -6,6 +6,7 @@ const {
   CAPABILITY_IDS,
   HARNESS_IDS,
   STAGE_IDS,
+  UTILITY_SKILL_IDS,
   buildHarnessCapabilityEvidence,
   getHarnessCapabilityMatrix,
   getRendererContract,
@@ -62,8 +63,10 @@ describe('skills-first stage graph', () => {
     const graph = getSkillsFirstStageGraph();
 
     expect(graph.stages.map(stage => stage.id)).toEqual(STAGE_IDS);
+    expect(graph.stages.map(stage => stage.id)).not.toContain('status');
     for (const stage of graph.stages) {
       expect(stage.canonicalSurface).toBe('skill');
+      expect(stage.workflowStage).toBe(true);
       expect(stage.superSkill).toBe(`${stage.id}`);
       expect(stage.subskills.length).toBeGreaterThan(0);
       expect(stage.renderTargets.claude.skill).toBe(`.claude/skills/${stage.id}/SKILL.md`);
@@ -73,6 +76,18 @@ describe('skills-first stage graph', () => {
       expect(stage.renderTargets.codex.skill).toBe(`.codex/skills/${stage.id}/SKILL.md`);
       expect(stage.renderTargets.codex.directRepoDiscoveryTarget).toBe(`.agents/skills/${stage.id}/SKILL.md`);
     }
+  });
+
+  test('models status as a utility skill outside workflow stages', () => {
+    const graph = getSkillsFirstStageGraph();
+
+    expect(graph.utilitySkills.map(skill => skill.id)).toEqual(UTILITY_SKILL_IDS);
+    expect(graph.utilitySkills).toContainEqual(expect.objectContaining({
+      id: 'status',
+      canonicalSurface: 'skill',
+      workflowStage: false,
+      superSkill: 'status',
+    }));
   });
 
   test('keeps Claude commands as shims instead of canonical workflow authority', () => {

--- a/test/harness-capability-matrix.test.js
+++ b/test/harness-capability-matrix.test.js
@@ -1,0 +1,144 @@
+const { describe, expect, test } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const {
+  CAPABILITY_IDS,
+  HARNESS_IDS,
+  STAGE_IDS,
+  buildHarnessCapabilityEvidence,
+  getHarnessCapabilityMatrix,
+  getRendererContract,
+  getSkillsFirstStageGraph,
+} = require('../lib/harness-capability-matrix');
+
+const ROOT = path.resolve(__dirname, '..');
+
+describe('harness capability matrix', () => {
+  test('covers every v3.0 harness and parity capability', () => {
+    const matrix = getHarnessCapabilityMatrix();
+
+    expect(Object.keys(matrix.harnesses)).toEqual(HARNESS_IDS);
+    for (const harnessId of HARNESS_IDS) {
+      expect(Object.keys(matrix.harnesses[harnessId].capabilities)).toEqual(CAPABILITY_IDS);
+    }
+  });
+
+  test('models Cursor skills and rules as different surfaces', () => {
+    const cursor = getHarnessCapabilityMatrix().harnesses.cursor.capabilities;
+
+    expect(cursor.skills.primarySurface).toBe('.cursor/skills/<skill>/SKILL.md');
+    expect(cursor.skills.role).toBe('on-demand workflow');
+    expect(cursor.rules.primarySurface).toBe('.cursor/rules/<rule>.mdc');
+    expect(cursor.rules.role).toBe('always-on or scoped policy');
+    expect(cursor.rules.activation).toContain('description');
+  });
+
+  test('records known unsupported or unproven harness surfaces explicitly', () => {
+    const matrix = getHarnessCapabilityMatrix();
+
+    expect(matrix.harnesses.cursor.capabilities.hooks.status).toBe('unsupported');
+    expect(matrix.harnesses.cursor.capabilities.hooks.knownIssue).toContain('No verified Cursor hook surface');
+    expect(matrix.harnesses.cursor.capabilities.agents.status).toBe('unproven');
+    expect(matrix.harnesses.claude.capabilities.commands.role).toBe('compatibility shim');
+  });
+
+  test('evidence object is machine-readable and source-backed', () => {
+    const evidence = buildHarnessCapabilityEvidence();
+
+    expect(evidence.kind).toBe('forge.harnessCapabilityMatrix');
+    expect(evidence.schemaVersion).toBe('1.0.0');
+    expect(evidence.harnesses.map(harness => harness.id)).toEqual(HARNESS_IDS);
+    expect(evidence.sources.every(source => source.label && source.url)).toBe(true);
+    expect(JSON.parse(JSON.stringify(evidence))).toEqual(evidence);
+  });
+});
+
+describe('skills-first stage graph', () => {
+  test('represents every default stage as a super skill with subskills', () => {
+    const graph = getSkillsFirstStageGraph();
+
+    expect(graph.stages.map(stage => stage.id)).toEqual(STAGE_IDS);
+    for (const stage of graph.stages) {
+      expect(stage.canonicalSurface).toBe('skill');
+      expect(stage.superSkill).toBe(`${stage.id}`);
+      expect(stage.subskills.length).toBeGreaterThan(0);
+      expect(stage.renderTargets.claude.skill).toBe(`.claude/skills/${stage.id}/SKILL.md`);
+      expect(stage.renderTargets.cursor.skill).toBe(`.cursor/skills/${stage.id}/SKILL.md`);
+      expect(stage.renderTargets.codex.skill).toBe(`.codex/skills/${stage.id}/SKILL.md`);
+    }
+  });
+
+  test('keeps Claude commands as shims instead of canonical workflow authority', () => {
+    const graph = getSkillsFirstStageGraph();
+
+    for (const stage of graph.stages) {
+      expect(stage.renderTargets.claude.commandShim).toEqual({
+        path: `.claude/commands/${stage.id}.md`,
+        pointsTo: `.claude/skills/${stage.id}/SKILL.md`,
+        shimOnly: true,
+      });
+    }
+  });
+
+  test('exposes plan phases as addressable subskills', () => {
+    const plan = getSkillsFirstStageGraph().stages.find(stage => stage.id === 'plan');
+
+    expect(plan.subskills.map(subskill => subskill.id)).toEqual([
+      'plan.intent_capture',
+      'plan.parallel_research',
+      'plan.parallel_critics',
+      'plan.synthesis',
+      'plan.final_lock',
+    ]);
+  });
+});
+
+describe('renderer contract', () => {
+  test('requires renderer evidence before broad harness generation', () => {
+    const contract = getRendererContract();
+
+    expect(contract.scope).toBe('contract-only');
+    expect(contract.beforeAddingRenderer).toEqual([
+      'capability-matrix-entry',
+      'target-path-contract',
+      'activation-metadata-contract',
+      'machine-readable-evidence',
+      'known-issue-if-unproven',
+    ]);
+  });
+
+  test('binds each renderer family to canonical Forge input and evidence', () => {
+    const contract = getRendererContract();
+    const rendererIds = contract.rendererFamilies.map(renderer => renderer.id);
+
+    expect(rendererIds).toEqual([
+      'instructions',
+      'skills',
+      'rules',
+      'mcp',
+      'hooks',
+      'commands',
+      'agents',
+      'stage-graph',
+      'state-and-memory',
+      'distribution',
+    ]);
+    expect(contract.rendererFamilies.every(renderer => renderer.canonicalInput && renderer.requiredEvidence.length > 0)).toBe(true);
+  });
+});
+
+describe('harness capability evidence CLI', () => {
+  test('prints the matrix as JSON for machine-readable evidence', () => {
+    const output = execFileSync(
+      process.execPath,
+      [path.join(ROOT, 'scripts', 'spikes', 'harness-capability-matrix.js')],
+      { cwd: ROOT, encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(output);
+
+    expect(parsed.kind).toBe('forge.harnessCapabilityMatrix');
+    expect(parsed.stageGraph.kind).toBe('forge.skillsFirstStageGraph');
+    expect(parsed.rendererContract.kind).toBe('forge.harnessRendererContract');
+  });
+});

--- a/test/harness-capability-matrix.test.js
+++ b/test/harness-capability-matrix.test.js
@@ -68,7 +68,10 @@ describe('skills-first stage graph', () => {
       expect(stage.subskills.length).toBeGreaterThan(0);
       expect(stage.renderTargets.claude.skill).toBe(`.claude/skills/${stage.id}/SKILL.md`);
       expect(stage.renderTargets.cursor.skill).toBe(`.cursor/skills/${stage.id}/SKILL.md`);
-      expect(stage.renderTargets.codex.skill).toBe(`.agents/skills/${stage.id}/SKILL.md`);
+      expect(stage.renderTargets.cursor.status).toBe('unproven');
+      expect(stage.renderTargets.cursor.knownIssue).toContain('matching source evidence');
+      expect(stage.renderTargets.codex.skill).toBe(`.codex/skills/${stage.id}/SKILL.md`);
+      expect(stage.renderTargets.codex.directRepoDiscoveryTarget).toBe(`.agents/skills/${stage.id}/SKILL.md`);
     }
   });
 


### PR DESCRIPTION
## Problem
Forge had a W0 skill metadata fixture, but the broader agent parity mechanism was still prose-only. That left unclear how skills, rules, MCPs, hooks, commands, agents/subagents, stages, Beads, memory, patch overrides, marketplace trust, and extension packs map across Claude, Cursor, and Codex.

## Root Cause
The previous parity PR intentionally stopped at deterministic skill metadata evidence. It did not create the machine-readable capability matrix or renderer contract needed before broad harness renderers.

## Fix
Adds a contract foundation for `forge-wj36`: a machine-readable Claude/Cursor/Codex capability matrix, a skills-first stage graph, a renderer evidence contract, and a JSON evidence CLI. Updates the parity docs to explain the end-to-end mechanism and known issues.

## Value
Future renderer PRs now have a source-of-truth contract instead of duplicating assumptions. Cursor skills vs rules, Claude command shims, Codex skills/plugins, unsupported Cursor hooks, and required renderer evidence are explicit and test-covered.

## Beads
Closes forge-wj36

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: `bun run check` passed with 770 pass / 22 skip / 0 fail in the full validation lane, plus pre-push targeted tests passed with 37 pass / 0 fail.
- Scenarios covered: required capability coverage, Cursor skills/rules separation, unsupported/unproven known issues, skills-first stage graph, Claude command shims, plan subskills, renderer evidence contract, JSON evidence CLI, docs consistency.

### Security Review
- OWASP Top 10: A08 software/data integrity is the relevant risk; mitigated by tests that require explicit known-issue records and renderer evidence before broad generation.
- Automated scan: `bun audit` reports one existing moderate `qs` advisory through `@stryker-mutator/core`; project validation marks moderate/low audit findings non-blocking.

### Design Doc
See: `docs/work/2026-05-23-harness-capability-parity/design.md`

### Key Decisions
- Model Cursor `.cursor/skills` as the on-demand workflow surface and `.cursor/rules/*.mdc` as policy/context.
- Make stages canonical super skills with addressable subskills.
- Keep Claude commands as shim-only compatibility wrappers.
- Record unsupported/unproven surfaces as known issues instead of claiming parity.
- Defer broad renderer implementation until each renderer has target-path and evidence contracts.

### Documentation Updated
- `docs/reference/AGENT_SKILL_PARITY.md`
- `docs/work/2026-05-23-harness-capability-parity/design.md`
- `docs/work/2026-05-23-harness-capability-parity/tasks.md`
- `docs/work/2026-05-23-harness-capability-parity/decisions.md`

### Validation
- [x] Type check passing (project has no TypeScript; check skips by design)
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun run check`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded harness-capability parity docs: formalized a skills-first workflow, clarified scope/known gaps, added decisions/design/tasks, tightened proof boundaries, and defined a renderer evidence contract plus machine-readable evidence expectations.

* **New Features**
  * Added a CLI and library to emit machine-readable harness capability evidence (capability matrix, skills-first stage graph, renderer contract) as JSON.

* **Tests**
  * Added and updated tests validating the capability matrix, stage graph, renderer contract, known-issue handling, and CLI JSON output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->