### PR TITLE
docs: plan week 3 capability packs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,6 +29,7 @@ This is the entry point for all Forge documentation. The structure mirrors how d
 - [extension-system.md](work/2026-04-28-skeleton-pivot/extension-system.md) — manifest spec, resolvers, lockfile, sandbox
 - [skill-distribution.md](work/2026-04-28-skeleton-pivot/skill-distribution.md) — marketplace allowlist + name collisions
 - [skill-generation.md](work/2026-04-28-skeleton-pivot/skill-generation.md) — observed-work mining → skill proposals (D18)
+- [week-3-runtime-capability-packs.md](work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md) — Week 3 capability pack registry, on-demand skills MCP, workflow composer, and plugin discovery plan
 - [agent-memory-architecture.md](work/2026-04-28-skeleton-pivot/agent-memory-architecture.md) — 7 typed memory categories (D22/D24)
 - [marketplace-patchmd-use-case-kits.md](work/2026-04-28-skeleton-pivot/marketplace-patchmd-use-case-kits.md) — use-case validation
 - [n1-moat-technical-deep-dive.md](work/2026-04-28-skeleton-pivot/n1-moat-technical-deep-dive.md) — moat analysis (D8/D9, kill criteria for D38)

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -73,6 +73,8 @@ Week 3 expands that into a runtime capability registry. The registry must cover 
 
 Invocation policy is part of parity. Required skills must be loaded by Forge runtime at stage or gate boundaries; expensive, dangerous, or long-running skills must remain gated, hidden, or execution-only until the user or runtime explicitly requests them.
 
+Parity is not accepted until an evaluator cross-checks the resolved workflow graph against generated harness projections and either passes, blocks, or records a known issue with evidence. The evaluator must also propose minimal repair diffs when a customer-installed workflow pack changes the active stage implementation.
+
 ## Evidence Command
 
 Run the parity fixture from the repository root:

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -4,6 +4,8 @@ Forge treats cross-agent skill compatibility as one canonical capability rendere
 
 This page documents the W0 metadata fixture only. It is not the full Forge extension parity model.
 
+For Week 3 planning, see [Week 3 Runtime Capability Packs](../work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md). That plan defines replaceable workflow packs, on-demand skill loading through MCP, runtime-enforced required skill policies, and per-project workflow composition.
+
 ## Supported Surfaces
 
 | Harness | Forge fixture path | Activation metadata | Proof status |
@@ -66,6 +68,10 @@ The full Forge extension parity model must cover more than skills:
 | Marketplace/extensions | `extension.yaml` plus lock metadata | plugin/skills/commands/hooks | skills/rules/MCP config | skills/MCP/hooks | lockfile, SHA, trust, generated targets |
 
 The next implementation should start with a machine-readable harness capability matrix and renderer contract before adding more generated files.
+
+Week 3 expands that into a runtime capability registry. The registry must cover skills, commands, hooks, MCPs, ACPs, books/docs, agents, memory policies, protected paths, marketplace metadata, and workflow stages. Harness files should be generated projections from the active project workflow, not the authority.
+
+Invocation policy is part of parity. Required skills must be loaded by Forge runtime at stage or gate boundaries; expensive, dangerous, or long-running skills must remain gated, hidden, or execution-only until the user or runtime explicitly requests them.
 
 ## Evidence Command
 

--- a/docs/work/2026-04-28-skeleton-pivot/README.md
+++ b/docs/work/2026-04-28-skeleton-pivot/README.md
@@ -47,7 +47,8 @@ See [release-plan.md](./release-plan.md) for scope, evaluator regions, gates, an
 4. [locked-decisions.md](./locked-decisions.md) - D1-D43 decisions with rationale, tradeoffs, and anti-decisions.
 5. [LEARNINGS.md](./LEARNINGS.md) - takeaways from the iteration process.
 6. [iteration-driven-planning-skill.md](./iteration-driven-planning-skill.md) - planning method, now treated as one configurable planning template/skill.
-7. [v3-redesign-strategy.md](./v3-redesign-strategy.md) - reference strategy with superseded sections preserved.
+7. [week-3-runtime-capability-packs.md](./week-3-runtime-capability-packs.md) - Week 3 target for replaceable workflow packs, on-demand skills MCP, runtime-enforced skill loading, and per-project workflow composition.
+8. [v3-redesign-strategy.md](./v3-redesign-strategy.md) - reference strategy with superseded sections preserved.
 
 Design references:
 
