### PR TITLE
feat: add kernel conflict evaluators

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@ This is the canonical map for Forge documentation. DeepWiki and other generated 
 - [Forge Kernel storage model](reference/FORGE_KERNEL_STORAGE_MODEL.md) - authority/cache/projection/archive storage rules for local and team modes.
 - [Forge Kernel schema and migrations](reference/forge-kernel-schema.md) - 0.0.20 schema registry, migration, and storage-class contracts.
 - [Decision drift guards](reference/DECISION_DRIFT_GUARDS.md) - evaluator checklist and required doc updates for Kernel-era architecture changes.
+- [Kernel conflict evaluators](reference/kernel-conflict-evaluators.md) - conflict quarantine, idempotency, duplicate write dedupe, dependency-cycle, and projection ordering contract.
 - [Toolchain](reference/TOOLCHAIN.md) - Bun, Node, Git, GitHub CLI, Beads, shell, and MCP conventions.
 - [Validation](reference/VALIDATION.md) - `bun run check`, failure meanings, and recovery.
 - [Templates](reference/TEMPLATES.md) - adoption profiles and the default workflow template.

--- a/docs/reference/forge-kernel-schema.md
+++ b/docs/reference/forge-kernel-schema.md
@@ -28,6 +28,8 @@ The schema registry covers these Kernel surfaces:
 - outbox entries,
 - dead letters.
 
+Kernel events persist `expected_revision` alongside the idempotency key and payload. Conflict evaluators depend on that revision metadata to distinguish a true equivalent retry from a later intentional write that returns an entity to an earlier payload.
+
 Every table and field must declare a storage class and field authority that match [FORGE_KERNEL_STORAGE_MODEL.md](FORGE_KERNEL_STORAGE_MODEL.md). Drift guard failures should name the missing or invalid table or field.
 
 ## Migration contract

--- a/docs/reference/forge-kernel-schema.md
+++ b/docs/reference/forge-kernel-schema.md
@@ -44,6 +44,8 @@ Every table and field must declare a storage class and field authority that matc
 
 Migration SQL generation should stay small and explicit. Runtime connection management, broker coordination, and remote execution are outside this slice.
 
+`expected_revision` on `kernel_events` is added by the additive `002_kernel_events_expected_revision` migration so existing local Kernel databases created by the initial schema migration gain the column during upgrade.
+
 ## Storage-class contract
 
 Storage-class metadata must answer the storage model questions before a table or field lands:

--- a/docs/reference/kernel-conflict-evaluators.md
+++ b/docs/reference/kernel-conflict-evaluators.md
@@ -1,0 +1,27 @@
+# Kernel Conflict Evaluators
+
+**Status**: 0.0.20 conflict quarantine slice.
+
+## Contract
+
+Kernel event writes are evaluated before projection. The evaluator can accept a write, return a prior accepted idempotency result, dedupe an equivalent write, or quarantine the write as a conflict.
+
+Quarantined writes insert `kernel_conflicts` records and do not enqueue projection outbox entries. This keeps Beads, GitHub, Linear, and other downstream projections from resolving authority conflicts.
+
+## Guarded Cases
+
+- Stale `expected_revision` values quarantine the write with the actual entity revision.
+- Duplicate idempotency keys return the original accepted event without creating a second event or projection.
+- Equivalent duplicate writes dedupe even when the retry uses a different idempotency key.
+- Dependency writes that would create a dependency cycle quarantine before projection.
+- Fixture cases cover import fidelity, priority ordering, dependency correctness, idempotency, and drift guard violations.
+
+## Broker Ordering
+
+The local broker remains dependency-free. Drivers provide the storage runtime and the broker enforces this order:
+
+1. Load the authority entity revision, prior events, and dependencies.
+2. Evaluate the event.
+3. Insert a conflict for quarantined writes and stop.
+4. Insert accepted events.
+5. Enqueue projection outbox rows only after event acceptance.

--- a/docs/work/2026-06-02-0.0.20-conflict-evaluators/decisions.md
+++ b/docs/work/2026-06-02-0.0.20-conflict-evaluators/decisions.md
@@ -1,0 +1,3 @@
+# Decisions: 0.0.20 Conflict Evaluators
+
+No decision gates fired yet.

--- a/docs/work/2026-06-02-0.0.20-conflict-evaluators/design.md
+++ b/docs/work/2026-06-02-0.0.20-conflict-evaluators/design.md
@@ -1,0 +1,31 @@
+# 0.0.20 Conflict Evaluators Design
+
+## Intent
+
+Add the first Kernel conflict evaluator surface after the schema, broker, and Beads adapter contracts. This slice keeps the broker dependency-free while proving the command path can detect stale revisions, idempotent replays, duplicate writes, and dependency cycles before projection.
+
+## Scope
+
+- Pure evaluator helpers for Kernel event acceptance, dedupe, and quarantine.
+- Broker orchestration through injected driver methods.
+- Fixtures and tests for stale revision quarantine, idempotency, dependency correctness, and decision drift guard coverage.
+- Conflict evaluator docs and fixtures that PR E can reference for final migration UX.
+
+## Boundaries
+
+- No bundled SQLite runtime.
+- No conflict resolution command UI.
+- No Beads projection writes from Kernel authority in this slice.
+- No closure for `forge-2agy.2.4` until this PR merges and verifies.
+- Tracker cleanup for already-merged A/B slices is handled in the parallel docs/migration UX PR to avoid direct protected-state edits from this worktree.
+
+## Architecture
+
+The evaluator accepts an event draft plus a minimal authority snapshot. It returns one of:
+
+- `accept`: insert the event and enqueue projection.
+- `duplicate`: return the previously accepted idempotency result.
+- `dedupe`: return the previously accepted equivalent write.
+- `quarantine`: insert a conflict record and skip projection.
+
+The broker owns operation order. Conflict insertion happens before projection enqueueing, and quarantined writes never create outbox rows.

--- a/docs/work/2026-06-02-0.0.20-conflict-evaluators/tasks.md
+++ b/docs/work/2026-06-02-0.0.20-conflict-evaluators/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: 0.0.20 Conflict Quarantine and Evaluators
+
+## Task 1: Pure evaluator decisions
+
+TDD:
+- RED: Add tests for stale revision quarantine, idempotency replay, duplicate write dedupe, and dependency-cycle quarantine.
+- GREEN: Implement a pure `lib/kernel/evaluators.js` module.
+- REFACTOR: Keep evaluator inputs serializable so fixtures can exercise them without a database runtime.
+
+## Task 2: Broker guard ordering
+
+TDD:
+- RED: Add tests proving the broker inserts conflicts before projection and skips outbox creation for quarantined writes.
+- GREEN: Add guarded event execution through injected broker driver methods.
+- REFACTOR: Preserve the existing broker contract and avoid bundling SQLite.
+
+## Task 3: Evaluator fixtures and drift guards
+
+TDD:
+- RED: Add fixture tests for import fidelity, priority ordering, dependency correctness, idempotency, and drift guard violations.
+- GREEN: Add evaluator fixtures under `test/fixtures/kernel-evaluators`.
+- REFACTOR: Keep expected outcomes explicit and readable.
+
+## Task 4: Docs handoff for migration UX
+
+TDD:
+- RED: Add docs tests proving the conflict evaluator reference is indexed.
+- GREEN: Document quarantine, idempotency, duplicate write dedupe, dependency-cycle guards, and projection ordering.
+- REFACTOR: Keep final migration UX closure in the parallel PR E branch.

