### PR TITLE
feat: add kernel schema migration contract

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@ This is the canonical map for Forge documentation. DeepWiki and other generated 
 - [Skills and command projections](reference/SKILLS.md) - current stage packaging across skills, commands, prompts, and harness projections.
 - [Release reference](reference/RELEASE.md) - validation, packaging, release handoff, and DeepWiki checklist.
 - [Forge Kernel storage model](reference/FORGE_KERNEL_STORAGE_MODEL.md) - authority/cache/projection/archive storage rules for local and team modes.
+- [Forge Kernel schema and migrations](reference/forge-kernel-schema.md) - 0.0.20 schema registry, migration, and storage-class contracts.
 - [Decision drift guards](reference/DECISION_DRIFT_GUARDS.md) - evaluator checklist and required doc updates for Kernel-era architecture changes.
 - [Toolchain](reference/TOOLCHAIN.md) - Bun, Node, Git, GitHub CLI, Beads, shell, and MCP conventions.
 - [Validation](reference/VALIDATION.md) - `bun run check`, failure meanings, and recovery.

--- a/docs/reference/forge-kernel-schema.md
+++ b/docs/reference/forge-kernel-schema.md
@@ -1,0 +1,68 @@
+# Forge Kernel Schema And Migrations
+
+**Status**: 0.0.20 schema slice reference.
+**Storage model**: [Forge Kernel storage model](FORGE_KERNEL_STORAGE_MODEL.md).
+
+## Purpose
+
+This document records the contract for the 0.0.20 Forge Kernel schema slice. It is a release reference for the schema registry, local migration plans, and storage-class metadata. It does not define the broker runtime, importer/exporter behavior, or conflict resolver behavior; those remain follow-up PRs.
+
+## Schema registry contract
+
+`lib/kernel/schema.js` is the source of truth for Kernel table definitions in this slice. The registry must keep table names, fields, primary keys, indexes, storage classes, and field authority metadata together so later broker and adapter work can consume one deterministic definition.
+
+The schema registry covers these Kernel surfaces:
+
+- issues,
+- dependencies,
+- comments,
+- priority events,
+- claims,
+- sessions,
+- worktrees,
+- stage runs,
+- evidence,
+- projections,
+- conflicts,
+- events,
+- outbox entries,
+- dead letters.
+
+Every table and field must declare a storage class and field authority that match [FORGE_KERNEL_STORAGE_MODEL.md](FORGE_KERNEL_STORAGE_MODEL.md). Drift guard failures should name the missing or invalid table or field.
+
+## Migration contract
+
+`lib/kernel/migrations.js` owns reversible local migration plans for this slice. Migration definitions must:
+
+- apply in declared order,
+- roll back in reverse order,
+- reject duplicate migration IDs,
+- produce deterministic SQL,
+- avoid introducing a database runtime dependency.
+
+Migration SQL generation should stay small and explicit. Runtime connection management, broker coordination, and remote execution are outside this slice.
+
+## Storage-class contract
+
+Storage-class metadata must answer the storage model questions before a table or field lands:
+
+- What is authoritative?
+- What is cached?
+- What is projected?
+- What is archived?
+- What remains local-only?
+- What requires server acceptance?
+- What happens when projection fails?
+
+The valid classes and authority rules are inherited from [FORGE_KERNEL_STORAGE_MODEL.md](FORGE_KERNEL_STORAGE_MODEL.md). This schema reference links that model so changes to schema, migrations, or storage classification cannot drift into undocumented authority behavior.
+
+## Follow-up PRs
+
+This document intentionally limits 0.0.20 to schema, migration, and storage-class contracts. Follow-up PRs should cover:
+
+- broker read/write execution,
+- Beads import and export adapters,
+- conflict detection and resolution workflows,
+- projection delivery workers,
+- dead-letter repair operations,
+- team-mode server acceptance paths.

--- a/docs/work/2026-06-01-0.0.20-kernel-schema/decisions.md
+++ b/docs/work/2026-06-01-0.0.20-kernel-schema/decisions.md
@@ -1,0 +1,3 @@
+# Decisions: 0.0.20 Kernel Schema, Migrations, and Storage Classifier
+
+No decision gates fired yet.