@@ -55,6 +56,7 @@ Design references:
 - [extension-system.md](./extension-system.md) - extension manifest, resolvers, lockfile, and sandbox notes.
 - [skill-distribution.md](./skill-distribution.md) - skill distribution and name collision rules.
 - [skill-generation.md](./skill-generation.md) - observed-work mining into skill proposals.
+- [week-3-runtime-capability-packs.md](./week-3-runtime-capability-packs.md) - capability pack registry, workflow composer, and plugin discovery plan.
 - [agent-memory-architecture.md](./agent-memory-architecture.md) - typed memory categories and storage choices.
 - [template-library-and-merge-flow.md](./template-library-and-merge-flow.md) - templates as adoption scaffolds, plus optional community merge flow.
 - [research/2026-05-18-open-questions-memory-ui-beads-post-018.md](./research/2026-05-18-open-questions-memory-ui-beads-post-018.md) - post-`0.0.18` memory, hooks, local UI, Beads scale, and control-plane findings.

--- a/docs/work/2026-04-28-skeleton-pivot/release-plan.md
+++ b/docs/work/2026-04-28-skeleton-pivot/release-plan.md
@@ -437,6 +437,10 @@ Scope:
 
 - Extension manifest `contributes` schema for stages, substages, evaluator regions, evidence collectors, hooks, adapters, templates, commands, and local UI panels.
 - `SKILL.md` package contribution is the canonical agent-facing format. Commands, slash aliases, hook files, generated docs, and UI panels are projections from the manifest, not separate hand-maintained sources.
+- Week 3 capability-pack resolver from [week-3-runtime-capability-packs.md](./week-3-runtime-capability-packs.md): Forge keeps the stable workflow shell while project/user-selected packs replace, extend, disable, or gate individual stage implementations.
+- On-demand skills MCP contract: installed skills can remain discoverable, hidden, gated, or execution-only until `resolve_required_capabilities` or `load_skill` is called by the runtime.
+- Runtime-enforced invocation policy: required stage/gate skills cannot be skipped by harness prompt discretion, and expensive or risky skills cannot be randomly auto-invoked.
+- Plugin/workflow discovery and recommendation: Forge scans installed packs, harness configs, MCP configs, and marketplace cache, then proposes project-level workflow changes with evidence, config diff, rollback path, and harness projection impact.
 - skills.sh/GitHub import path through `packages/skills`: import disabled by default, pin source/ref, validate `SKILL.md`, record trust/permission metadata, then allow project-level enablement through config or UI.
 - Documentation validators are a required example extension type: a docs adapter can declare supported file types, discovery signals, config files, CI projections, local hook projections, and UI fields.
 - Resolver adds source, trust, permission, collision, and config-source metadata into the runtime graph.
@@ -449,11 +453,14 @@ Evaluator regions:
 - Collision and trust handling.
 - Toggle/rollback correctness.
 - Skill package provenance and permission review.
+- Required skill loading and gated-skill non-invocation.
+- Harness projection status: `native`, `translated`, `fallback`, `unsupported_known_issue`, or `disabled_by_policy`.
 
 Release gate:
 
 - A local extension can contribute a verification substage and UI panel, be toggled on for one project, and be removed without leaving generated artifacts behind.
 - A third-party skill package can be imported, reviewed, pinned, enabled for one project, projected into at least Claude and Codex, and disabled without leaving stale command aliases.
+- A project can replace Forge `/plan` with a Superpowers-style planning pack, extend frontend review with an Impeccable-style pack, and emit machine-readable evidence showing required skills loaded, optional skills skipped, and per-harness projection status.
 
 ## 0.0.25 - Scaled Team Runtime And External Orchestrator Bridge
 

--- a/docs/work/2026-04-28-skeleton-pivot/release-plan.md
+++ b/docs/work/2026-04-28-skeleton-pivot/release-plan.md
@@ -455,12 +455,14 @@ Evaluator regions:
 - Skill package provenance and permission review.
 - Required skill loading and gated-skill non-invocation.
 - Harness projection status: `native`, `translated`, `fallback`, `unsupported_known_issue`, or `disabled_by_policy`.
+- Evaluator cross-check loop that compares the resolved workflow graph to generated harness projections, proposes minimal repair diffs, and re-runs until `pass`, `blocked`, or `known_issue`.
 
 Release gate:
 
 - A local extension can contribute a verification substage and UI panel, be toggled on for one project, and be removed without leaving generated artifacts behind.
 - A third-party skill package can be imported, reviewed, pinned, enabled for one project, projected into at least Claude and Codex, and disabled without leaving stale command aliases.
 - A project can replace Forge `/plan` with a Superpowers-style planning pack, extend frontend review with an Impeccable-style pack, and emit machine-readable evidence showing required skills loaded, optional skills skipped, and per-harness projection status.
