### PR TITLE
feat: add local kernel broker contract

### DIFF
--- a/docs/work/2026-06-01-0.0.20-local-broker/decisions.md
+++ b/docs/work/2026-06-01-0.0.20-local-broker/decisions.md
@@ -1,0 +1,17 @@
+# Decisions: 0.0.20 Local Broker Contract
+
+## D1: Keep SQLite runtime injected
+
+Decision: Implement the local broker as a contract around an injected driver instead of adding a SQLite package in this PR.
+
+Rationale: The existing 0.0.20 schema slice is dependency-free, and this broker slice only needs to lock the command/API boundary, Git common-dir authority lookup, WAL pragmas, and migration ordering. A driver boundary lets later storage-runtime work bind the same contract without rewriting command routing.
+
+Impact: Kernel command paths can be tested now through `kernelBroker` or `kernelDriver` injection. Default Beads behavior remains unchanged until the import/export and runtime storage PRs are ready.
+
+## D2: Kernel command path is opt-in for this PR
+
+Decision: `runIssueOperation` selects the Kernel backend only when `useKernelBroker`, `issueBackend: "kernel"`, or `kernelBroker` is supplied.
+
+Rationale: PR B must create the Kernel broker and command API contract without breaking current users whose issue commands still rely on Beads. This also avoids treating Beads as authority for new Kernel paths.
+
+Impact: Representative command interactions can prove Kernel routing now, while the default command surface stays compatible.

--- a/docs/work/2026-06-01-0.0.20-local-broker/design.md
+++ b/docs/work/2026-06-01-0.0.20-local-broker/design.md
@@ -1,0 +1,47 @@
+# Feature: 0.0.20 Local Broker Contract
+
+Date: 2026-06-01
+Status: implemented
+Issue: forge-2agy.2.2
+Branch: codex/0.0.20-local-broker
+
+## Purpose
+
+Add the first local Forge Kernel broker API surface for command-facing issue operations. This slice binds local mode to the Git common-dir so linked worktrees share one authority location, and exposes SQLite-style WAL behavior as a small, testable storage contract without adding a SQLite runtime dependency.
+
+## Scope
+
+- Add `lib/kernel/broker.js` for Git common-dir broker lookup, local database path planning, WAL pragmas, and migration application through an injected driver.
+- Add `KernelIssueAdapter` so commands can route through a Kernel broker interface.
+- Add an opt-in Kernel path in `runIssueOperation` via `useKernelBroker`, `issueBackend: "kernel"`, or an injected `kernelBroker`.
+- Keep the default Beads path intact until import/export compatibility work lands separately.
+- Add a top-level `comment` alias and `forge issue comment` mapping because comment is part of the issue command API contract.
+
+## Authority Answers
+
+- Authoritative: local Kernel broker state under the Git common-dir.
+- Cached: none added in this slice.
+- Projected: Beads remains a legacy/default command backend, not Kernel authority for opt-in Kernel paths.
+- Archived: none added.
+- Local-only: broker database path and full worktree/common-dir paths.
+- Server acceptance: not required in local mode.
+- Projection failure: out of scope for this PR; no Beads import/export behavior is added.
+
+## Storage Contract
+
+The broker config plans a local SQLite database at:
+
+```text
+<git-common-dir>/forge/kernel.sqlite
+```
+
+Initialization applies these statements before schema migrations:
+
+```sql
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA foreign_keys=ON;
+PRAGMA busy_timeout=5000;
+```
+
+The actual SQLite driver remains injected through the broker boundary. This keeps the API testable and avoids adding a heavy dependency before the storage runtime decision is locked.

--- a/docs/work/2026-06-01-0.0.20-local-broker/tasks.md
+++ b/docs/work/2026-06-01-0.0.20-local-broker/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: 0.0.20 Local Broker Contract
+
+## Task 1: Local broker common-dir contract
+
+TDD:
+- RED: Add tests proving the broker resolves `git rev-parse --git-common-dir`, stores under the common-dir, and does not use `.beads`.
+- GREEN: Implement `lib/kernel/broker.js` with common-dir lookup and deterministic local config.
+- REFACTOR: Keep path planning separate from storage driver execution.
+
+## Task 2: WAL-style initialization contract
+
+TDD:
+- RED: Add tests proving WAL, synchronous, foreign key, and busy-timeout pragmas are applied before Kernel migrations.
+- GREEN: Add broker initialization through an injected driver.
+- REFACTOR: Leave SQLite dependency selection outside this PR.
+
+## Task 3: Kernel issue adapter and command routing
+
+TDD:
+- RED: Add tests proving Kernel issue operations route through a broker boundary and command aliases can opt into that path.
+- GREEN: Add `KernelIssueAdapter`, Kernel backend creation, and opt-in dispatch in `runIssueOperation`.
+- REFACTOR: Preserve existing Beads defaults for compatibility.
+
+## Task 4: Comment command API surface
+
+TDD:
+- RED: Add tests for `comment` argument mapping.
+- GREEN: Add the `comment` issue subcommand and top-level alias.
+- REFACTOR: Keep legacy Beads mapping as `bd comments add` while Kernel paths pass `comment` through the broker interface.