--- a/docs/work/2026-06-01-0.0.20-kernel-schema/design.md
+++ b/docs/work/2026-06-01-0.0.20-kernel-schema/design.md
@@ -1,0 +1,56 @@
+# Feature: 0.0.20 Kernel Schema, Migrations, and Storage Classifier
+
+Date: 2026-06-01
+Status: locked for development
+Issue: forge-2agy.2.1
+Branch: codex/0.0.20-kernel-schema
+
+## Purpose
+
+Define the first Forge Kernel authority implementation surface. This slice gives later broker, Beads adapter, conflict quarantine, and workflow work a stable schema contract, reversible local migrations, and a storage classifier grounded in `docs/reference/FORGE_KERNEL_STORAGE_MODEL.md`.
+
+## Success Criteria
+
+- Kernel entities are represented as explicit schema definitions for issues, dependencies, comments, priorities, claims, sessions, worktrees, stage runs, evidence, projections, conflicts, events, outbox entries, and dead letters.
+- Local migrations can apply and roll back deterministically without depending on Beads or Dolt.
+- Storage classification covers authority, read model, projection, archive, configuration, cache, and external-provider fields.
+- The schema exposes indexes needed by ready queues, issue detail reads, dependency traversal, stage/run queries, projection repair, and conflict quarantine.
+- Tests prove migration reversibility, entity coverage, storage classification, and drift guards against the storage model reference.
+
+## Out of Scope
+
+- No command routing through the Kernel API; that belongs to `forge-2agy.2.2`.
+- No full SQLite broker mutation API; this PR only provides schema and migration primitives.
+- No Beads import/export implementation; this PR only reserves schema surfaces for `forge-2agy.2.3`.
+- No conflict resolution engine; this PR only defines conflict/quarantine tables for `forge-2agy.2.4`.
+- No Cloudflare, D1, Durable Object, or team-authority implementation.
+
+## Approach Selected
+
+Add a small Kernel schema module and migration runner:
+
+- `lib/kernel/schema.js` exports table definitions, indexes, storage classes, field authority metadata, and validation helpers.
+- `lib/kernel/migrations.js` exposes reversible migration planning for local SQLite-style stores without requiring a SQLite dependency in this slice.
+- `test/kernel-schema.test.js` verifies entity coverage, migration ordering, reversible SQL shape, index coverage, and storage classification drift guards.
+
+The migration runner emits deterministic SQL statements and rollback statements. The next PR can bind those plans to the actual local SQLite WAL broker while this PR remains testable with the current dependency set.
+
+## Constraints
+
+- Keep this PR dependency-free unless an existing dependency already supports the need.
+- Do not mutate `.beads` files or treat Beads as write authority.
+- Keep schema names stable and boring; later broker and adapter PRs should consume them directly.
+- Keep generated SQL deterministic across Windows and Unix.
+- Preserve the public command surface until the broker PR routes commands through Kernel APIs.
+
+## Edge Cases
+
+- Duplicate migration IDs must be rejected.
+- Rollback order must be the reverse of apply order.
+- Unknown storage classes and field authorities must fail validation.
+- Projection and conflict tables must be present even before adapter/conflict engines exist.
+- Worktree/session fields must include Git common-dir and branch/path metadata so 0.0.21 can build lease coordination on top.
+
+## Ambiguity Policy
+
+Use the 7-dimension `/dev` decision gate. If confidence is at least 80%, proceed and document the choice in `decisions.md`. If confidence is below 80%, stop and request developer input.