+- The evaluator catches at least one intentionally broken projection, emits a repair recommendation, and passes after the projection is regenerated.
 
 ## 0.0.25 - Scaled Team Runtime And External Orchestrator Bridge
 

--- a/docs/work/2026-04-28-skeleton-pivot/release-plan.md
+++ b/docs/work/2026-04-28-skeleton-pivot/release-plan.md
@@ -456,6 +456,7 @@ Evaluator regions:
 - Required skill loading and gated-skill non-invocation.
 - Harness projection status: `native`, `translated`, `fallback`, `unsupported_known_issue`, or `disabled_by_policy`.
 - Evaluator cross-check loop that compares the resolved workflow graph to generated harness projections, proposes minimal repair diffs, and re-runs until `pass`, `blocked`, or `known_issue`.
+- Negative evaluator fixtures for omitted required skills, ungated gated skills, leaked hidden skills, stale disabled-pack artifacts, and unsupported native hook claims.
 
 Release gate:
 
@@ -463,6 +464,7 @@ Release gate:
 - A third-party skill package can be imported, reviewed, pinned, enabled for one project, projected into at least Claude and Codex, and disabled without leaving stale command aliases.
 - A project can replace Forge `/plan` with a Superpowers-style planning pack, extend frontend review with an Impeccable-style pack, and emit machine-readable evidence showing required skills loaded, optional skills skipped, and per-harness projection status.
 - The evaluator catches at least one intentionally broken projection, emits a repair recommendation, and passes after the projection is regenerated.
+- The release evidence distinguishes landed behavior from in-flight PR behavior so the plan never claims unmerged parity as current `master` capability.
 
 ## 0.0.25 - Scaled Team Runtime And External Orchestrator Bridge
 

--- a/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
+++ b/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
@@ -11,7 +11,7 @@ Current Forge implementation does not yet match the full parity model discussed 
 What exists:
 
 - W0 skill metadata parity: one canonical skill fixture rendered to Claude Code, Cursor, and Codex surfaces, documented in [AGENT_SKILL_PARITY.md](../../reference/AGENT_SKILL_PARITY.md).
-- W1 protected-path parity work: a protected-path manifest and evidence command prove seven protected-path categories across Claude, Cursor, and Codex, with Cursor marked as fallback.
+- W1 protected-path parity work exists as PR #187 at verification time, not as landed `master` behavior. That PR adds a protected-path manifest and evidence command for seven protected-path categories across Claude, Cursor, and Codex, with Cursor marked as fallback.
 - v3 docs already frame templates as adoption scaffolds and runtime building blocks as the product.
 
 What is missing:
@@ -168,6 +168,20 @@ Every projection must report one of:
 
 Week 3 implementation must include an evaluator loop so the runtime does not silently drift from the configured workflow.
 
+### Evaluator Inputs
+
+The evaluator must read the same inputs the runtime uses, not an independent checklist:
+
+- `.forge/capabilities.yaml` and any project-local pack manifests
+- user profile preferences and project workflow overrides
+- task classification and explicit CLI/UI run overrides
+- installed pack lock metadata and marketplace trust records
+- MCP server configs and discovered MCP capability metadata
+- generated Claude, Codex, and Cursor projection files
+- protected-path manifest and generated hook/fallback policy
+- stage ledger entries showing required, loaded, skipped, gated, and hidden capabilities
+- known-issue records for unsupported harness surfaces
+
 The loop runs after capability discovery, workflow resolution, and harness projection:
 
 1. **Collect** installed packs, project/user preferences, task classification, harness support, and current generated files.
@@ -182,6 +196,18 @@ The loop runs after capability discovery, workflow resolution, and harness proje
    - disabled packs leave no stale aliases, hooks, rules, or MCP config
 5. **Improve** by proposing a minimal config or projection patch when the cross-check fails.
 6. **Re-run** the evaluator until it reaches `pass`, `blocked`, or `known_issue`.
+
+### Negative Fixtures
+
+Week 3 must include intentionally broken projection fixtures so the evaluator proves it can catch and repair real drift. Required negative fixtures:
+
+- a required stage skill omitted from one harness projection
+- a gated skill invoked without approval evidence
+- a hidden skill exposed in an always-on harness rule
+- a disabled pack leaving behind a stale command alias or hook
+- a Cursor projection claiming native hook support when only fallback evidence exists
+
+Each negative fixture must fail before repair, emit a minimal repair recommendation, regenerate or update the projection, and pass on the next evaluator run.
 
 The evaluator must emit machine-readable results:
 

