### PR TITLE
feat: add protected path harness manifest

### DIFF
--- a/.forge/protected-paths.yaml
+++ b/.forge/protected-paths.yaml
@@ -2,6 +2,8 @@ version: 1
 schemaVersion: 1.0.0
 kind: ProtectedPathManifest
 manifestPath: .forge/protected-paths.yaml
+surfacesDeprecated: true
+surfacesMigrationNote: Legacy surfaces remain for 0.0.19 protected-state docs/runtime parity; every example below must be covered by the authoritative W1 categories.
 surfaces:
   immutable:
     examples:
@@ -76,6 +78,11 @@ categories:
       - CLAUDE.md
       - .cursorrules
       - opencode.json
+      - .mcp.json
+      - .forge/config.yaml
+      - .forge/config.yml
+      - .forge/config.json
+      - .forge/protected-paths.yaml
     ownerSurface: forge setup or forge options
     repairHint: Use Forge setup/options commands so harness protocol files stay synchronized.
   - id: generated_artifacts
@@ -86,13 +93,45 @@ categories:
       - .cursor/rules/**
       - .cursor/skills/**
       - .codex/skills/**
+      - .cline/**
+      - .roo/**
+      - .kilocode/**
+      - .opencode/**
+      - .github/prompts/**
+      - .github/workflows/**
+      - .forge/hooks/**
+      - lefthook.yml
+      - .forge/extensions/*/manifest.json
+      - .github/PLUGIN_TEMPLATE.json
+      - plugins/*/plugin.json
+      - plugins/*/extension.json
+      - plugins/*/manifest.json
+      - bun.lock
+      - package-lock.json
+      - pnpm-lock.yaml
+      - yarn.lock
+      - requirements.lock
+      - poetry.lock
+      - Cargo.lock
+      - go.sum
+      - .forge/extensions.lock
+      - docs/sessions/**
+      - docs/memory/**
+      - .forge/memory/**
+      - memory.md
+      - MEMORY.md
+      - "**/memory.md"
+      - "**/MEMORY.md"
     ownerSurface: Forge harness renderer
     repairHint: Regenerate harness artifacts from the canonical Forge contract.
   - id: append_only_logs
     mode: runtime-only
     paths:
       - .forge/*.jsonl
+      - .forge/audit.log
+      - .forge/agent-log.ndjson
       - .beads/*.jsonl
+      - .beads/interactions.jsonl
     ownerSurface: Forge or Beads audit writer
     repairHint: Append through the runtime writer; do not rewrite audit history.
   - id: secrets
@@ -102,6 +141,10 @@ categories:
       - .env.*
       - "**/.env"
       - "**/.env.*"
+      - secrets.json
+      - "**/secrets.json"
+      - credentials.json
+      - "**/credentials.json"
     ownerSurface: secret manager
     repairHint: Move secrets to the configured secret manager or local ignored env file.
   - id: beads_state

--- a/.forge/protected-paths.yaml
+++ b/.forge/protected-paths.yaml
@@ -1,4 +1,7 @@
 version: 1
+schemaVersion: 1.0.0
+kind: ProtectedPathManifest
+manifestPath: .forge/protected-paths.yaml
 surfaces:
   immutable:
     examples:
@@ -56,3 +59,62 @@ surfaces:
       - docs/memory/
       - .forge/memory/
     repair: Use the Forge memory projection writer.