--- a/docs/work/2026-06-01-0.0.20-kernel-schema/tasks.md
+++ b/docs/work/2026-06-01-0.0.20-kernel-schema/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: 0.0.20 Kernel Schema, Migrations, and Storage Classifier
+
+## Task 1: Kernel schema registry
+
+TDD:
+- RED: Add tests proving the registry includes issues, dependencies, comments, priority events, claims, sessions, worktrees, stage runs, evidence, projections, conflicts, events, outbox entries, and dead letters.
+- GREEN: Implement `lib/kernel/schema.js` with entity/table definitions, fields, primary keys, and indexes.
+- REFACTOR: Keep definitions data-driven so later broker and adapter PRs can consume the same registry.
+
+## Task 2: Storage classifier and field authority metadata
+
+TDD:
+- RED: Add tests proving every table and field has a valid storage class and field authority aligned to `docs/reference/FORGE_KERNEL_STORAGE_MODEL.md`.
+- GREEN: Add storage classes, field authorities, and classifier helpers to `lib/kernel/schema.js`.
+- REFACTOR: Make drift failures point at the missing table or field.
+
+## Task 3: Reversible local migration plans
+
+TDD:
+- RED: Add tests proving migrations apply in order, roll back in reverse order, reject duplicate IDs, and generate deterministic SQL.
+- GREEN: Implement `lib/kernel/migrations.js` with migration validation, apply-plan generation, and rollback-plan generation.
+- REFACTOR: Keep SQL generation small and explicit; do not introduce a database runtime dependency in this slice.
+
+## Task 4: Drift guards and release documentation
+
+TDD:
+- RED: Add tests proving docs mention the schema, migration, and storage-class contract and that the reference model stays linked.
+- GREEN: Add `docs/reference/forge-kernel-schema.md` and update `docs/INDEX.md`.
+- REFACTOR: Keep docs scoped to the 0.0.20 schema slice and clearly mark broker/import/conflict work as follow-up PRs.

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -1,0 +1,110 @@
+const { getKernelSchema, validateKernelSchema } = require('./schema');
+
+function assertIdentifier(identifier, label) {
+	if (!/^[a-z][a-z0-9_]*$/.test(identifier)) {
+		throw new Error(`Invalid Kernel SQL ${label}: ${identifier}`);
+	}
+}
+
+function renderReference(reference) {
+	const [tableName, columnName] = String(reference || '').split('.');
+	assertIdentifier(tableName, 'reference table');
+	assertIdentifier(columnName, 'reference column');
+	return `REFERENCES kernel_${tableName}(${columnName})`;
+}
+
+function renderColumn(field) {
+	assertIdentifier(field.name, 'column');
+	const parts = [field.name, field.type];
+	if (field.primaryKey) parts.push('PRIMARY KEY');
+	if (field.notNull && !field.primaryKey) parts.push('NOT NULL');
+	if (field.default !== undefined) parts.push(`DEFAULT ${field.default}`);
+	if (field.references) parts.push(renderReference(field.references));
+	return parts.join(' ');
+}
+
+function renderCreateTable(table) {
+	assertIdentifier(table.sqlName, 'table');
+	const columns = table.fields.map(field => `  ${renderColumn(field)}`).join(',\n');
+	return `CREATE TABLE IF NOT EXISTS ${table.sqlName} (\n${columns}\n);`;
+}
+
+function renderCreateIndex(table, index) {
+	assertIdentifier(index.name, 'index');
+	const unique = index.unique ? 'UNIQUE ' : '';
+	const columns = index.columns.join(', ');
+	return `CREATE ${unique}INDEX IF NOT EXISTS ${index.name} ON ${table.sqlName} (${columns});`;
+}
+
+function renderDropIndex(index) {
+	assertIdentifier(index.name, 'index');
+	return `DROP INDEX IF EXISTS ${index.name};`;
+}
+
+function renderDropTable(table) {
+	assertIdentifier(table.sqlName, 'table');
+	return `DROP TABLE IF EXISTS ${table.sqlName};`;
+}
+
+function buildSchemaMigration() {
+	const schema = getKernelSchema();
+	validateKernelSchema(schema);
+
+	const apply = [];
+	for (const table of schema.tables) {
+		apply.push(renderCreateTable(table));
+		for (const tableIndex of table.indexes) {
+			apply.push(renderCreateIndex(table, tableIndex));
+		}
+	}
+
+	const rollback = [];
+	for (const table of [...schema.tables].reverse()) {
+		for (const tableIndex of [...table.indexes].reverse()) {
+			rollback.push(renderDropIndex(tableIndex));
+		}
+		rollback.push(renderDropTable(table));
+	}
+
+	return {
+		id: '001_kernel_schema',
+		apply,
+		rollback,
+	};
+}
+
+function validateKernelMigrations(migrations) {
+	const ids = new Set();
+	for (const migration of migrations) {
+		if (!migration || !migration.id) {
+			throw new Error('Kernel migration is missing an id');
+		}
+		if (ids.has(migration.id)) {
+			throw new Error(`Duplicate Kernel migration id: ${migration.id}`);
+		}
+		ids.add(migration.id);
+		if (!Array.isArray(migration.apply) || migration.apply.length === 0) {
+			throw new Error(`Kernel migration ${migration.id} has no apply statements`);
+		}
+		if (!Array.isArray(migration.rollback) || migration.rollback.length === 0) {
+			throw new Error(`Kernel migration ${migration.id} has no rollback statements`);
+		}
+	}
+
+	return true;
+}
+
+function buildKernelMigrationPlan(migrations = [buildSchemaMigration()]) {
+	validateKernelMigrations(migrations);
+
+	return {
+		migrations,
+		apply: migrations.flatMap(migration => migration.apply),
+		rollback: [...migrations].reverse().flatMap(migration => migration.rollback),
+	};
+}
+
+module.exports = {
+	buildKernelMigrationPlan,
+	validateKernelMigrations,
+};

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -7,7 +7,11 @@ function assertIdentifier(identifier, label) {
 }
 
 function renderReference(reference) {
-	const [tableName, columnName] = String(reference || '').split('.');
+	const parts = String(reference || '').split('.');
+	if (parts.length !== 2) {
+		throw new Error(`Invalid Kernel SQL reference: ${reference}`);
+	}
+	const [tableName, columnName] = parts;
 	assertIdentifier(tableName, 'reference table');
 	assertIdentifier(columnName, 'reference column');
 	return `REFERENCES kernel_${tableName}(${columnName})`;
@@ -32,7 +36,10 @@ function renderCreateTable(table) {
 function renderCreateIndex(table, index) {
 	assertIdentifier(index.name, 'index');
 	const unique = index.unique ? 'UNIQUE ' : '';
-	const columns = index.columns.join(', ');
+	const columns = index.columns.map(column => {
+		assertIdentifier(column, 'index column');
+		return column;
+	}).join(', ');
 	return `CREATE ${unique}INDEX IF NOT EXISTS ${index.name} ON ${table.sqlName} (${columns});`;
 }
 
@@ -46,8 +53,7 @@ function renderDropTable(table) {
 	return `DROP TABLE IF EXISTS ${table.sqlName};`;
 }
 
-function buildSchemaMigration() {
-	const schema = getKernelSchema();
+function buildSchemaMigration(schema = getKernelSchema()) {
 	validateKernelSchema(schema);
 
 	const apply = [];
@@ -106,5 +112,6 @@ function buildKernelMigrationPlan(migrations = [buildSchemaMigration()]) {
 
 module.exports = {
 	buildKernelMigrationPlan,
+	buildSchemaMigration,
 	validateKernelMigrations,
 };

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -16,8 +16,8 @@ function renderReference(reference) {
 function renderColumn(field) {
 	assertIdentifier(field.name, 'column');
 	const parts = [field.name, field.type];
+	if (field.notNull) parts.push('NOT NULL');
 	if (field.primaryKey) parts.push('PRIMARY KEY');
-	if (field.notNull && !field.primaryKey) parts.push('NOT NULL');
 	if (field.default !== undefined) parts.push(`DEFAULT ${field.default}`);
 	if (field.references) parts.push(renderReference(field.references));
 	return parts.join(' ');

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -1,0 +1,275 @@
+const KERNEL_STORAGE_CLASSES = Object.freeze([
+	'authority',
+	'read_model',
+	'projection',
+	'archive',
+	'configuration',
+	'cache',
+	'external_provider',
+]);
+
+const KERNEL_FIELD_AUTHORITIES = Object.freeze([
+	'forge',
+	'provider',
+	'configured_provider',
+	'projection_only',
+]);
+
+function field(name, type, options = {}) {
+	return {
+		name,
+		type,
+		storageClass: options.storageClass,
+		authority: options.authority || 'forge',
+		primaryKey: Boolean(options.primaryKey),
+		notNull: Boolean(options.notNull || options.primaryKey),
+		default: options.default,
+		references: options.references,
+	};
+}
+
+function index(name, columns, options = {}) {
+	return {
+		name,
+		columns,
+		unique: Boolean(options.unique),
+	};
+}
+
+function table(name, storageClass, fields, indexes = []) {
+	return {
+		name,
+		sqlName: `kernel_${name}`,
+		storageClass,
+		authority: 'forge',
+		fields: fields.map(fieldDefinition => ({
+			...fieldDefinition,
+			storageClass: fieldDefinition.storageClass || storageClass,
+		})),
+		indexes,
+	};
+}
+
+const TABLE_LIST = Object.freeze([
+	table('issues', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('title', 'TEXT', { notNull: true }),
+		field('body', 'TEXT'),
+		field('type', 'TEXT', { notNull: true, default: "'task'" }),
+		field('status', 'TEXT', { notNull: true, default: "'open'" }),
+		field('priority', 'TEXT', { notNull: true, default: "'P2'" }),
+		field('priority_rank', 'INTEGER', { notNull: true, default: '0', storageClass: 'read_model' }),
+		field('created_at', 'TEXT', { notNull: true }),
+		field('updated_at', 'TEXT', { notNull: true }),
+		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
+	], [
+		index('idx_kernel_issues_status_priority', ['status', 'priority_rank']),
+		index('idx_kernel_issues_updated_at', ['updated_at']),
+	]),
+	table('dependencies', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('issue_id', 'TEXT', { notNull: true, references: 'issues.id' }),
+		field('blocks_issue_id', 'TEXT', { notNull: true, references: 'issues.id' }),
+		field('dependency_type', 'TEXT', { notNull: true, default: "'blocks'" }),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_dependencies_issue', ['issue_id']),
+		index('idx_kernel_dependencies_blocks', ['blocks_issue_id']),
+	]),
+	table('comments', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('issue_id', 'TEXT', { notNull: true, references: 'issues.id' }),
+		field('body', 'TEXT', { notNull: true }),
+		field('actor', 'TEXT', { notNull: true }),
+		field('visibility', 'TEXT', { notNull: true, default: "'local'" }),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_comments_issue_created', ['issue_id', 'created_at']),
+	]),
+	table('priority_events', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('issue_id', 'TEXT', { notNull: true, references: 'issues.id' }),
+		field('old_priority', 'TEXT'),
+		field('new_priority', 'TEXT', { notNull: true }),
+		field('priority_rank', 'INTEGER', { notNull: true }),
+		field('actor', 'TEXT', { notNull: true }),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_priority_events_issue_created', ['issue_id', 'created_at']),
+	]),
+	table('claims', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('issue_id', 'TEXT', { notNull: true, references: 'issues.id' }),
+		field('actor', 'TEXT', { notNull: true }),
+		field('state', 'TEXT', { notNull: true, default: "'active'" }),
+		field('session_id', 'TEXT'),
+		field('worktree_id', 'TEXT'),
+		field('claimed_at', 'TEXT', { notNull: true }),
+		field('expires_at', 'TEXT'),
+	], [
+		index('idx_kernel_claims_issue_state', ['issue_id', 'state']),
+		index('idx_kernel_claims_actor_state', ['actor', 'state']),
+	]),
+	table('sessions', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('actor', 'TEXT', { notNull: true }),
+		field('git_common_dir', 'TEXT', { notNull: true }),
+		field('worktree_id', 'TEXT'),
+		field('started_at', 'TEXT', { notNull: true }),
+		field('ended_at', 'TEXT'),
+		field('state', 'TEXT', { notNull: true, default: "'active'" }),
+	], [
+		index('idx_kernel_sessions_common_dir_state', ['git_common_dir', 'state']),
+	]),
+	table('worktrees', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('git_common_dir', 'TEXT', { notNull: true }),
+		field('path', 'TEXT', { notNull: true, storageClass: 'configuration' }),
+		field('branch', 'TEXT', { notNull: true }),
+		field('actor', 'TEXT'),
+		field('registered_at', 'TEXT', { notNull: true }),
+		field('state', 'TEXT', { notNull: true, default: "'active'" }),
+	], [
+		index('idx_kernel_worktrees_common_dir_branch', ['git_common_dir', 'branch']),
+	]),
+	table('stage_runs', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('issue_id', 'TEXT', { notNull: true, references: 'issues.id' }),
+		field('stage', 'TEXT', { notNull: true }),
+		field('substage', 'TEXT'),
+		field('status', 'TEXT', { notNull: true }),
+		field('started_at', 'TEXT', { notNull: true }),
+		field('completed_at', 'TEXT'),
+		field('evidence_id', 'TEXT'),
+	], [
+		index('idx_kernel_stage_runs_issue_stage', ['issue_id', 'stage']),
+		index('idx_kernel_stage_runs_status', ['status']),
+	]),
+	table('evidence', 'archive', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('issue_id', 'TEXT'),
+		field('run_id', 'TEXT'),
+		field('kind', 'TEXT', { notNull: true }),
+		field('uri', 'TEXT'),
+		field('summary', 'TEXT'),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_evidence_issue_kind', ['issue_id', 'kind']),
+	]),
+	table('projections', 'projection', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('target', 'TEXT', { notNull: true, storageClass: 'external_provider', authority: 'configured_provider' }),
+		field('entity_type', 'TEXT', { notNull: true }),
+		field('entity_id', 'TEXT', { notNull: true }),
+		field('status', 'TEXT', { notNull: true }),
+		field('last_error', 'TEXT', { storageClass: 'cache', authority: 'projection_only' }),
+		field('updated_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_projections_target_status', ['target', 'status']),
+		index('idx_kernel_projections_entity', ['entity_type', 'entity_id']),
+	]),
+	table('conflicts', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('entity_type', 'TEXT', { notNull: true }),
+		field('entity_id', 'TEXT', { notNull: true }),
+		field('expected_revision', 'INTEGER', { notNull: true }),
+		field('actual_revision', 'INTEGER', { notNull: true }),
+		field('status', 'TEXT', { notNull: true, default: "'quarantined'" }),
+		field('payload_json', 'TEXT', { notNull: true }),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_conflicts_status', ['status']),
+		index('idx_kernel_conflicts_entity', ['entity_type', 'entity_id']),
+	]),
+	table('events', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('entity_type', 'TEXT', { notNull: true }),
+		field('entity_id', 'TEXT', { notNull: true }),
+		field('event_type', 'TEXT', { notNull: true }),
+		field('idempotency_key', 'TEXT', { notNull: true }),
+		field('actor', 'TEXT', { notNull: true }),
+		field('origin', 'TEXT', { notNull: true }),
+		field('payload_json', 'TEXT', { notNull: true }),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_events_entity_created', ['entity_type', 'entity_id', 'created_at']),
+		index('idx_kernel_events_idempotency', ['idempotency_key'], { unique: true }),
+	]),
+	table('outbox', 'projection', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('event_id', 'TEXT', { notNull: true, references: 'events.id' }),
+		field('target', 'TEXT', { notNull: true }),
+		field('status', 'TEXT', { notNull: true, default: "'pending'" }),
+		field('attempts', 'INTEGER', { notNull: true, default: '0' }),
+		field('next_attempt_at', 'TEXT'),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_outbox_target_status', ['target', 'status']),
+	]),
+	table('dead_letters', 'projection', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('outbox_id', 'TEXT'),
+		field('target', 'TEXT', { notNull: true }),
+		field('status', 'TEXT', { notNull: true, default: "'open'" }),
+		field('error', 'TEXT', { notNull: true }),
+		field('payload_json', 'TEXT', { notNull: true }),
+		field('created_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_dead_letters_status', ['status']),
+	]),
+]);
+
+const KERNEL_TABLES = Object.freeze(Object.fromEntries(TABLE_LIST.map(candidate => [candidate.name, candidate])));
+
+function classifyKernelStorage(tableName) {
+	const tableDefinition = KERNEL_TABLES[tableName];
+	if (!tableDefinition) {
+		throw new Error(`Unknown Kernel table: ${tableName}`);
+	}
+
+	return {
+		table: tableDefinition.name,
+		sqlName: tableDefinition.sqlName,
+		storageClass: tableDefinition.storageClass,
+		authority: tableDefinition.authority,
+	};
+}
+
+function validateKernelSchema(schema = getKernelSchema()) {
+	const tableNames = new Set();
+	for (const tableDefinition of schema.tables) {
+		if (tableNames.has(tableDefinition.name)) {
+			throw new Error(`Duplicate Kernel table: ${tableDefinition.name}`);
+		}
+		tableNames.add(tableDefinition.name);
+		if (!KERNEL_STORAGE_CLASSES.includes(tableDefinition.storageClass)) {
+			throw new Error(`Invalid storage class for ${tableDefinition.name}: ${tableDefinition.storageClass}`);
+		}
+		for (const fieldDefinition of tableDefinition.fields) {
+			if (!KERNEL_STORAGE_CLASSES.includes(fieldDefinition.storageClass)) {
+				throw new Error(`Invalid storage class for ${tableDefinition.name}.${fieldDefinition.name}: ${fieldDefinition.storageClass}`);
+			}
+			if (!KERNEL_FIELD_AUTHORITIES.includes(fieldDefinition.authority)) {
+				throw new Error(`Invalid field authority for ${tableDefinition.name}.${fieldDefinition.name}: ${fieldDefinition.authority}`);
+			}
+		}
+	}
+
+	return true;
+}
+
+function getKernelSchema() {
+	return {
+		version: 1,
+		tables: TABLE_LIST,
+	};
+}
+
+module.exports = {
+	KERNEL_FIELD_AUTHORITIES,
+	KERNEL_STORAGE_CLASSES,
+	KERNEL_TABLES,
+	classifyKernelStorage,
+	getKernelSchema,
+	validateKernelSchema,
+};

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -264,7 +264,14 @@ function validateKernelSchema(schema = getKernelSchema()) {
 function getKernelSchema() {
 	return {
 		version: 1,
-		tables: TABLE_LIST,
+		tables: TABLE_LIST.map(tableDefinition => ({
+			...tableDefinition,
+			fields: tableDefinition.fields.map(fieldDefinition => ({ ...fieldDefinition })),
+			indexes: tableDefinition.indexes.map(indexDefinition => ({
+				...indexDefinition,
+				columns: [...indexDefinition.columns],
+			})),
+		})),
 	};
 }
 

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -15,6 +15,15 @@ const KERNEL_FIELD_AUTHORITIES = Object.freeze([
 	'projection_only',
 ]);
 
+function deepFreeze(value) {
+	if (!value || typeof value !== 'object') return value;
+	Object.freeze(value);
+	for (const nestedValue of Object.values(value)) {
+		deepFreeze(nestedValue);
+	}
+	return value;
+}
+
 function field(name, type, options = {}) {
 	return {
 		name,
@@ -50,7 +59,7 @@ function table(name, storageClass, fields, indexes = []) {
 	};
 }
 
-const TABLE_LIST = Object.freeze([
+const TABLE_LIST = deepFreeze([
 	table('issues', 'authority', [
 		field('id', 'TEXT', { primaryKey: true }),
 		field('title', 'TEXT', { notNull: true }),
@@ -219,7 +228,7 @@ const TABLE_LIST = Object.freeze([
 	]),
 ]);
 
-const KERNEL_TABLES = Object.freeze(Object.fromEntries(TABLE_LIST.map(candidate => [candidate.name, candidate])));
+const KERNEL_TABLES = deepFreeze(Object.fromEntries(TABLE_LIST.map(candidate => [candidate.name, candidate])));
 
 function classifyKernelStorage(tableName) {
 	const tableDefinition = KERNEL_TABLES[tableName];

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -245,6 +245,9 @@ function validateKernelSchema(schema = getKernelSchema()) {
 		if (!KERNEL_STORAGE_CLASSES.includes(tableDefinition.storageClass)) {
 			throw new Error(`Invalid storage class for ${tableDefinition.name}: ${tableDefinition.storageClass}`);
 		}
+		if (!KERNEL_FIELD_AUTHORITIES.includes(tableDefinition.authority)) {
+			throw new Error(`Invalid table authority for ${tableDefinition.name}: ${tableDefinition.authority}`);
+		}
 		for (const fieldDefinition of tableDefinition.fields) {
 			if (!KERNEL_STORAGE_CLASSES.includes(fieldDefinition.storageClass)) {
 				throw new Error(`Invalid storage class for ${tableDefinition.name}.${fieldDefinition.name}: ${fieldDefinition.storageClass}`);

--- a/test/kernel-schema-docs.test.js
+++ b/test/kernel-schema-docs.test.js
@@ -1,0 +1,38 @@
+const { describe, it, expect } = require('bun:test');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const ROOT = join(__dirname, '..');
+
+function readDoc(relPath) {
+  return readFileSync(join(ROOT, relPath), 'utf8');
+}
+
+describe('Forge Kernel schema release docs', () => {
+  it('links the schema reference from the documentation index', () => {
+    const index = readDoc('docs/INDEX.md');
+
+    expect(index).toContain('reference/forge-kernel-schema.md');
+    expect(index).toContain('Forge Kernel schema and migrations');
+  });
+
+  it('documents the schema, migration, and storage-class contract', () => {
+    const doc = readDoc('docs/reference/forge-kernel-schema.md');
+
+    expect(doc).toContain('lib/kernel/schema.js');
+    expect(doc).toContain('lib/kernel/migrations.js');
+    expect(doc).toContain('FORGE_KERNEL_STORAGE_MODEL.md');
+    expect(doc).toContain('Schema registry contract');
+    expect(doc).toContain('Migration contract');
+    expect(doc).toContain('Storage-class contract');
+  });
+
+  it('keeps broker, import, and conflict handling marked as follow-up work', () => {
+    const doc = readDoc('docs/reference/forge-kernel-schema.md');
+
+    expect(doc).toContain('Follow-up PRs');
+    expect(doc).toContain('broker');
+    expect(doc).toContain('import');
+    expect(doc).toContain('conflict');
+  });
+});

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -13,9 +13,10 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toEqual(secondPlan.apply);
 		expect(plan.rollback).toEqual(secondPlan.rollback);
 		expect(plan.apply[0]).toContain('CREATE TABLE IF NOT EXISTS kernel_issues');
+		expect(plan.apply[0]).toContain('id TEXT NOT NULL PRIMARY KEY');
 		expect(plan.apply).toContain('CREATE INDEX IF NOT EXISTS idx_kernel_issues_status_priority ON kernel_issues (status, priority_rank);');
-		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_dependencies (\n  id TEXT PRIMARY KEY,\n  issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  blocks_issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  dependency_type TEXT NOT NULL DEFAULT \'blocks\',\n  created_at TEXT NOT NULL\n);');
-		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
+		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_dependencies (\n  id TEXT NOT NULL PRIMARY KEY,\n  issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  blocks_issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  dependency_type TEXT NOT NULL DEFAULT \'blocks\',\n  created_at TEXT NOT NULL\n);');
+		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_dead_letters_status;');
 		expect(plan.rollback.at(-1)).toBe('DROP TABLE IF EXISTS kernel_issues;');
 		expect(plan.migrations.map(migration => migration.id)).toEqual(['001_kernel_schema']);

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -1,0 +1,53 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+	buildKernelMigrationPlan,
+	validateKernelMigrations,
+} = require('../../lib/kernel/migrations');
+
+describe('kernel migration plans', () => {
+	test('generates deterministic apply and rollback SQL for the schema', () => {
+		const plan = buildKernelMigrationPlan();
+		const secondPlan = buildKernelMigrationPlan();
+
+		expect(plan.apply).toEqual(secondPlan.apply);
+		expect(plan.rollback).toEqual(secondPlan.rollback);
+		expect(plan.apply[0]).toContain('CREATE TABLE IF NOT EXISTS kernel_issues');
+		expect(plan.apply).toContain('CREATE INDEX IF NOT EXISTS idx_kernel_issues_status_priority ON kernel_issues (status, priority_rank);');
+		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_dependencies (\n  id TEXT PRIMARY KEY,\n  issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  blocks_issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  dependency_type TEXT NOT NULL DEFAULT \'blocks\',\n  created_at TEXT NOT NULL\n);');
+		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
+		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_dead_letters_status;');
+		expect(plan.rollback.at(-1)).toBe('DROP TABLE IF EXISTS kernel_issues;');
+		expect(plan.migrations.map(migration => migration.id)).toEqual(['001_kernel_schema']);
+	});
+
+	test('rejects duplicate migration IDs', () => {
+		const migration = {
+			id: '001_kernel_schema',
+			apply: ['SELECT 1;'],
+			rollback: ['SELECT 0;'],
+		};
+
+		expect(() => validateKernelMigrations([migration, migration])).toThrow('Duplicate Kernel migration id');
+	});
+
+	test('orders multiple migrations forward and rolls them back in reverse migration order', () => {
+		const migrations = [
+			{
+				id: '001_kernel_schema',
+				apply: ['APPLY 1A;', 'APPLY 1B;'],
+				rollback: ['ROLLBACK 1B;', 'ROLLBACK 1A;'],
+			},
+			{
+				id: '002_kernel_projection_status',
+				apply: ['APPLY 2;'],
+				rollback: ['ROLLBACK 2;'],
+			},
+		];
+
+		const plan = buildKernelMigrationPlan(migrations);
+
+		expect(plan.apply).toEqual(['APPLY 1A;', 'APPLY 1B;', 'APPLY 2;']);
+		expect(plan.rollback).toEqual(['ROLLBACK 2;', 'ROLLBACK 1B;', 'ROLLBACK 1A;']);
+	});
+});

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -2,8 +2,10 @@ const { describe, expect, test } = require('bun:test');
 
 const {
 	buildKernelMigrationPlan,
+	buildSchemaMigration,
 	validateKernelMigrations,
 } = require('../../lib/kernel/migrations');
+const { getKernelSchema } = require('../../lib/kernel/schema');
 
 describe('kernel migration plans', () => {
 	test('generates deterministic apply and rollback SQL for the schema', () => {
@@ -50,5 +52,34 @@ describe('kernel migration plans', () => {
 
 		expect(plan.apply).toEqual(['APPLY 1A;', 'APPLY 1B;', 'APPLY 2;']);
 		expect(plan.rollback).toEqual(['ROLLBACK 2;', 'ROLLBACK 1B;', 'ROLLBACK 1A;']);
+	});
+
+	test('rejects malformed references and index columns before rendering SQL', () => {
+		const schema = getKernelSchema();
+		const badReferenceTable = {
+			...schema.tables[0],
+			fields: [
+				...schema.tables[0].fields,
+				{
+					name: 'bad_reference_id',
+					type: 'TEXT',
+					notNull: true,
+					authority: 'forge',
+					storageClass: 'authority',
+					references: 'issues.id.extra',
+				},
+			],
+		};
+		const badIndexTable = {
+			...schema.tables[0],
+			indexes: [{
+				name: 'idx_kernel_bad_column',
+				columns: ['status, priority_rank'],
+				unique: false,
+			}],
+		};
+
+		expect(() => buildSchemaMigration({ tables: [badReferenceTable] })).toThrow('Invalid Kernel SQL reference');
+		expect(() => buildSchemaMigration({ tables: [badIndexTable] })).toThrow('Invalid Kernel SQL index column');
 	});
 });

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -144,4 +144,17 @@ describe('kernel schema registry', () => {
 		expect(() => validateKernelSchema(invalidAuthoritySchema)).toThrow('Invalid field authority for issues.id');
 		expect(() => validateKernelSchema(invalidTableAuthoritySchema)).toThrow('Invalid table authority for issues');
 	});
+
+	test('returns isolated schema definitions for consumer planning', () => {
+		const schema = getKernelSchema();
+		schema.tables[0].fields[0].name = 'mutated';
+		schema.tables[0].indexes[0].columns.push('mutated_column');
+
+		const freshSchema = getKernelSchema();
+
+		expect(freshSchema.tables[0].fields[0].name).toBe('id');
+		expect(freshSchema.tables[0].indexes[0].columns).not.toContain('mutated_column');
+		expect(KERNEL_TABLES.issues.fields[0].name).toBe('id');
+		expect(KERNEL_TABLES.issues.indexes[0].columns).not.toContain('mutated_column');
+	});
 });

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -133,8 +133,15 @@ describe('kernel schema registry', () => {
 				fields: [{ ...KERNEL_TABLES.issues.fields[0], authority: 'invalid' }],
 			}],
 		};
+		const invalidTableAuthoritySchema = {
+			tables: [{
+				...KERNEL_TABLES.issues,
+				authority: 'invalid',
+			}],
+		};
 
 		expect(() => validateKernelSchema(invalidStorageSchema)).toThrow('Invalid storage class for issues.id');
 		expect(() => validateKernelSchema(invalidAuthoritySchema)).toThrow('Invalid field authority for issues.id');
+		expect(() => validateKernelSchema(invalidTableAuthoritySchema)).toThrow('Invalid table authority for issues');
 	});
 });

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -157,4 +157,12 @@ describe('kernel schema registry', () => {
 		expect(KERNEL_TABLES.issues.fields[0].name).toBe('id');
 		expect(KERNEL_TABLES.issues.indexes[0].columns).not.toContain('mutated_column');
 	});
+
+	test('deep-freezes the exported schema registry', () => {
+		KERNEL_TABLES.issues.fields[0].name = 'mutated';
+
+		expect(() => KERNEL_TABLES.issues.indexes[0].columns.push('mutated_column')).toThrow();
+		expect(KERNEL_TABLES.issues.fields[0].name).toBe('id');
+		expect(KERNEL_TABLES.issues.indexes[0].columns).not.toContain('mutated_column');
+	});
 });

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -1,0 +1,140 @@
+const { describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+	KERNEL_STORAGE_CLASSES,
+	KERNEL_FIELD_AUTHORITIES,
+	KERNEL_TABLES,
+	classifyKernelStorage,
+	getKernelSchema,
+	validateKernelSchema,
+} = require('../../lib/kernel/schema');
+
+const REQUIRED_TABLES = [
+	'issues',
+	'dependencies',
+	'comments',
+	'priority_events',
+	'claims',
+	'sessions',
+	'worktrees',
+	'stage_runs',
+	'evidence',
+	'projections',
+	'conflicts',
+	'events',
+	'outbox',
+	'dead_letters',
+];
+
+describe('kernel schema registry', () => {
+	test('defines the 0.0.20 authority entities and indexes', () => {
+		const schema = getKernelSchema();
+
+		expect(schema.tables.map(table => table.name)).toEqual(REQUIRED_TABLES);
+		for (const tableName of REQUIRED_TABLES) {
+			const table = KERNEL_TABLES[tableName];
+			expect(table).toBeDefined();
+			expect(table.sqlName).toMatch(/^kernel_[a-z0-9_]+$/);
+			expect(table.fields.some(field => field.primaryKey)).toBe(true);
+			expect(table.fields.length).toBeGreaterThan(2);
+		}
+
+		expect(KERNEL_TABLES.issues.indexes.map(index => index.name)).toContain('idx_kernel_issues_status_priority');
+		expect(KERNEL_TABLES.dependencies.indexes.map(index => index.name)).toContain('idx_kernel_dependencies_blocks');
+		expect(KERNEL_TABLES.stage_runs.indexes.map(index => index.name)).toContain('idx_kernel_stage_runs_issue_stage');
+		expect(KERNEL_TABLES.projections.indexes.map(index => index.name)).toContain('idx_kernel_projections_target_status');
+		expect(KERNEL_TABLES.conflicts.indexes.map(index => index.name)).toContain('idx_kernel_conflicts_status');
+	});
+
+	test('classifies every table and field with valid storage and authority metadata', () => {
+		expect(KERNEL_STORAGE_CLASSES).toEqual([
+			'authority',
+			'read_model',
+			'projection',
+			'archive',
+			'configuration',
+			'cache',
+			'external_provider',
+		]);
+		expect(KERNEL_FIELD_AUTHORITIES).toEqual([
+			'forge',
+			'provider',
+			'configured_provider',
+			'projection_only',
+		]);
+
+		for (const table of getKernelSchema().tables) {
+			expect(KERNEL_STORAGE_CLASSES).toContain(table.storageClass);
+			expect(classifyKernelStorage(table.name).storageClass).toBe(table.storageClass);
+			for (const field of table.fields) {
+				expect(KERNEL_STORAGE_CLASSES).toContain(field.storageClass);
+				expect(KERNEL_FIELD_AUTHORITIES).toContain(field.authority);
+			}
+		}
+
+		const usedStorageClasses = new Set();
+		for (const table of getKernelSchema().tables) {
+			usedStorageClasses.add(table.storageClass);
+			for (const field of table.fields) {
+				usedStorageClasses.add(field.storageClass);
+			}
+		}
+		expect([...usedStorageClasses].sort()).toEqual([...KERNEL_STORAGE_CLASSES].sort());
+
+		expect(classifyKernelStorage('issues')).toMatchObject({
+			storageClass: 'authority',
+			authority: 'forge',
+		});
+		expect(classifyKernelStorage('projections')).toMatchObject({
+			storageClass: 'projection',
+			authority: 'forge',
+		});
+		expect(classifyKernelStorage('evidence')).toMatchObject({
+			storageClass: 'archive',
+			authority: 'forge',
+		});
+		expect(() => classifyKernelStorage('unknown')).toThrow('Unknown Kernel table');
+		expect(validateKernelSchema()).toBe(true);
+	});
+
+	test('guards storage metadata against storage-model drift', () => {
+		const storageModel = fs.readFileSync(
+			path.join(__dirname, '..', '..', 'docs', 'reference', 'FORGE_KERNEL_STORAGE_MODEL.md'),
+			'utf8',
+		);
+		const requiredStorageModelPhrases = {
+			authority: 'Authority',
+			read_model: 'Read model',
+			projection: 'Projection state',
+			archive: 'Archive',
+			configuration: 'Configuration',
+			cache: 'cached',
+			external_provider: 'provider',
+		};
+
+		for (const [storageClass, phrase] of Object.entries(requiredStorageModelPhrases)) {
+			expect(KERNEL_STORAGE_CLASSES).toContain(storageClass);
+			expect(storageModel).toContain(phrase);
+		}
+		expect(storageModel).toContain('Forge Kernel owns issue, claim, stage, run, and projection state');
+		expect(storageModel).toContain('Beads is import/export compatibility only');
+
+		const invalidStorageSchema = {
+			tables: [{
+				...KERNEL_TABLES.issues,
+				fields: [{ ...KERNEL_TABLES.issues.fields[0], storageClass: 'invalid' }],
+			}],
+		};
+		const invalidAuthoritySchema = {
+			tables: [{
+				...KERNEL_TABLES.issues,
+				fields: [{ ...KERNEL_TABLES.issues.fields[0], authority: 'invalid' }],
+			}],
+		};
+
+		expect(() => validateKernelSchema(invalidStorageSchema)).toThrow('Invalid storage class for issues.id');
+		expect(() => validateKernelSchema(invalidAuthoritySchema)).toThrow('Invalid field authority for issues.id');
+	});
+});


### PR DESCRIPTION
## Summary
- Adds the first Forge Kernel schema registry for 0.0.20 authority entities, indexes, storage classes, and field authority metadata.
- Adds deterministic reversible migration-plan generation with foreign-key references rendered from schema metadata.
- Adds schema reference docs, docs index link, and plan/dev artifacts for forge-2agy.2.1.

## Workflow Evidence
- RED: `bun test .\test\kernel-schema.test.js` failed before `lib/kernel/schema.js` existed.
- GREEN/REFACTOR: targeted tests pass after mirrored TDD test split.
- Spec review subagent: PASS after fixing field-level storage metadata and multi-migration coverage.
- Quality review subagent: PASS after rendering declared references and adding storage-model drift guards.

## Validation
- `bun test .\test\kernel\schema.test.js .\test\kernel\migrations.test.js .\test\kernel-schema-docs.test.js` -> 9 pass, 0 fail, 346 expect calls.
- `bunx eslint .\lib\kernel\schema.js .\lib\kernel\migrations.js .\test\kernel\schema.test.js .\test\kernel\migrations.test.js .\test\kernel-schema-docs.test.js` -> pass.
- `bun run check` -> passed; security audit reports existing moderate `qs` advisory as non-blocking.
- Pre-commit hooks passed: protected-state and tdd-check.
- Pre-push hooks passed: branch-protection, lint, team-sync, tests.

## Issue
- Implements forge-2agy.2.1 under 0.0.20 Kernel Schema And Local Broker Contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference documentation for the 0.0.20 Kernel Schema, including schema specifications, migration contracts, and storage classification guidance.

* **New Features**
  * Introduced Kernel schema registry with deterministic migration plan generation and validation.
  * Added schema validation to detect drift in storage classes and field authorities.

* **Tests**
  * Added test coverage for schema validation and migration generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->