--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -335,6 +335,11 @@ function buildPriorityEvent(issue, importedAt) {
   };
 }
 
+function normalizeEntityRevision(value) {
+  const revision = Number(value);
+  return Number.isFinite(revision) ? revision : 0;
+}
+
 function buildCloseEvent(issue, importedAt) {
   if (!issue.closed_at && !issue.close_reason) {
     return null;
@@ -347,7 +352,7 @@ function buildCloseEvent(issue, importedAt) {
     entity_id: issue.id,
     event_type: 'beads.issue.closed',
     idempotency_key: `beads-close:${issue.id}:${createdAt}`,
-    expected_revision: Number(issue.entity_revision || 0),
+    expected_revision: normalizeEntityRevision(issue.entity_revision),
     actor: issue.closed_by || issue.created_by || 'beads',
     origin: 'beads_import',
     payload_json: JSON.stringify({

--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -347,6 +347,7 @@ function buildCloseEvent(issue, importedAt) {
     entity_id: issue.id,
     event_type: 'beads.issue.closed',
     idempotency_key: `beads-close:${issue.id}:${createdAt}`,
+    expected_revision: Number(issue.entity_revision || 0),
     actor: issue.closed_by || issue.created_by || 'beads',
     origin: 'beads_import',
     payload_json: JSON.stringify({

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -91,6 +91,7 @@ function parseEventPayload(event = {}) {
 function buildDependencyScope(event) {
 	if (event.event_type !== 'dependency.add') return null;
 	const payload = parseEventPayload(event);
+	if (!payload.issue_id || !payload.blocks_issue_id) return null;
 	return {
 		issue_id: payload.issue_id,
 		blocks_issue_id: payload.blocks_issue_id,

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -68,6 +68,26 @@ function requireDriverMethod(driver, methodName) {
 	}
 }
 
+function isExpectedRevisionAddColumn(statement) {
+	return statement === 'ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;';
+}
+
+function isDuplicateColumnError(error) {
+	return /duplicate column name/i.test(String(error && error.message ? error.message : error));
+}
+
+async function execMigrationStatement(driver, statement, config) {
+	try {
+		await driver.exec(statement, config);
+	} catch (error) {
+		if (isExpectedRevisionAddColumn(statement) && isDuplicateColumnError(error)) {
+			return { skipped: true, reason: 'column-already-exists' };
+		}
+		throw error;
+	}
+	return { skipped: false };
+}
+
 function buildProjectionOutboxEntry(event, target, now) {
 	return {
 		event_id: event.id,
@@ -120,8 +140,11 @@ function createLocalBroker(options = {}) {
 		async initialize() {
 			requireDriverMethod(driver, 'exec');
 			const config = getConfig();
-			for (const statement of [...config.pragmas, ...config.migrationPlan.apply]) {
+			for (const statement of config.pragmas) {
 				await driver.exec(statement, config);
+			}
+			for (const statement of config.migrationPlan.apply) {
+				await execMigrationStatement(driver, statement, config);
 			}
 
 			return {

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -2,6 +2,7 @@
 
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');
+const { evaluateKernelEvent } = require('./evaluators');
 const { buildKernelMigrationPlan } = require('./migrations');
 
 const LOCAL_BROKER_PRAGMAS = Object.freeze([
@@ -67,6 +68,16 @@ function requireDriverMethod(driver, methodName) {
 	}
 }
 
+function buildProjectionOutboxEntry(event, target, now) {
+	return {
+		event_id: event.id,
+		target,
+		status: 'pending',
+		attempts: 0,
+		created_at: now,
+	};
+}
+
 function createLocalBroker(options = {}) {
 	const driver = options.driver;
 	let cachedConfig;
@@ -105,6 +116,68 @@ function createLocalBroker(options = {}) {
 		async runIssueOperation(operation, args = [], context = {}) {
 			requireDriverMethod(driver, 'issueOperation');
 			return driver.issueOperation(operation, args, context, getConfig());
+		},
+
+		async runGuardedEvent(event, context = {}) {
+			for (const methodName of [
+				'loadKernelEntity',
+				'listKernelEvents',
+				'listKernelDependencies',
+				'insertKernelConflict',
+				'insertKernelEvent',
+				'enqueueKernelProjection',
+			]) {
+				requireDriverMethod(driver, methodName);
+			}
+
+			const config = getConfig();
+			const now = context.now || new Date().toISOString();
+			const normalizedEvent = {
+				...event,
+				created_at: event.created_at || now,
+			};
+			const [entity, priorEvents, dependencies] = await Promise.all([
+				driver.loadKernelEntity(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
+				driver.listKernelEvents(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
+				driver.listKernelDependencies(context, config),
+			]);
+			const evaluation = evaluateKernelEvent({
+				event: normalizedEvent,
+				entity,
+				priorEvents,
+				dependencies,
+			});
+
+			if (evaluation.decision === 'quarantine') {
+				const conflict = await driver.insertKernelConflict({
+					...evaluation.conflict,
+					created_at: evaluation.conflict.created_at || now,
+				}, context, config);
+				return {
+					...evaluation,
+					conflict,
+				};
+			}
+
+			if (evaluation.decision !== 'accept') {
+				return evaluation;
+			}
+
+			const acceptedEvent = await driver.insertKernelEvent({
+				...evaluation.event,
+				created_at: evaluation.event.created_at || now,
+			}, context, config);
+			const outboxEntry = await driver.enqueueKernelProjection(
+				buildProjectionOutboxEntry(acceptedEvent, context.projectionTarget || 'beads', now),
+				context,
+				config,
+			);
+
+			return {
+				...evaluation,
+				event: acceptedEvent,
+				outboxEntry,
+			};
 		},
 	};
 }

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -78,6 +78,28 @@ function buildProjectionOutboxEntry(event, target, now) {
 	};
 }
 
+function parseEventPayload(event = {}) {
+	if (event.payload) return event.payload;
+	if (!event.payload_json) return {};
+	try {
+		return JSON.parse(event.payload_json);
+	} catch {
+		return {};
+	}
+}
+
+function buildDependencyScope(event) {
+	if (event.event_type !== 'dependency.add') return null;
+	const payload = parseEventPayload(event);
+	return {
+		issue_id: payload.issue_id,
+		blocks_issue_id: payload.blocks_issue_id,
+		dependency_type: payload.dependency_type || 'blocks',
+		entity_type: event.entity_type,
+		entity_id: event.entity_id,
+	};
+}
+
 function createLocalBroker(options = {}) {
 	const driver = options.driver;
 	let cachedConfig;
@@ -122,7 +144,7 @@ function createLocalBroker(options = {}) {
 			for (const methodName of [
 				'loadKernelEntity',
 				'listKernelEvents',
-				'listKernelDependencies',
+				'loadKernelEventByIdempotencyKey',
 				'insertKernelConflict',
 				'insertKernelEvent',
 				'enqueueKernelProjection',
@@ -136,11 +158,22 @@ function createLocalBroker(options = {}) {
 				...event,
 				created_at: event.created_at || now,
 			};
-			const [entity, priorEvents, dependencies] = await Promise.all([
+			const dependencyScope = buildDependencyScope(normalizedEvent);
+			if (dependencyScope) {
+				requireDriverMethod(driver, 'listKernelDependencies');
+			}
+
+			const [entity, entityEvents, idempotencyEvent, dependencies] = await Promise.all([
 				driver.loadKernelEntity(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
 				driver.listKernelEvents(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
-				driver.listKernelDependencies(context, config),
+				driver.loadKernelEventByIdempotencyKey(normalizedEvent.idempotency_key, context, config),
+				dependencyScope
+					? driver.listKernelDependencies(dependencyScope, context, config)
+					: Promise.resolve([]),
 			]);
+			const priorEvents = idempotencyEvent
+				? [idempotencyEvent, ...entityEvents.filter(candidate => candidate.id !== idempotencyEvent.id)]
+				: entityEvents;
 			const evaluation = evaluateKernelEvent({
 				event: normalizedEvent,
 				entity,

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -44,13 +44,18 @@ function findEquivalentEvent(event, priorEvents = []) {
 	));
 }
 
+function isBlockingDependency(dependency = {}) {
+	return !dependency.dependency_type || dependency.dependency_type === 'blocks';
+}
+
 function dependencyCreatesCycle(payload, dependencies = []) {
 	const issueId = payload.issue_id;
 	const blocksIssueId = payload.blocks_issue_id;
 	if (!issueId || !blocksIssueId) return false;
+	if (!isBlockingDependency(payload)) return false;
 
 	const edges = new Map();
-	for (const dependency of [...dependencies, { issue_id: issueId, blocks_issue_id: blocksIssueId }]) {
+	for (const dependency of [...dependencies, { issue_id: issueId, blocks_issue_id: blocksIssueId }].filter(isBlockingDependency)) {
 		if (!edges.has(dependency.issue_id)) edges.set(dependency.issue_id, []);
 		edges.get(dependency.issue_id).push(dependency.blocks_issue_id);
 	}

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -1,0 +1,161 @@
+'use strict';
+
+function stableStringify(value) {
+	if (value === undefined) return '{}';
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value);
+	}
+	if (Array.isArray(value)) {
+		return `[${value.map(stableStringify).join(',')}]`;
+	}
+
+	return `{${Object.keys(value).sort((left, right) => left.localeCompare(right))
+		.map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+		.join(',')}}`;
+}
+
+function normalizePayload(event) {
+	if (event.payload_json) {
+		try {
+			return JSON.parse(event.payload_json);
+		} catch {
+			return event.payload_json;
+		}
+	}
+	return event.payload || {};
+}
+
+function payloadJsonFor(event) {
+	return stableStringify(normalizePayload(event));
+}
+
+function findOriginalIdempotencyEvent(event, priorEvents = []) {
+	return priorEvents.find(priorEvent => priorEvent.idempotency_key === event.idempotency_key);
+}
+
+function findEquivalentEvent(event, priorEvents = []) {
+	const payloadJson = payloadJsonFor(event);
+	return priorEvents.find(priorEvent => (
+		priorEvent.idempotency_key !== event.idempotency_key
+		&& priorEvent.entity_type === event.entity_type
+		&& priorEvent.entity_id === event.entity_id
+		&& priorEvent.event_type === event.event_type
+		&& payloadJsonFor(priorEvent) === payloadJson
+	));
+}
+
+function dependencyCreatesCycle(payload, dependencies = []) {
+	const issueId = payload.issue_id;
+	const blocksIssueId = payload.blocks_issue_id;
+	if (!issueId || !blocksIssueId) return false;
+
+	const edges = new Map();
+	for (const dependency of [...dependencies, { issue_id: issueId, blocks_issue_id: blocksIssueId }]) {
+		if (!edges.has(dependency.issue_id)) edges.set(dependency.issue_id, []);
+		edges.get(dependency.issue_id).push(dependency.blocks_issue_id);
+	}
+
+	const seen = new Set();
+	const stack = [blocksIssueId];
+	while (stack.length > 0) {
+		const candidate = stack.pop();
+		if (candidate === issueId) return true;
+		if (seen.has(candidate)) continue;
+		seen.add(candidate);
+		for (const next of edges.get(candidate) || []) {
+			stack.push(next);
+		}
+	}
+
+	return false;
+}
+
+function buildConflict(event, reason, actualRevision) {
+	const payload = normalizePayload(event);
+	return {
+		entity_type: event.entity_type,
+		entity_id: event.entity_id,
+		expected_revision: Number(event.expected_revision || 0),
+		actual_revision: Number(actualRevision || 0),
+		status: 'quarantined',
+		reason,
+		payload,
+		payload_json: stableStringify({
+			reason,
+			event: {
+				entity_type: event.entity_type,
+				entity_id: event.entity_id,
+				event_type: event.event_type,
+				idempotency_key: event.idempotency_key,
+				payload,
+			},
+		}),
+		created_at: event.created_at,
+	};
+}
+
+function evaluateKernelEvent(input = {}) {
+	const event = input.event || {};
+	if (!event.entity_type) throw new Error('Kernel event entity_type is required');
+	if (!event.entity_id) throw new Error('Kernel event entity_id is required');
+	if (!event.event_type) throw new Error('Kernel event event_type is required');
+	if (!event.idempotency_key) throw new Error('Kernel event idempotency_key is required');
+
+	const priorEvents = input.priorEvents || [];
+	const originalEvent = findOriginalIdempotencyEvent(event, priorEvents);
+	if (originalEvent) {
+		return {
+			decision: 'duplicate',
+			reason: 'idempotency_replay',
+			originalEvent,
+			projection: false,
+		};
+	}
+
+	const equivalentEvent = findEquivalentEvent(event, priorEvents);
+	if (equivalentEvent) {
+		return {
+			decision: 'dedupe',
+			reason: 'equivalent_write',
+			originalEvent: equivalentEvent,
+			projection: false,
+		};
+	}
+
+	const actualRevision = Number(input.entity?.entity_revision || 0);
+	const expectedRevision = Number(event.expected_revision || 0);
+	if (expectedRevision !== actualRevision) {
+		return {
+			decision: 'quarantine',
+			reason: 'stale_revision',
+			conflict: buildConflict(event, 'stale_revision', actualRevision),
+			projection: false,
+		};
+	}
+
+	const payload = normalizePayload(event);
+	if (event.event_type === 'dependency.add' && dependencyCreatesCycle(payload, input.dependencies || [])) {
+		return {
+			decision: 'quarantine',
+			reason: 'dependency_cycle',
+			conflict: buildConflict(event, 'dependency_cycle', actualRevision),
+			projection: false,
+		};
+	}
+
+	return {
+		decision: 'accept',
+		reason: 'accepted',
+		event: {
+			...event,
+			payload_json: payloadJsonFor(event),
+		},
+		projection: true,
+	};
+}
+
+module.exports = {
+	dependencyCreatesCycle,
+	evaluateKernelEvent,
+	stableStringify,
+};

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -37,6 +37,8 @@ function findEquivalentEvent(event, priorEvents = []) {
 	const payloadJson = payloadJsonFor(event);
 	return priorEvents.find(priorEvent => (
 		priorEvent.idempotency_key !== event.idempotency_key
+		&& priorEvent.expected_revision !== undefined
+		&& Number(priorEvent.expected_revision) === Number(event.expected_revision || 0)
 		&& priorEvent.entity_type === event.entity_type
 		&& priorEvent.entity_id === event.entity_id
 		&& priorEvent.event_type === event.event_type

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -155,6 +155,7 @@ function evaluateKernelEvent(input = {}) {
 		reason: 'accepted',
 		event: {
 			...event,
+			expected_revision: Number(event.expected_revision || 0),
 			payload_json: payloadJsonFor(event),
 		},
 		projection: true,

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -53,7 +53,21 @@ function renderDropTable(table) {
 	return `DROP TABLE IF EXISTS ${table.sqlName};`;
 }
 
-function buildSchemaMigration(schema = getKernelSchema()) {
+function getInitialKernelSchema() {
+	const schema = getKernelSchema();
+	return {
+		...schema,
+		tables: schema.tables.map(table => {
+			if (table.name !== 'events') return table;
+			return {
+				...table,
+				fields: table.fields.filter(field => field.name !== 'expected_revision'),
+			};
+		}),
+	};
+}
+
+function buildSchemaMigration(schema = getInitialKernelSchema()) {
 	validateKernelSchema(schema);
 
 	const apply = [];
@@ -79,6 +93,14 @@ function buildSchemaMigration(schema = getKernelSchema()) {
 	};
 }
 
+function buildEventExpectedRevisionMigration() {
+	return {
+		id: '002_kernel_events_expected_revision',
+		apply: ['ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;'],
+		rollback: ['ALTER TABLE kernel_events DROP COLUMN expected_revision;'],
+	};
+}
+
 function validateKernelMigrations(migrations) {
 	const ids = new Set();
 	for (const migration of migrations) {
@@ -100,7 +122,7 @@ function validateKernelMigrations(migrations) {
 	return true;
 }
 
-function buildKernelMigrationPlan(migrations = [buildSchemaMigration()]) {
+function buildKernelMigrationPlan(migrations = [buildSchemaMigration(), buildEventExpectedRevisionMigration()]) {
 	validateKernelMigrations(migrations);
 
 	return {
@@ -111,6 +133,7 @@ function buildKernelMigrationPlan(migrations = [buildSchemaMigration()]) {
 }
 
 module.exports = {
+	buildEventExpectedRevisionMigration,
 	buildKernelMigrationPlan,
 	buildSchemaMigration,
 	validateKernelMigrations,

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -97,7 +97,14 @@ function buildEventExpectedRevisionMigration() {
 	return {
 		id: '002_kernel_events_expected_revision',
 		apply: ['ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;'],
-		rollback: ['ALTER TABLE kernel_events DROP COLUMN expected_revision;'],
+		rollback: [
+			'CREATE TABLE IF NOT EXISTS kernel_events_002_rollback (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);',
+			'INSERT INTO kernel_events_002_rollback (id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at) SELECT id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at FROM kernel_events;',
+			'DROP TABLE kernel_events;',
+			'ALTER TABLE kernel_events_002_rollback RENAME TO kernel_events;',
+			'CREATE INDEX IF NOT EXISTS idx_kernel_events_entity_created ON kernel_events (entity_type, entity_id, created_at);',
+			'CREATE UNIQUE INDEX IF NOT EXISTS idx_kernel_events_idempotency ON kernel_events (idempotency_key);',
+		],
 	};
 }
 

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -196,6 +196,7 @@ const TABLE_LIST = deepFreeze([
 		field('entity_id', 'TEXT', { notNull: true }),
 		field('event_type', 'TEXT', { notNull: true }),
 		field('idempotency_key', 'TEXT', { notNull: true }),
+		field('expected_revision', 'INTEGER', { notNull: true }),
 		field('actor', 'TEXT', { notNull: true }),
 		field('origin', 'TEXT', { notNull: true }),
 		field('payload_json', 'TEXT', { notNull: true }),

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -122,6 +122,17 @@ describe('Beads Kernel compatibility adapter', () => {
 		});
 	});
 
+	test('falls back to revision zero for malformed Beads close-event revisions', () => {
+		const snapshot = JSON.parse(JSON.stringify(loadBeadsSnapshotFromDirectory(FIXTURE_DIR)));
+		const closedIssue = snapshot.issues.find(issue => issue.id === 'forge-child');
+		closedIssue.entity_revision = 'abc';
+
+		const result = importBeadsSnapshot(snapshot, { importedAt: IMPORTED_AT });
+		const closeEvent = result.kernel.events.find(event => event.event_type === 'beads.issue.closed');
+
+		expect(closeEvent.expected_revision).toBe(0);
+	});
+
 	test('exports Kernel records to Beads JSONL as a dry-run without mutating files', () => {
 		const importResult = importBeadsSnapshot(loadBeadsSnapshotFromDirectory(FIXTURE_DIR), { importedAt: IMPORTED_AT });
 		const exportResult = exportKernelToBeads(importResult.kernel, { dryRun: true });

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -85,6 +85,7 @@ describe('Beads Kernel compatibility adapter', () => {
 			entity_id: 'forge-child',
 			actor: 'Harsha Nanda',
 			origin: 'beads_import',
+			expected_revision: 0,
 			created_at: '2026-05-29T11:45:00Z',
 		});
 		expect(JSON.parse(closeEvent.payload_json)).toMatchObject({

--- a/test/fixtures/kernel-evaluators/cases.json
+++ b/test/fixtures/kernel-evaluators/cases.json
@@ -57,6 +57,7 @@
           "entity_id": "forge-priority",
           "event_type": "issue.priority",
           "idempotency_key": "priority:forge-priority:first",
+          "expected_revision": 4,
           "payload_json": "{\"priority\":\"P0\",\"priority_rank\":0}"
         }
       ],

--- a/test/fixtures/kernel-evaluators/cases.json
+++ b/test/fixtures/kernel-evaluators/cases.json
@@ -1,0 +1,163 @@
+[
+  {
+    "name": "import fidelity accepts matching revision",
+    "input": {
+      "event": {
+        "entity_type": "issue",
+        "entity_id": "forge-import",
+        "event_type": "issue.import",
+        "idempotency_key": "import:forge-import",
+        "expected_revision": 0,
+        "payload": {
+          "id": "forge-import",
+          "title": "Imported issue",
+          "status": "open",
+          "priority": "P1",
+          "dependencies": [
+            {
+              "issue_id": "forge-import",
+              "blocks_issue_id": "forge-parent",
+              "dependency_type": "parent-child"
+            }
+          ]
+        }
+      },
+      "entity": {
+        "entity_revision": 0
+      },
+      "priorEvents": [],
+      "dependencies": []
+    },
+    "expected": {
+      "decision": "accept",
+      "projection": true
+    }
+  },
+  {
+    "name": "priority ordering dedupes equivalent rank write",
+    "input": {
+      "event": {
+        "entity_type": "issue",
+        "entity_id": "forge-priority",
+        "event_type": "issue.priority",
+        "idempotency_key": "priority:forge-priority:retry",
+        "expected_revision": 4,
+        "payload": {
+          "priority": "P0",
+          "priority_rank": 0
+        }
+      },
+      "entity": {
+        "entity_revision": 4
+      },
+      "priorEvents": [
+        {
+          "id": "evt-priority",
+          "entity_type": "issue",
+          "entity_id": "forge-priority",
+          "event_type": "issue.priority",
+          "idempotency_key": "priority:forge-priority:first",
+          "payload_json": "{\"priority\":\"P0\",\"priority_rank\":0}"
+        }
+      ],
+      "dependencies": []
+    },
+    "expected": {
+      "decision": "dedupe",
+      "projection": false
+    }
+  },
+  {
+    "name": "dependency correctness quarantines cycle",
+    "input": {
+      "event": {
+        "entity_type": "dependency",
+        "entity_id": "dep-cycle",
+        "event_type": "dependency.add",
+        "idempotency_key": "dep:cycle",
+        "expected_revision": 0,
+        "payload": {
+          "issue_id": "forge-a",
+          "blocks_issue_id": "forge-c"
+        }
+      },
+      "entity": {
+        "entity_revision": 0
+      },
+      "priorEvents": [],
+      "dependencies": [
+        {
+          "issue_id": "forge-b",
+          "blocks_issue_id": "forge-a"
+        },
+        {
+          "issue_id": "forge-c",
+          "blocks_issue_id": "forge-b"
+        }
+      ]
+    },
+    "expected": {
+      "decision": "quarantine",
+      "reason": "dependency_cycle",
+      "projection": false
+    }
+  },
+  {
+    "name": "idempotency returns original accepted event",
+    "input": {
+      "event": {
+        "entity_type": "issue",
+        "entity_id": "forge-idempotent",
+        "event_type": "issue.close",
+        "idempotency_key": "close:forge-idempotent",
+        "expected_revision": 7,
+        "payload": {
+          "status": "closed"
+        }
+      },
+      "entity": {
+        "entity_revision": 7
+      },
+      "priorEvents": [
+        {
+          "id": "evt-idempotent",
+          "entity_type": "issue",
+          "entity_id": "forge-idempotent",
+          "event_type": "issue.close",
+          "idempotency_key": "close:forge-idempotent",
+          "payload_json": "{\"status\":\"closed\"}"
+        }
+      ],
+      "dependencies": []
+    },
+    "expected": {
+      "decision": "duplicate",
+      "projection": false
+    }
+  },
+  {
+    "name": "drift guard quarantines stale revision",
+    "input": {
+      "event": {
+        "entity_type": "issue",
+        "entity_id": "forge-drift",
+        "event_type": "issue.update",
+        "idempotency_key": "drift:forge-drift",
+        "expected_revision": 3,
+        "payload": {
+          "title": "Stale title"
+        }
+      },
+      "entity": {
+        "entity_revision": 4
+      },
+      "priorEvents": [],
+      "dependencies": []
+    },
+    "expected": {
+      "decision": "quarantine",
+      "reason": "stale_revision",
+      "projection": false
+    }
+  }
+]

--- a/test/kernel-schema-docs.test.js
+++ b/test/kernel-schema-docs.test.js
@@ -25,6 +25,7 @@ describe('Forge Kernel schema release docs', () => {
     expect(doc).toContain('Schema registry contract');
     expect(doc).toContain('Migration contract');
     expect(doc).toContain('Storage-class contract');
+    expect(doc).toContain('expected_revision');
   });
 
   it('keeps broker, import, and conflict handling marked as follow-up work', () => {

--- a/test/kernel/broker-guards.test.js
+++ b/test/kernel/broker-guards.test.js
@@ -16,6 +16,9 @@ describe('local Kernel broker guard ordering', () => {
 				async listKernelEvents() {
 					return [];
 				},
+				async loadKernelEventByIdempotencyKey() {
+					return null;
+				},
 				async listKernelDependencies() {
 					return [];
 				},
@@ -60,6 +63,9 @@ describe('local Kernel broker guard ordering', () => {
 				async listKernelEvents() {
 					return [];
 				},
+				async loadKernelEventByIdempotencyKey() {
+					return null;
+				},
 				async listKernelDependencies() {
 					return [];
 				},
@@ -92,5 +98,124 @@ describe('local Kernel broker guard ordering', () => {
 			['event', 'issue.update'],
 			['projection', 'beads'],
 		]);
+	});
+
+	test('returns idempotency replays accepted for any entity before inserting', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const calls = [];
+		const originalEvent = {
+			id: 'event-original',
+			entity_type: 'issue',
+			entity_id: 'forge-other',
+			event_type: 'issue.close',
+			idempotency_key: 'close:shared-key',
+			payload_json: '{"status":"closed"}',
+		};
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+			driver: {
+				async loadKernelEntity() {
+					return { entity_revision: 2 };
+				},
+				async listKernelEvents() {
+					return [];
+				},
+				async loadKernelEventByIdempotencyKey(idempotencyKey) {
+					calls.push(['idempotency', idempotencyKey]);
+					return originalEvent;
+				},
+				async insertKernelConflict(conflict) {
+					calls.push(['conflict', conflict.reason]);
+					return conflict;
+				},
+				async insertKernelEvent(event) {
+					calls.push(['event', event.event_type]);
+					return event;
+				},
+				async enqueueKernelProjection(outboxEntry) {
+					calls.push(['projection', outboxEntry.target]);
+					return outboxEntry;
+				},
+			},
+		});
+
+		const result = await broker.runGuardedEvent({
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.close',
+			idempotency_key: 'close:shared-key',
+			expected_revision: 2,
+			payload: { status: 'closed' },
+		});
+
+		expect(result).toMatchObject({
+			decision: 'duplicate',
+			originalEvent,
+			projection: false,
+		});
+		expect(calls).toEqual([['idempotency', 'close:shared-key']]);
+	});
+
+	test('loads dependencies only for dependency-add events with scoped edge metadata', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const scopes = [];
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+			driver: {
+				async loadKernelEntity() {
+					return { entity_revision: 0 };
+				},
+				async listKernelEvents() {
+					return [];
+				},
+				async loadKernelEventByIdempotencyKey() {
+					return null;
+				},
+				async listKernelDependencies(scope) {
+					scopes.push(scope);
+					return [];
+				},
+				async insertKernelConflict(conflict) {
+					return conflict;
+				},
+				async insertKernelEvent(event) {
+					return { ...event, id: 'event-1' };
+				},
+				async enqueueKernelProjection(outboxEntry) {
+					return outboxEntry;
+				},
+			},
+		});
+
+		await broker.runGuardedEvent({
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.update',
+			idempotency_key: 'update:forge-1',
+			expected_revision: 0,
+			payload: { title: 'Renamed' },
+		});
+		await broker.runGuardedEvent({
+			entity_type: 'dependency',
+			entity_id: 'dep-1',
+			event_type: 'dependency.add',
+			idempotency_key: 'dep:forge-a:forge-b',
+			expected_revision: 0,
+			payload: {
+				issue_id: 'forge-a',
+				blocks_issue_id: 'forge-b',
+				dependency_type: 'blocks',
+			},
+		});
+
+		expect(scopes).toEqual([{
+			issue_id: 'forge-a',
+			blocks_issue_id: 'forge-b',
+			dependency_type: 'blocks',
+			entity_type: 'dependency',
+			entity_id: 'dep-1',
+		}]);
 	});
 });

--- a/test/kernel/broker-guards.test.js
+++ b/test/kernel/broker-guards.test.js
@@ -218,4 +218,49 @@ describe('local Kernel broker guard ordering', () => {
 			entity_id: 'dep-1',
 		}]);
 	});
+
+	test('does not build dependency scope when dependency endpoints are incomplete', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const calls = [];
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+			driver: {
+				async loadKernelEntity() {
+					return { entity_revision: 0 };
+				},
+				async listKernelEvents() {
+					return [];
+				},
+				async loadKernelEventByIdempotencyKey() {
+					return null;
+				},
+				async listKernelDependencies() {
+					calls.push('dependencies');
+					return [];
+				},
+				async insertKernelConflict(conflict) {
+					return conflict;
+				},
+				async insertKernelEvent(event) {
+					return { ...event, id: 'event-1' };
+				},
+				async enqueueKernelProjection(outboxEntry) {
+					return outboxEntry;
+				},
+			},
+		});
+
+		const result = await broker.runGuardedEvent({
+			entity_type: 'dependency',
+			entity_id: 'dep-incomplete',
+			event_type: 'dependency.add',
+			idempotency_key: 'dep:incomplete',
+			expected_revision: 0,
+			payload: { issue_id: 'forge-a' },
+		});
+
+		expect(result.decision).toBe('accept');
+		expect(calls).toEqual([]);
+	});
 });

--- a/test/kernel/broker-guards.test.js
+++ b/test/kernel/broker-guards.test.js
@@ -1,0 +1,96 @@
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+
+describe('local Kernel broker guard ordering', () => {
+	test('inserts a conflict and skips projection for quarantined writes', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const calls = [];
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+			driver: {
+				async loadKernelEntity() {
+					return { entity_revision: 3 };
+				},
+				async listKernelEvents() {
+					return [];
+				},
+				async listKernelDependencies() {
+					return [];
+				},
+				async insertKernelConflict(conflict) {
+					calls.push(['conflict', conflict.reason]);
+					return { ...conflict, id: 'conflict-1' };
+				},
+				async insertKernelEvent(event) {
+					calls.push(['event', event.event_type]);
+					return { ...event, id: 'event-1' };
+				},
+				async enqueueKernelProjection(outboxEntry) {
+					calls.push(['projection', outboxEntry.target]);
+					return { ...outboxEntry, id: 'outbox-1' };
+				},
+			},
+		});
+
+		const result = await broker.runGuardedEvent({
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.update',
+			idempotency_key: 'issue-update:forge-1:rev-2',
+			expected_revision: 2,
+			payload: { title: 'Renamed' },
+		});
+
+		expect(result.decision).toBe('quarantine');
+		expect(calls).toEqual([['conflict', 'stale_revision']]);
+	});
+
+	test('inserts accepted events before projection outbox entries', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const calls = [];
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+			driver: {
+				async loadKernelEntity() {
+					return { entity_revision: 2 };
+				},
+				async listKernelEvents() {
+					return [];
+				},
+				async listKernelDependencies() {
+					return [];
+				},
+				async insertKernelConflict(conflict) {
+					calls.push(['conflict', conflict.reason]);
+					return conflict;
+				},
+				async insertKernelEvent(event) {
+					calls.push(['event', event.event_type]);
+					return { ...event, id: 'event-1' };
+				},
+				async enqueueKernelProjection(outboxEntry) {
+					calls.push(['projection', outboxEntry.target]);
+					return { ...outboxEntry, id: 'outbox-1' };
+				},
+			},
+		});
+
+		const result = await broker.runGuardedEvent({
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.update',
+			idempotency_key: 'issue-update:forge-1:rev-2',
+			expected_revision: 2,
+			payload: { title: 'Renamed' },
+		}, { projectionTarget: 'beads' });
+
+		expect(result.decision).toBe('accept');
+		expect(calls).toEqual([
+			['event', 'issue.update'],
+			['projection', 'beads'],
+		]);
+	});
+});

--- a/test/kernel/broker.test.js
+++ b/test/kernel/broker.test.js
@@ -62,6 +62,33 @@ describe('local Kernel broker contract', () => {
 		expect(statements).toContain('CREATE TABLE IF NOT EXISTS kernel_issues (\n  id TEXT NOT NULL PRIMARY KEY,\n  title TEXT NOT NULL,\n  body TEXT,\n  type TEXT NOT NULL DEFAULT \'task\',\n  status TEXT NOT NULL DEFAULT \'open\',\n  priority TEXT NOT NULL DEFAULT \'P2\',\n  priority_rank INTEGER NOT NULL DEFAULT 0,\n  created_at TEXT NOT NULL,\n  updated_at TEXT NOT NULL,\n  entity_revision INTEGER NOT NULL DEFAULT 0\n);');
 	});
 
+	test('does not fail when the expected revision column migration is replayed', async () => {
+		const { createLocalBroker } = require('../../lib/kernel/broker');
+		const addColumn = 'ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;';
+		let addColumnAttempts = 0;
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+			migrationPlan: {
+				migrations: [{ id: '002_kernel_events_expected_revision' }],
+				apply: [addColumn],
+			},
+			driver: {
+				async exec(statement) {
+					if (statement !== addColumn) return;
+					addColumnAttempts += 1;
+					if (addColumnAttempts > 1) {
+						throw new Error('duplicate column name: expected_revision');
+					}
+				},
+			},
+		});
+
+		await expect(broker.initialize()).resolves.toMatchObject({ success: true });
+		await expect(broker.initialize()).resolves.toMatchObject({ success: true });
+		expect(addColumnAttempts).toBe(2);
+	});
+
 	test('exposes a testable issue-operation boundary without requiring a bundled sqlite dependency', async () => {
 		const { createLocalBroker } = require('../../lib/kernel/broker');
 		const calls = [];

--- a/test/kernel/conflict-evaluator-docs.test.js
+++ b/test/kernel/conflict-evaluator-docs.test.js
@@ -1,0 +1,28 @@
+const { describe, expect, test } = require('bun:test');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const ROOT = join(__dirname, '..', '..');
+
+function readDoc(relPath) {
+	return readFileSync(join(ROOT, relPath), 'utf8');
+}
+
+describe('Kernel conflict evaluator docs', () => {
+	test('links the conflict evaluator reference from the documentation index', () => {
+		const index = readDoc('docs/INDEX.md');
+
+		expect(index).toContain('reference/kernel-conflict-evaluators.md');
+		expect(index).toContain('Kernel conflict evaluators');
+	});
+
+	test('documents quarantine, idempotency, dedupe, and projection ordering', () => {
+		const doc = readDoc('docs/reference/kernel-conflict-evaluators.md');
+
+		expect(doc).toContain('Quarantined writes insert `kernel_conflicts` records');
+		expect(doc).toContain('Duplicate idempotency keys return the original accepted event');
+		expect(doc).toContain('Equivalent duplicate writes dedupe');
+		expect(doc).toContain('Enqueue projection outbox rows only after event acceptance');
+		expect(doc).toContain('Fixture cases cover import fidelity');
+	});
+});

--- a/test/kernel/evaluator-fixtures.test.js
+++ b/test/kernel/evaluator-fixtures.test.js
@@ -1,0 +1,35 @@
+const { describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+const fixturePath = path.join(__dirname, '..', 'fixtures', 'kernel-evaluators', 'cases.json');
+const fixtureCases = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+
+describe('Kernel evaluator fixtures', () => {
+	test('cover the required conflict evaluator release scenarios', () => {
+		expect(fixtureCases.map(fixture => fixture.name)).toEqual([
+			'import fidelity accepts matching revision',
+			'priority ordering dedupes equivalent rank write',
+			'dependency correctness quarantines cycle',
+			'idempotency returns original accepted event',
+			'drift guard quarantines stale revision',
+		]);
+	});
+
+	for (const fixture of fixtureCases) {
+		test(fixture.name, () => {
+			const result = evaluateKernelEvent(fixture.input);
+
+			expect(result).toMatchObject(fixture.expected);
+			if (fixture.expected.decision === 'quarantine') {
+				expect(result.conflict).toMatchObject({
+					status: 'quarantined',
+					entity_type: fixture.input.event.entity_type,
+					entity_id: fixture.input.event.entity_id,
+				});
+			}
+		});
+	}
+});

--- a/test/kernel/evaluators.test.js
+++ b/test/kernel/evaluators.test.js
@@ -65,6 +65,7 @@ describe('Kernel conflict evaluators', () => {
 			entity_id: 'forge-1',
 			event_type: 'issue.priority',
 			idempotency_key: 'priority:forge-1:first',
+			expected_revision: 4,
 			payload_json: '{"priority":"P1"}',
 		};
 
@@ -84,6 +85,35 @@ describe('Kernel conflict evaluators', () => {
 		expect(result.decision).toBe('dedupe');
 		expect(result.originalEvent).toBe(originalEvent);
 		expect(result.projection).toBe(false);
+	});
+
+	test('does not dedupe intentional returns to an earlier payload at a later revision', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+		const originalTitleEvent = {
+			id: 'evt-title-a',
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.update',
+			idempotency_key: 'title:forge-1:a',
+			expected_revision: 1,
+			payload_json: '{"title":"A"}',
+		};
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'issue',
+				entity_id: 'forge-1',
+				event_type: 'issue.update',
+				idempotency_key: 'title:forge-1:back-to-a',
+				expected_revision: 3,
+				payload: { title: 'A' },
+			},
+			entity: { entity_revision: 3 },
+			priorEvents: [originalTitleEvent],
+		});
+
+		expect(result.decision).toBe('accept');
+		expect(result.projection).toBe(true);
 	});
 
 	test('quarantines dependency writes that would create a cycle', () => {

--- a/test/kernel/evaluators.test.js
+++ b/test/kernel/evaluators.test.js
@@ -116,4 +116,58 @@ describe('Kernel conflict evaluators', () => {
 		});
 		expect(result.projection).toBe(false);
 	});
+
+	test('ignores non-blocking dependency edges when checking cycles', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'dependency',
+				entity_id: 'dep-related',
+				event_type: 'dependency.add',
+				idempotency_key: 'dep:related',
+				expected_revision: 0,
+				payload: {
+					issue_id: 'forge-a',
+					blocks_issue_id: 'forge-c',
+					dependency_type: 'related',
+				},
+			},
+			entity: { entity_revision: 0 },
+			dependencies: [
+				{ issue_id: 'forge-b', blocks_issue_id: 'forge-a', dependency_type: 'blocks' },
+				{ issue_id: 'forge-c', blocks_issue_id: 'forge-b', dependency_type: 'blocks' },
+			],
+		});
+
+		expect(result.decision).toBe('accept');
+		expect(result.projection).toBe(true);
+	});
+
+	test('ignores existing non-blocking edges when checking cycles', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'dependency',
+				entity_id: 'dep-blocks',
+				event_type: 'dependency.add',
+				idempotency_key: 'dep:blocks',
+				expected_revision: 0,
+				payload: {
+					issue_id: 'forge-a',
+					blocks_issue_id: 'forge-c',
+					dependency_type: 'blocks',
+				},
+			},
+			entity: { entity_revision: 0 },
+			dependencies: [
+				{ issue_id: 'forge-b', blocks_issue_id: 'forge-a', dependency_type: 'related' },
+				{ issue_id: 'forge-c', blocks_issue_id: 'forge-b', dependency_type: 'blocks' },
+			],
+		});
+
+		expect(result.decision).toBe('accept');
+		expect(result.projection).toBe(true);
+	});
 });

--- a/test/kernel/evaluators.test.js
+++ b/test/kernel/evaluators.test.js
@@ -1,0 +1,119 @@
+const { describe, expect, test } = require('bun:test');
+
+describe('Kernel conflict evaluators', () => {
+	test('quarantines stale revision writes before projection', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'issue',
+				entity_id: 'forge-1',
+				event_type: 'issue.update',
+				idempotency_key: 'issue-update:forge-1:rev-2',
+				expected_revision: 2,
+				payload: { title: 'Renamed' },
+			},
+			entity: { entity_revision: 3 },
+		});
+
+		expect(result.decision).toBe('quarantine');
+		expect(result.reason).toBe('stale_revision');
+		expect(result.conflict).toMatchObject({
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			expected_revision: 2,
+			actual_revision: 3,
+			status: 'quarantined',
+		});
+		expect(result.projection).toBe(false);
+	});
+
+	test('returns the original accepted event for duplicate idempotency keys', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+		const originalEvent = {
+			id: 'evt-1',
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.close',
+			idempotency_key: 'close:forge-1',
+			payload_json: '{"status":"closed"}',
+		};
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'issue',
+				entity_id: 'forge-1',
+				event_type: 'issue.close',
+				idempotency_key: 'close:forge-1',
+				expected_revision: 4,
+				payload: { status: 'closed' },
+			},
+			entity: { entity_revision: 4 },
+			priorEvents: [originalEvent],
+		});
+
+		expect(result.decision).toBe('duplicate');
+		expect(result.originalEvent).toBe(originalEvent);
+		expect(result.projection).toBe(false);
+	});
+
+	test('dedupes equivalent writes with different idempotency keys', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+		const originalEvent = {
+			id: 'evt-1',
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.priority',
+			idempotency_key: 'priority:forge-1:first',
+			payload_json: '{"priority":"P1"}',
+		};
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'issue',
+				entity_id: 'forge-1',
+				event_type: 'issue.priority',
+				idempotency_key: 'priority:forge-1:retry',
+				expected_revision: 4,
+				payload: { priority: 'P1' },
+			},
+			entity: { entity_revision: 4 },
+			priorEvents: [originalEvent],
+		});
+
+		expect(result.decision).toBe('dedupe');
+		expect(result.originalEvent).toBe(originalEvent);
+		expect(result.projection).toBe(false);
+	});
+
+	test('quarantines dependency writes that would create a cycle', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'dependency',
+				entity_id: 'dep-3',
+				event_type: 'dependency.add',
+				idempotency_key: 'dep:forge-a:forge-c',
+				expected_revision: 0,
+				payload: {
+					issue_id: 'forge-a',
+					blocks_issue_id: 'forge-c',
+				},
+			},
+			entity: { entity_revision: 0 },
+			dependencies: [
+				{ issue_id: 'forge-b', blocks_issue_id: 'forge-a' },
+				{ issue_id: 'forge-c', blocks_issue_id: 'forge-b' },
+			],
+		});
+
+		expect(result.decision).toBe('quarantine');
+		expect(result.reason).toBe('dependency_cycle');
+		expect(result.conflict.payload).toMatchObject({
+			issue_id: 'forge-a',
+			blocks_issue_id: 'forge-c',
+		});
+		expect(result.projection).toBe(false);
+	});
+});

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -18,6 +18,7 @@ describe('kernel migration plans', () => {
 		expect(plan.apply[0]).toContain('id TEXT NOT NULL PRIMARY KEY');
 		expect(plan.apply).toContain('CREATE INDEX IF NOT EXISTS idx_kernel_issues_status_priority ON kernel_issues (status, priority_rank);');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_dependencies (\n  id TEXT NOT NULL PRIMARY KEY,\n  issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  blocks_issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  dependency_type TEXT NOT NULL DEFAULT \'blocks\',\n  created_at TEXT NOT NULL\n);');
+		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  expected_revision INTEGER NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_dead_letters_status;');
 		expect(plan.rollback.at(-1)).toBe('DROP TABLE IF EXISTS kernel_issues;');

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -18,11 +18,15 @@ describe('kernel migration plans', () => {
 		expect(plan.apply[0]).toContain('id TEXT NOT NULL PRIMARY KEY');
 		expect(plan.apply).toContain('CREATE INDEX IF NOT EXISTS idx_kernel_issues_status_priority ON kernel_issues (status, priority_rank);');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_dependencies (\n  id TEXT NOT NULL PRIMARY KEY,\n  issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  blocks_issue_id TEXT NOT NULL REFERENCES kernel_issues(id),\n  dependency_type TEXT NOT NULL DEFAULT \'blocks\',\n  created_at TEXT NOT NULL\n);');
-		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  expected_revision INTEGER NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
+		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
+		expect(plan.apply).toContain('ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
-		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_dead_letters_status;');
+		expect(plan.rollback[0]).toBe('ALTER TABLE kernel_events DROP COLUMN expected_revision;');
 		expect(plan.rollback.at(-1)).toBe('DROP TABLE IF EXISTS kernel_issues;');
-		expect(plan.migrations.map(migration => migration.id)).toEqual(['001_kernel_schema']);
+		expect(plan.migrations.map(migration => migration.id)).toEqual([
+			'001_kernel_schema',
+			'002_kernel_events_expected_revision',
+		]);
 	});
 
 	test('rejects duplicate migration IDs', () => {

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -21,7 +21,9 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.apply).toContain('ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
-		expect(plan.rollback[0]).toBe('ALTER TABLE kernel_events DROP COLUMN expected_revision;');
+		expect(plan.rollback[0]).toBe('CREATE TABLE IF NOT EXISTS kernel_events_002_rollback (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
+		expect(plan.rollback).toContain('INSERT INTO kernel_events_002_rollback (id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at) SELECT id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at FROM kernel_events;');
+		expect(plan.rollback).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_kernel_events_idempotency ON kernel_events (idempotency_key);');
 		expect(plan.rollback.at(-1)).toBe('DROP TABLE IF EXISTS kernel_issues;');
 		expect(plan.migrations.map(migration => migration.id)).toEqual([
 			'001_kernel_schema',

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -46,6 +46,7 @@ describe('kernel schema registry', () => {
 		expect(KERNEL_TABLES.stage_runs.indexes.map(index => index.name)).toContain('idx_kernel_stage_runs_issue_stage');
 		expect(KERNEL_TABLES.projections.indexes.map(index => index.name)).toContain('idx_kernel_projections_target_status');
 		expect(KERNEL_TABLES.conflicts.indexes.map(index => index.name)).toContain('idx_kernel_conflicts_status');
+		expect(KERNEL_TABLES.events.fields.map(field => field.name)).toContain('expected_revision');
 	});
 
 	test('classifies every table and field with valid storage and authority metadata', () => {


### PR DESCRIPTION
## Summary
- Add Kernel conflict evaluator contract for stale revision quarantine, idempotency replay, equivalent write dedupe, and dependency-cycle guards.
- Add broker guarded-event ordering so conflicts are inserted before projection and accepted events enqueue projection only after event insertion.
- Add evaluator fixtures and docs for the PR D migration UX handoff.

## Validation
- bun test test/kernel/evaluators.test.js test/kernel/evaluator-fixtures.test.js test/kernel/broker-guards.test.js test/kernel/broker.test.js test/kernel/schema.test.js test/kernel/conflict-evaluator-docs.test.js test/kernel-schema-docs.test.js
- bun run lint
- git diff --check --cached
- pre-push hook: lint, targeted tests, affected edge-case tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kernel conflict evaluators: detect/quarantine conflicting writes, dedupe equivalent writes, handle idempotency replays, detect dependency cycles, and ensure projection outbox rows are enqueued only after acceptance; guarded kernel event ingestion added.

* **Documentation**
  * Added reference, design, decisions, tasks and schema notes covering evaluator behavior, quarantines, idempotency, migrations, and test guidance.

* **Tests**
  * New fixtures and suites validating evaluator outcomes, guard ordering, idempotency, dedupe, cycle and stale-revision handling, plus docs coverage checks.

* **Chores**
  * Schema, migrations, and adapter imports updated to include expected_revision and migration plan adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->