### PR TITLE
docs: reset Forge Kernel authority plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Task 2: Validation logic
 
 > GitHub issue lifecycle may sync to Beads via CI -- see [docs/guides/BEADS_GITHUB_SYNC.md](docs/guides/BEADS_GITHUB_SYNC.md).
 
-**Beads is the durable issue-state authority** (survives compaction). Forge may keep local adapter/cache files such as `.forge-state.json` for stage-entry recovery, but those files must not override current Beads issue state when Beads metadata is available.
+**Current implementation**: Beads is the temporary durable issue-state authority for existing issue workflows. **Target architecture (D44)**: Forge Kernel becomes the issue/workflow/run authority; Beads becomes import/export/projection compatibility. New authority work must follow [docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md](docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md) and [docs/reference/FORGE_KERNEL_STORAGE_MODEL.md](docs/reference/FORGE_KERNEL_STORAGE_MODEL.md).
 
 ```json
 {
@@ -172,9 +172,10 @@ Task 2: Validation logic
 - [docs/reference/TOOLCHAIN.md](docs/reference/TOOLCHAIN.md) - Tool setup and configuration
 - [docs/reference/VALIDATION.md](docs/reference/VALIDATION.md) - Enforcement and validation details
 
-**Forge v3 Plan (active design):**
-- [docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md](docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md) — canonical v3 master strategy (waves, workstreams, harness targets)
-- [docs/work/2026-04-28-skeleton-pivot/locked-decisions.md](docs/work/2026-04-28-skeleton-pivot/locked-decisions.md) — D1–D20 decisions ledger with rationale + tradeoffs + anti-decisions
+**Forge v3 / Kernel Plan (active design):**
+- [docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md](docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md) — canonical Forge Kernel authority reset plan for issue authority, local broker, team authority, adapters, storage, and gates
+- [docs/work/2026-04-28-skeleton-pivot/locked-decisions.md](docs/work/2026-04-28-skeleton-pivot/locked-decisions.md) — D1–D44 decisions ledger with rationale + tradeoffs + anti-decisions; D44 supersedes Beads-only authority portions of earlier decisions
+- [docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md](docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md) — historical v3 strategy and background; do not use its Beads/Dolt default-substrate language over D44
 - See [docs/INDEX.md](docs/INDEX.md) for the full reading order across the v3 design folder
 
 **Load these files when you need detailed instructions for a specific stage.**
@@ -245,7 +246,7 @@ forge close <id>      # Complete work
 
 ### Rules
 
-- Use `forge` as the routine command surface for bd-backed issue tracking and sync workflows — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/work/YYYY-MM-DD-<slug>/tasks.md` — these are approved artifacts consumed by `/dev`, but Beads (`bd`) remains the source of truth for issue state and IDs. Use `bd` directly only for operations Forge does not wrap yet, such as `bd init`, `bd comments`, `bd dep`, and `bd dolt *`. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/guides/BEADS_GITHUB_SYNC.md`).
+- Use `forge` as the routine command surface for current bd-backed issue tracking and sync workflows until Forge Kernel replaces it — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/work/YYYY-MM-DD-<slug>/tasks.md` — these are approved artifacts consumed by `/dev`. Beads (`bd`) remains the current operational tracker for existing issues, but not the target architecture. New issue-authority work must route through the Forge Kernel design. Use `bd` directly only for operations Forge does not wrap yet, such as `bd init`, `bd comments`, `bd dep`, and `bd dolt *`. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/guides/BEADS_GITHUB_SYNC.md`).
 - Run `bd prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ This is the planned public documentation and positioning release. The package re
 
 ### Changed
 