--- a/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
+++ b/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
@@ -1,0 +1,187 @@
+# Week 3 Runtime Capability Packs
+
+**Status:** Week 3 planning target.
+**Verified on:** 2026-05-24.
+**Depends on:** W0 cross-harness skill parity and W1 protected-path harness evidence.
+
+## Current Implementation Check
+
+Current Forge implementation does not yet match the full parity model discussed for v3.
+
+What exists:
+
+- W0 skill metadata parity: one canonical skill fixture rendered to Claude Code, Cursor, and Codex surfaces, documented in [AGENT_SKILL_PARITY.md](../../reference/AGENT_SKILL_PARITY.md).
+- W1 protected-path parity work: a protected-path manifest and evidence command prove seven protected-path categories across Claude, Cursor, and Codex, with Cursor marked as fallback.
+- v3 docs already frame templates as adoption scaffolds and runtime building blocks as the product.
+
+What is missing:
+
+- A canonical capability registry covering skills, commands, hooks, MCPs, ACPs, books/docs, agents, memory policies, protected paths, marketplace metadata, and workflow stages.
+- Replaceable workflow packs so users can disable Forge defaults and activate packs such as Superpowers, Impeccable, project-local packs, or marketplace packs.
+- Runtime-enforced required skill loading at stage/gate boundaries.
+- On-demand skill loading through a Forge skills MCP server so large or expensive skills stay hidden until needed.
+- Installed plugin/workflow discovery and recommendation based on project preferences.
+- Harness projections generated from the active project workflow, not hand-maintained per-agent copies.
+
+## Product Rule
+
+Forge owns the stable workflow shell. Capability packs own the implementation.
+
+The user-facing shell remains familiar:
+
+```text
+status -> plan -> dev -> validate -> ship -> review -> premerge -> verify
+```
+
+Each stage can be implemented by Forge defaults, an external pack, a local project pack, or a composed chain. The runtime must resolve the active graph before any harness receives instructions.
+
+## Capability Pack Model
+
+A pack can contribute:
+
+- stages and substages
+- skills and subskills
+- commands and command shims
+- hooks and fallback checks
+- MCP servers, tools, and resources
+- ACP adapters
+- books, docs, and reference bundles
+- agent/subagent roles
+- memory policies and patch override rules
+- protected-path categories
+- marketplace metadata and trust policy
+- UI workflow-composer fields
+
+Each pack must declare:
+
+- `id`, `name`, `version`, `source`, and `lock`
+- provided stages and capabilities
+- supported harnesses
+- permissions and trust requirements
+- cost, latency, and risk hints
+- conflicts, replacements, and extension points
+- recommended task types and project types
+- rollback and stale-artifact cleanup rules
+
+## Workflow Composition
+
+Project configuration must support stage-level composition:
+
+| Mode | Meaning | Example |
+| --- | --- | --- |
+| `replace` | Use this pack instead of the default stage implementation. | Replace Forge `/plan` with Superpowers planning. |
+| `extend_before` | Run this pack before the default stage. | Add project context discovery before `/dev`. |
+| `extend_after` | Run this pack after the default stage. | Add Impeccable design review after frontend implementation. |
+| `optional` | Recommend but do not require the capability. | Offer a security review for low-risk UI copy changes. |
+| `disabled` | Do not expose or invoke this capability. | Disable Forge default planning in a Superpowers-only project. |
+| `blocked` | Never auto-load; explicit user approval only. | Dangerous migrations, destructive cleanup, or paid long-running scans. |
+
+Resolution precedence:
+
+1. explicit run override from CLI/UI
+2. task classification override
+3. project config
+4. user profile default
+5. Forge default pack
+
+## Skill Invocation Policy
+
+Skills cannot rely only on model discretion. The runtime must enforce loading policy.
+
+| Policy | Runtime behavior |
+| --- | --- |
+| `required` | Must load before a stage, gate, or protected action can proceed. |
+| `recommended` | Router should load when task metadata matches. |
+| `on_demand` | Metadata is visible, body is loaded only after selection. |
+| `gated` | Requires explicit user/runtime approval before loading. |
+| `hidden` | Not discoverable unless an explicit command, dependency, or policy asks for it. |
+| `execution_only` | Agent never receives full instructions; MCP/runtime executes and returns evidence. |
+
+Mandatory examples:
+
+- `/plan` loads the active planning pack and any required research/critic subskills.
+- `/dev` loads TDD, protected-path, task execution, and decision-gate policies.
+- `/validate` loads validation and debug policies.
+- `/ship` loads PR, docs, and check policy.
+- `/review` loads GitHub review/comment policy.
+- `/verify` loads post-merge proof policy.
+
+## On-Demand Skills MCP
+
+Forge should expose a `forge-skills-mcp` server instead of projecting every skill body into every harness.
+
+Required tools:
+
+- `search_capabilities(task, projectContext)`
+- `inspect_capability(id)`
+- `resolve_required_capabilities(stage, action)`
+- `load_skill(id, reason)`
+- `assert_required_loaded(stage, action)`
+- `run_capability(id, inputs)`
+- `record_invocation_evidence(event)`
+- `recommend_workflow_changes(projectContext)`
+
+The always-visible harness payload should be a small router skill/rule. Most skill bodies remain in the registry until the runtime or user requests them.
+
+## Plugin Discovery And Recommendation
+
+Forge must recognize installed customer workflows and recommend adaptations.
+
+Discovery sources:
+
+- project `.forge/packs`
+- user-level Forge pack directory
+- `.claude`, `.codex`, and `.cursor` harness folders
+- MCP server configs
+- marketplace registry/cache
+- project-local extension manifests
+
+Recommendation examples:
+
+- Superpowers can replace Forge `/plan`.
+- Impeccable can extend frontend design review.
+- A GitHub MCP can strengthen `/review`.
+- Cursor lacks a verified native hook for a gate, so Forge should keep fallback enforcement.
+- A hidden or expensive skill should stay gated because the project prefers low-cost runs.
+
+Recommendations must include evidence, a config diff, rollback path, and affected harness projections.
+
+## Harness Projection Contract
+
+The resolved workflow graph generates harness-specific files:
+
+| Harness | Projection |
+| --- | --- |
+| Claude Code | plugin manifest, skills, hooks, MCP config, command shims, `CLAUDE.md` if needed |
+| Codex | skills, config, MCP config, lifecycle hooks where supported, `AGENTS.md` sections |
+| Cursor | `.cursor/rules`, Cursor skills where supported, MCP config, `AGENTS.md`, fallback hook checks |
+
+Every projection must report one of:
+
+- `native`
+- `translated`
+- `fallback`
+- `unsupported_known_issue`
+- `disabled_by_policy`
+
+## Week 3 Deliverables
+
+1. Add `.forge/capabilities.yaml` with Forge default pack metadata, visibility, invocation policy, and stage bindings.
+2. Add a capability registry loader and validator.
+3. Add a workflow resolver that applies user/project/task overrides.
+4. Add an on-demand skills MCP contract with stubbed tools and JSON evidence.
+5. Add generated harness projection evidence for Claude, Codex, and Cursor.
+6. Add docs showing how to replace Forge `/plan` with Superpowers and extend frontend review with Impeccable.
+7. Add tests proving required skills cannot be skipped at stage boundaries.
+
+## Acceptance Evidence
+
+Week 3 is complete only when Forge can emit machine-readable evidence for:
+
+- active project workflow graph
+- installed packs and disabled packs
+- required, recommended, gated, hidden, and execution-only capabilities
+- skills loaded for a stage and skills intentionally skipped
+- harness projection status for Claude, Codex, and Cursor
+- known issues when a harness cannot provide native parity
+- rollback cleanup for disabled or replaced packs