--- a/lib/adapters/kernel-issue-adapter.js
+++ b/lib/adapters/kernel-issue-adapter.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const {
+	IssueAdapter,
+	decideIssueAuthority,
+	normalizeIssueStatus,
+} = require('../issue-adapter.js');
+
+class KernelIssueAdapter extends IssueAdapter {
+	constructor(options = {}) {
+		super({
+			id: options.id || 'kernel-local',
+			kind: 'issue',
+			name: options.name || 'Forge Kernel Local Issue Adapter',
+			version: options.version || '0.1.0',
+		});
+		this.broker = options.broker;
+	}
+
+	run(operation, args = [], context = {}) {
+		if (!this.broker || typeof this.broker.runIssueOperation !== 'function') {
+			throw new TypeError('KernelIssueAdapter requires a broker with runIssueOperation()');
+		}
+
+		return this.broker.runIssueOperation(operation, args, context);
+	}
+
+	list(args = [], context = {}) {
+		return this.run('list', args, context);
+	}
+
+	ready(args = [], context = {}) {
+		return this.run('ready', args, context);
+	}
+
+	read(args = [], context = {}) {
+		return this.run('show', args, context);
+	}
+
+	show(args = [], context = {}) {
+		return this.read(args, context);
+	}
+
+	create(args = [], context = {}) {
+		return this.run('create', args, context);
+	}
+
+	update(args = [], context = {}) {
+		return this.run('update', args, context);
+	}
+
+	claim(args = [], context = {}) {
+		return this.run('claim', args, context);
+	}
+
+	close(args = [], context = {}) {
+		return this.run('close', args, context);
+	}
+
+	comment(args = [], context = {}) {
+		return this.run('comment', args, context);
+	}
+
+	mapStatus(status, context = {}) {
+		return normalizeIssueStatus(status, context);
+	}
+
+	decideAuthority(change = {}, context = {}) {
+		return decideIssueAuthority(change, context);
+	}
+}
+
+module.exports = {
+	KernelIssueAdapter,
+};

--- a/lib/adapters/kernel-issue-adapter.js
+++ b/lib/adapters/kernel-issue-adapter.js
@@ -6,6 +6,18 @@ const {
 	normalizeIssueStatus,
 } = require('../issue-adapter.js');
 