+categories:
+  - id: forge_core
+    mode: checksum-verified
+    paths:
+      - lib/**
+      - bin/**
+      - scripts/**
+      - skills/**
+    ownerSurface: Forge core release or checksum updater
+    repairHint: Use the Forge release/update flow; do not hand-edit checksum-protected core files.
+  - id: user_protocol
+    mode: cli-only
+    paths:
+      - AGENTS.md
+      - CLAUDE.md
+      - .cursorrules
+      - opencode.json
+    ownerSurface: forge setup or forge options
+    repairHint: Use Forge setup/options commands so harness protocol files stay synchronized.
+  - id: generated_artifacts
+    mode: ci-blocked
+    paths:
+      - .claude/commands/**
+      - .claude/skills/**
+      - .cursor/rules/**
+      - .cursor/skills/**
+      - .codex/skills/**
+    ownerSurface: Forge harness renderer
+    repairHint: Regenerate harness artifacts from the canonical Forge contract.
+  - id: append_only_logs
+    mode: runtime-only
+    paths:
+      - .forge/*.jsonl
+      - .beads/*.jsonl
+    ownerSurface: Forge or Beads audit writer
+    repairHint: Append through the runtime writer; do not rewrite audit history.
+  - id: secrets
+    mode: secret-scan-blocked
+    paths:
+      - .env
+      - .env.*
+      - "**/.env"
+      - "**/.env.*"
+    ownerSurface: secret manager
+    repairHint: Move secrets to the configured secret manager or local ignored env file.
+  - id: beads_state
+    mode: bd-cli-only
+    paths:
+      - .beads/**
+    ownerSurface: bd CLI or Forge issue adapter
+    repairHint: Use bd or Forge issue commands instead of editing Beads state files.
+  - id: immutable
+    mode: tool-owned
+    paths:
+      - .git/**
+      - .hg/**
+      - .svn/**
+    ownerSurface: VCS tool
+    repairHint: Use the owning VCS command instead of editing runtime internals.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -75,6 +75,7 @@ See [work/](work/) for the full list of date-prefixed work folders. Each folder 
 - [INSIGHTS_RECAP.md](reference/INSIGHTS_RECAP.md) — `forge insights` and `forge recap` evidence sources, output, and limitations
 - [STATUS_BOARD.md](reference/STATUS_BOARD.md) — `forge status` and `forge board` local runtime state surfaces, JSON mode, and limits
 - [protected-state-surfaces.md](reference/protected-state-surfaces.md) — Protected paths, allowed Forge API writes, audit payloads, and repair hints
+- [PROTECTED_PATH_MANIFEST.md](reference/PROTECTED_PATH_MANIFEST.md) — Protected path manifest schema, harness enforcement mapping, and evidence command
 - [RESEARCH_TEMPLATE.md](reference/RESEARCH_TEMPLATE.md) — Template for research docs (formerly docs/research/TEMPLATE.md)
 
 ## Guides

--- a/docs/reference/PROTECTED_PATH_MANIFEST.md
+++ b/docs/reference/PROTECTED_PATH_MANIFEST.md
@@ -1,0 +1,25 @@
+# Protected Path Manifest
+
+Forge uses `.forge/protected-paths.yaml` as the canonical protected-path contract for the schema and integrity rail.
+
+The manifest defines seven W1 categories:
+
+- `forge_core`: checksum-verified Forge runtime files.
+- `user_protocol`: user-facing protocol files that should be changed through Forge CLI surfaces.
+- `generated_artifacts`: generated harness files that should come from renderers.
+- `append_only_logs`: audit logs that must not be rewritten.
+- `secrets`: env and secret-bearing files.
+- `beads_state`: Beads state owned by `bd` or Forge issue adapters.
+- `immutable`: VCS/runtime internals owned by their tools.
+
+## Harness Enforcement
+
+Claude and Codex use native hook contracts for write/edit enforcement. Cursor fallback remains Forge CLI/pre-commit or file-watcher enforcement until a native Cursor hook surface is proven by fixture evidence.
+
+## Evidence Command
+
+```bash
+node scripts/spikes/protected-path-manifest.js
+```
+
+The command emits machine-readable JSON containing the manifest categories, per-harness enforcement mapping, validation result, and known issue for Cursor fallback.

--- a/docs/work/2026-05-24-protected-path-harness-parity/decisions.md
+++ b/docs/work/2026-05-24-protected-path-harness-parity/decisions.md
@@ -1,0 +1,10 @@
+# Decisions
+
+## D1: Contract First
+
+The first protected-path PR is a contract/evidence slice. Runtime hook installers are deferred to the follow-up renderer work so we do not overreach the W1 parity foundation.
+
+## D2: Cursor Fallback
+
+Cursor enforcement is documented as a file-watcher or Forge CLI/pre-commit fallback until a native hook surface is proven by fixture evidence.
+

--- a/docs/work/2026-05-24-protected-path-harness-parity/design.md
+++ b/docs/work/2026-05-24-protected-path-harness-parity/design.md
@@ -27,6 +27,30 @@ Forge owns a canonical protected path manifest and projects enforcement into har
 
 The validator proves the manifest has the seven W1 categories from `forge-5146`: `forge_core`, `user_protocol`, `generated_artifacts`, `append_only_logs`, `secrets`, `beads_state`, and `immutable`.
 
+## Technical Research (/plan)
+
+### Goals
+
+The plan phase scoped this as a machine-readable protected-path contract that can be projected into Claude, Cursor, and Codex harness enforcement without installing broad hooks in this PR. The contract must preserve the seven W1 categories from `forge-5146` while leaving later runtime work a stable manifest, validator, and evidence command.
+
+### Alternatives Considered
+
+- Full hook rollout now: rejected because the PR only needs a shared manifest and evidence boundary.
+- Harness-only rules: rejected because Claude, Cursor, and Codex expose different enforcement surfaces and need one Forge-owned source of truth.
+- Category-only manifest with no legacy surface record: rejected because the 0.0.19 protected-state docs/runtime still use named surfaces such as `forge_config`, `lockfiles`, `workflows`, and `memory_projection`.
+
+### Tradeoffs
+
+The canonical validator stays category-driven, using `forge_core`, `user_protocol`, `generated_artifacts`, `append_only_logs`, `secrets`, `beads_state`, and `immutable` as the durable W1 vocabulary. The legacy `surfaces` block remains as deprecated compatibility context, and its examples must be covered by the authoritative category path patterns so drift is visible in evidence.
+
+### Risks
+
+Cursor remains on fallback enforcement until a verified first-party hook surface is proven. Legacy surface names can also drift from the category contract unless the validator keeps checking coverage for the examples listed in `.forge/protected-paths.yaml`.
+
+### Next Steps
+
+Later runtime PRs should wire the protected-path manifest into harness-specific write gates, produce blocked-write repair hints per category, and remove or migrate the deprecated `surfaces` block after the protected-state docs no longer need it.
+
 ## Evidence
 
 The evidence command should print JSON:
@@ -34,4 +58,3 @@ The evidence command should print JSON:
 ```bash
 node scripts/spikes/protected-path-manifest.js
 ```
-

--- a/docs/work/2026-05-24-protected-path-harness-parity/design.md
+++ b/docs/work/2026-05-24-protected-path-harness-parity/design.md
@@ -1,0 +1,37 @@
+# Protected Path Harness Parity
+
+Issue: `forge-5146`
+
+## Scope
+
+This PR ships the next harness parity foundation after the capability matrix:
+
+- A machine-readable `.forge/protected-paths.yaml` default manifest.
+- A validator and evidence builder for the protected path contract.
+- A per-harness enforcement matrix for Claude, Cursor, and Codex.
+- User documentation that later renderer/runtime work can link to.
+
+## Non-Scope
+
+- Do not install broad runtime hooks into every harness in this PR.
+- Do not rewrite the existing protected-state write guard.
+- Do not change Beads storage or synchronization behavior.
+
+## Design
+
+Forge owns a canonical protected path manifest and projects enforcement into harness-native surfaces:
+
+- Claude: `PreToolUse` hook contract for write/edit tools.
+- Cursor: file watcher or CLI/pre-commit fallback until a first-party hook surface is proven.
+- Codex: lifecycle hook contract for write/edit tools.
+
+The validator proves the manifest has the seven W1 categories from `forge-5146`: `forge_core`, `user_protocol`, `generated_artifacts`, `append_only_logs`, `secrets`, `beads_state`, and `immutable`.
+
+## Evidence
+
+The evidence command should print JSON:
+
+```bash
+node scripts/spikes/protected-path-manifest.js
+```
+

--- a/docs/work/2026-05-24-protected-path-harness-parity/tasks.md
+++ b/docs/work/2026-05-24-protected-path-harness-parity/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Task 1: RED Tests
+
+- Add protected path manifest tests for the default manifest, validator, YAML file, harness enforcement matrix, evidence JSON, and docs link.
+- Run the focused test and confirm it fails before implementation.
+
+## Task 2: Manifest Contract
+
+- Add `.forge/protected-paths.yaml`.
+- Add `lib/protected-path-manifest.js` with validator and evidence helpers.
+- Add `scripts/spikes/protected-path-manifest.js`.
+
+## Task 3: Documentation
+
+- Add `docs/reference/PROTECTED_PATH_MANIFEST.md`.
+- Link it from `docs/INDEX.md`.
+
+## Task 4: Validation and Ship
+
+- Run focused tests.
+- Run `bun run check`.
+- Commit, push, and open the PR.
+

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -13,7 +13,7 @@ const PROTECTED_PATH_CATEGORY_IDS = [
 	'immutable',
 ];
 
-const ALLOWED_MODES = [
+const ALLOWED_MODES = new Set([
 	'checksum-verified',
 	'cli-only',
 	'ci-blocked',
@@ -21,7 +21,10 @@ const ALLOWED_MODES = [
 	'secret-scan-blocked',
 	'bd-cli-only',
 	'tool-owned',
-];
+]);
+
+const REGEX_SPECIAL_CHARACTERS = /[|\\{}()[\]^$+?.]/g;
+const REGEX_ESCAPE_REPLACEMENT = String.raw`\$&`;
 
 const EXPECTED_CATEGORY_MODES = {
 	forge_core: 'checksum-verified',
@@ -48,73 +51,28 @@ const DEFAULT_PROTECTED_PATH_MANIFEST = {
 		{
 			id: 'user_protocol',
 			mode: 'cli-only',
-			paths: [
-				'AGENTS.md',
-				'CLAUDE.md',
-				'.cursorrules',
-				'opencode.json',
-				'.mcp.json',
-				'.forge/config.yaml',
-				'.forge/config.yml',
-				'.forge/config.json',
-				'.forge/protected-paths.yaml',
-			],
+			paths: ['AGENTS.md', 'CLAUDE.md', '.cursorrules', 'opencode.json'],
 			ownerSurface: 'forge setup or forge options',
 			repairHint: 'Use Forge setup/options commands so harness protocol files stay synchronized.',
 		},
 		{
 			id: 'generated_artifacts',
 			mode: 'ci-blocked',
-			paths: [
-				'.claude/commands/**',
-				'.claude/skills/**',
-				'.cursor/rules/**',
-				'.cursor/skills/**',
-				'.codex/skills/**',
-				'.cline/**',
-				'.roo/**',
-				'.kilocode/**',
-				'.opencode/**',
-				'.github/prompts/**',
-				'.github/workflows/**',
-				'.forge/hooks/**',
-				'lefthook.yml',
-				'.forge/extensions/*/manifest.json',
-				'.github/PLUGIN_TEMPLATE.json',
-				'plugins/*/plugin.json',
-				'plugins/*/extension.json',
-				'plugins/*/manifest.json',
-				'bun.lock',
-				'package-lock.json',
-				'pnpm-lock.yaml',
-				'yarn.lock',
-				'requirements.lock',
-				'poetry.lock',
-				'Cargo.lock',
-				'go.sum',
-				'.forge/extensions.lock',
-				'docs/sessions/**',
-				'docs/memory/**',
-				'.forge/memory/**',
-				'memory.md',
-				'MEMORY.md',
-				'**/memory.md',
-				'**/MEMORY.md',
-			],
+			paths: ['.claude/commands/**', '.claude/skills/**', '.cursor/rules/**', '.cursor/skills/**', '.codex/skills/**'],
 			ownerSurface: 'Forge harness renderer',
 			repairHint: 'Regenerate harness artifacts from the canonical Forge contract.',
 		},
 		{
 			id: 'append_only_logs',
 			mode: 'runtime-only',
-			paths: ['.forge/*.jsonl', '.forge/audit.log', '.forge/agent-log.ndjson', '.beads/*.jsonl', '.beads/interactions.jsonl'],
+			paths: ['.forge/*.jsonl', '.beads/*.jsonl'],
 			ownerSurface: 'Forge or Beads audit writer',
 			repairHint: 'Append through the runtime writer; do not rewrite audit history.',
 		},
 		{
 			id: 'secrets',
 			mode: 'secret-scan-blocked',
-			paths: ['.env', '.env.*', '**/.env', '**/.env.*', 'secrets.json', '**/secrets.json', 'credentials.json', '**/credentials.json'],
+			paths: ['.env', '.env.*', '**/.env', '**/.env.*'],
 			ownerSurface: 'secret manager',
 			repairHint: 'Move secrets to the configured secret manager or local ignored env file.',
 		},