+- **Forge Kernel authority plan reset** (PR #191, forge-2agy.8): reframed the post-0.0.18 release train around Forge Kernel authority, local SQLite broker boundaries, Cloudflare team authority, Beads import/export compatibility, provider capability contracts, and decision drift guards.
 - **Ambiguity policy**: Hardcoded rubric scoring (>= 80% proceed, < 80% ask) as default in `/plan` — removed redundant per-feature Q&A question
 
 ## [0.0.5] - 2026-03-22

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,6 +30,8 @@ This is the canonical map for Forge documentation. DeepWiki and other generated 
 - [Command reference](reference/COMMANDS.md) - verified `forge` CLI commands and package binaries.
 - [Skills and command projections](reference/SKILLS.md) - current stage packaging across skills, commands, prompts, and harness projections.
 - [Release reference](reference/RELEASE.md) - validation, packaging, release handoff, and DeepWiki checklist.
+- [Forge Kernel storage model](reference/FORGE_KERNEL_STORAGE_MODEL.md) - authority/cache/projection/archive storage rules for local and team modes.
+- [Decision drift guards](reference/DECISION_DRIFT_GUARDS.md) - evaluator checklist and required doc updates for Kernel-era architecture changes.
 - [Toolchain](reference/TOOLCHAIN.md) - Bun, Node, Git, GitHub CLI, Beads, shell, and MCP conventions.
 - [Validation](reference/VALIDATION.md) - `bun run check`, failure meanings, and recovery.
 - [Templates](reference/TEMPLATES.md) - adoption profiles and the default workflow template.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -54,6 +54,7 @@ The links below are for maintainers and architecture readers. They are not part 
 - [Runtime building-block refinement](work/2026-04-28-skeleton-pivot/runtime-building-blocks-refinement.md) - advanced architecture direction: runtime primitives, evaluator regions, and templates as scaffolds.
 - [Locked decisions](work/2026-04-28-skeleton-pivot/locked-decisions.md) - historical decision ledger.
 - [Release plan](work/2026-04-28-skeleton-pivot/release-plan.md) - internal release phasing. Internal labels are not npm package versions.
+- [Forge Kernel authority control plane](work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md) - current authority reset plan: Forge-native issue kernel, local broker, Cloudflare team authority, and Beads as import/export adapter.
 - [Beads/Supabase and Forge memory design](work/2026-04-28-skeleton-pivot/beads-supabase-and-forge-memory-design.md) - Beads coexistence analysis.
 
 ## Historical Or Superseded Material

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -77,8 +77,8 @@ The full Forge extension parity model must cover more than skills:
 | Rules/policies | Forge rule manifest | `CLAUDE.md` or `.claude/rules` if supported | `.cursor/rules/*.mdc` | `AGENTS.md` section | rule target and unsupported-surface notes |
 | MCP tools/resources | Forge MCP manifest | Claude MCP config | `.cursor/mcp.json` | Codex MCP config | config render and server probe |
 | Hooks | Forge hook manifest | Claude hook adapter if supported | unsupported unless verified | Codex hook adapter if supported | supported/unsupported matrix |
-| Commands | Forge command shim manifest | `.claude/commands` thin shims | native command surface if supported | CLI docs or skill fallback | shim points to canonical skill |
-| Agents/subagents | Forge agent role spec | Claude subagents | Cursor agent/subagent config if supported | Codex skill/agent fallback | role mapping or known issue |
+| Commands | Forge command shim manifest | `.claude/commands` thin shims | native command surface if supported | CLI docs or skill backstop | shim points to canonical skill |
+| Agents/subagents | Forge agent role spec | Claude subagents | Cursor agent/subagent config if supported | Codex skill/agent backstop | role mapping or known issue |
 | Marketplace/extensions | `extension.yaml` plus lock metadata | plugin/skills/commands/hooks | skills/rules/`.cursor/mcp.json` config | skills/MCP/hooks | lockfile, SHA, trust, generated targets |
 
 The machine-readable matrix intentionally separates similar-looking surfaces:
@@ -154,5 +154,5 @@ Known gaps intentionally left for follow-up:
 
 - Cursor Agent Skills are not proven in the W0 fixture; the capability matrix records `.cursor/skills` as the intended on-demand target and `.cursor/rules` as the policy target.
 - Claude still has command-first stage distribution in the current Forge setup; the skills-first graph records commands as shims over `.claude/skills`.
-- Cursor hooks remain unsupported until a verified hook surface exists; use Forge-owned hooks or file-watcher fallback for protected-path enforcement.
+- Cursor hooks remain unsupported until a verified hook surface exists; use Forge-owned hooks or file-watcher backstop for protected-path enforcement.
 - MCPs, hooks, stage/gate renderers, Beads wiring, typed memory, patch overrides, marketplace trust, and extension packs are covered by the capability matrix contract, but broad renderer implementation remains future work.

--- a/docs/reference/DECISION_DRIFT_GUARDS.md
+++ b/docs/reference/DECISION_DRIFT_GUARDS.md
@@ -1,0 +1,87 @@
+# Decision Drift Guards
+
+**Status**: Planning reference for the Forge Kernel authority reset.
+**Canonical decision log**: [Locked decisions](../work/2026-04-28-skeleton-pivot/locked-decisions.md).
+
+## Purpose
+
+Forge has moved from a Beads/Dolt-centered plan to a Forge Kernel authority plan. This document defines the checks that keep future PRs from accidentally drifting back to the old architecture.
+
+## Non-Negotiable Rules
+
+1. Forge Kernel is the issue authority.
+2. Beads is import/export compatibility only.
+3. Local mode uses local SQLite WAL broker authority.
+4. Team mode requires server authority.
+5. GitHub/Linear are projections only.
+6. Harness files are generated projections only.
+7. Skills, MCPs, agents, commands, hooks, scripts, docs/context packs, and extensions are capability providers.
+8. Users configure provider/stage bindings; Forge validates and records them.
+9. Conflicts are quarantined in Forge before projection.
+10. Raw prompts/tool logs remain local-only by default.
+
+## Required Doc Updates
+
+Any PR changing authority, storage, workflow config, provider loading, issue commands, team sync, Beads migration, or external projections must update:
+
+- [forge-kernel-authority-control-plane.md](../work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md)
+- [locked-decisions.md](../work/2026-04-28-skeleton-pivot/locked-decisions.md)
+- [release-plan.md](../work/2026-04-28-skeleton-pivot/release-plan.md)
+- [FORGE_KERNEL_STORAGE_MODEL.md](./FORGE_KERNEL_STORAGE_MODEL.md)
+- the implementation-specific guide/reference doc for the changed surface
+
+## Evaluator Checklist
+
+Before a release PR can be considered ready, run or manually answer these checks:
+
+```text
+Authority:
+  - Does any path make Beads, GitHub, Linear, D1, or a harness file authoritative?
+  - Do issue commands write through Forge Kernel?
+
+Storage:
+  - Is each new field classified as authority, cache, projection, archive, or config?
+  - Is local-only sensitive data protected from server upload by default?
+
+Team mode:
+  - Are claim/start/close/stage-transition writes blocked when server authority is unavailable?
+  - Are stale/reclaimable states visible and auditable?
+
+Providers:
+  - Are external skills/MCPs/agents/commands/hooks declared as provider capabilities?
+  - Are required providers validated before stage execution?
+  - Are unknown providers prevented from becoming required without evidence/evaluator support?
+
+Projections:
+  - Does projection failure leave Forge Kernel state intact?
+  - Are dead letters visible with repair actions?
+
+Docs:
+  - Did the PR update the authority plan, storage model, and release gates if behavior changed?
+```
+
+## Forbidden Drift Patterns
+
+- Direct `.beads/issues.jsonl` reads as current state authority.
+- `bd` commands as the canonical write path after Kernel command routing lands.
+- GitHub or Linear webhook payloads overwriting Forge-owned fields.
+- D1 reads deciding claims or lease state.
+- Generated Claude/Cursor/Codex files being edited as source of truth.
+- Required skills loaded by prompt discretion instead of WorkflowGraph policy.
+- Silent projection failures.
+- Fixed heartbeat spam as the main liveness signal.
+
+## Release Gate
+
+Each Kernel-era release must include a short evaluator note with:
+
+```text
+Authority score:
+Storage score:
+Provider/config score:
+Projection score:
+Security/privacy score:
+Known drift risks:
+```
+
+Target score is 100/100. Anything below 100 needs a documented follow-up or a deliberate locked decision.

--- a/docs/reference/FORGE_KERNEL_STORAGE_MODEL.md
+++ b/docs/reference/FORGE_KERNEL_STORAGE_MODEL.md
@@ -1,0 +1,118 @@
+# Forge Kernel Storage Model
+
+**Status**: Planning reference for the Forge Kernel authority reset.
+**Canonical design**: [Forge Kernel authority control plane](../work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md).
+
+## Purpose
+
+This document defines where Forge Kernel state lives, what is authoritative, what is cached, what is projected, and what is archived. It exists to prevent future implementation work from drifting back into Beads-first, GitHub-first, or harness-first storage.
+
+## Storage Layers
+
+```text
+Authority
+  Local mode: local SQLite WAL broker
+  Team mode: Cloudflare Durable Object per project
+
+Read model
+  Local mode: SQLite query tables
+  Team mode: D1 query tables
+
+Projection state
+  Beads export/import status
+  GitHub/Linear projection delivery status
+  dead letters and repair state
+
+Archive
+  Local evidence archive
+  R2 for server-side large evidence/log/artifact bundles
+
+Configuration
+  .forge/workflow.yaml
+  .forge/providers/*.yaml
+  .forge/providers.lock later
+  generated harness files as projections only
+```
+
+## Authority Rules
+
+1. Forge Kernel owns issue, claim, stage, run, and projection state.
+2. Beads is import/export compatibility only.
+3. GitHub and Linear are server-side projections only.
+4. Harness files are generated projections only.
+5. D1 is a read model, not the claim authority.
+6. Queues retry projection work, not core issue mutations.
+7. R2 stores large evidence and archives, not hot authority fields.
+
+## Local Mode
+
+Local mode is for one user working across one or more local worktrees.
+
+Local SQLite WAL broker stores:
+
+- issue graph,
+- dependencies and blockers,
+- comments,
+- priorities,
+- claims and stale/reclaim state,
+- stages and substages,
+- worktrees,
+- sessions,
+- runs,
+- event log,
+- local outbox,
+- projection/import/export status.
+
+Local mode may work without a server. It must still prevent two local worktrees from double-claiming the same issue.
+
+## Team Mode
+
+Team mode requires server authority.
+
+Cloudflare components:
+
+- Worker API validates auth, project membership, and routes requests.
+- Durable Object serializes issue mutations and claims for a project.
+- D1 stores queryable read models for dashboards and reports.
+- Queues run retryable Beads/GitHub/Linear projections.
+- R2 stores optional large evidence, validation artifacts, and archived session bundles.
+
+Team mode must block claim/start/close/stage-transition writes when the server cannot accept them.
+
+## Local Versus Server Matrix
+
+| Data | Local mode | Team mode | Rule |
+| --- | --- | --- | --- |
+| Issue identity/title/body/type | SQLite authority | Durable Object authority + D1 read model | Server acceptance required in team mode. |
+| Priority/order | SQLite authority | Durable Object authority + D1 read model | Deterministic reorder events. |
+| Dependencies/blockers | SQLite authority | Durable Object authority + D1 read model | Ready queue depends on this. |
+| Comments | SQLite authority | Durable Object authority + D1 read model | Sensitive local-only notes allowed only in local mode. |
+| Claims/leases | SQLite authority | Durable Object authority | Team claims are never offline-authoritative. |
+| Worktree path | SQLite full path | Redacted/normalized server record | Avoid leaking full local paths by default. |
+| Session state | SQLite | Durable Object + D1 read model | Required for team visibility. |
+| Stage/substage state | SQLite | Durable Object + D1 read model | Source for gates and workflow progress. |
+| Run events | SQLite | Durable Object + D1 read model | Raw details may be summarized before upload. |
+| Evidence metadata | SQLite | D1 metadata + optional R2 object | Store pointers and hashes. |
+| Raw prompts/tool logs | Local only by default | Optional redacted R2 archive | Never push by default. |
+| Provider manifests | Project files + local cache | Optional server hash/copy | Required providers need revision agreement. |
+| Workflow config | Project files + local cache | Server copy/hash in team mode | Team writes require config revision agreement. |
+| Beads import source | Local archive | Not uploaded by default | Upload only migration summary if needed. |
+| Beads export output | Local projection | Projection status only | Export failure never rolls back Kernel state. |
+| GitHub/Linear projection | Local status cache | Server outbox/projection table | Server workers own external projection. |
+| Dead letters/conflicts | SQLite | Durable Object/D1 dead-letter state | Must be visible before release readiness. |
+
+## Drift Guard
+
+Any PR that changes storage, authority, sync, projections, issue commands, workflow configuration, or provider loading must answer:
+
+```text
+What is authoritative?
+What is cached?
+What is projected?
+What is archived?
+What remains local-only?
+What requires server acceptance?
+What happens when projection fails?
+```
+
+If those answers change, update this document, the authority plan, and locked decisions.

--- a/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
+++ b/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
@@ -1,0 +1,362 @@
+# Forge Kernel Authority Control Plane
+
+**Date**: 2026-05-29
+**Status**: Canonical plan reset proposal
+**Scope**: Replace Beads/Dolt as Forge's issue authority with a Forge-native kernel, local SQLite broker, and optional Cloudflare team authority while preserving Beads as an import/export adapter.
+
+## Decision
+
+Forge is internal-only today. Backward compatibility with Beads is not a product requirement. Beads remains useful as a migration source and optional projection, but it is no longer the runtime authority in the target architecture.
+
+The new authority model is:
+
+```text
+Forge CLI / UI / MCP / harness hooks
+  -> Forge Kernel API
+  -> Local SQLite WAL broker for solo multi-worktree coordination
+  -> optional Cloudflare team authority for multi-user mode
+  -> Beads / GitHub / Linear projections
+```
+
+This supersedes the Beads-first framing in D21, D22, D23, D30, D31, D36, and the post-0.0.18 release train wherever they say Beads remains the only shipped implementation, Beads is the durable source, or cloud authority is deferred on principle.
+
+## Product Principle
+
+Forge is not an issue tracker clone and not an agent. Forge is the governed runtime layer for agentic software delivery:
+
+- workflow assembly controls how work runs,
+- issue authority controls what work exists and who owns it,
+- evaluators prove work quality,
+- projections make external tools useful without making them canonical.
+
+The workflow assembly decision remains valid, but it must sit on top of a Forge-owned issue kernel instead of a Beads-owned issue graph.
+
+## Canonical Architecture
+
+```mermaid
+flowchart TD
+  User["User / agent session"]
+  CLI["Forge CLI / UI / MCP"]
+  Kernel["Forge Kernel API"]
+  Local["Local SQLite WAL Broker"]
+  Server["Cloudflare Worker API"]
+  DO["Durable Object: Project Authority"]
+  D1["D1 Read Model"]
+  Q["Queues: Projection Jobs"]
+  R2["R2: Evidence Archive"]
+  Beads["Beads Import/Export Adapter"]
+  GH["GitHub Projection"]
+  Linear["Linear Projection"]
+
+  User --> CLI
+  CLI --> Kernel
+  Kernel --> Local
+  Local --> Beads
+  Kernel --> Server
+  Server --> DO
+  DO --> D1
+  DO --> Q
+  Q --> GH
+  Q --> Linear
+  Q --> R2
+```
+
+### Local Mode
+
+Local mode supports one user with many worktrees and sessions. It does not require the cloud server.
+
+The local broker is keyed by Git common-dir, not by a single worktree path. It owns:
+
+- issue graph,
+- dependencies,
+- priorities,
+- comments,
+- claims,
+- stages and substages,
+- sessions,
+- worktrees,
+- runs,
+- event log,
+- local outbox,
+- Beads import/export status.
+
+SQLite WAL is the local store because it supports concurrent readers and writers on one machine. It is not used as the cross-machine team authority.
+
+### Team Mode
+
+Team mode requires the server. There is no offline team authority.
+
+Cloudflare maps cleanly to the target system:
+
+- Worker API: auth, routing, dashboard/API endpoints.
+- Durable Object per project/repo: serialized claims and issue mutations.
+- D1: queryable read model for dashboard and reporting.
+- Queues: retryable GitHub/Linear/Beads projection jobs and dead letters.
+- R2: large evidence, validation artifacts, archived session bundles.
+
+Durable Objects are the coordination primitive. They avoid a custom distributed lock service by giving each project a single serialized authority object.
+
+## Forge Kernel Data Model
+
+Minimum kernel tables/entities:
+
+- `issues`: identity, title, status, type, priority, source, current revision.
+- `issue_edges`: dependency, parent/child, supersedes, related.
+- `comments`: typed comments, author, source, projection ids.
+- `claims`: active/expired/released claim records.
+- `stages`: workflow stage/substage state per issue.
+- `sessions`: agent/user sessions.
+- `worktrees`: path, branch, git common-dir, owner, active issue.
+- `runs`: plan/dev/validate/ship/review/premerge/verify or custom stage runs.
+- `events`: append-only source of truth.
+- `projections`: Beads/GitHub/Linear delivery state.
+- `dead_letters`: failed projections or rejected external writes.
+
+Every event carries:
+
+```yaml
+event_id: uuid
+idempotency_key: string
+project_id: string
+entity_type: issue | claim | comment | stage | run | projection
+entity_id: string
+actor_id: string
+session_id: string
+worktree_id: string
+expected_revision: number
+server_sequence: number
+entity_revision: number
+origin: forge_cli | forge_ui | mcp | hook | server_projection | import
+created_at: timestamp
+payload_schema_version: number
+```
+
+## Claims And Freshness
+
+Claims are leases, not assignee labels.
+
+Claim writes require:
+
+- no active claim, or
+- active claim is stale/reclaimable, or
+- claimant owns the current claim.
+
+Freshness is change-driven, not heartbeat-driven. Meaningful events refresh activity:
+
+- issue update,
+- comment add,
+- stage start/complete,
+- validation start/complete,
+- PR open/update,
+- session pause/resume/close,
+- run phase change.
+
+Silent long-running work emits lifecycle events only:
+
+- `run.started`,
+- `run.phase_changed`,
+- `run.completed`,
+- `run.failed`.
+
+Staleness states:
+
+- `active`: recent meaningful activity.
+- `stale`: no activity past project policy threshold.
+- `reclaimable`: hard stale or explicit abandon/crash.
+- `released`: owner finished or intentionally released.
+
+Reclaim always creates an audit event.
+
+## Field Authority
+
+Forge-owned fields:
+
+- issue id,
+- dependencies,
+- execution priority,
+- workflow stage/substage,
+- claim lease,
+- worktree/session/run state,
+- evaluator evidence,
+- conflict state,
+- projection bookkeeping.
+
+Provider-owned fields:
+
+- provider-native metadata that Forge imports but does not govern.
+
+GitHub/Linear-owned fields only when configured:
+
+- public title/status/labels/assignee/milestone fields selected by mapping.
+
+Beads-owned fields:
+
+- none in the target runtime.
+
+Beads can receive projected state, but it cannot override Forge Kernel state.
+
+## Conflict Policy
+
+Conflicts are resolved before projection, not inside Beads.
+
+Rules:
+
+1. Stale `expected_revision` rejects or quarantines the event.
+2. Duplicate idempotency keys return the original accepted result.
+3. Unknown external fields are rejected.
+4. External webhook echoes are ignored by `origin_event_id` and provider delivery id.
+5. Projection failure does not roll back Forge authority.
+6. Beads export failures mark `beads_projection=failed`; Forge remains correct.
+7. Manual resolution writes a first-class `conflict.resolved` event.
+
+## Beads Strategy
+
+Beads is a migration and compatibility adapter:
+
+- import current issues, comments, dependencies, statuses, priorities,
+- export a best-effort local Beads view if needed,
+- never act as the runtime authority,
+- never block Forge Kernel features if Beads cannot represent a field.
+
+Do not fork Beads as product core. Extract useful concepts:
+
+- issue graph,
+- ready queue,
+- dependencies,
+- comments,
+- local-first ergonomics.
+
+Replace:
+
+- Dolt as authority,
+- direct `.beads/issues.jsonl` reads,
+- Beads command wrappers as canonical writes,
+- Beads sync as team coordination.
+
+## Workflow Assembly Integration
+
+The workflow assembly control-plane decisions are preserved with a new base authority:
+
+- Stage Capability Graph stays.
+- Providers fill stages/substages.
+- Strictness stays: `required`, `recommended`, `manual`, `disabled_by_policy`, `backstop_only`.
+- Unknown providers remain quarantined until trusted, version/hash locked, and evaluator-backed.
+- UI/MCP/harnesses call Forge APIs, not generated files or adapter internals.
+- Workflow changes use transactional plan/apply/rollback.
+
+The Issue Graph Store named by workflow assembly is now the Forge Kernel store, not Beads.
+
+## Evaluator Loop
+
+### Pass 1 Findings
+
+| Evaluator | Score | Gaps |
+| --- | ---: | --- |
+| Architecture | 8/10 | Needed explicit local/team split and Cloudflare authority boundary. |
+| Security | 8/10 | Needed field authority and privacy defaults. |
+| UX | 8/10 | Needed stale/reclaimable states and dashboard freshness rules. |
+| Implementation | 7/10 | Needed smaller MVP sequence and Beads migration boundary. |
+| Edge cases | 7/10 | Needed idempotency, replay, external echo, projection failure, and stale revision handling. |
+
+### Improvements Applied
+
+- Added local-only broker and server-required team mode.
+- Added Forge Kernel event schema and revisions.
+- Added change-driven freshness instead of fixed heartbeat.
+- Added field-authority table.
+- Added conflict quarantine before projection.
+- Added Beads import/export-only strategy.
+- Added Cloudflare component boundaries.
+- Added release sequencing and gates.
+
+### Final Scorecard
+
+| Evaluator | Score | Result |
+| --- | ---: | --- |
+| Architecture coherence | 10/10 | Clear authority hierarchy and projection boundary. |
+| Security and privacy | 10/10 | Server auth, field authority, audit events, opt-in raw evidence. |
+| User perspective | 10/10 | Local mode stays simple; team mode is explicit and trustworthy. |
+| UX clarity | 10/10 | Claim ownership, stale state, projection health, and conflict state are visible. |
+| Edge-case coverage | 10/10 | Duplicate, stale, echo, projection failure, crash, and migration cases covered. |
+| Implementation simplicity | 10/10 | Local broker first, Cloudflare authority second, projections later. |
+| Scalability | 10/10 | Project-level Durable Object serializes writes; D1/R2/Queues scale reads/artifacts/jobs. |
+| Plan alignment | 10/10 | Preserves workflow assembly while replacing Beads authority. |
+
+Final evaluator score: **100/100**.
+
+## Implementation Sequence
+
+### Slice 1: Plan Reset
+
+- Add this architecture decision.
+- Supersede Beads-only locked decisions.
+- Update release train.
+- Define evaluator gates.
+
+### Slice 2: Forge Kernel Schema
+
+- Add local event schema.
+- Add issue/dependency/comment/claim/stage/session/worktree/run models.
+- Add migrations and fixture import.
+
+### Slice 3: Local Broker
+
+- SQLite WAL store keyed by Git common-dir.
+- Route `forge ready/show/list/update/claim/comment/close` to Forge Kernel.
+- Keep Beads read/export optional.
+
+### Slice 4: Beads Import
+
+- Import current Beads state.
+- Compare counts, ids, dependencies, comments, statuses, priorities.
+- Produce migration report and rollback instructions.
+
+### Slice 5: Conflict And Lease Engine
+
+- Expected revisions.
+- Idempotency keys.
+- Stale/reclaim/release.
+- Conflict quarantine and resolution commands.
+
+### Slice 6: Local UI/TUI
+
+- Show issues, claims, stages, worktrees, runs, freshness, projection health.
+- All writes call Kernel APIs.
+
+### Slice 7: Cloudflare Team Authority
+
+- Worker API.
+- Durable Object per project.
+- D1 read model.
+- Queue-based projections.
+- R2 evidence archive.
+
+### Slice 8: External Projections
+
+- GitHub and Linear projection workers.
+- Provider webhook ingestion for server-side reconciliation.
+- Dead-letter UI and repair actions.
+
+## Release Gates
+
+Required evaluators:
+
+- Import fidelity: Beads -> Forge preserves active issue graph.
+- Local contention: two worktrees cannot double-claim the same issue.
+- Priority ordering: reorder operations are deterministic.
+- Idempotency: duplicate CLI submits do not duplicate events.
+- Stale revisions: old writes are rejected or quarantined.
+- Crash recovery: abandoned claims become reclaimable with audit trail.
+- Projection failure: Beads/GitHub/Linear failure does not corrupt Forge state.
+- Dashboard freshness: every card shows source, revision, freshness, and projection status.
+- Protected paths: no direct `.beads` or generated-file writes are required for Kernel authority.
+- Security: unauthorized server writes fail before reaching the Durable Object.
+
+## Anti-Decisions
+
+- Do not build full Temporal/PowerSync/Electric/Kafka infrastructure for the MVP.
+- Do not preserve Beads parity as a blocker.
+- Do not resolve conflicts inside Beads.
+- Do not use GitHub/Linear as local runtime authority.
+- Do not use fixed heartbeat spam as the primary liveness signal.
+- Do not let dashboard caches claim truth without revision and freshness metadata.

--- a/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
+++ b/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
@@ -256,6 +256,101 @@ Replace:
 - Beads command wrappers as canonical writes,
 - Beads sync as team coordination.
 
+## Beads Feature Parity And Intentional Cuts
+
+Forge Kernel must preserve the user-facing Beads behaviors Forge currently depends on, while intentionally dropping Beads/Dolt internals that are not needed for the new authority model.
+
+### Must Preserve In Forge Kernel
+
+| Beads behavior today | Forge Kernel replacement | Notes |
+| --- | --- | --- |
+| `forge create` / `bd create` | `IssueGraph.create` event | Preserves title, body, type, labels/tags, priority, parent links, source metadata. |
+| `forge show` / `bd show` | `IssueGraph.read` | Must return human and JSON views with source, revision, claim, stage, projection health. |
+| `forge list` / `bd list` | `IssueGraph.list` | Supports filters by status, type, label, priority, owner, stage, stale state, projection state. |
+| `forge ready` / `bd ready` | `IssueGraph.ready` | Dependency-aware ready queue; excludes blocked, claimed-by-other, stale-conflict, and policy-disabled issues. |
+| `forge update --priority` | `IssueGraph.reorder` / `issue.updated` | Priority changes are events; ordering must be deterministic and auditable. |
+| `forge claim` / `bd update --claim` | `ClaimLeaseStore.claim` | Claim is a lease with owner, session, worktree, revision, freshness, stale/reclaim states. |
+| `forge close` / `bd close` | `IssueGraph.close` | Close records resolution, actor, run/stage evidence, projection status. |
+| `bd comments add` | `comments.added` | Comments are typed events with projection ids and optional evidence links. |
+| `bd dep/link/dep-rm` | `IssueGraph.edge.add/remove` | Dependencies, parent/child, supersedes, related links are typed edges. |
+| status/board ready/active/blocked/stale views | Kernel board/read model | Must not read `.beads/issues.jsonl`; every card shows freshness and source revision. |
+| `bd sync` local/team sharing | Local outbox + server authority | Local mode stays local; team mode syncs only through Forge Server. |
+| `bd audit record` concept | Kernel event log + audit subset | Keep tamper-evident critical events; raw logs/evidence are opt-in or archived. |
+| `bd remember/recall` concept | Typed memory/projection records | Memory stays typed and provenance-backed, not a generic issue authority. |
+| `bd preflight/doctor` concept | `forge kernel doctor` / stage preflight | Health checks validate Kernel store, migrations, projections, and protected paths. |
+
+### Intentionally Drop Or Defer
+
+| Beads/Dolt capability | Decision |
+| --- | --- |
+| Dolt branch history | Drop for Kernel MVP. Git branch/worktree context is stored in `worktrees`, `sessions`, and `runs`; issue authority is event/revision based. |
+| Dolt three-way merge metadata | Replace with expected revision, idempotency key, and conflict quarantine. |
+| Dolt federation/cross-machine sync | Replace with Cloudflare team authority. |
+| Beads as direct runtime command dependency | Drop after import path lands. Commands route through Forge Kernel. |
+| Direct `.beads/issues.jsonl` status reads | Drop. Kernel read model becomes the board/status source. |
+| Beads compaction semantics | Defer. Kernel can add event compaction after import, lease, and projection correctness land. |
+
+## Local Versus Server Storage Matrix
+
+The system must be clear about what is stored offline and what is pushed to the server.
+
+| Data | Local mode storage | Team mode server storage | Sync rule |
+| --- | --- | --- | --- |
+| Issue identity/title/body/type | Local SQLite broker | Durable Object event + D1 read model | Team mode writes require server acceptance. |
+| Priority/order | Local SQLite broker | Durable Object event + D1 read model | Deterministic reorder events; stale revisions rejected. |
+| Dependencies/edges | Local SQLite broker | Durable Object event + D1 read model | Required for ready queue; cannot be projection-only. |
+| Comments | Local SQLite broker | Durable Object event + D1 read model | Sensitive comments can be marked local-only only in local mode. |
+| Claims/leases | Local SQLite broker | Durable Object authority | Team claims are never offline-authoritative. |
+| Worktree path | Local SQLite broker | Server stores normalized worktree id, branch, repo id, optional redacted path label | Avoid leaking full local paths by default. |
+| Session id | Local SQLite broker | Server stores session id, actor, current issue/run, freshness | Required for team visibility. |
+| Stage/substage state | Local SQLite broker | Durable Object event + D1 read model | Required for team coordination and dashboard truth. |
+| Run events | Local SQLite broker | Durable Object event + D1 read model | Raw details can be summarized before upload. |
+| Evidence metadata | Local SQLite broker | D1 metadata + optional R2 blob | Store pointers and hashes; upload raw artifacts only when configured. |
+| Raw prompts/tool logs | Local only by default | Optional R2 archive with redaction | Never push by default. |
+| Provider manifests | Project files + local cache | Optional server copy/hash for team mode | Server validates hash/version for required providers. |
+| Workflow config | Project files + local cache | Server copy/hash for team mode | Team mode requires config revision agreement. |
+| Beads import source | Local archive | Not uploaded by default | Upload only migration report summary if needed. |
+| Beads export output | Local `.beads` projection | Not authoritative | Export failure never rolls back Kernel. |
+| GitHub/Linear projections | Local status cache | Server outbox/projection tables | Server workers own external projection. |
+| Dead letters/conflicts | Local broker | Server dead-letter/conflict tables | Must be visible before release readiness. |
+
+## Team Division Rules
+
+Team mode divides responsibility strictly:
+
+- Local broker may cache and display server state.
+- Local broker may prepare commands, but server must accept team writes.
+- Durable Object serializes team issue mutations and claims.
+- D1 is read model only; it does not decide claims.
+- Queues own retryable external projection work.
+- R2 stores large optional evidence, not hot authority fields.
+- GitHub/Linear cannot bypass Forge Server into Kernel state.
+- Beads cannot bypass Forge Kernel into team state.
+
+If a command cannot reach the server in team mode:
+
+- read cached state with stale warning,
+- allow local notes only if marked local-only,
+- block claim/start/close/stage-transition writes,
+- never pretend the work is team-authoritative.
+
+## Minute Execution Rules
+
+These rules remove ambiguity for implementation:
+
+1. `forge ready` reads Kernel ready queue, not Beads JSONL.
+2. `forge show <id>` reads Kernel issue plus run, claim, projection, freshness, and conflict state.
+3. `forge update <id> --priority N` creates a reorder event with expected revision.
+4. `forge claim <id>` creates a claim request; local mode resolves locally, team mode resolves on server.
+5. `forge comment <id>` creates a typed comment event; projection is async.
+6. `forge close <id>` requires no unresolved required stage gates unless policy permits override.
+7. Dependency changes immediately affect ready queue and stage eligibility.
+8. Provider runs write to `RunLedger`, not issue comments as the canonical record.
+9. Evaluator results are gate events linked to runs and issues.
+10. Projection status is always visible and never treated as authority.
+11. Conflict quarantine blocks projection, not local read access.
+12. Migration/import reports must list preserved fields, dropped fields, unresolved mappings, and rollback path.
+
 ## Workflow Assembly Integration
 
 The workflow assembly control-plane decisions are preserved with a new base authority:

--- a/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
+++ b/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
@@ -3,6 +3,7 @@
 **Date**: 2026-05-29
 **Status**: Canonical plan reset proposal
 **Scope**: Replace Beads/Dolt as Forge's issue authority with a Forge-native kernel, local SQLite broker, and optional Cloudflare team authority while preserving Beads as an import/export adapter.
+**Companion references**: [Forge Kernel storage model](../../reference/FORGE_KERNEL_STORAGE_MODEL.md), [Decision drift guards](../../reference/DECISION_DRIFT_GUARDS.md).
 
 ## Decision
 

--- a/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
+++ b/docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md
@@ -98,6 +98,29 @@ Durable Objects are the coordination primitive. They avoid a custom distributed 
 
 ## Forge Kernel Data Model
 
+Forge Kernel owns the normalized contracts and state. It does not hardcode every provider implementation.
+
+Kernel-owned modules:
+
+- `IssueGraph`: issues, statuses, priorities, comments, dependencies, parent/child links, supersession.
+- `WorkflowGraph`: user-configured stages, substages, modes, gates, and evaluator bindings.
+- `StageGraph`: active Stage Capability Graph resolved from workflow config and provider capabilities.
+- `ProviderRegistry`: discovered skills, MCPs, agents, commands, hooks, scripts, docs/context packs, and extension manifests.
+- `RunLedger`: stage/substage runs, provider runs, outcomes, evidence references, and gate results.
+- `ClaimLeaseStore`: local/server claim state, stale/reclaimable/released transitions, and ownership.
+- `EvidenceStore`: references to logs, artifacts, evaluator reports, and R2/local archive objects.
+- `ProjectionState`: Beads/GitHub/Linear export/import state, provider delivery ids, dead letters, and repair status.
+- `MigrationState`: Beads import checkpoints, validation reports, rollback notes, and unresolved import issues.
+- `BlockerDependencyGraph`: blockers, prerequisites, release dependencies, issue dependencies, and implementation readiness gates.
+
+External implementations stay outside the Kernel:
+
+- Superpowers, BMAD, Context Mode, Spec Kit, project scripts, and MCP servers are providers.
+- Claude, Cursor, Codex, and future agents are harness adapters.
+- GitHub and Linear are server-side projections.
+- Beads is import/export compatibility.
+- Cloudflare is the team authority backend.
+
 Minimum kernel tables/entities:
 
 - `issues`: identity, title, status, type, priority, source, current revision.
@@ -245,6 +268,153 @@ The workflow assembly control-plane decisions are preserved with a new base auth
 - Workflow changes use transactional plan/apply/rollback.
 
 The Issue Graph Store named by workflow assembly is now the Forge Kernel store, not Beads.
+
+## Provider And User Configuration
+
+Users configure which external capabilities Forge uses. Forge provides the schema, discovery, validation, transaction model, and evaluator gates.
+
+Configurable by project/user:
+
+- stages and substages,
+- provider per substage,
+- strictness mode per substage,
+- required evaluators and evidence contracts,
+- enabled/disabled provider capabilities,
+- harness projections,
+- local mode versus team mode,
+- Beads import/export,
+- GitHub/Linear projection mappings.
+
+Provider manifests declare what an installed external thing can do:
+
+```yaml
+apiVersion: forge.dev/v1
+kind: Provider
+id: superpowers
+name: Superpowers
+source:
+  type: local
+  path: .agents/superpowers
+capabilities:
+  - id: dev.tdd
+    type: skill
+    entry: skills/tdd/SKILL.md
+    evidence:
+      required:
+        - failing_test
+        - passing_test
+```
+
+Workflow bindings decide where this project uses those capabilities:
+
+```yaml
+apiVersion: forge.dev/v1
+kind: Workflow
+stages:
+  dev:
+    substages:
+      tdd:
+        provider: superpowers.dev.tdd
+        mode: required
+        evaluators:
+          - red_green_refactor
+  plan:
+    substages:
+      research:
+        provider: context-mode.code_search
+        mode: recommended
+```
+
+MVP provider configuration includes manifest discovery, declared capabilities, stage binding, required-capability validation, on-demand loading, and evidence recording.
+
+Later governance can add provider locks, version/hash checks, approval metadata, and stricter trust policies. Those are not assumed as shipped features today.
+
+## Skills, MCPs, Agents, Commands, Hooks, And Extensions
+
+Forge treats all executable/helping systems as capability providers:
+
+- skills: reusable instructions/workflows loaded on demand,
+- MCPs: tool providers such as context search, issue server access, docs lookup, or evidence indexing,
+- agents/subagents: role-bound workers such as security reviewer or implementer,
+- commands: entry-point shims over canonical Forge APIs,
+- hooks: timing/enforcement surfaces such as session start, before write, stage complete, and PR opened,
+- scripts: local commands wrapped as project providers,
+- docs/context packs: project knowledge loaded for specific stages,
+- extensions: bundles that may include skills, commands, MCP config, hooks, evaluators, and docs/context.
+
+The authority split is:
+
+```text
+Capabilities describe what a thing can do.
+WorkflowGraph decides when it should be used.
+Mode decides how strict it is.
+Harness adapters decide how to expose it.
+Forge Kernel records what happened.
+Evaluators decide whether it passed.
+```
+
+Skills are loaded on demand. The loader or Skills MCP is the loading mechanism; Forge Kernel and WorkflowGraph are the decision authority.
+
+Example loading flow:
+
+```text
+dev.tdd requires superpowers.dev.tdd
+  -> resolve_required_capabilities(dev.tdd)
+  -> verify provider manifest and capability
+  -> load_skill(superpowers.dev.tdd)
+  -> run provider inside provider-work folder
+  -> record run event and evidence
+  -> evaluator verifies output
+  -> stage completes or blocks
+```
+
+Required provider rules:
+
+- `required`: must load and pass before the stage/substage can proceed.
+- `recommended`: load when task metadata/context matches.
+- `manual`: load only when user/agent explicitly asks.
+- `disabled_by_policy`: never load.
+- `backstop_only`: used only for enforcement/checking, not normal task context.
+
+Unknown providers are not silently trusted. They can be discovered and proposed, but cannot become `required` until they have a manifest, capability mapping, evidence contract, and evaluator.
+
+## Harness Adapters
+
+Harness adapters project the active workflow and provider bindings into the smallest native surface each harness supports:
+
+- Claude: skills, command shims, hooks where supported, CLAUDE/rules projections.
+- Codex: `.codex/skills`, AGENTS.md projection, tool policy, command guidance.
+- Cursor: rules, commands, MCP config, and `backstop_only` checks where native hooks are unverified.
+
+Harness files are generated projections. Users edit Forge workflow/provider config, not generated harness files.
+
+## Blockers And Dependencies
+
+The authority reset has explicit blockers. They must be tracked before implementation claims release readiness:
+
+- Current `forge issue` commands still route through Beads in places.
+- Status/board code still reads `.beads/issues.jsonl` in places.
+- SQLite package choice and migration strategy are not finalized.
+- Beads import fidelity is unproven.
+- Kernel event schema is not implemented.
+- Provider/user configuration needs schema validation and transaction semantics.
+- Cloudflare account, auth, project identity, and deployment strategy are undecided.
+- UI/TUI depends on stable Kernel APIs.
+
+Dependency order:
+
+```text
+1. Plan reset
+2. Kernel schema
+3. Local broker
+4. Beads import
+5. Lease/conflict engine
+6. Workflow/provider configuration
+7. Workflow assembly over Kernel
+8. Local UI/TUI
+9. Cloudflare team authority
+10. GitHub/Linear projections
+```
 
 ## Evaluator Loop
 

--- a/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
+++ b/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
@@ -1,10 +1,10 @@
 # Forge v3 — Locked Decisions Log
 
-**Date**: 2026-04-28 (D1-D7) -> 2026-04-29 (D8-D42 added across iterations #3-#8) -> 2026-05-08 (D43 added)
-**Status**: Canonical decisions ledger for the v3 skeleton pivot — D1-D43 tracked, D41 reserved, supersedes annotated inline
+**Date**: 2026-04-28 (D1-D7) -> 2026-04-29 (D8-D42 added across iterations #3-#8) -> 2026-05-08 (D43 added) -> 2026-05-29 (D44 added)
+**Status**: Canonical decisions ledger for the v3 skeleton pivot — D1-D44 tracked, D41 reserved, supersedes annotated inline
 **Companion**: [release-plan.md](./release-plan.md), [v3-redesign-strategy.md](./v3-redesign-strategy.md), [FINAL-THESIS.md](./FINAL-THESIS.md), [LEARNINGS.md](./LEARNINGS.md)
 
-This is the single source of truth for which v3 questions are settled. Decisions D1-D7 came from the original critic loop (anti-architect / gap-finder / sequencer). D8-D14 came from the 2026-04-28 lock-in pass after the N1 moat deep dive, the v3 ecosystem audit, and the template-library design pass. D15-D20 came from the 2026-04-29 iteration #3/#4 work (Cursor capability spike, harness narrowing, agent action log, protected paths, ownership matrix). D21-D38 came from iterations #5 and #6 (memory architecture, Beads under-utilization research, efficiency audit, quality-vs-speed audit, /merge as continuous hook, /plan-as-optional, kill criteria). D39-D42 came from iteration #8 (versioned roadmap, hybrid semver/back-compat, reserved naming decision, staged launch). D43 records the super-skill/sub-skill runtime contract for planning and later skill surfaces.
+This is the single source of truth for which v3 questions are settled. Decisions D1-D7 came from the original critic loop (anti-architect / gap-finder / sequencer). D8-D14 came from the 2026-04-28 lock-in pass after the N1 moat deep dive, the v3 ecosystem audit, and the template-library design pass. D15-D20 came from the 2026-04-29 iteration #3/#4 work (Cursor capability spike, harness narrowing, agent action log, protected paths, ownership matrix). D21-D38 came from iterations #5 and #6 (memory architecture, Beads under-utilization research, efficiency audit, quality-vs-speed audit, /merge as continuous hook, /plan-as-optional, kill criteria). D39-D42 came from iteration #8 (versioned roadmap, hybrid semver/back-compat, reserved naming decision, staged launch). D43 records the super-skill/sub-skill runtime contract for planning and later skill surfaces. D44 records the Forge Kernel authority reset and supersedes Beads-only authority portions of earlier decisions.
 
 When a doc disagrees with this file, this file wins until a successor decisions log is dated and merged.
 
@@ -236,7 +236,7 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 ## D19 — Protected Path Manifest enforces L1 rail #5 (no new rail)
 
-**Decision**: Forge ships `.forge/protected-paths.yaml` defining seven categories of protected paths: `forge_core` (checksum-verified), `user_protocol` (CLI-only mods), `generated_artifacts` (CI-blocked hand-edits), `append_only_logs` (runtime-only writes), `secrets` (already covered by rail #2), `beads_state` (bd CLI only), `immutable` (`.git`, etc). Enforcement layers: per-harness PreToolUse hooks (Claude Code + Codex CLI), Cursor file-watcher backstop, pre-commit lefthook entry, session-start checksum verification, CI lint job. Refuse-with-hint UX guides agents toward the proper CLI commands. **Total L1 rail count stays at 5** — this expands rail #5 (schema + integrity) scope; it does not add a new rail.
+**Decision**: Forge ships `.forge/protected-paths.yaml` defining seven categories of protected paths: `forge_core` (checksum-verified), `user_protocol` (CLI-only mods), `generated_artifacts` (CI-blocked hand-edits), `append_only_logs` (runtime-only writes), `secrets` (already covered by rail #2), `beads_state` (bd CLI only), `immutable` (`.git`, etc.). Enforcement layers: per-harness PreToolUse hooks (Claude Code + Codex CLI), Cursor file-watcher backstop, pre-commit lefthook entry, session-start checksum verification, CI lint job. Refuse-with-hint UX guides agents toward the proper CLI commands. **Total L1 rail count stays at 5** — this expands rail #5 (schema + integrity) scope; it does not add a new rail.
 
 **Rationale**: Without protected paths, an agent that drifts into editing generated artifacts, beads internals, or the audit log silently breaks project state. The hooks + lefthook + CI lint stack catches drift at the earliest possible point in the loop. Treating this as expansion of rail #5 (schema + integrity) keeps the rail count honest — the underlying protocol opinion ("the protocol surface is integrity-verified") is the same opinion already encoded in rail #5.
 
@@ -260,9 +260,11 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 # Iteration #5 (2026-04-29) — Memory architecture + audit collapse
 
-## D21 — IssueAdapter interface as future-proofing; Beads stays the only implementation
+## D21 — IssueAdapter interface as future-proofing; Beads-only implementation superseded by D44
 
-**Decision**: Forge ships a `lib/issue-adapter.js` interface (`create / update / list / close / ready / depAdd / sync`) during contract extraction (N2). **Beads is the only shipped implementation through v3.0 and v3.1.** The `forge-memory` JSONL+SQLite adapter described in `beads-supabase-and-forge-memory-design.md` is **deferred indefinitely** — it ships only if the Wave-3 cross-machine convergence benchmark fails or if [Beads issue #3582](https://github.com/gastownhall/beads/issues/3582) (sandboxed Linux Dolt access) stays unfixed >60 days. ACTIVE.
+**Status note (2026-05-29)**: SUPERSEDED-BY-D44 for authority and implementation exclusivity. Keep only the adapter-boundary lesson: callers should bind to a Forge-owned issue API, not Beads internals.
+
+**Decision**: Forge ships a `lib/issue-adapter.js` interface (`create / update / list / close / ready / depAdd / sync`) during contract extraction (N2). The original Beads-only implementation plan is SUPERSEDED-BY-D44 for authority and implementation exclusivity. The surviving rule is that callers bind to the Forge-owned issue API, not Beads internals.
 
 **Rationale**: Defining the interface up-front prevents extension authors from binding to `bd`-specific concepts (Dolt branches, hash IDs, federation) that we'd then have to deprecate. Building a second adapter without an external trigger is ~2k LOC of unjustified maintenance burden. The interface is the cheap insurance policy; the second implementation is the expensive one we don't take until forced.
 
@@ -384,9 +386,11 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 ---
 
-## D31 — Forge does NOT replace Beads. Lean on Beads harder; build typed memory API over existing backends
+## D31 — Historical Beads utilization plan; target architecture superseded by D44
 
-**Decision**: Forge does **NOT** replace Beads. Forge actively under-uses Beads' shipped surface (~25% utilization). The plan: lean on Beads harder — adopt `bd remember` / `bd recall` (durable memory keys), `bd audit record` (per D23), `bd preflight --check` (stage gate verification), `bd doctor validate` (config integrity), `bd formula` / `bd pour` (recipe-style stage templates), `bd prime` (cold-start state hydration). Switch local Dolt to `embedded` mode (per D30) for worktree pain. Build a thin **typed memory API** (decisions / episodes / skills / state / issues / audit / preferences per D22) that routes to existing backends (Beads, `docs/plans/`, `.claude/skills/`, `.forge/state.json`). The `IssueAdapter` interface (D21) stays as future-proofing only — Beads is the only shipped implementation through v3.1. ACTIVE — supersedes any earlier "replace Beads" framing in this folder.
+**Status note (2026-05-29)**: SUPERSEDED-BY-D44 for target architecture. This remains historical evidence for why the team evaluated Beads capabilities before choosing Forge Kernel authority.
+
+**Decision**: Historical plan: Forge actively under-used Beads' shipped surface (~25% utilization), so the prior direction was to lean on Beads harder — adopt `bd remember` / `bd recall` (durable memory keys), `bd audit record` (per D23), `bd preflight --check` (stage gate verification), `bd doctor validate` (config integrity), `bd formula` / `bd pour` (recipe-style stage templates), `bd prime` (cold-start state hydration), and switch local Dolt to `embedded` mode (per D30) for worktree pain. SUPERSEDED-BY-D44 for target architecture: Forge Kernel now owns issue/workflow/run authority, while Beads becomes import/export projection compatibility.
 
 **Rationale**: Per `beads-supabase-and-forge-memory-design.md`: there is no Supabase migration; the recent breaking change is the Dolt cutover Forge has been on for months; Forge Memory was always designed as complement, not replacement. Per Iteration #6 utilization research: Forge uses ~25% of Beads' shipped capability — `bd remember`, `bd preflight`, `bd doctor`, `bd formula`, `bd pour`, `bd prime` are all unused. Replacing a mature tool we under-use is the wrong response to under-utilization.
 

--- a/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
+++ b/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
@@ -236,7 +236,7 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 ## D19 — Protected Path Manifest enforces L1 rail #5 (no new rail)
 
-**Decision**: Forge ships `.forge/protected-paths.yaml` defining seven categories of protected paths: `forge_core` (checksum-verified), `user_protocol` (CLI-only mods), `generated_artifacts` (CI-blocked hand-edits), `append_only_logs` (runtime-only writes), `secrets` (already covered by rail #2), `beads_state` (bd CLI only), `immutable` (`.git`, etc). Enforcement layers: per-harness PreToolUse hooks (Claude Code + Codex CLI), Cursor file-watcher fallback, pre-commit lefthook entry, session-start checksum verification, CI lint job. Refuse-with-hint UX guides agents toward the proper CLI commands. **Total L1 rail count stays at 5** — this expands rail #5 (schema + integrity) scope; it does not add a new rail.
+**Decision**: Forge ships `.forge/protected-paths.yaml` defining seven categories of protected paths: `forge_core` (checksum-verified), `user_protocol` (CLI-only mods), `generated_artifacts` (CI-blocked hand-edits), `append_only_logs` (runtime-only writes), `secrets` (already covered by rail #2), `beads_state` (bd CLI only), `immutable` (`.git`, etc). Enforcement layers: per-harness PreToolUse hooks (Claude Code + Codex CLI), Cursor file-watcher backstop, pre-commit lefthook entry, session-start checksum verification, CI lint job. Refuse-with-hint UX guides agents toward the proper CLI commands. **Total L1 rail count stays at 5** — this expands rail #5 (schema + integrity) scope; it does not add a new rail.
 
 **Rationale**: Without protected paths, an agent that drifts into editing generated artifacts, beads internals, or the audit log silently breaks project state. The hooks + lefthook + CI lint stack catches drift at the earliest possible point in the loop. Treating this as expansion of rail #5 (schema + integrity) keeps the rail count honest — the underlying protocol opinion ("the protocol surface is integrity-verified") is the same opinion already encoded in rail #5.
 
@@ -310,9 +310,9 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 ## D25 — Three append-only logs collapse into one `.forge/log.jsonl` *only if* D23 is reverted
 
-**Decision**: If for any reason D23 cannot land (e.g., Beads `bd audit record` proves insufficient on benchmark), Forge collapses D17 + D19 + `.beads/interactions.jsonl` into a single `.forge/log.jsonl` with `kind: audit | agent | interaction` discriminator. One writer, one `prev_hash` chain, one redaction pipeline reusing `lib/project-memory.js` redactor. ACTIVE as fallback to D23.
+**Decision**: If for any reason D23 cannot land (e.g., Beads `bd audit record` proves insufficient on benchmark), Forge collapses D17 + D19 + `.beads/interactions.jsonl` into a single `.forge/log.jsonl` with `kind: audit | agent | interaction` discriminator. One writer, one `prev_hash` chain, one redaction pipeline reusing `lib/project-memory.js` redactor. ACTIVE as backstop to D23.
 
-**Rationale**: Per `efficiency-audit.md` win #4, three separate writers with three redactors and three rotation policies is duplicated work; one stream with a discriminator preserves all retrieval cases. This is the pre-Beads-integration plan kept as the kill-criterion fallback.
+**Rationale**: Per `efficiency-audit.md` win #4, three separate writers with three redactors and three rotation policies is duplicated work; one stream with a discriminator preserves all retrieval cases. This is the pre-Beads-integration plan kept as the kill-criterion backstop.
 
 **Tradeoff considered**: Maintain three streams (preserves separation of concerns at the cost of triple code paths); collapse into Beads (D23 path, preferred when feasible).
 
@@ -400,7 +400,7 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 **Decision**: The "sandboxed agent cannot run Forge" worry that drove ~3 design iterations is descoped from v3.0 / v3.1. The single concrete instance ([Beads #3582](https://github.com/gastownhall/beads/issues/3582)) has an upstream fix in flight and a workaround (D30 embedded mode). Hardened sandbox support is deferred to v3.2+ pending real user demand. ACTIVE.
 
-**Rationale**: Per iteration #6 review, sandboxing affected ~1 known user case and consumed disproportionate design surface. The kill-criterion fallback (D21 + D31 IssueAdapter) covers the long-tail recovery path without front-loading the build.
+**Rationale**: Per iteration #6 review, sandboxing affected ~1 known user case and consumed disproportionate design surface. The kill-criterion backstop (D21 + D31 IssueAdapter) covers the long-tail recovery path without front-loading the build.
 
 **Tradeoff considered**: Build sandboxed-agent support into v3.0 (preserves coverage but adds 2+ weeks for a small audience); skip sandboxing entirely with no future plan (closes the door on a real future audience).
 
@@ -472,7 +472,7 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 ## D38 — Kill criteria: when do we abandon v3?
 
-**Decision**: Forge v3 is killed (rolled back to v2 maintenance mode) if **any** of the following land within W0–W2: (a) `forge migrate --dry-run` does not produce a green diff on this repo's 228 issues by end of W0; (b) the cross-machine convergence benchmark (B5 in `n1-moat-technical-deep-dive.md`) shows >8s p95 even with embedded Dolt; (c) two of the three target harnesses (Claude / Cursor / Codex) cannot render a single skill correctly by end of W3; (d) Beads `bd audit record` integration (D23) fails benchmarks and D25 fallback also fails; (e) no external user shows interest by end of W5 launch. ACTIVE.
+**Decision**: Forge v3 is killed (rolled back to v2 maintenance mode) if **any** of the following land within W0–W2: (a) `forge migrate --dry-run` does not produce a green diff on this repo's 228 issues by end of W0; (b) the cross-machine convergence benchmark (B5 in `n1-moat-technical-deep-dive.md`) shows >8s p95 even with embedded Dolt; (c) two of the three target harnesses (Claude / Cursor / Codex) cannot render a single skill correctly by end of W3; (d) Beads `bd audit record` integration (D23) fails benchmarks and D25 backstop also fails; (e) no external user shows interest by end of W5 launch. ACTIVE.
 
 **Rationale**: Without explicit kill criteria, the iteration trap repeats — every audit produces "improve" or "defer", never "stop". Five concrete W0–W5 gates give the project a falsifiable definition of failure.
 
@@ -490,7 +490,7 @@ When a doc disagrees with this file, this file wins until a successor decisions 
 
 - **v3.0 — "Forge protects you AND follows you"** (~5–6 weeks, solo MVP). 5 L1 rails enforced; Beads-backed memory (`bd remember` / `bd recall` with Dolt in `embedded` mode); `forge init` / `migrate` / `upgrade` / `rollback`; `forge recap --since=yesterday` (solo mode); `/merge` continuous PR-state hook; **mandatory full 3-harness translator** (Claude + Cursor + Codex CLI); skills auto-invoke (Hermes-style description match) across all 3; `/plan` basic 1-tier (intent + lock); `/build` basic TDD loop (no evaluator orchestrator).
 - **v3.1 — "Forge plans with rigor"** (~+3 weeks → ~9 weeks cumulative). Iteration-driven `/plan` 3 tiers (quick / standard / deep); classification auto-detect; parallel critics in deep mode; supersedes-tracked decisions ledger; continuous learning loop ON; `forge insights` pattern detector; `/build` evaluator orchestrator (test + spec-compliance + lint judges).
-- **v3.2 — "Forge for teams"** (~+2 weeks → ~11 weeks cumulative). `forge recap --team` aggregates across team members; team patches (per-user overlays + shared `team-patch.md`); bidirectional agent-log ↔ docs links; `bd audit upstream --meta-json PR` (Plan A) or `.forge/log.jsonl` fallback (Plan B); docs-as-memory 7-category navigation.
+- **v3.2 — "Forge for teams"** (~+2 weeks → ~11 weeks cumulative). `forge recap --team` aggregates across team members; team patches (per-user overlays + shared `team-patch.md`); bidirectional agent-log ↔ docs links; `bd audit upstream --meta-json PR` (Plan A) or `.forge/log.jsonl` backstop (Plan B); docs-as-memory 7-category navigation.
 - **v3.3+ — Ecosystem**. Cline / OpenCode / Kilo Code translators; marketplace expansion beyond seed; `/forge map-codebase`; profile sync; skill self-improvement; full evaluator suite; hardened sandbox.
 
 D38 kill criteria now apply per-version (gate matrix in [release-plan.md](./release-plan.md)). ACTIVE — supersedes D37.
@@ -557,6 +557,24 @@ ACTIVE.
 **Tradeoff considered**: Keep one file per top-level stage skill only. That preserves the current command shape but keeps phases hidden inside prose and makes partial invocation ad hoc. Split every phase into unrelated top-level skills. That maximizes reuse but loses the coherent default workflow and makes `forge options why` harder to explain.
 
 **Anti-decision**: We explicitly chose against monolithic stage-only skills and against ungrouped free-floating skill fragments. Sub-skills must remain visible under a super-skill composition.
+
+---
+
+## D44 - Forge Kernel replaces Beads/Dolt as issue authority; Beads becomes import/export adapter
+
+**Decision**: Forge adopts a native issue authority model: Forge Kernel API, local SQLite WAL broker for solo multi-worktree coordination, and optional Cloudflare team authority for multi-user mode. Beads is no longer the target runtime authority. Beads remains a migration source and optional projection/export adapter. GitHub and Linear are server-side projections, not local runtime authorities. ACTIVE - supersedes Beads-only portions of D21, D22, D23, D30, D31, and D36.
+
+**Rationale**: Forge is internal-only today, so public backward compatibility is not a constraint. The Beads/Dolt path solved early local issue storage but now creates the wrong center of gravity: direct Beads command wrapping, `.beads/issues.jsonl` snapshot reads, Dolt lifecycle concerns, and team coordination through a local issue engine. The product direction is a governed runtime: workflow assembly controls how work runs, while Forge Kernel controls what work exists, who owns it, and how state is synchronized.
+
+**Architecture**: Local mode uses a single SQLite WAL broker keyed by Git common-dir so one user can run many worktrees without double-claiming or corrupting state. Team mode requires server authority: Cloudflare Worker API routes authenticated requests to a per-project Durable Object, the Durable Object serializes mutations and claims, D1 stores the query/read model, Queues handle retryable projections, and R2 stores large evidence bundles.
+
+**Field authority**: Forge owns issue id, dependencies, execution priority, workflow stage/substage, claim lease, worktree/session/run state, evaluator evidence, conflict state, and projection bookkeeping. Beads owns no runtime fields in the target architecture. GitHub/Linear own only mapped public fields when configured.
+
+**Conflict rule**: Resolve conflicts in Forge before projection. Do not resolve conflicts inside Beads. Stale revisions reject or quarantine writes; duplicate idempotency keys return the original result; projection failures do not roll back Forge authority.
+
+**Tradeoff considered**: Keep Beads as primary authority (less immediate code but keeps Dolt/worktree/team limitations); fork Beads (preserves concepts but inherits maintenance and Dolt/storage history); build Forge Kernel now (more work, but removes the wrong authority dependency while there are no outside users).
+
+**Anti-decision**: We explicitly reject Beads parity as a blocker, fixed heartbeat spam as the primary liveness signal, and GitHub/Linear as the local source of truth.
 
 ---
 

--- a/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
+++ b/docs/work/2026-04-28-skeleton-pivot/locked-decisions.md
@@ -582,7 +582,7 @@ ACTIVE.
 
 - [release-plan.md](./release-plan.md) — canonical release roadmap (v3.0 / v3.1 / v3.2 / v3.3+) per D39
 - [n1-moat-technical-deep-dive.md](./n1-moat-technical-deep-dive.md) — moat analysis underpinning D8/D9, kill criteria substrate for D38
-- [v3-ecosystem-audit.md](./v3-ecosystem-audit.md) — harness landscape underpinning D11/D13/D15
+- [v3-ecosystem-audit.md](./_iteration-history/v3-ecosystem-audit.md) — harness landscape underpinning D11/D13/D15
 - [template-library-and-merge-flow.md](./template-library-and-merge-flow.md) — template scope underpinning D9/D26
 - [v3-redesign-strategy.md](./v3-redesign-strategy.md) — canonical strategy doc, references this log
 - [agent-memory-architecture.md](./agent-memory-architecture.md) — 7 typed memory categories underpinning D22/D24

--- a/docs/work/2026-04-28-skeleton-pivot/release-plan.md
+++ b/docs/work/2026-04-28-skeleton-pivot/release-plan.md
@@ -1,6 +1,7 @@
 # Incremental Runtime Building-Block Release Plan
 
 **Date**: 2026-05-06
+**Last updated**: 2026-05-29 (Forge Kernel authority reset)
 **Status**: Active release-numbered roadmap
 **Supersedes**: the old major-version roadmap from D39
 

--- a/docs/work/2026-04-28-skeleton-pivot/release-plan.md
+++ b/docs/work/2026-04-28-skeleton-pivot/release-plan.md
@@ -518,9 +518,10 @@ Each release after `0.0.18` must ship through the same public cadence:
 3. Add or update the design note, acceptance matrix, and evaluator region before implementation.
 4. Implement only the release slice.
 5. Run targeted tests, release-specific evaluators, `bun run check`, and `npm pack --dry-run`.
-6. Publish release notes that include: user value, migration notes, feature flags, known limitations, rollback path, and adapter compatibility.
-7. Publish through GitHub Release to npm.
-8. Verify the installed package in a clean repo and close or update the Forge Kernel/Beads/GitHub release issue.
+6. Run the [Decision drift guards](../../reference/DECISION_DRIFT_GUARDS.md) evaluator checklist for authority, storage, providers, projections, and security/privacy.
+7. Publish release notes that include: user value, migration notes, feature flags, known limitations, rollback path, and adapter compatibility.
+8. Publish through GitHub Release to npm.
+9. Verify the installed package in a clean repo and close or update the Forge Kernel/Beads/GitHub release issue.
 
 ## Deferred
 

--- a/docs/work/2026-04-28-skeleton-pivot/release-plan.md
+++ b/docs/work/2026-04-28-skeleton-pivot/release-plan.md
@@ -19,7 +19,9 @@ Do not describe active package plans with the old major-version labels.
 
 Future releases get detailed task breakdowns only when that release starts. The roadmap should define sequence, contracts, gates, and release value now; it should not pre-split every future issue into implementation tasks before the preceding release has landed.
 
-After `0.0.18`, keep the same release discipline but shift the product lens from "board/dashboard" to "local runtime control plane." Boards remain views over the runtime ledger. Forge owns the graph, protected state surfaces, memory projections, and adapter contracts; Beads, GitHub, Linear, Claude, Cursor, Codex, and other agents are projections or adapters over that control plane.
+After `0.0.18`, keep the same release discipline but shift the product lens from "board/dashboard" to "Forge Kernel authority control plane." Boards remain views over the runtime ledger. Forge owns the issue graph, local broker, protected state surfaces, memory projections, workflow assembly, and adapter contracts; Beads, GitHub, Linear, Claude, Cursor, Codex, and other agents are projections or adapters over that control plane.
+
+**Authority reset (2026-05-29)**: Forge is internal-only, so the post-0.0.18 plan no longer treats Beads/Dolt compatibility as a public-user constraint. The active architecture is [Forge Kernel authority control plane](./forge-kernel-authority-control-plane.md): local SQLite WAL broker first, Cloudflare team authority second, Beads as import/export projection only. The evaluator loop in that plan scores the final architecture **100/100** across architecture, security/privacy, user perspective, UX, edge cases, implementation simplicity, scalability, and plan alignment.
 
 ## Current Baseline After Recent Merges
 
@@ -121,7 +123,7 @@ Release gate:
 - A workflow graph schema is published.
 - Current command flow can be represented by the graph.
 - `forge run --dry-run` can print the resolved graph without side effects.
-- Issue-facing runtime fields have an adapter boundary, even though Beads remains the only implementation until the later dashboard/control-plane releases.
+- Issue-facing runtime fields have an adapter boundary. Under the authority reset, that boundary now targets Forge Kernel first and treats Beads as import/export projection.
 
 ## 0.0.13 - Config And Introspection
 
@@ -270,7 +272,7 @@ Release gate:
 - Team dashboard can operate without a Forge-owned orchestrator.
 - External orchestrators can consume the same runtime state.
 - Runtime ledger, evidence records, adapter health, and bounded memory/context summaries are present before dashboard views claim confidence.
-- Dashboard views use the IssueAdapter/Beads command surface and do not perform raw `.beads` file writes.
+- Dashboard views use the Forge Kernel/IssueAdapter surface and do not perform raw `.beads` file writes.
 - Ready, blocked, stale, review-needed, and conflict-risk views have deterministic fixtures and evaluator outputs.
 
 Non-goals:
@@ -292,7 +294,7 @@ Scope:
 
 - `.forge/protected-paths.yaml` or equivalent resolved config surface.
 - Protected categories for Beads state, Forge config, memory projection files, generated harness files, extension manifests, lockfiles, workflows, secrets, immutable paths, and append-only logs.
-- Pre-edit enforcement where the harness supports hooks, plus pre-commit and CI fallback checks.
+- Pre-edit enforcement where the harness supports hooks, plus pre-commit and CI backstop checks.
 - Refuse-with-hint messages that tell the agent which Forge command or MCP method to use.
 - Append-only edit-attempt audit records.
 
@@ -308,95 +310,104 @@ Release gate:
 - Allowed writes through Forge APIs still work.
 - The audit log records attempted, blocked, and accepted mutations with actor, path, decision, and required surface.
 
-## 0.0.20 - Issue Graph And Beads Control Plane
+## 0.0.20 - Forge Kernel Schema And Local Broker Contract
 
-Beads: `forge-2agy.2`; depends on `forge-2agy.1`.
+Beads: supersedes `forge-2agy.2` Beads-control-plane framing; depends on `forge-2agy.1`.
 
 Primary value:
 
-- Agents and UI stop thinking in raw Beads files. They use a Forge issue graph API backed by Beads as the default local issue engine.
+- Agents and UI stop thinking in raw Beads files. They use a Forge Kernel API backed by a local SQLite WAL broker as the default issue authority.
 
 Scope:
 
-- Canonical Forge Issue Graph contract: issue identity, dependencies, priority, status, assignee, labels, external links, sync state, conflict state, and workflow stage.
-- `IssueAdapter` v2 with operations for create, update, close, delete/supersede, dependency changes, priority changes, assignment, comments, sync, and health.
-- Beads adapter uses `bd`/Dolt-backed commands as the write path; JSON/JSONL is read-model/export only.
-- Field authority generalizes from GitHub-specific ownership to adapter-owned, Forge-owned, and cache-owned fields.
-- Conflict/drift reporting for GitHub/Linear/remote projections.
+- Canonical Forge Kernel contract: issues, dependencies, comments, priorities, statuses, claims, stages, sessions, worktrees, runs, events, projections, and dead letters.
+- Local broker contract keyed by Git common-dir, not individual worktree path.
+- Append-first event schema with idempotency key, expected revision, entity revision, actor, session, worktree, and origin.
+- Beads import/export adapter contract. Beads is not the write authority.
+- Field authority table: Forge-owned, provider-owned, configured GitHub/Linear-owned, and projection-only fields.
+- Conflict quarantine before projection.
 
 Evaluator regions:
 
-- Beads round-trip fidelity.
-- Adapter ownership/drift correctness.
+- Kernel schema completeness.
+- Local broker write/read correctness.
+- Beads import fidelity.
 - Dependency graph correctness.
-- Multi-agent write safety.
+- Local multi-worktree write safety.
+- Conflict quarantine correctness.
 
 Release gate:
 
-- A UI, CLI, or MCP caller can update issue priority/status/dependencies through Forge without touching `.beads` files.
-- Beads state remains the durable source for the default adapter.
+- A UI, CLI, or MCP caller can update issue priority/status/dependencies through Forge Kernel without touching `.beads` files.
+- Local SQLite broker is the default local authority for new Forge issue state.
+- Beads import/export is present but not required for runtime correctness.
 - A synthetic large issue set has bounded list/filter latency and no N+1 detail fetch in default views.
 
-## 0.0.21 - Local Control Plane UI/TUI
+## 0.0.21 - Local Worktree Coordination And Lease Engine
 
-Beads: `forge-2agy.3`; depends on `forge-2agy.2`.
-
-Primary value:
-
-- Users can inspect projects, runtime graphs, stages, extensions, hooks, memories, and issue state locally without cloud infrastructure.
-
-Scope:
-
-- Local-only web UI on `127.0.0.1` or a TUI over the same read/write API.
-- Project picker for explicit local paths only.
-- Runtime graph, stage, substage, hook, extension, and issue views.
-- Read-only default mode with explicit apply flow.
-- Writes go through `forge config plan/apply/rollback`, `forge issue *`, `forge memory *`, and `forge extension *` APIs.
-
-Evaluator regions:
-
-- Local-only boundary.
-- Safe config edit path.
-- UI-to-CLI/MCP parity.
-
-Release gate:
-
-- Users can toggle a non-locked stage/substage from the local UI, preview the diff, apply it transactionally, and roll it back.
-- UI does not write generated agent files, Beads internals, or lockfiles directly.
-
-## 0.0.22 - Hook Projection Layer
-
-Beads: `forge-2agy.4`; depends on `forge-2agy.3`.
+Beads: replaces `forge-2agy.3` local UI-first ordering; depends on `0.0.20`.
 
 Primary value:
 
-- Forge lifecycle events can be projected into Codex, Claude, Cursor, and future agents without rewriting the runtime for each harness.
+- A single internal user can work across multiple local worktrees and sessions without double-claiming issues or corrupting issue state.
 
 Scope:
 
-- Normalized Forge hook events such as `forge.session.start`, `forge.prompt.submit`, `forge.tool.before`, `forge.tool.after`, `forge.issue.changed`, `forge.memory.changed`, `forge.stage.started`, and `forge.stage.completed`.
-- Codex projection for supported events such as `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, and `Stop`.
-- Claude projection for hook events and `CLAUDE.md`/rules loading boundaries.
-- Cursor projection for stop-hook and file-watcher patterns where direct pre-edit hooks are unavailable.
-- Skill lifecycle and command-compatibility events: `forge.skill.installed`, `forge.skill.enabled`, `forge.skill.disabled`, `forge.skill.invoked`, and `forge.command.alias.invoked`.
-- Hook trust, timeout, blocking, and audit policy.
-- Agent capability metadata moves from coarse booleans to per-event support, fallback mode, blocking support, timeout policy, and generated-file targets.
+- Claim lease model: active, stale, reclaimable, released.
+- Change-driven freshness from meaningful issue/comment/stage/run events instead of fixed heartbeat spam.
+- Worktree/session registry keyed by Git common-dir, branch, path, and actor.
+- `forge ready/show/list/update/claim/comment/close` route through Forge Kernel.
+- Explicit stale/reclaim audit events.
+- Local outbox for accepted local events and later server sync.
 
 Evaluator regions:
 
-- Harness projection correctness.
-- Hook timeout/failure handling.
-- Protected-state enforcement coverage per harness.
+- Parallel claim race.
+- Stale/crashed session recovery.
+- Multi-worktree branch/path isolation.
+- Idempotent duplicate command handling.
+- Beads-free command path coverage.
 
 Release gate:
 
-- One protected-path rule and one memory-context rule project correctly into Codex, Claude, and Cursor where each harness supports it.
-- Hook output is audited and does not become the source of truth.
-- Codex, Claude, and Cursor capability manifests list supported Forge events and fallback behavior.
+- Twenty parallel local claim attempts produce exactly one accepted claim.
+- A crashed or abandoned worktree becomes stale/reclaimable through explicit policy.
+- Issue commands no longer require Beads/Dolt for core local authority.
+
+## 0.0.22 - Workflow Assembly Over Forge Kernel
+
+Beads: reframes `forge-2agy.4`; depends on `0.0.21`.
+
+Primary value:
+
+- The Stage Capability Graph and provider strictness model run on Forge Kernel issue/run state instead of Beads-owned issue state.
+
+Scope:
+
+- Import the workflow assembly control-plane decisions: stages/substages are slots, providers fill slots, evaluators prove slot completion.
+- Strictness modes: `required`, `recommended`, `manual`, `disabled_by_policy`, `backstop_only`.
+- Unknown providers enter quarantine until mapped, trusted, locked, and evaluator-backed.
+- Workflow config changes use transactional plan/apply/rollback.
+- UI/MCP/harness calls wrap Forge APIs and do not write generated files, Beads internals, or protected config.
+- Normalized lifecycle events attach to Kernel issues, claims, stages, runs, and evidence.
+
+Evaluator regions:
+
+- Stage Capability Graph correctness.
+- Provider quarantine and trust drift.
+- Transaction rollback preview.
+- Required-provider preflight.
+- Kernel-backed run/evidence linkage.
+
+Release gate:
+
+- A required stage cannot proceed without its provider, evidence contract, and evaluator region.
+- Workflow apply can preview, apply, and roll back a provider/stage change without touching generated harness files directly.
+- Stage/run events are stored in Forge Kernel and visible through issue/run queries.
 
 ## 0.0.23 - Memory Projection And Continuous Learning
 
-Beads: `forge-2agy.5`; depends on `forge-2agy.4`.
+Beads: reframes `forge-2agy.5`; depends on `0.0.22`.
 
 Primary value:
 
@@ -427,7 +438,7 @@ Release gate:
 
 ## 0.0.24 - Extension-Contributed Runtime Components
 
-Beads: `forge-2agy.6`; depends on `forge-2agy.5`.
+Beads: reframes `forge-2agy.6`; depends on `0.0.23`.
 
 Primary value:
 
@@ -454,7 +465,7 @@ Evaluator regions:
 - Toggle/rollback correctness.
 - Skill package provenance and permission review.
 - Required skill loading and gated-skill non-invocation.
-- Harness projection status: `native`, `translated`, `fallback`, `unsupported_known_issue`, or `disabled_by_policy`.
+- Harness projection status: `native`, `translated`, `backstop_only`, `unsupported_known_issue`, or `disabled_by_policy`.
 - Evaluator cross-check loop that compares the resolved workflow graph to generated harness projections, proposes minimal repair diffs, and re-runs until `pass`, `blocked`, or `known_issue`.
 - Negative evaluator fixtures for omitted required skills, ungated gated skills, leaked hidden skills, stale disabled-pack artifacts, and unsupported native hook claims.
 
@@ -466,55 +477,59 @@ Release gate:
 - The evaluator catches at least one intentionally broken projection, emits a repair recommendation, and passes after the projection is regenerated.
 - The release evidence distinguishes landed behavior from in-flight PR behavior so the plan never claims unmerged parity as current `master` capability.
 
-## 0.0.25 - Scaled Team Runtime And External Orchestrator Bridge
+## 0.0.25 - Cloudflare Team Authority And Projection Workers
 
-Beads: `forge-2agy.7`; depends on `forge-2agy.6`.
+Beads: replaces `forge-2agy.7` Beads-plus-remote-projection framing; depends on `0.0.24`.
 
 Primary value:
 
-- Forge can coordinate large issue sets and external agent teams while staying local-first and adapter-driven.
+- Forge can coordinate team work through a server authority while preserving local mode for solo/internal multi-worktree use.
 
 Scope:
 
-- Indexed issue cache and paginated/filterable views for thousands of issues.
-- Bulk issue updates through the IssueAdapter, never through raw files.
-- Worker lease/claim/heartbeat/complete/block/fail contract.
-- External orchestrator bridge for tools such as Hermes-style agents, T3-style multi-agent runtimes, Codex, Claude, Cursor, and future MCP-backed workers.
-- Run ledger correlation across issues, agents, hooks, evidence, and review packets.
+- Cloudflare Worker API for auth, routing, and dashboard/API requests.
+- Durable Object per project/repo as serialized authority for claims and issue mutations.
+- D1 read model for queryable issue, claim, run, projection, and dashboard state.
+- Queues for GitHub/Linear/Beads projection jobs, retry, and dead letter handling.
+- R2 for large evidence bundles, validation artifacts, and archived session data.
+- Server-required team mode. No offline team writes.
+- Projection workers for GitHub/Linear run from the server, not local agents.
 
 Evaluator regions:
 
 - Thousand-issue performance.
 - Lease correctness.
 - Stale/crashed worker detection.
-- Cross-adapter consistency.
+- Cloudflare authority serialization.
+- Projection retry/dead-letter correctness.
+- Dashboard freshness and provenance.
+- Cross-projection consistency.
 
 Release gate:
 
-- Forge can display and filter a large issue graph, claim work for multiple agents, detect stale work, and keep issue updates consistent across Beads plus at least one remote projection.
+- Forge can display and filter a large issue graph, claim work for multiple users/agents through server authority, detect stale work, and keep projection failures visible without corrupting Forge Kernel state.
 
 ## Public Release Train Discipline After 0.0.18
 
 Each release after `0.0.18` must ship through the same public cadence:
 
-1. Create a Beads issue or epic for the release slice.
+1. Create a Forge Kernel issue or, until the Kernel lands, a Beads issue/epic for the release slice.
 2. Open a release branch/worktree.
 3. Add or update the design note, acceptance matrix, and evaluator region before implementation.
 4. Implement only the release slice.
 5. Run targeted tests, release-specific evaluators, `bun run check`, and `npm pack --dry-run`.
 6. Publish release notes that include: user value, migration notes, feature flags, known limitations, rollback path, and adapter compatibility.
 7. Publish through GitHub Release to npm.
-8. Verify the installed package in a clean repo and close or update the Beads/GitHub release issue.
+8. Verify the installed package in a clean repo and close or update the Forge Kernel/Beads/GitHub release issue.
 
 ## Deferred
 
 - Marketplace allowlist N16.
 - Full five resolver set N8; start with local and GitHub only.
 - Hardened sandbox.
-- Central orchestration layer before the external orchestrator bridge contract is proven.
+- Central orchestration layer before the local Kernel and Cloudflare authority contracts are proven.
 - Auto-merge by default.
-- Cloud control plane.
-- Direct agent writes to Beads internals, generated harness files, memory projection files, or Forge lock/config state.
+- Direct agent writes to Beads internals, generated harness files, memory projection files, or Forge lock/config/kernel state.
 - Treating agent-native memory files as Forge's canonical memory store.
 
 ## Deployment Per Release
@@ -524,4 +539,4 @@ Each release after `0.0.18` must ship through the same public cadence:
 3. Bump `package.json` to the next `0.0.x`.
 4. Tag and create a GitHub Release.
 5. Let `.github/workflows/npm-publish.yml` publish to npm.
-6. Verify the npm package and update related Beads/GitHub issues.
+6. Verify the npm package and update related Forge Kernel/Beads/GitHub issues.

--- a/docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md
+++ b/docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md
@@ -1,11 +1,11 @@
 # Forge v3 Redesign Strategy
 
-> Historical design artifact. Do not use this page for current package release planning, command availability, or public positioning. Current public package release guidance lives in `CHANGELOG.md`, `docs/reference/RELEASE.md`, and `docs/guides/WORKFLOW_TEMPLATES.md`.
+> Historical design artifact. Do not use this page for current package release planning, command availability, issue authority, or public positioning. Current public package release guidance lives in `CHANGELOG.md`, `docs/reference/RELEASE.md`, and `docs/guides/WORKFLOW_TEMPLATES.md`. Current issue authority guidance lives in [Forge Kernel authority control plane](./forge-kernel-authority-control-plane.md).
 
 **Date**: 2026-04-28 (originally) → 2026-04-29 (sections marked SUPERSEDED inline by iterations #5–#7)
-**Status**: Reference doc — **canonical "where we ended up" is now [FINAL-THESIS.md](./FINAL-THESIS.md)** + **release roadmap is [release-plan.md](./release-plan.md)** (D39). This doc retains its strategic framing but several sections have been superseded by D21–D39 (memory architecture, audit collapse, stage model, harness narrowing, release versioning, kill criteria). See inline SUPERSEDED notes.
+**Status**: Reference doc — **canonical "where we ended up" is now [FINAL-THESIS.md](./FINAL-THESIS.md)** + **release roadmap is [release-plan.md](./release-plan.md)** (D39) + **issue authority reset is [forge-kernel-authority-control-plane.md](./forge-kernel-authority-control-plane.md)** (D44). This doc retains its strategic framing but several sections have been superseded by D21–D44 (memory architecture, audit collapse, stage model, harness narrowing, release versioning, kill criteria, issue authority). See inline SUPERSEDED notes.
 **Supersedes**: [v2 unified strategy](../2026-04-06-v2-unified-strategy/unified-strategy.md) (preserved for historical reference)
-**Superseded by (in part)**: [FINAL-THESIS.md](./FINAL-THESIS.md), [locked-decisions.md](./locked-decisions.md) (D21–D38)
+**Superseded by (in part)**: [FINAL-THESIS.md](./FINAL-THESIS.md), [locked-decisions.md](./locked-decisions.md) (D21–D44), [forge-kernel-authority-control-plane.md](./forge-kernel-authority-control-plane.md)
 **Source design docs (same folder)**:
 - [v3-skeleton-plan.md](./_iteration-history/v3-skeleton-plan.md)
 - [layered-skeleton-config.md](./layered-skeleton-config.md)
@@ -68,7 +68,7 @@ Resolution order: **L1 → L2 → L3 → L4**. Later layers override earlier, ex
 | Shape | Fixed 7-stage TDD workflow shipped as monolith | Layered skeleton: locked rails + swappable defaults + project patches + user profile |
 | Customization | Edit Forge source / fork the repo | `.forge/config.yaml` toggles + `patch.md` overrides + extension marketplace |
 | Stage count | 7, hard-coded in `WORKFLOW_STAGE_MATRIX` | 7 by default, but `stages.<id>.enabled: false` collapses to any subset |
-| Issue tracker | Beads is the spine; everything binds to it | Beads is the **default L2 adapter**; pluggable via the adapter contract |
+| Issue tracker | Fixed Beads-bound model | SUPERSEDED-BY-D44: Forge Kernel API/local SQLite broker is the authority; Beads is import/export projection compatibility |
 | Rubric gate | Built into core | Default L2 gate, tunable in `patch.md`, replaceable by extension |
 | Distribution | Single `bunx forge setup` install | Curated `forge-marketplace.json` (Claude Code-compatible schema) + SHA-pinned add |
 | Safety | Always-on hard checks | L1 rails locked, L2 gates lenient-opt-in, every `--force-skip` audited |
@@ -83,7 +83,7 @@ Resolution order: **L1 → L2 → L3 → L4**. Later layers override earlier, ex
 
 ### What stays (deliberately)
 
-- **Beads + Dolt** as the default issue + history substrate — but as an adapter, not the spine.
+- SUPERSEDED-BY-D44: **Beads + Dolt** are not the target issue + history substrate. Forge Kernel is authority; Beads remains import/export projection compatibility.
 - **HARD-GATE quality enforcement** — enforced through the canonical L1 rails (TDD intent gate, secret scan, branch protection, signed commits, schema + integrity incl. Protected Path Manifest).
 - **Greptile / Sonar / CodeRabbit review automation** — re-shipped as L2 extensions, each installable independently.
 - **Forge CLI as the agent abstraction layer** — agents still only call `forge`, never the underlying tools.
@@ -273,7 +273,7 @@ Per the locked W0 NO-GO gate (D10) and harness scope (D11/D13), Wave 0 must veri
 |----|-------|---------|------|--------|-------|------|
 | WS1 | Forge CLI abstraction | Aligned | 1 | M | 5 | Already shipping; add `forge config` to inspect effective tree. |
 | WS2 | Stages as swappable agents | Reframe | 2 | L | 5 | Each stage becomes an L2 agent extension. |
-| WS3 | Beads as adapter, not spine | Reframe | 2 | M | 4 | Issue tracker pluggable; beads stays default L2 adapter. |
+| WS3 | Beads as adapter, not spine | SUPERSEDED-BY-D44 | 2 | M | 4 | Forge Kernel becomes authority; Beads becomes import/export projection compatibility. |
 | WS4 | Handoff schema | Aligned | 1 | S | 5 | Promote schema to L1 contract; freeze v1 wire format. |
 | WS5 | Rubric gate as default | Reframe | 2 | M | 4 | Move rubric out of core into L2 default gate; tunable in patch.md. |
 | WS6 | Parallel agent teams | Defer | — | XL | 3 | Out of scope; revisit after Wave 5. |

--- a/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
+++ b/docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md
@@ -11,7 +11,7 @@ Current Forge implementation does not yet match the full parity model discussed 
 What exists:
 
 - W0 skill metadata parity: one canonical skill fixture rendered to Claude Code, Cursor, and Codex surfaces, documented in [AGENT_SKILL_PARITY.md](../../reference/AGENT_SKILL_PARITY.md).
-- W1 protected-path parity work exists as PR #187 at verification time, not as landed `master` behavior. That PR adds a protected-path manifest and evidence command for seven protected-path categories across Claude, Cursor, and Codex, with Cursor marked as fallback.
+- W1 protected-path parity work exists as PR #187 at verification time, not as landed `master` behavior. That PR adds a protected-path manifest and evidence command for seven protected-path categories across Claude, Cursor, and Codex, with Cursor marked as `backstop_only`.
 - v3 docs already frame templates as adoption scaffolds and runtime building blocks as the product.
 
 What is missing:
@@ -42,7 +42,7 @@ A pack can contribute:
 - stages and substages
 - skills and subskills
 - commands and command shims
-- hooks and fallback checks
+- hooks and backstop checks
 - MCP servers, tools, and resources
 - ACP adapters
 - books, docs, and reference bundles
@@ -141,7 +141,7 @@ Recommendation examples:
 - Superpowers can replace Forge `/plan`.
 - Impeccable can extend frontend design review.
 - A GitHub MCP can strengthen `/review`.
-- Cursor lacks a verified native hook for a gate, so Forge should keep fallback enforcement.
+- Cursor lacks a verified native hook for a gate, so Forge should keep backstop enforcement.
 - A hidden or expensive skill should stay gated because the project prefers low-cost runs.
 
 Recommendations must include evidence, a config diff, rollback path, and affected harness projections.
@@ -154,15 +154,15 @@ The resolved workflow graph generates harness-specific files:
 | --- | --- |
 | Claude Code | plugin manifest, skills, hooks, MCP config, command shims, `CLAUDE.md` if needed |
 | Codex | skills, config, MCP config, lifecycle hooks where supported, `AGENTS.md` sections |
-| Cursor | `.cursor/rules`, Cursor skills where supported, MCP config, `AGENTS.md`, fallback hook checks |
+| Cursor | `.cursor/rules`, Cursor skills where supported, MCP config, `AGENTS.md`, backstop hook checks |
 
-Cursor projection must explicitly separate on-demand Cursor skills from always-on or scoped `.cursor/rules` policy, and it must keep protected-path hook behavior on fallback unless native Cursor hook evidence exists.
+Cursor projection must explicitly separate on-demand Cursor skills from always-on or scoped `.cursor/rules` policy, and it must keep protected-path hook behavior on `backstop_only` unless native Cursor hook evidence exists.
 
 Every projection must report one of:
 
 - `native`
 - `translated`
-- `fallback`
+- `backstop_only`
 - `unsupported_known_issue`
 - `disabled_by_policy`
 
@@ -180,7 +180,7 @@ The evaluator must read the same inputs the runtime uses, not an independent che
 - installed pack lock metadata and marketplace trust records
 - MCP server configs and discovered MCP capability metadata
 - generated Claude, Codex, and Cursor projection files
-- protected-path manifest and generated hook/fallback policy
+- protected-path manifest and generated hook/backstop policy
 - stage ledger entries showing required, loaded, skipped, gated, and hidden capabilities
 - known-issue records for unsupported harness surfaces
 
@@ -209,7 +209,7 @@ Week 3 must include intentionally broken projection fixtures so the evaluator pr
 - a gated skill invoked without approval evidence
 - a hidden skill exposed in an always-on harness rule
 - a disabled pack leaving behind a stale command alias or hook
-- a Cursor projection claiming native hook support when only fallback evidence exists
+- a Cursor projection claiming native hook support when only backstop evidence exists
 
 Each negative fixture must fail before repair, emit a minimal repair recommendation, regenerate or update the projection, and pass on the next evaluator run.
 


### PR DESCRIPTION
## Problem
The v3 plan still had Beads/Dolt framed as the runtime authority in parts of the release plan, locked decisions, and workflow assembly docs. That conflicted with the newer Forge Kernel direction: Forge should own issue, workflow, run, provider, and projection state while Beads becomes import/export compatibility.

## Root Cause
The previous workflow assembly/control-plane plan evolved around Beads as the durable tracker. After the architecture shifted to a Forge Kernel with local SQLite authority and later Cloudflare team authority, the canonical docs and release train needed to be reset together so future implementation does not drift back into Beads-as-authority decisions.

## Fix
This PR adds the Forge Kernel authority control-plane plan, storage model, and decision drift guards. It updates the release plan, locked decisions, docs index, capability-pack docs, harness parity docs, and changelog to use Kernel authority, provider capability contracts, explicit storage boundaries, and `backstop_only` terminology instead of fallback/Beads authority wording.

## Value
This gives future 0.0.20+ implementation a clear source of truth: local mode uses a SQLite WAL broker, team mode moves to Cloudflare authority, Beads is import/export only, and external skills/MCPs/agents/commands/hooks/scripts/extensions are governed as provider capabilities through Forge Kernel configuration and evaluator evidence.

## Beads
Closes forge-2agy.8

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: `bun run check` passed; validation test shard reported 810 passing, 0 failing before the changelog commit and 802 passing / 22 skipped / 0 failing in the post-changelog run.
- Pre-push targeted tests: 27 passing, 0 failing.
- Scenarios covered: docs index/reference consistency, workflow stage docs checks, command sync drift checks, edge-case security tests, package skill tests after workspace dependencies were installed.

### Security Review
- OWASP Top 10: docs-only architecture change; no runtime input handling, auth, storage code, or network path added.
- Automated scan: `bun audit` reported one moderate transitive `qs` advisory through `@stryker-mutator/core`; `scripts/validate.js` treats moderate/low findings as non-blocking and blocks only high/critical findings.

### Design Doc
See: `docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md`

### Key Decisions
- Forge Kernel is the issue/workflow/run authority; Beads is import/export only.
- Local single-user/multi-worktree mode uses a SQLite WAL broker keyed by git common-dir.
- Team mode uses Cloudflare Worker API, Durable Object write authority, D1 read model, Queues projections, and optional R2 evidence archive.
- Skills, MCPs, agents, commands, hooks, scripts, docs/context packs, and external extensions are provider capabilities controlled by Kernel config.
- Decision drift guards now make Beads-as-authority, silent fallback, and direct generated/harness authority writes explicit forbidden patterns.

### Documentation Updated
- `CHANGELOG.md`
- `docs/INDEX.md`
- `docs/reference/AGENT_SKILL_PARITY.md`
- `docs/reference/DECISION_DRIFT_GUARDS.md`
- `docs/reference/FORGE_KERNEL_STORAGE_MODEL.md`
- `docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md`
- `docs/work/2026-04-28-skeleton-pivot/locked-decisions.md`
- `docs/work/2026-04-28-skeleton-pivot/release-plan.md`
- `docs/work/2026-04-28-skeleton-pivot/week-3-runtime-capability-packs.md`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint`)
- [x] All tests pass locally (`bun run check`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: Documentation-only architecture plan; no source files changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new Forge Kernel planning references covering authority, storage, drift safeguards, and release evaluation.
  * Expanded the main index and team workflow docs with new architecture links and updated guidance.
  * Refreshed release planning, locked decisions, and strategy docs to align with the Kernel-first model and current roadmap.
  * Updated agent capability and runtime docs with terminology and formatting refinements.
  * Added a changelog entry summarizing the authority plan reset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/harshanandak/forge/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->