--- a/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
+++ b/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
@@ -199,6 +199,8 @@ The loop runs after capability discovery, workflow resolution, and harness proje
 5. **Improve** by proposing a minimal config or projection patch when the cross-check fails.
 6. **Re-run** the evaluator until it reaches `pass`, `blocked`, or `known_issue`.
 
+The re-run loop must be bounded. The default limit is three repair attempts or five minutes of wall-clock time, whichever comes first. If the evaluator still fails after the limit, it must stop with `blocked`, emit the remaining findings, and include the last proposed repair diff. It must not continue regenerating projections indefinitely.
+
 ### Negative Fixtures
 
 Week 3 must include intentionally broken projection fixtures so the evaluator proves it can catch and repair real drift. Required negative fixtures:

--- a/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
+++ b/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
@@ -156,6 +156,8 @@ The resolved workflow graph generates harness-specific files:
 | Codex | skills, config, MCP config, lifecycle hooks where supported, `AGENTS.md` sections |
 | Cursor | `.cursor/rules`, Cursor skills where supported, MCP config, `AGENTS.md`, fallback hook checks |
 
+Cursor projection must explicitly separate on-demand Cursor skills from always-on or scoped `.cursor/rules` policy, and it must keep protected-path hook behavior on fallback unless native Cursor hook evidence exists.
+
 Every projection must report one of:
 
 - `native`