@@ -158,7 +116,7 @@ const PROTECTED_PATH_HARNESS_ENFORCEMENT = {
 };
 
 function clone(value) {
-	return JSON.parse(JSON.stringify(value));
+	return structuredClone(value);
 }
 
 function getDefaultProtectedPathManifest() {
@@ -191,7 +149,7 @@ function validateProtectedPathManifest(manifest) {
 	if (!Array.isArray(manifest.categories)) errors.push('categories must be an array.');
 
 	const categories = Array.isArray(manifest.categories) ? manifest.categories : [];
-	const ids = categories.map(category => category && category.id).filter(Boolean);
+	const ids = categories.map(category => category?.id).filter(Boolean);
 	for (const requiredId of PROTECTED_PATH_CATEGORY_IDS) {
 		if (!ids.includes(requiredId)) errors.push(`Missing required protected path category: ${requiredId}.`);
 	}
@@ -212,7 +170,7 @@ function validateCategory(category, errors) {
 		return;
 	}
 	if (!category.id || typeof category.id !== 'string') errors.push('Category id must be a string.');
-	if (!ALLOWED_MODES.includes(category.mode)) errors.push(`Invalid mode for ${category.id || 'unknown'}: ${category.mode}.`);
+	if (!ALLOWED_MODES.has(category.mode)) errors.push(`Invalid mode for ${category.id || 'unknown'}: ${category.mode}.`);
 	const expectedMode = EXPECTED_CATEGORY_MODES[category.id];
 	if (expectedMode && category.mode !== expectedMode) {
 		errors.push(`Category ${category.id} must use mode ${expectedMode}.`);
@@ -252,11 +210,12 @@ function loadProtectedPathManifest(filePath) {
 }
 
 function buildProtectedPathManifestEvidence(manifest = getDefaultProtectedPathManifest()) {
-	const categoryIds = Array.isArray(manifest.categoryIds)
-		? manifest.categoryIds
-		: Array.isArray(manifest.categories)
-			? manifest.categories.map(category => category && category.id).filter(Boolean)
-			: PROTECTED_PATH_CATEGORY_IDS;
+	let categoryIds = PROTECTED_PATH_CATEGORY_IDS;
+	if (Array.isArray(manifest.categoryIds)) {
+		categoryIds = manifest.categoryIds;
+	} else if (Array.isArray(manifest.categories)) {
+		categoryIds = manifest.categories.map(category => category?.id).filter(Boolean);
+	}
 	return {
 		schemaVersion: manifest.schemaVersion,
 		kind: 'forge.protectedPathManifest',
@@ -302,7 +261,7 @@ function pathPatternCoversExample(pattern, example) {
 }
 
 function normalizeManifestPath(value) {
-	return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/g, '');
+	return String(value || '').replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/+$/g, '');
 }
 
 function wildcardPatternToRegex(pattern) {
@@ -315,7 +274,7 @@ function wildcardPatternToRegex(pattern) {
 		} else if (character === '*') {
 			source += '[^/]*';
 		} else {
-			source += character.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+			source += character.replace(REGEX_SPECIAL_CHARACTERS, REGEX_ESCAPE_REPLACEMENT);
 		}
 	}
 	return new RegExp(`^${source}$`);

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -208,9 +208,7 @@ function loadProtectedPathManifest(filePath) {
 
 function buildProtectedPathManifestEvidence(manifest = getDefaultProtectedPathManifest()) {
 	let categoryIds = PROTECTED_PATH_CATEGORY_IDS;
-	if (Array.isArray(manifest.categoryIds)) {
-		categoryIds = manifest.categoryIds;
-	} else if (Array.isArray(manifest.categories)) {
+	if (Array.isArray(manifest.categories)) {
 		categoryIds = manifest.categories.map(category => category?.id).filter(Boolean);
 	}
 	return {

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -23,9 +23,6 @@ const ALLOWED_MODES = new Set([
 	'tool-owned',
 ]);
 
-const REGEX_SPECIAL_CHARACTERS = /[|\\{}()[\]^$+?.]/g;
-const REGEX_ESCAPE_REPLACEMENT = String.raw`\$&`;
-
 const EXPECTED_CATEGORY_MODES = {
 	forge_core: 'checksum-verified',
 	user_protocol: 'cli-only',
@@ -257,27 +254,61 @@ function pathPatternCoversExample(pattern, example) {
 		const prefix = normalizedPattern.slice(0, -3);
 		return normalizedExample === prefix || normalizedExample.startsWith(`${prefix}/`);
 	}
-	return wildcardPatternToRegex(normalizedPattern).test(normalizedExample);
+	return wildcardPathMatches(normalizedPattern, normalizedExample);
 }
 
 function normalizeManifestPath(value) {
 	return String(value || '').replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/+$/g, '');
 }
 
-function wildcardPatternToRegex(pattern) {
-	let source = '';
-	for (let index = 0; index < pattern.length; index += 1) {
-		const character = pattern[index];
-		if (character === '*' && pattern[index + 1] === '*') {
-			source += '.*';
-			index += 1;
-		} else if (character === '*') {
-			source += '[^/]*';
+function wildcardPathMatches(pattern, candidate) {
+	return pathSegmentsMatch(pattern.split('/'), candidate.split('/'), 0, 0, new Map());
+}
+
+function pathSegmentsMatch(patternParts, candidateParts, patternIndex, candidateIndex, memo) {
+	const memoKey = `${patternIndex}:${candidateIndex}`;
+	if (memo.has(memoKey)) return memo.get(memoKey);
+	if (patternIndex === patternParts.length) return candidateIndex === candidateParts.length;
+
+	const patternPart = patternParts[patternIndex];
+	let matches;
+	if (patternPart === '**') {
+		matches =
+			pathSegmentsMatch(patternParts, candidateParts, patternIndex + 1, candidateIndex, memo) ||
+			(candidateIndex < candidateParts.length && pathSegmentsMatch(patternParts, candidateParts, patternIndex, candidateIndex + 1, memo));
+	} else {
+		matches =
+			candidateIndex < candidateParts.length &&
+			segmentPatternMatches(patternPart, candidateParts[candidateIndex]) &&
+			pathSegmentsMatch(patternParts, candidateParts, patternIndex + 1, candidateIndex + 1, memo);
+	}
+	memo.set(memoKey, matches);
+	return matches;
+}
+
+function segmentPatternMatches(pattern, candidate) {
+	let patternIndex = 0;
+	let candidateIndex = 0;
+	let starIndex = -1;
+	let candidateCheckpoint = 0;
+	while (candidateIndex < candidate.length) {
+		if (pattern[patternIndex] === candidate[candidateIndex]) {
+			patternIndex += 1;
+			candidateIndex += 1;
+		} else if (pattern[patternIndex] === '*') {
+			starIndex = patternIndex;
+			candidateCheckpoint = candidateIndex;
+			patternIndex += 1;
+		} else if (starIndex !== -1) {
+			patternIndex = starIndex + 1;
+			candidateCheckpoint += 1;
+			candidateIndex = candidateCheckpoint;
 		} else {
-			source += character.replace(REGEX_SPECIAL_CHARACTERS, REGEX_ESCAPE_REPLACEMENT);
+			return false;
 		}
 	}
-	return new RegExp(`^${source}$`);
+	while (pattern[patternIndex] === '*') patternIndex += 1;
+	return patternIndex === pattern.length;
 }
 
 module.exports = {

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 const YAML = require('yaml');
 
 const PROTECTED_PATH_CATEGORY_IDS = [
@@ -33,62 +34,7 @@ const EXPECTED_CATEGORY_MODES = {
 	immutable: 'tool-owned',
 };
 
-const DEFAULT_PROTECTED_PATH_MANIFEST = {
-	schemaVersion: '1.0.0',
-	kind: 'ProtectedPathManifest',
-	manifestPath: '.forge/protected-paths.yaml',
-	categories: [
-		{
-			id: 'forge_core',
-			mode: 'checksum-verified',
-			paths: ['lib/**', 'bin/**', 'scripts/**', 'skills/**'],
-			ownerSurface: 'Forge core release or checksum updater',
-			repairHint: 'Use the Forge release/update flow; do not hand-edit checksum-protected core files.',
-		},
-		{
-			id: 'user_protocol',
-			mode: 'cli-only',
-			paths: ['AGENTS.md', 'CLAUDE.md', '.cursorrules', 'opencode.json'],
-			ownerSurface: 'forge setup or forge options',
-			repairHint: 'Use Forge setup/options commands so harness protocol files stay synchronized.',
-		},
-		{
-			id: 'generated_artifacts',
-			mode: 'ci-blocked',
-			paths: ['.claude/commands/**', '.claude/skills/**', '.cursor/rules/**', '.cursor/skills/**', '.codex/skills/**'],
-			ownerSurface: 'Forge harness renderer',
-			repairHint: 'Regenerate harness artifacts from the canonical Forge contract.',
-		},
-		{
-			id: 'append_only_logs',
-			mode: 'runtime-only',
-			paths: ['.forge/*.jsonl', '.beads/*.jsonl'],
-			ownerSurface: 'Forge or Beads audit writer',
-			repairHint: 'Append through the runtime writer; do not rewrite audit history.',
-		},
-		{
-			id: 'secrets',
-			mode: 'secret-scan-blocked',
-			paths: ['.env', '.env.*', '**/.env', '**/.env.*'],
-			ownerSurface: 'secret manager',
-			repairHint: 'Move secrets to the configured secret manager or local ignored env file.',
-		},
-		{
-			id: 'beads_state',
-			mode: 'bd-cli-only',
-			paths: ['.beads/**'],
-			ownerSurface: 'bd CLI or Forge issue adapter',
-			repairHint: 'Use bd or Forge issue commands instead of editing Beads state files.',
-		},
-		{
-			id: 'immutable',
-			mode: 'tool-owned',
-			paths: ['.git/**', '.hg/**', '.svn/**'],
-			ownerSurface: 'VCS tool',
-			repairHint: 'Use the owning VCS command instead of editing runtime internals.',
-		},
-	],
-};
+const DEFAULT_PROTECTED_PATH_MANIFEST_PATH = path.resolve(__dirname, '..', '.forge', 'protected-paths.yaml');
 
 const PROTECTED_PATH_HARNESS_ENFORCEMENT = {
 	claude: {
@@ -117,7 +63,7 @@ function clone(value) {
 }
 
 function getDefaultProtectedPathManifest() {
-	return clone(DEFAULT_PROTECTED_PATH_MANIFEST);
+	return loadProtectedPathManifest(DEFAULT_PROTECTED_PATH_MANIFEST_PATH);
 }
 
 function getProtectedPathHarnessEnforcement() {

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const fs = require('node:fs');
+const YAML = require('yaml');
+
+const PROTECTED_PATH_CATEGORY_IDS = [
+	'forge_core',
+	'user_protocol',
+	'generated_artifacts',
+	'append_only_logs',
+	'secrets',
+	'beads_state',
+	'immutable',
+];
+
+const ALLOWED_MODES = [
+	'checksum-verified',
+	'cli-only',
+	'ci-blocked',
+	'runtime-only',
+	'secret-scan-blocked',
+	'bd-cli-only',
+	'tool-owned',
+];
+
+const DEFAULT_PROTECTED_PATH_MANIFEST = {
+	schemaVersion: '1.0.0',
+	kind: 'ProtectedPathManifest',
+	manifestPath: '.forge/protected-paths.yaml',
+	categories: [
+		{
+			id: 'forge_core',
+			mode: 'checksum-verified',
+			paths: ['lib/**', 'bin/**', 'scripts/**', 'skills/**'],
+			ownerSurface: 'Forge core release or checksum updater',
+			repairHint: 'Use the Forge release/update flow; do not hand-edit checksum-protected core files.',
+		},
+		{
+			id: 'user_protocol',
+			mode: 'cli-only',
+			paths: ['AGENTS.md', 'CLAUDE.md', '.cursorrules', 'opencode.json'],
+			ownerSurface: 'forge setup or forge options',
+			repairHint: 'Use Forge setup/options commands so harness protocol files stay synchronized.',
+		},
+		{
+			id: 'generated_artifacts',
+			mode: 'ci-blocked',
+			paths: ['.claude/commands/**', '.claude/skills/**', '.cursor/rules/**', '.cursor/skills/**', '.codex/skills/**'],
+			ownerSurface: 'Forge harness renderer',
+			repairHint: 'Regenerate harness artifacts from the canonical Forge contract.',
+		},
+		{
+			id: 'append_only_logs',
+			mode: 'runtime-only',
+			paths: ['.forge/*.jsonl', '.beads/*.jsonl'],
+			ownerSurface: 'Forge or Beads audit writer',
+			repairHint: 'Append through the runtime writer; do not rewrite audit history.',
+		},
+		{
+			id: 'secrets',
+			mode: 'secret-scan-blocked',
+			paths: ['.env', '.env.*', '**/.env', '**/.env.*'],
+			ownerSurface: 'secret manager',
+			repairHint: 'Move secrets to the configured secret manager or local ignored env file.',
+		},
+		{
+			id: 'beads_state',
+			mode: 'bd-cli-only',
+			paths: ['.beads/**'],
+			ownerSurface: 'bd CLI or Forge issue adapter',
+			repairHint: 'Use bd or Forge issue commands instead of editing Beads state files.',
+		},
+		{
+			id: 'immutable',
+			mode: 'tool-owned',
+			paths: ['.git/**', '.hg/**', '.svn/**'],
+			ownerSurface: 'VCS tool',
+			repairHint: 'Use the owning VCS command instead of editing runtime internals.',
+		},
+	],
+};
+
+const PROTECTED_PATH_HARNESS_ENFORCEMENT = {
+	claude: {
+		status: 'native-hook-contract',
+		surface: 'Claude PreToolUse hook for write/edit tools',
+		configPath: '.claude/settings.json',
+		evidenceRequired: ['hook receives target path', 'blocked write returns repair hint'],
+	},
+	cursor: {
+		status: 'fallback',
+		surface: 'Forge CLI/pre-commit check or file-watcher fallback',
+		configPath: 'lefthook.yml',
+		evidenceRequired: ['staged file check', 'watcher proof before native hook claim'],
+		knownIssue: 'No verified Cursor hook surface; keep Cursor protected-path enforcement on Forge CLI/pre-commit fallback until proven.',
+	},
+	codex: {
+		status: 'native-hook-contract',
+		surface: 'Codex lifecycle hook for write/edit tools',
+		configPath: '.codex/config.toml',
+		evidenceRequired: ['hook receives target path', 'blocked write returns repair hint'],
+	},
+};
+
+function clone(value) {
+	return JSON.parse(JSON.stringify(value));
+}
+
+function getDefaultProtectedPathManifest() {
+	return clone(DEFAULT_PROTECTED_PATH_MANIFEST);
+}
+
+function getProtectedPathHarnessEnforcement() {
+	return clone(PROTECTED_PATH_HARNESS_ENFORCEMENT);
+}
+
+function validateProtectedPathManifest(manifest) {
+	const errors = [];
+	if (!manifest || typeof manifest !== 'object') {
+		return { ok: false, errors: ['Manifest must be an object.'] };
+	}
+	if (manifest.kind !== 'ProtectedPathManifest') errors.push('kind must be ProtectedPathManifest.');
+	if (manifest.schemaVersion !== '1.0.0') errors.push('schemaVersion must be 1.0.0.');
+	if (!Array.isArray(manifest.categories)) errors.push('categories must be an array.');
+
+	const categories = Array.isArray(manifest.categories) ? manifest.categories : [];
+	const ids = categories.map(category => category && category.id).filter(Boolean);
+	for (const requiredId of PROTECTED_PATH_CATEGORY_IDS) {
+		if (!ids.includes(requiredId)) errors.push(`Missing required protected path category: ${requiredId}.`);
+	}
+	const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+	if (duplicates.length > 0) errors.push(`Duplicate protected path categories: ${[...new Set(duplicates)].join(', ')}.`);
+
+	for (const category of categories) {
+		validateCategory(category, errors);
+	}
+
+	return { ok: errors.length === 0, errors };
+}
+
+function validateCategory(category, errors) {
+	if (!category || typeof category !== 'object') {
+		errors.push('Each category must be an object.');
+		return;
+	}
+	if (!category.id || typeof category.id !== 'string') errors.push('Category id must be a string.');
+	if (!ALLOWED_MODES.includes(category.mode)) errors.push(`Invalid mode for ${category.id || 'unknown'}: ${category.mode}.`);
+	if (!Array.isArray(category.paths) || category.paths.length === 0) {
+		errors.push(`Category ${category.id || 'unknown'} must declare at least one path.`);
+	}
+	if (!category.ownerSurface || typeof category.ownerSurface !== 'string') {
+		errors.push(`Category ${category.id || 'unknown'} must declare ownerSurface.`);
+	}
+	if (!category.repairHint || typeof category.repairHint !== 'string') {
+		errors.push(`Category ${category.id || 'unknown'} must declare repairHint.`);
+	}
+}
+
+function loadProtectedPathManifest(filePath) {
+	const content = fs.readFileSync(filePath, 'utf8');
+	return YAML.parse(content);
+}
+
+function buildProtectedPathManifestEvidence(manifest = getDefaultProtectedPathManifest()) {
+	return {
+		schemaVersion: manifest.schemaVersion,
+		kind: 'forge.protectedPathManifest',
+		manifestPath: manifest.manifestPath || '.forge/protected-paths.yaml',
+		categoryIds: PROTECTED_PATH_CATEGORY_IDS,
+		categories: manifest.categories,
+		harnessEnforcement: getProtectedPathHarnessEnforcement(),
+		validation: validateProtectedPathManifest(manifest),
+	};
+}
+
+module.exports = {
+	PROTECTED_PATH_CATEGORY_IDS,
+	buildProtectedPathManifestEvidence,
+	getDefaultProtectedPathManifest,
+	getProtectedPathHarnessEnforcement,
+	loadProtectedPathManifest,
+	validateProtectedPathManifest,
+};

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -165,7 +165,7 @@ function loadProtectedPathManifest(filePath) {
 }
 
 function buildProtectedPathManifestEvidence(manifest = getDefaultProtectedPathManifest()) {
-	let categoryIds = PROTECTED_PATH_CATEGORY_IDS;
+	let categoryIds = [];
 	if (Array.isArray(manifest.categories)) {
 		categoryIds = manifest.categories.map(category => category?.id).filter(Boolean);
 	}

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -232,7 +232,7 @@ function validateLegacySurfaceCoverage(manifest, categories, errors) {
 	if (!manifest.surfacesMigrationNote || typeof manifest.surfacesMigrationNote !== 'string') {
 		errors.push('surfacesMigrationNote must describe the legacy surfaces migration.');
 	}
-	const categoryPaths = categories.flatMap(category => (Array.isArray(category.paths) ? category.paths : []));
+	const categoryPaths = categories.flatMap(category => (Array.isArray(category?.paths) ? category.paths : []));
 	for (const [surfaceId, surface] of Object.entries(manifest.surfaces)) {
 		if (!Array.isArray(surface?.examples) || surface.examples.length === 0) {
 			errors.push(`Legacy surface ${surfaceId} must declare examples for category coverage.`);

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -113,7 +113,10 @@ function validateCategory(category, errors) {
 		return;
 	}
 	if (!category.id || typeof category.id !== 'string') errors.push('Category id must be a string.');
-	if (!ALLOWED_MODES.has(category.mode)) errors.push(`Invalid mode for ${category.id || 'unknown'}: ${category.mode}.`);
+	if (!ALLOWED_MODES.has(category.mode)) {
+		const modeLabel = category.mode ?? '<missing>';
+		errors.push(`Invalid mode for ${category.id || 'unknown'}: ${modeLabel}.`);
+	}
 	const expectedMode = EXPECTED_CATEGORY_MODES[category.id];
 	if (expectedMode && category.mode !== expectedMode) {
 		errors.push(`Category ${category.id} must use mode ${expectedMode}.`);
@@ -148,8 +151,17 @@ function isLegacyProtectedPathsManifest(manifest) {
 }
 
 function loadProtectedPathManifest(filePath) {
-	const content = fs.readFileSync(filePath, 'utf8');
-	return YAML.parse(content);
+	try {
+		const content = fs.readFileSync(filePath, 'utf8');
+		return YAML.parse(content);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const wrapped = new Error(`Failed to load protected path manifest at ${filePath}: ${message}`, { cause: error });
+		if (error && typeof error === 'object' && 'code' in error) {
+			wrapped.code = error.code;
+		}
+		throw wrapped;
+	}
 }
 
 function buildProtectedPathManifestEvidence(manifest = getDefaultProtectedPathManifest()) {

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -258,7 +258,10 @@ function pathPatternCoversExample(pattern, example) {
 }
 
 function normalizeManifestPath(value) {
-	return String(value || '').replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/+$/g, '');
+	let normalized = String(value || '').replaceAll('\\', '/');
+	if (normalized.startsWith('./')) normalized = normalized.slice(2);
+	while (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+	return normalized;
 }
 
 function wildcardPathMatches(pattern, candidate) {
@@ -299,12 +302,12 @@ function segmentPatternMatches(pattern, candidate) {
 			starIndex = patternIndex;
 			candidateCheckpoint = candidateIndex;
 			patternIndex += 1;
-		} else if (starIndex !== -1) {
+		} else if (starIndex === -1) {
+			return false;
+		} else {
 			patternIndex = starIndex + 1;
 			candidateCheckpoint += 1;
 			candidateIndex = candidateCheckpoint;
-		} else {
-			return false;
 		}
 	}
 	while (pattern[patternIndex] === '*') patternIndex += 1;

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -48,28 +48,73 @@ const DEFAULT_PROTECTED_PATH_MANIFEST = {
 		{
 			id: 'user_protocol',
 			mode: 'cli-only',
-			paths: ['AGENTS.md', 'CLAUDE.md', '.cursorrules', 'opencode.json'],
+			paths: [
+				'AGENTS.md',
+				'CLAUDE.md',
+				'.cursorrules',
+				'opencode.json',
+				'.mcp.json',
+				'.forge/config.yaml',
+				'.forge/config.yml',
+				'.forge/config.json',
+				'.forge/protected-paths.yaml',
+			],
 			ownerSurface: 'forge setup or forge options',
 			repairHint: 'Use Forge setup/options commands so harness protocol files stay synchronized.',
 		},
 		{
 			id: 'generated_artifacts',
 			mode: 'ci-blocked',
-			paths: ['.claude/commands/**', '.claude/skills/**', '.cursor/rules/**', '.cursor/skills/**', '.codex/skills/**'],
+			paths: [
+				'.claude/commands/**',
+				'.claude/skills/**',
+				'.cursor/rules/**',
+				'.cursor/skills/**',
+				'.codex/skills/**',
+				'.cline/**',
+				'.roo/**',
+				'.kilocode/**',
+				'.opencode/**',
+				'.github/prompts/**',
+				'.github/workflows/**',
+				'.forge/hooks/**',
+				'lefthook.yml',
+				'.forge/extensions/*/manifest.json',
+				'.github/PLUGIN_TEMPLATE.json',
+				'plugins/*/plugin.json',
+				'plugins/*/extension.json',
+				'plugins/*/manifest.json',
+				'bun.lock',
+				'package-lock.json',
+				'pnpm-lock.yaml',
+				'yarn.lock',
+				'requirements.lock',
+				'poetry.lock',
+				'Cargo.lock',
+				'go.sum',
+				'.forge/extensions.lock',
+				'docs/sessions/**',
+				'docs/memory/**',
+				'.forge/memory/**',
+				'memory.md',
+				'MEMORY.md',
+				'**/memory.md',
+				'**/MEMORY.md',
+			],
 			ownerSurface: 'Forge harness renderer',
 			repairHint: 'Regenerate harness artifacts from the canonical Forge contract.',
 		},
 		{
 			id: 'append_only_logs',
 			mode: 'runtime-only',
-			paths: ['.forge/*.jsonl', '.beads/*.jsonl'],
+			paths: ['.forge/*.jsonl', '.forge/audit.log', '.forge/agent-log.ndjson', '.beads/*.jsonl', '.beads/interactions.jsonl'],
 			ownerSurface: 'Forge or Beads audit writer',
 			repairHint: 'Append through the runtime writer; do not rewrite audit history.',
 		},
 		{
 			id: 'secrets',
 			mode: 'secret-scan-blocked',
-			paths: ['.env', '.env.*', '**/.env', '**/.env.*'],
+			paths: ['.env', '.env.*', '**/.env', '**/.env.*', 'secrets.json', '**/secrets.json', 'credentials.json', '**/credentials.json'],
 			ownerSurface: 'secret manager',
 			repairHint: 'Move secrets to the configured secret manager or local ignored env file.',
 		},
@@ -156,6 +201,7 @@ function validateProtectedPathManifest(manifest) {
 	for (const category of categories) {
 		validateCategory(category, errors);
 	}
+	validateLegacySurfaceCoverage(manifest, categories, errors);
 
 	return { ok: errors.length === 0, errors };
 }
@@ -187,7 +233,13 @@ function isSupportedManifestKind(manifest) {
 }
 
 function isSupportedManifestVersion(manifest) {
-	return manifest.schemaVersion === '1.0.0' || manifest.schemaVersion === '1' || manifest.schemaVersion === 1 || manifest.version === '1' || manifest.version === 1;
+	if (manifest.kind === 'ProtectedPathManifest') {
+		return manifest.schemaVersion === '1.0.0';
+	}
+	if (manifest.kind === 'forge.protectedPaths') {
+		return manifest.version === '1' || manifest.version === 1;
+	}
+	return false;
 }
 
 function isLegacyProtectedPathsManifest(manifest) {
@@ -200,15 +252,73 @@ function loadProtectedPathManifest(filePath) {
 }
 
 function buildProtectedPathManifestEvidence(manifest = getDefaultProtectedPathManifest()) {
+	const categoryIds = Array.isArray(manifest.categoryIds)
+		? manifest.categoryIds
+		: Array.isArray(manifest.categories)
+			? manifest.categories.map(category => category && category.id).filter(Boolean)
+			: PROTECTED_PATH_CATEGORY_IDS;
 	return {
 		schemaVersion: manifest.schemaVersion,
 		kind: 'forge.protectedPathManifest',
 		manifestPath: manifest.manifestPath || '.forge/protected-paths.yaml',
-		categoryIds: PROTECTED_PATH_CATEGORY_IDS,
+		categoryIds,
 		categories: manifest.categories,
 		harnessEnforcement: getProtectedPathHarnessEnforcement(),
 		validation: validateProtectedPathManifest(manifest),
 	};
+}
+
+function validateLegacySurfaceCoverage(manifest, categories, errors) {
+	if (!manifest.surfaces) return;
+	if (manifest.surfacesDeprecated !== true) {
+		errors.push('surfaces must be marked surfacesDeprecated: true when categories are authoritative.');
+	}
+	if (!manifest.surfacesMigrationNote || typeof manifest.surfacesMigrationNote !== 'string') {
+		errors.push('surfacesMigrationNote must describe the legacy surfaces migration.');
+	}
+	const categoryPaths = categories.flatMap(category => (Array.isArray(category.paths) ? category.paths : []));
+	for (const [surfaceId, surface] of Object.entries(manifest.surfaces)) {
+		if (!Array.isArray(surface?.examples) || surface.examples.length === 0) {
+			errors.push(`Legacy surface ${surfaceId} must declare examples for category coverage.`);
+			continue;
+		}
+		for (const example of surface.examples) {
+			if (!categoryPaths.some(pattern => pathPatternCoversExample(pattern, example))) {
+				errors.push(`Legacy surface ${surfaceId} example is not covered by category paths: ${example}.`);
+			}
+		}
+	}
+}
+
+function pathPatternCoversExample(pattern, example) {
+	const normalizedPattern = normalizeManifestPath(pattern);
+	const normalizedExample = normalizeManifestPath(example);
+	if (normalizedPattern === normalizedExample) return true;
+	if (normalizedPattern.endsWith('/**')) {
+		const prefix = normalizedPattern.slice(0, -3);
+		return normalizedExample === prefix || normalizedExample.startsWith(`${prefix}/`);
+	}
+	return wildcardPatternToRegex(normalizedPattern).test(normalizedExample);
+}
+
+function normalizeManifestPath(value) {
+	return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/g, '');
+}
+
+function wildcardPatternToRegex(pattern) {
+	let source = '';
+	for (let index = 0; index < pattern.length; index += 1) {
+		const character = pattern[index];
+		if (character === '*' && pattern[index + 1] === '*') {
+			source += '.*';
+			index += 1;
+		} else if (character === '*') {
+			source += '[^/]*';
+		} else {
+			source += character.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+		}
+	}
+	return new RegExp(`^${source}$`);
 }
 
 module.exports = {

--- a/lib/protected-path-manifest.js
+++ b/lib/protected-path-manifest.js
@@ -23,6 +23,16 @@ const ALLOWED_MODES = [
 	'tool-owned',
 ];
 
+const EXPECTED_CATEGORY_MODES = {
+	forge_core: 'checksum-verified',
+	user_protocol: 'cli-only',
+	generated_artifacts: 'ci-blocked',
+	append_only_logs: 'runtime-only',
+	secrets: 'secret-scan-blocked',
+	beads_state: 'bd-cli-only',
+	immutable: 'tool-owned',
+};
+
 const DEFAULT_PROTECTED_PATH_MANIFEST = {
 	schemaVersion: '1.0.0',
 	kind: 'ProtectedPathManifest',
@@ -119,8 +129,20 @@ function validateProtectedPathManifest(manifest) {
 	if (!manifest || typeof manifest !== 'object') {
 		return { ok: false, errors: ['Manifest must be an object.'] };
 	}
-	if (manifest.kind !== 'ProtectedPathManifest') errors.push('kind must be ProtectedPathManifest.');
-	if (manifest.schemaVersion !== '1.0.0') errors.push('schemaVersion must be 1.0.0.');
+	if (!isSupportedManifestKind(manifest)) {
+		errors.push('kind must be ProtectedPathManifest or forge.protectedPaths.');
+	}
+	if (!isSupportedManifestVersion(manifest)) {
+		errors.push('schemaVersion/version must be 1.0.0 or 1.');
+	}
+
+	if (isLegacyProtectedPathsManifest(manifest)) {
+		if (!Array.isArray(manifest.paths) || manifest.paths.length === 0) {
+			errors.push('Legacy forge.protectedPaths manifest must declare at least one path.');
+		}
+		return { ok: errors.length === 0, errors };
+	}
+
 	if (!Array.isArray(manifest.categories)) errors.push('categories must be an array.');
 
 	const categories = Array.isArray(manifest.categories) ? manifest.categories : [];
@@ -145,6 +167,10 @@ function validateCategory(category, errors) {
 	}
 	if (!category.id || typeof category.id !== 'string') errors.push('Category id must be a string.');
 	if (!ALLOWED_MODES.includes(category.mode)) errors.push(`Invalid mode for ${category.id || 'unknown'}: ${category.mode}.`);
+	const expectedMode = EXPECTED_CATEGORY_MODES[category.id];
+	if (expectedMode && category.mode !== expectedMode) {
+		errors.push(`Category ${category.id} must use mode ${expectedMode}.`);
+	}
 	if (!Array.isArray(category.paths) || category.paths.length === 0) {
 		errors.push(`Category ${category.id || 'unknown'} must declare at least one path.`);
 	}
@@ -154,6 +180,18 @@ function validateCategory(category, errors) {
 	if (!category.repairHint || typeof category.repairHint !== 'string') {
 		errors.push(`Category ${category.id || 'unknown'} must declare repairHint.`);
 	}
+}
+
+function isSupportedManifestKind(manifest) {
+	return manifest.kind === 'ProtectedPathManifest' || manifest.kind === 'forge.protectedPaths';
+}
+
+function isSupportedManifestVersion(manifest) {
+	return manifest.schemaVersion === '1.0.0' || manifest.schemaVersion === '1' || manifest.schemaVersion === 1 || manifest.version === '1' || manifest.version === 1;
+}
+
+function isLegacyProtectedPathsManifest(manifest) {
+	return manifest.kind === 'forge.protectedPaths';
 }
 
 function loadProtectedPathManifest(filePath) {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     ".github/workflows/github-to-beads.yml",
     ".github/workflows/beads-to-github.yml",
     ".forge/hooks/",
+    ".forge/protected-paths.yaml",
     "docs/*.md",
     "install.sh",
     "lefthook.yml",

--- a/scripts/spikes/protected-path-manifest.js
+++ b/scripts/spikes/protected-path-manifest.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('node:path');
+const {
+	buildProtectedPathManifestEvidence,
+	loadProtectedPathManifest,
+} = require('../../lib/protected-path-manifest');
+
+const root = path.resolve(__dirname, '..', '..');
+const manifestPath = path.join(root, '.forge', 'protected-paths.yaml');
+const manifest = loadProtectedPathManifest(manifestPath);
+
+process.stdout.write(`${JSON.stringify(buildProtectedPathManifestEvidence(manifest), null, 2)}\n`);

--- a/scripts/spikes/protected-path-manifest.js
+++ b/scripts/spikes/protected-path-manifest.js
@@ -9,6 +9,12 @@ const {
 
 const root = path.resolve(__dirname, '..', '..');
 const manifestPath = path.join(root, '.forge', 'protected-paths.yaml');
-const manifest = loadProtectedPathManifest(manifestPath);
 
-process.stdout.write(`${JSON.stringify(buildProtectedPathManifestEvidence(manifest), null, 2)}\n`);
+try {
+	const manifest = loadProtectedPathManifest(manifestPath);
+	process.stdout.write(`${JSON.stringify(buildProtectedPathManifestEvidence(manifest), null, 2)}\n`);
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	process.stderr.write(`Failed to build protected path manifest evidence from ${manifestPath}: ${message}\n`);
+	process.exit(1);
+}

--- a/test/package-distribution.test.js
+++ b/test/package-distribution.test.js
@@ -83,6 +83,12 @@ describe('package distribution (npm pack --dry-run)', () => {
     }
   });
 
+  describe('.forge/ protected state manifest', () => {
+    it('includes the canonical protected-path manifest used by runtime defaults', () => {
+      expect(packFiles).toContain('.forge/protected-paths.yaml');
+    });
+  });
+
   describe('excludes development/test artifacts', () => {
     it('does NOT include test/ directory files', () => {
       const testFiles = packFiles.filter((f) => f.startsWith('test/'));

--- a/test/protected-path-manifest.test.js
+++ b/test/protected-path-manifest.test.js
@@ -78,11 +78,38 @@ describe('protected path manifest contract', () => {
     expect(invalid.errors.join('\n')).toContain('Category secrets must use mode secret-scan-blocked.');
   });
 
+  test('reports missing category modes with a readable placeholder', () => {
+    const manifest = getDefaultProtectedPathManifest();
+    const invalid = validateProtectedPathManifest({
+      ...manifest,
+      categories: manifest.categories.map(category =>
+        category.id === 'secrets'
+          ? { ...category, mode: undefined }
+          : category,
+      ),
+    });
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors).toContain('Invalid mode for secrets: <missing>.');
+  });
+
   test('loads the repository default YAML manifest', () => {
     const loaded = loadProtectedPathManifest(path.join(ROOT, '.forge', 'protected-paths.yaml'));
 
     expect(loaded.kind).toBe('ProtectedPathManifest');
     expect(validateProtectedPathManifest(loaded).ok).toBe(true);
+  });
+
+  test('adds file path context to manifest load failures', () => {
+    const missingPath = path.join(ROOT, '.forge', 'missing-protected-paths.yaml');
+
+    try {
+      loadProtectedPathManifest(missingPath);
+      throw new Error('Expected missing manifest load to fail');
+    } catch (error) {
+      expect(error.message).toContain(`Failed to load protected path manifest at ${missingPath}`);
+      expect(error.code).toBe('ENOENT');
+    }
   });
 
   test('rejects legacy surface examples outside canonical category paths', () => {

--- a/test/protected-path-manifest.test.js
+++ b/test/protected-path-manifest.test.js
@@ -175,6 +175,18 @@ describe('protected path manifest contract', () => {
     expect(evidence.categoryIds).toEqual(PROTECTED_PATH_CATEGORY_IDS.filter(id => id !== 'immutable'));
     expect(evidence.validation.ok).toBe(false);
   });
+
+  test('does not report canonical categoryIds for legacy manifests without categories', () => {
+    const evidence = buildProtectedPathManifestEvidence({
+      kind: 'forge.protectedPaths',
+      version: 1,
+      paths: [{ path: '.forge/config.yaml', reason: 'Forge runtime configuration' }],
+    });
+
+    expect(evidence.validation.ok).toBe(true);
+    expect(evidence.categoryIds).toEqual([]);
+    expect(evidence.categories).toBeUndefined();
+  });
 });
 
 describe('protected path manifest docs', () => {

--- a/test/protected-path-manifest.test.js
+++ b/test/protected-path-manifest.test.js
@@ -1,0 +1,82 @@
+const { describe, expect, test } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const {
+  PROTECTED_PATH_CATEGORY_IDS,
+  buildProtectedPathManifestEvidence,
+  getDefaultProtectedPathManifest,
+  getProtectedPathHarnessEnforcement,
+  loadProtectedPathManifest,
+  validateProtectedPathManifest,
+} = require('../lib/protected-path-manifest');
+
+const ROOT = path.resolve(__dirname, '..');
+
+describe('protected path manifest contract', () => {
+  test('defines the seven W1 protected path categories', () => {
+    const manifest = getDefaultProtectedPathManifest();
+
+    expect(manifest.kind).toBe('ProtectedPathManifest');
+    expect(manifest.categories.map(category => category.id)).toEqual(PROTECTED_PATH_CATEGORY_IDS);
+    expect(manifest.categories.find(category => category.id === 'forge_core').mode).toBe('checksum-verified');
+    expect(manifest.categories.find(category => category.id === 'beads_state').mode).toBe('bd-cli-only');
+  });
+
+  test('validates the default manifest and rejects missing categories', () => {
+    const manifest = getDefaultProtectedPathManifest();
+    const valid = validateProtectedPathManifest(manifest);
+
+    expect(valid.ok).toBe(true);
+    expect(valid.errors).toEqual([]);
+
+    const invalid = validateProtectedPathManifest({
+      ...manifest,
+      categories: manifest.categories.filter(category => category.id !== 'immutable'),
+    });
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors.join('\n')).toContain('immutable');
+  });
+
+  test('loads the repository default YAML manifest', () => {
+    const loaded = loadProtectedPathManifest(path.join(ROOT, '.forge', 'protected-paths.yaml'));
+
+    expect(loaded.kind).toBe('ProtectedPathManifest');
+    expect(validateProtectedPathManifest(loaded).ok).toBe(true);
+  });
+
+  test('documents harness enforcement without pretending Cursor hooks are proven', () => {
+    const enforcement = getProtectedPathHarnessEnforcement();
+
+    expect(enforcement.claude.surface).toContain('PreToolUse');
+    expect(enforcement.codex.surface).toContain('hook');
+    expect(enforcement.cursor.status).toBe('fallback');
+    expect(enforcement.cursor.knownIssue).toContain('No verified Cursor hook surface');
+  });
+
+  test('prints machine-readable manifest evidence', () => {
+    const output = execFileSync(
+      process.execPath,
+      [path.join(ROOT, 'scripts', 'spikes', 'protected-path-manifest.js')],
+      { cwd: ROOT, encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(output);
+
+    expect(parsed.kind).toBe('forge.protectedPathManifest');
+    expect(parsed.validation.ok).toBe(true);
+    expect(parsed.harnessEnforcement.cursor.status).toBe('fallback');
+  });
+});
+
+describe('protected path manifest docs', () => {
+  test('links the reference docs and evidence command', () => {
+    const evidence = buildProtectedPathManifestEvidence();
+    const docsIndex = require('node:fs').readFileSync(path.join(ROOT, 'docs', 'INDEX.md'), 'utf8');
+    const docs = require('node:fs').readFileSync(path.join(ROOT, 'docs', 'reference', 'PROTECTED_PATH_MANIFEST.md'), 'utf8');
+
+    expect(evidence.manifestPath).toBe('.forge/protected-paths.yaml');
+    expect(docsIndex).toContain('PROTECTED_PATH_MANIFEST.md');
+    expect(docs).toContain('node scripts/spikes/protected-path-manifest.js');
+    expect(docs).toContain('Cursor fallback');
+  });
+});

--- a/test/protected-path-manifest.test.js
+++ b/test/protected-path-manifest.test.js
@@ -140,6 +140,7 @@ describe('protected path manifest contract', () => {
     const manifest = getDefaultProtectedPathManifest();
     const custom = {
       ...manifest,
+      categoryIds: PROTECTED_PATH_CATEGORY_IDS,
       categories: manifest.categories.filter(category => category.id !== 'immutable'),
     };
     const evidence = buildProtectedPathManifestEvidence(custom);

--- a/test/protected-path-manifest.test.js
+++ b/test/protected-path-manifest.test.js
@@ -51,6 +51,18 @@ describe('protected path manifest contract', () => {
     expect(legacy.errors).toEqual([]);
   });
 
+  test('requires schemaVersion for canonical manifests', () => {
+    const manifest = getDefaultProtectedPathManifest();
+    const invalid = validateProtectedPathManifest({
+      ...manifest,
+      schemaVersion: undefined,
+      version: 1,
+    });
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors.join('\n')).toContain('schemaVersion/version must be 1.0.0 or 1.');
+  });
+
   test('rejects categories that use the wrong protected-path mode', () => {
     const manifest = getDefaultProtectedPathManifest();
     const invalid = validateProtectedPathManifest({
@@ -73,6 +85,23 @@ describe('protected path manifest contract', () => {
     expect(validateProtectedPathManifest(loaded).ok).toBe(true);
   });
 
+  test('rejects legacy surface examples outside canonical category paths', () => {
+    const manifest = loadProtectedPathManifest(path.join(ROOT, '.forge', 'protected-paths.yaml'));
+    const invalid = validateProtectedPathManifest({
+      ...manifest,
+      surfaces: {
+        ...manifest.surfaces,
+        forge_config: {
+          ...manifest.surfaces.forge_config,
+          examples: [...manifest.surfaces.forge_config.examples, 'uncovered/protected-file.yaml'],
+        },
+      },
+    });
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors.join('\n')).toContain('Legacy surface forge_config example is not covered by category paths');
+  });
+
   test('documents harness enforcement without pretending Cursor hooks are proven', () => {
     const enforcement = getProtectedPathHarnessEnforcement();
 
@@ -91,8 +120,21 @@ describe('protected path manifest contract', () => {
     const parsed = JSON.parse(output);
 
     expect(parsed.kind).toBe('forge.protectedPathManifest');
+    expect(parsed.categoryIds).toEqual(PROTECTED_PATH_CATEGORY_IDS);
     expect(parsed.validation.ok).toBe(true);
     expect(parsed.harnessEnforcement.cursor.status).toBe('fallback');
+  });
+
+  test('derives evidence categoryIds from the passed manifest', () => {
+    const manifest = getDefaultProtectedPathManifest();
+    const custom = {
+      ...manifest,
+      categories: manifest.categories.filter(category => category.id !== 'immutable'),
+    };
+    const evidence = buildProtectedPathManifestEvidence(custom);
+
+    expect(evidence.categoryIds).toEqual(PROTECTED_PATH_CATEGORY_IDS.filter(id => id !== 'immutable'));
+    expect(evidence.validation.ok).toBe(false);
   });
 });
 

--- a/test/protected-path-manifest.test.js
+++ b/test/protected-path-manifest.test.js
@@ -102,6 +102,17 @@ describe('protected path manifest contract', () => {
     expect(invalid.errors.join('\n')).toContain('Legacy surface forge_config example is not covered by category paths');
   });
 
+  test('reports null categories without crashing legacy surface coverage', () => {
+    const manifest = loadProtectedPathManifest(path.join(ROOT, '.forge', 'protected-paths.yaml'));
+    const invalid = validateProtectedPathManifest({
+      ...manifest,
+      categories: [...manifest.categories, null],
+    });
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors.join('\n')).toContain('Each category must be an object.');
+  });
+
   test('documents harness enforcement without pretending Cursor hooks are proven', () => {
     const enforcement = getProtectedPathHarnessEnforcement();
 

--- a/test/protected-path-manifest.test.js
+++ b/test/protected-path-manifest.test.js
@@ -38,6 +38,34 @@ describe('protected path manifest contract', () => {
     expect(invalid.errors.join('\n')).toContain('immutable');
   });
 
+  test('accepts the legacy forge init protected paths scaffold identity', () => {
+    const legacy = validateProtectedPathManifest({
+      kind: 'forge.protectedPaths',
+      version: 1,
+      classification: 'standard',
+      harness: { targets: ['codex'] },
+      paths: [{ path: '.forge/config.yaml', reason: 'Forge runtime configuration' }],
+    });
+
+    expect(legacy.ok).toBe(true);
+    expect(legacy.errors).toEqual([]);
+  });
+
+  test('rejects categories that use the wrong protected-path mode', () => {
+    const manifest = getDefaultProtectedPathManifest();
+    const invalid = validateProtectedPathManifest({
+      ...manifest,
+      categories: manifest.categories.map(category =>
+        category.id === 'secrets'
+          ? { ...category, mode: 'tool-owned' }
+          : category,
+      ),
+    });
+
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors.join('\n')).toContain('Category secrets must use mode secret-scan-blocked.');
+  });
+
   test('loads the repository default YAML manifest', () => {
     const loaded = loadProtectedPathManifest(path.join(ROOT, '.forge', 'protected-paths.yaml'));
 


### PR DESCRIPTION
## Summary
- Add a protected-path manifest contract that preserves the existing `.forge/protected-paths.yaml` surfaces map while adding seven portable path categories.
- Add machine-readable harness evidence for Claude, Cursor, and Codex protected-path enforcement surfaces.
- Document the protected-path manifest contract and known Cursor fallback so later docs work can link to it.

## Validation
- `bun test test\protected-path-manifest.test.js`
- `bun test test\protected-path-manifest.test.js test\docs-consistency.test.js test\protected-state-surfaces.test.js test\protected-state-docs.test.js`
- `bun run lint`
- `bun run check`

## Known Issues
- Cursor is documented as a fallback enforcement surface because no verified native Cursor write/edit hook surface is proven in this repo yet.

Refs forge-5146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a canonical protected-path manifest (seven protection categories) with per-category modes, owner/repair guidance, harness-enforcement mapping, validator, and a CLI to emit machine-readable manifest/evidence JSON.

* **Documentation**
  * Added reference doc, design and decision notes, tasks plan, and linked the reference from the docs index.

* **Tests**
  * Added end-to-end tests for defaults, schema/validation, loading, harness enforcement reporting, evidence output, and package inclusion.

* **Chores**
  * Included the protected-path manifest in the published package files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->