+const KERNEL_ISSUE_OPERATIONS = Object.freeze({
+	list: 'list',
+	ready: 'ready',
+	read: 'show',
+	show: 'show',
+	create: 'create',
+	update: 'update',
+	claim: 'claim',
+	close: 'close',
+	comment: 'comment',
+});
+
 class KernelIssueAdapter extends IssueAdapter {
 	constructor(options = {}) {
 		super({
@@ -25,42 +37,6 @@ class KernelIssueAdapter extends IssueAdapter {
 		return this.broker.runIssueOperation(operation, args, context);
 	}
 
-	list(args = [], context = {}) {
-		return this.run('list', args, context);
-	}
-
-	ready(args = [], context = {}) {
-		return this.run('ready', args, context);
-	}
-
-	read(args = [], context = {}) {
-		return this.run('show', args, context);
-	}
-
-	show(args = [], context = {}) {
-		return this.read(args, context);
-	}
-
-	create(args = [], context = {}) {
-		return this.run('create', args, context);
-	}
-
-	update(args = [], context = {}) {
-		return this.run('update', args, context);
-	}
-
-	claim(args = [], context = {}) {
-		return this.run('claim', args, context);
-	}
-
-	close(args = [], context = {}) {
-		return this.run('close', args, context);
-	}
-
-	comment(args = [], context = {}) {
-		return this.run('comment', args, context);
-	}
-
 	mapStatus(status, context = {}) {
 		return normalizeIssueStatus(status, context);
 	}
@@ -70,6 +46,13 @@ class KernelIssueAdapter extends IssueAdapter {
 	}
 }
 
+for (const [methodName, operation] of Object.entries(KERNEL_ISSUE_OPERATIONS)) {
+	KernelIssueAdapter.prototype[methodName] = function issueOperation(args = [], context = {}) {
+		return this.run(operation, args, context);
+	};
+}
+
 module.exports = {
+	KERNEL_ISSUE_OPERATIONS,
 	KernelIssueAdapter,
 };

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -28,6 +28,12 @@ const SUBCOMMANDS = {
       return ['update', issueId, '--claim', ...rest];
     },
   },
+  comment: {
+    description: 'Add an issue comment via Forge',
+    usage: 'forge comment <id> <body...>',
+    helpCommand: 'comments',
+    buildBdArgs: (args) => ['comments', 'add', ...args],
+  },
   close: {
     description: 'Close a Beads issue via Forge',
     usage: 'forge close <id...> [bd-close-flags]',
@@ -82,6 +88,7 @@ function formatIssueHelp() {
   lines.push('  forge claim forge-abc');
   lines.push('  forge update forge-abc --priority 1');
   lines.push('  forge close forge-abc --reason "Done"');
+  lines.push('  forge comment forge-abc "Handoff note"');
   lines.push('  forge issue show forge-abc --json');
 
   return lines.join('\n');
@@ -111,7 +118,11 @@ function buildBdArgs(subcommand, rawArgs) {
   return spec.buildBdArgs(args);
 }
 
-const WRITE_SUBCOMMANDS = new Set(['create', 'update', 'claim', 'close']);
+const WRITE_SUBCOMMANDS = new Set(['create', 'update', 'claim', 'comment', 'close']);
+
+function shouldUseKernelBroker(opts = {}) {
+  return Boolean(opts.useKernelBroker || opts.kernelBroker || opts.issueBackend === 'kernel');
+}
 
 async function runIssueSubcommand(subcommand, args, projectRoot, opts = {}) {
   const bdArgs = buildBdArgs(subcommand, args);
@@ -120,10 +131,14 @@ async function runIssueSubcommand(subcommand, args, projectRoot, opts = {}) {
     return { success: false, error: bdArgs.error };
   }
 
-  if (WRITE_SUBCOMMANDS.has(subcommand)) {
+  if (WRITE_SUBCOMMANDS.has(subcommand) || shouldUseKernelBroker(opts)) {
     const runner = opts.runIssueOperation || runIssueOperation;
-    const operation = subcommand === 'claim' ? 'update' : subcommand;
-    return runner(operation, bdArgs.slice(1), projectRoot, opts);
+    const useKernelBroker = shouldUseKernelBroker(opts);
+    const operation = subcommand === 'claim' && !useKernelBroker ? 'update' : subcommand;
+    const operationArgs = subcommand === 'claim' && useKernelBroker
+      ? normalizeArgs(args)
+      : bdArgs.slice(1);
+    return runner(operation, operationArgs, projectRoot, opts);
   }
 
   const exec = opts._exec || execFileSync;

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -135,7 +135,7 @@ async function runIssueSubcommand(subcommand, args, projectRoot, opts = {}) {
     const runner = opts.runIssueOperation || runIssueOperation;
     const useKernelBroker = shouldUseKernelBroker(opts);
     const operation = subcommand === 'claim' && !useKernelBroker ? 'update' : subcommand;
-    const operationArgs = subcommand === 'claim' && useKernelBroker
+    const operationArgs = subcommand === 'comment' || (subcommand === 'claim' && useKernelBroker)
       ? normalizeArgs(args)
       : bdArgs.slice(1);
     return runner(operation, operationArgs, projectRoot, opts);

--- a/lib/commands/comment.js
+++ b/lib/commands/comment.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { makeAliasCommand } = require('./_issue');
+
+module.exports = makeAliasCommand('comment');

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -5,7 +5,9 @@ const { existsSync } = require('node:fs');
 const path = require('node:path');
 const { isBeadsInitialized } = require('./beads-setup');
 const { BeadsIssueAdapter } = require('./adapters/beads-issue-adapter');
+const { KernelIssueAdapter } = require('./adapters/kernel-issue-adapter');
 const { createGitHubProjectionPlan } = require('./issue-sync/project-github');
+const { createLocalBroker } = require('./kernel/broker');
 
 const OPERATION_TO_BD = {
   create: 'create',
@@ -258,6 +260,25 @@ function createBeadsIssueBackend(deps = {}) {
   });
 }
 
+function createKernelIssueBackend(context = {}) {
+  const deps = context.deps || {};
+  const createBroker = deps.createKernelBroker || ((brokerContext) => createLocalBroker({
+    projectRoot: brokerContext.projectRoot,
+    gitCommonDir: deps.gitCommonDir,
+    databasePath: deps.kernelDatabasePath,
+    driver: deps.kernelDriver,
+    execFileSync: deps.execFileSync,
+  }));
+
+  return new KernelIssueAdapter({
+    broker: deps.kernelBroker || createBroker(context),
+  });
+}
+
+function shouldUseKernelBroker(deps = {}) {
+  return Boolean(deps.useKernelBroker || deps.kernelBroker || deps.issueBackend === 'kernel');
+}
+
 function createIssueService({ backend } = {}) {
   const resolvedBackend = backend || createBeadsIssueBackend();
 
@@ -281,6 +302,17 @@ function createIssueService({ backend } = {}) {
 
 async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
   const createService = deps.createService || (() => {
+    const context = {
+      projectRoot,
+      deps,
+    };
+
+    if (shouldUseKernelBroker(deps)) {
+      return createIssueService({
+        backend: createKernelIssueBackend(context),
+      });
+    }
+
     const backendDeps = {
       isBeadsInitialized: deps.isBeadsInitialized,
       runBdCommand: deps.runBdCommand,
@@ -319,6 +351,7 @@ async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
 module.exports = {
   createIssueService,
   createBeadsIssueBackend,
+  createKernelIssueBackend,
   runBeadsOperation,
   runIssueOperation,
   buildBdArgs,

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const { buildKernelMigrationPlan } = require('./migrations');
+
+const LOCAL_BROKER_PRAGMAS = Object.freeze([
+	'PRAGMA journal_mode=WAL;',
+	'PRAGMA synchronous=NORMAL;',
+	'PRAGMA foreign_keys=ON;',
+	'PRAGMA busy_timeout=5000;',
+]);
+
+function normalizeExecOutput(output) {
+	if (Buffer.isBuffer(output)) {
+		return output.toString('utf8');
+	}
+	return String(output || '');
+}
+
+function resolveGitCommonDir(projectRoot, deps = {}) {
+	if (!projectRoot) {
+		throw new Error('projectRoot is required to resolve the Kernel broker common-dir');
+	}
+
+	const exec = deps.execFileSync || execFileSync;
+	const rawCommonDir = normalizeExecOutput(exec('git', [
+		'-C',
+		projectRoot,
+		'rev-parse',
+		'--git-common-dir',
+	], { encoding: 'utf8' })).trim();
+
+	if (!rawCommonDir) {
+		throw new Error('git rev-parse --git-common-dir returned an empty path');
+	}
+
+	return path.resolve(path.isAbsolute(rawCommonDir)
+		? rawCommonDir
+		: path.join(projectRoot, rawCommonDir));
+}
+
+function buildLocalBrokerConfig(options = {}) {
+	const projectRoot = options.projectRoot || process.cwd();
+	const gitCommonDir = path.resolve(options.gitCommonDir || resolveGitCommonDir(projectRoot, options));
+	const brokerDir = path.join(gitCommonDir, 'forge');
+
+	return {
+		mode: 'local',
+		storage: 'sqlite',
+		journalMode: 'WAL',
+		synchronous: 'NORMAL',
+		foreignKeys: true,
+		busyTimeoutMs: 5000,
+		projectRoot,
+		gitCommonDir,
+		brokerDir,
+		databasePath: options.databasePath || path.join(brokerDir, 'kernel.sqlite'),
+		pragmas: [...LOCAL_BROKER_PRAGMAS],
+		migrationPlan: options.migrationPlan || buildKernelMigrationPlan(),
+	};
+}
+
+function requireDriverMethod(driver, methodName) {
+	if (!driver || typeof driver[methodName] !== 'function') {
+		throw new Error(`Kernel local broker driver must provide ${methodName}()`);
+	}
+}
+
+function createLocalBroker(options = {}) {
+	const driver = options.driver;
+	let cachedConfig;
+
+	function getConfig() {
+		if (!cachedConfig) {
+			cachedConfig = buildLocalBrokerConfig(options);
+		}
+		return cachedConfig;
+	}
+
+	return {
+		get config() {
+			return getConfig();
+		},
+
+		async initialize() {
+			requireDriverMethod(driver, 'exec');
+			const config = getConfig();
+			for (const statement of [...config.pragmas, ...config.migrationPlan.apply]) {
+				await driver.exec(statement, config);
+			}
+
+			return {
+				success: true,
+				mode: config.mode,
+				databasePath: config.databasePath,
+				gitCommonDir: config.gitCommonDir,
+				journalMode: config.journalMode,
+				synchronous: config.synchronous,
+				foreignKeys: config.foreignKeys,
+				migrationsApplied: config.migrationPlan.migrations.map(migration => migration.id),
+			};
+		},
+
+		async runIssueOperation(operation, args = [], context = {}) {
+			requireDriverMethod(driver, 'issueOperation');
+			return driver.issueOperation(operation, args, context, getConfig());
+		},
+	};
+}
+
+module.exports = {
+	LOCAL_BROKER_PRAGMAS,
+	buildLocalBrokerConfig,
+	createLocalBroker,
+	resolveGitCommonDir,
+};

--- a/test/adapters/kernel-issue-adapter.test.js
+++ b/test/adapters/kernel-issue-adapter.test.js
@@ -21,7 +21,10 @@ describe('KernelIssueAdapter', () => {
 	});
 
 	test('delegates representative command API operations to the broker boundary', async () => {
-		const { KernelIssueAdapter } = require('../../lib/adapters/kernel-issue-adapter');
+		const {
+			KERNEL_ISSUE_OPERATIONS,
+			KernelIssueAdapter,
+		} = require('../../lib/adapters/kernel-issue-adapter');
 		const calls = [];
 		const adapter = new KernelIssueAdapter({
 			broker: {
@@ -32,24 +35,23 @@ describe('KernelIssueAdapter', () => {
 			},
 		});
 		const context = { projectRoot: '/repo', deps: { source: 'test' } };
-
-		await expect(adapter.list(['--json'], context)).resolves.toMatchObject({ operation: 'list' });
-		await expect(adapter.ready([], context)).resolves.toMatchObject({ operation: 'ready' });
-		await expect(adapter.read(['forge-1'], context)).resolves.toMatchObject({ operation: 'show' });
-		await expect(adapter.update(['forge-1', '--status', 'in_progress'], context)).resolves.toMatchObject({ operation: 'update' });
-		await expect(adapter.claim(['forge-1'], context)).resolves.toMatchObject({ operation: 'claim' });
-		await expect(adapter.close(['forge-1'], context)).resolves.toMatchObject({ operation: 'close' });
-		await expect(adapter.comment(['forge-1', 'handoff'], context)).resolves.toMatchObject({ operation: 'comment' });
-
-		expect(calls.map(call => [call.operation, call.args])).toEqual([
+		const scenarios = [
 			['list', ['--json']],
 			['ready', []],
-			['show', ['forge-1']],
+			['read', ['forge-1']],
 			['update', ['forge-1', '--status', 'in_progress']],
 			['claim', ['forge-1']],
 			['close', ['forge-1']],
 			['comment', ['forge-1', 'handoff']],
-		]);
+		];
+
+		for (const [methodName, args] of scenarios) {
+			await expect(adapter[methodName](args, context))
+				.resolves.toMatchObject({ operation: KERNEL_ISSUE_OPERATIONS[methodName] });
+		}
+
+		expect(calls.map(call => [call.operation, call.args]))
+			.toEqual(scenarios.map(([methodName, args]) => [KERNEL_ISSUE_OPERATIONS[methodName], args]));
 		expect(calls[0].context).toBe(context);
 	});
 });

--- a/test/adapters/kernel-issue-adapter.test.js
+++ b/test/adapters/kernel-issue-adapter.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+
+describe('KernelIssueAdapter', () => {
+	test('implements the IssueAdapter contract over a Kernel broker', () => {
+		const { validateIssueAdapter } = require('../../lib/issue-adapter');
+		const { KernelIssueAdapter } = require('../../lib/adapters/kernel-issue-adapter');
+
+		const adapter = new KernelIssueAdapter({
+			broker: {
+				async runIssueOperation() {
+					return { success: true };
+				},
+			},
+		});
+
+		expect(adapter.id).toBe('kernel-local');
+		expect(adapter.kind).toBe('issue');
+		expect(validateIssueAdapter(adapter)).toEqual({ valid: true, errors: [] });
+	});
+
+	test('delegates representative command API operations to the broker boundary', async () => {
+		const { KernelIssueAdapter } = require('../../lib/adapters/kernel-issue-adapter');
+		const calls = [];
+		const adapter = new KernelIssueAdapter({
+			broker: {
+				async runIssueOperation(operation, args, context) {
+					calls.push({ operation, args, context });
+					return { success: true, operation, output: `${operation}:ok` };
+				},
+			},
+		});
+		const context = { projectRoot: '/repo', deps: { source: 'test' } };
+
+		await expect(adapter.list(['--json'], context)).resolves.toMatchObject({ operation: 'list' });
+		await expect(adapter.ready([], context)).resolves.toMatchObject({ operation: 'ready' });
+		await expect(adapter.read(['forge-1'], context)).resolves.toMatchObject({ operation: 'show' });
+		await expect(adapter.update(['forge-1', '--status', 'in_progress'], context)).resolves.toMatchObject({ operation: 'update' });
+		await expect(adapter.claim(['forge-1'], context)).resolves.toMatchObject({ operation: 'claim' });
+		await expect(adapter.close(['forge-1'], context)).resolves.toMatchObject({ operation: 'close' });
+		await expect(adapter.comment(['forge-1', 'handoff'], context)).resolves.toMatchObject({ operation: 'comment' });
+
+		expect(calls.map(call => [call.operation, call.args])).toEqual([
+			['list', ['--json']],
+			['ready', []],
+			['show', ['forge-1']],
+			['update', ['forge-1', '--status', 'in_progress']],
+			['claim', ['forge-1']],
+			['close', ['forge-1']],
+			['comment', ['forge-1', 'handoff']],
+		]);
+		expect(calls[0].context).toBe(context);
+	});
+});

--- a/test/commands/_issue.test.js
+++ b/test/commands/_issue.test.js
@@ -42,4 +42,33 @@ describe('forge issue helpers', () => {
       },
     }]);
   });
+
+  test('read aliases route through the shared issue operation runner for Kernel backends', async () => {
+    const calls = [];
+    const list = makeAliasCommand('list');
+
+    const result = await list.handler(['--json'], {}, '/repo', {
+      useKernelBroker: true,
+      runIssueOperation: async (operation, args, projectRoot, deps) => {
+        calls.push({ operation, args, projectRoot, deps });
+        return { success: true, operation, output: '[]' };
+      },
+    });
+
+    expect(result).toEqual({ success: true, operation: 'list', output: '[]' });
+    expect(calls).toEqual([{
+      operation: 'list',
+      args: ['--json'],
+      projectRoot: '/repo',
+      deps: {
+        useKernelBroker: true,
+        runIssueOperation: expect.any(Function),
+      },
+    }]);
+  });
+
+  test('buildBdArgs maps comment to bd comments add passthrough', () => {
+    expect(buildBdArgs('comment', ['forge-abc', 'handoff note']))
+      .toEqual(['comments', 'add', 'forge-abc', 'handoff note']);
+  });
 });

--- a/test/commands/comment.test.js
+++ b/test/commands/comment.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+
+describe('forge comment command', () => {
+	test('exports a top-level comment alias through the shared issue command surface', async () => {
+		const comment = require('../../lib/commands/comment');
+		const calls = [];
+
+		const result = await comment.handler(['forge-1', 'handoff note'], {}, '/repo', {
+			runIssueOperation: async (operation, args, projectRoot) => {
+				calls.push({ operation, args, projectRoot });
+				return { success: true, operation };
+			},
+		});
+
+		expect(comment.name).toBe('comment');
+		expect(result).toEqual({ success: true, operation: 'comment' });
+		expect(calls).toEqual([{
+			operation: 'comment',
+			args: ['add', 'forge-1', 'handoff note'],
+			projectRoot: '/repo',
+		}]);
+	});
+});

--- a/test/commands/comment.test.js
+++ b/test/commands/comment.test.js
@@ -18,7 +18,7 @@ describe('forge comment command', () => {
 		expect(result).toEqual({ success: true, operation: 'comment' });
 		expect(calls).toEqual([{
 			operation: 'comment',
-			args: ['add', 'forge-1', 'handoff note'],
+			args: ['forge-1', 'handoff note'],
 			projectRoot: '/repo',
 		}]);
 	});

--- a/test/commands/issue.test.js
+++ b/test/commands/issue.test.js
@@ -5,6 +5,7 @@ const { describe, test, expect } = require('bun:test');
 const issue = require('../../lib/commands/issue');
 const create = require('../../lib/commands/create');
 const claim = require('../../lib/commands/claim');
+const comment = require('../../lib/commands/comment');
 describe('forge issue command surface', () => {
   test('exports the canonical issue command module', () => {
     expect(issue.name).toBe('issue');
@@ -20,6 +21,11 @@ describe('forge issue command surface', () => {
   test('exports top-level claim alias', () => {
     expect(claim.name).toBe('claim');
     expect(typeof claim.handler).toBe('function');
+  });
+
+  test('exports top-level comment alias', () => {
+    expect(comment.name).toBe('comment');
+    expect(typeof comment.handler).toBe('function');
   });
 
   test('issue handler dispatches to create subcommand', async () => {

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -212,6 +212,38 @@ describe('forge issue service contract', () => {
     }
   });
 
+  test('top-level operation runner selects the Kernel broker backend when requested', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+    const calls = [];
+
+    const result = await runIssueOperation('comment', ['forge-1', 'handoff note'], '/repo', {
+      useKernelBroker: true,
+      createKernelBroker: (context) => ({
+        async runIssueOperation(operation, args, operationContext) {
+          calls.push({ context, operation, args, operationContext });
+          return { success: true, operation, output: 'kernel ok' };
+        },
+      }),
+      isBeadsInitialized: () => {
+        throw new Error('Beads should not be consulted for Kernel broker operations');
+      },
+    });
+
+    expect(result).toEqual({ success: true, operation: 'comment', output: 'kernel ok' });
+    expect(calls).toEqual([{
+      context: {
+        projectRoot: '/repo',
+        deps: expect.objectContaining({ useKernelBroker: true }),
+      },
+      operation: 'comment',
+      args: ['forge-1', 'handoff note'],
+      operationContext: {
+        projectRoot: '/repo',
+        deps: expect.objectContaining({ useKernelBroker: true }),
+      },
+    }]);
+  });
+
   test('default beads backend rejects issue operations when beads is not initialized', async () => {
     const { createBeadsIssueBackend } = require('../lib/forge-issues');
 

--- a/test/kernel/broker.test.js
+++ b/test/kernel/broker.test.js
@@ -1,0 +1,91 @@
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+
+describe('local Kernel broker contract', () => {
+	test('keys the local broker by git common-dir instead of worktree path', () => {
+		const {
+			buildLocalBrokerConfig,
+			resolveGitCommonDir,
+		} = require('../../lib/kernel/broker');
+		const projectRoot = path.join(os.tmpdir(), 'forge-worktree');
+		const calls = [];
+
+		const commonDir = resolveGitCommonDir(projectRoot, {
+			execFileSync: (command, args, options) => {
+				calls.push({ command, args, options });
+				return `.git${os.EOL}`;
+			},
+		});
+		const config = buildLocalBrokerConfig({ projectRoot, gitCommonDir: commonDir });
+
+		expect(commonDir).toBe(path.resolve(projectRoot, '.git'));
+		expect(config.gitCommonDir).toBe(commonDir);
+		expect(config.databasePath).toBe(path.join(commonDir, 'forge', 'kernel.sqlite'));
+		expect(config.databasePath).not.toContain(`${path.sep}.beads${path.sep}`);
+		expect(calls).toEqual([{
+			command: 'git',
+			args: ['-C', projectRoot, 'rev-parse', '--git-common-dir'],
+			options: { encoding: 'utf8' },
+		}]);
+	});
+
+	test('initializes SQLite-style WAL pragmas before applying Kernel migrations', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const projectRoot = path.join(os.tmpdir(), 'forge-worktree');
+		const statements = [];
+
+		const broker = createLocalBroker({
+			projectRoot,
+			execFileSync: () => path.join(projectRoot, '.git'),
+			driver: {
+				async exec(statement) {
+					statements.push(statement);
+				},
+			},
+		});
+
+		const result = await broker.initialize();
+
+		expect(result).toMatchObject({
+			success: true,
+			journalMode: 'WAL',
+			synchronous: 'NORMAL',
+			foreignKeys: true,
+		});
+		expect(statements.slice(0, 4)).toEqual([
+			'PRAGMA journal_mode=WAL;',
+			'PRAGMA synchronous=NORMAL;',
+			'PRAGMA foreign_keys=ON;',
+			'PRAGMA busy_timeout=5000;',
+		]);
+		expect(statements).toContain('CREATE TABLE IF NOT EXISTS kernel_issues (\n  id TEXT NOT NULL PRIMARY KEY,\n  title TEXT NOT NULL,\n  body TEXT,\n  type TEXT NOT NULL DEFAULT \'task\',\n  status TEXT NOT NULL DEFAULT \'open\',\n  priority TEXT NOT NULL DEFAULT \'P2\',\n  priority_rank INTEGER NOT NULL DEFAULT 0,\n  created_at TEXT NOT NULL,\n  updated_at TEXT NOT NULL,\n  entity_revision INTEGER NOT NULL DEFAULT 0\n);');
+	});
+
+	test('exposes a testable issue-operation boundary without requiring a bundled sqlite dependency', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const calls = [];
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+			driver: {
+				async issueOperation(operation, args, context, brokerConfig) {
+					calls.push({ operation, args, context, brokerConfig });
+					return { success: true, operation, output: '[]' };
+				},
+			},
+		});
+
+		await expect(broker.runIssueOperation('list', ['--json'], { actor: 'tester' }))
+			.resolves.toEqual({ success: true, operation: 'list', output: '[]' });
+		expect(calls).toEqual([{
+			operation: 'list',
+			args: ['--json'],
+			context: { actor: 'tester' },
+			brokerConfig: expect.objectContaining({
+				mode: 'local',
+				journalMode: 'WAL',
+			}),
+		}]);
+	});
+});


### PR DESCRIPTION
## Problem
0.0.20 needs the first local Kernel broker surface after the schema/migration contract merged in PR #195. Commands need an opt-in Kernel authority path keyed by Git common-dir without making `.beads` files the new authority.

## Root Cause
The schema existed, but there was no broker contract, WAL initialization boundary, common-dir authority lookup, or command-facing adapter for Kernel issue operations.

## Fix
Adds a local Kernel broker contract, WAL-style initialization via an injected driver, a Kernel issue adapter, opt-in routing through the issue command service, and a `comment` command API surface while preserving default Beads compatibility.

## Value
This gives 0.0.20 a testable local authority boundary for future ready/show/list/update/claim/comment/close and MCP routing without destabilizing existing Beads-backed commands.

## Beads
Closes forge-2agy.2.2

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 35 targeted tests passing locally; pre-push affected tests reported 266 pass, 0 fail.
- Scenarios covered: common-dir broker path resolution, WAL pragma initialization contract, Kernel migration application, Kernel issue adapter routing, opt-in command operation routing, comment command API surface, and default Beads compatibility.

### Security Review
- OWASP Top 10: no auth/payment/web input surface added; broker path is derived from Git common-dir and tests cover the authority lookup boundary.
- Automated scan: `bun audit --audit-level high` passed with exit 0.

### Design Doc
See: `docs/work/2026-06-01-0.0.20-local-broker/design.md`

### Key Decisions
- Keep storage behind an injected driver so the broker contract is testable without adding a new heavy dependency in this PR.
- Key local authority by Git common-dir so linked worktrees share one Kernel authority store.
- Preserve Beads as the default command backend and make Kernel routing opt-in for this slice.
- Run WAL/synchronous/foreign-key/busy-timeout pragmas before Kernel migrations.

### Documentation Updated
- `docs/work/2026-06-01-0.0.20-local-broker/design.md`
- `docs/work/2026-06-01-0.0.20-local-broker/tasks.md`
- `docs/work/2026-06-01-0.0.20-local-broker/decisions.md`

### Validation
- [x] Type check passing
- [x] Lint passing (0 errors)
- [x] All targeted tests passing
- [x] Security review completed

</details>

---

### Self-Review Checklist

- [x] I reviewed the full local diff before PR creation
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes (`bun run lint`)
- [x] Targeted tests pass locally
- [x] No hardcoded secrets or API keys
- [x] No breaking changes; default Beads compatibility is preserved
- [x] TDD compliance: source changes have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top-level `comment` command and alias mapping for issue comments.
  * Optional "kernel" issue backend (opt-in routing) alongside the existing backend.
  * Local broker storing a database under the Git common-dir with WAL/safety initialization before migrations.

* **Tests**
  * Added coverage for broker behavior, adapter delegation, command routing, and the `comment` command.

* **Chores**
  * Added design, decisions, and task documentation for v0.0.20 Local Broker Contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->