--- a/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
+++ b/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
@@ -164,6 +164,42 @@ Every projection must report one of:
 - `unsupported_known_issue`
 - `disabled_by_policy`
 
+## Evaluator Cross-Check Loop
+
+Week 3 implementation must include an evaluator loop so the runtime does not silently drift from the configured workflow.
+
+The loop runs after capability discovery, workflow resolution, and harness projection:
+
+1. **Collect** installed packs, project/user preferences, task classification, harness support, and current generated files.
+2. **Resolve** the active workflow graph with replacement, extension, disabled, gated, hidden, and execution-only rules applied.
+3. **Project** the graph into Claude, Codex, and Cursor surfaces.
+4. **Cross-check** projections against the graph:
+   - every `required` capability is loaded or blocked with a hard error
+   - every `gated` capability has an approval record before use
+   - every `hidden` capability stays hidden unless a policy dependency opens it
+   - every unsupported harness surface is marked `unsupported_known_issue`
+   - generated command shims point back to canonical skills or runtime actions
+   - disabled packs leave no stale aliases, hooks, rules, or MCP config
+5. **Improve** by proposing a minimal config or projection patch when the cross-check fails.
+6. **Re-run** the evaluator until it reaches `pass`, `blocked`, or `known_issue`.
+
+The evaluator must emit machine-readable results:
+
+```json
+{
+  "kind": "forge.capabilityPackEvaluation",
+  "workflowId": "project-default",
+  "status": "pass",
+  "requiredLoaded": ["forge.plan", "forge.tdd"],
+  "gatedAwaitingApproval": [],
+  "hiddenOpenedByPolicy": [],
+  "projectionFindings": [],
+  "knownIssues": []
+}
+```
+
+This evaluator is the safety net for customer-installed workflows. If a user installs Superpowers, Impeccable, or a private workflow pack, Forge must re-evaluate the graph, recommend the right replacement or extension, and prove the harness projections still match the active project policy.
+
 ## Week 3 Deliverables
 
 1. Add `.forge/capabilities.yaml` with Forge default pack metadata, visibility, invocation policy, and stage bindings.
@@ -172,7 +208,8 @@ Every projection must report one of:
 4. Add an on-demand skills MCP contract with stubbed tools and JSON evidence.
 5. Add generated harness projection evidence for Claude, Codex, and Cursor.
 6. Add docs showing how to replace Forge `/plan` with Superpowers and extend frontend review with Impeccable.
-7. Add tests proving required skills cannot be skipped at stage boundaries.
+7. Add an evaluator loop that cross-checks active workflow graph, required skills, gated/hidden policy, generated projections, stale artifacts, and known issues.
+8. Add tests proving required skills cannot be skipped at stage boundaries and evaluator failures produce repair recommendations.
 
 ## Acceptance Evidence
 
@@ -185,3 +222,4 @@ Week 3 is complete only when Forge can emit machine-readable evidence for:
 - harness projection status for Claude, Codex, and Cursor
 - known issues when a harness cannot provide native parity
 - rollback cleanup for disabled or replaced packs
+- evaluator result showing `pass`, `blocked`, or `known_issue` after every generated projection


### PR DESCRIPTION
## Summary
- Add Week 3 runtime capability-pack plan covering replaceable workflow packs, on-demand skills MCP, runtime-enforced skill loading, plugin discovery, and project-level workflow composition.
- Link the Week 3 plan from the v3 reading order, docs index, skill parity reference, and 0.0.24 release plan.
- Document the verified gap: current implementation proves W0/W1 parity slices, not full skills/MCP/ACP/books/hooks/commands/memory/marketplace parity.

## Validation
- `bun test test/docs-consistency.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Week 3 specification for Runtime Capability Packs and linked it in the docs index and work README.
  * Defined a v3 runtime capability model, on-demand skill contract, composition/resolution rules, and runtime-enforced invocation policies.
  * Introduced harness projection status categories, required recommendation outputs (evidence, config diffs, rollback paths), and evaluator cross-check loop with machine-readable result schema, negative fixtures, and repair-diff requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->