### PR TITLE
fix(kernel): suppress Beads projection echoes

### DIFF
--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -51,20 +51,6 @@ function stringifyJsonl(records = []) {
   return `${records.map(record => JSON.stringify(record)).join('\n')}\n`;
 }
 
-function stableStringify(value) {
-  if (value === undefined) return '{}';
-  if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`;
-  }
-
-  return `{${Object.keys(value).sort((left, right) => left.localeCompare(right))
-    .map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
-    .join(',')}}`;
-}
-
 function readJsonlIfPresent(filePath) {
   if (!fs.existsSync(filePath)) {
     return [];
@@ -287,7 +273,7 @@ function getForgeProjectionOrigin(issue = {}, currentPayload = {}) {
     entity_id: issue.id,
     entity_revision: normalizeEntityRevision(projection.entity_revision),
     payload_hash: projection.payload_hash,
-    imported_payload_hash: stableStringify(currentPayload),
+    imported_payload_hash: JSON.stringify(currentPayload),
   };
 }
 
@@ -315,7 +301,7 @@ function buildForgeProjectionMetadata(issue = {}, closeMetadata = {}) {
     entity_type: 'issue',
     entity_id: issue.id,
     entity_revision: normalizeEntityRevision(issue.entity_revision),
-    payload_hash: stableStringify(buildCloseProjectionPayload(closeMetadata)),
+    payload_hash: JSON.stringify(buildCloseProjectionPayload(closeMetadata)),
   };
   return metadata;
 }

--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -272,6 +272,8 @@ function getForgeProjectionOrigin(issue = {}, currentPayload = {}) {
   const metadata = parseMetadataObject(issue.metadata);
   const projection = metadata[FORGE_PROJECTION_METADATA_KEY];
   if (!isValidForgeProjection(projection, issue.id)) return null;
+  const importedPayloadHash = JSON.stringify(currentPayload);
+  if (projection.payload_hash !== importedPayloadHash) return null;
 
   return {
     source: 'forge-kernel',
@@ -280,7 +282,7 @@ function getForgeProjectionOrigin(issue = {}, currentPayload = {}) {
     entity_id: issue.id,
     entity_revision: normalizeEntityRevision(projection.entity_revision),
     payload_hash: projection.payload_hash,
-    imported_payload_hash: JSON.stringify(currentPayload),
+    imported_payload_hash: importedPayloadHash,
   };
 }
 
@@ -300,6 +302,13 @@ function buildCloseProjectionPayload(closeMetadata = {}) {
   };
 }
 
+function buildCloseProjectionFingerprint(issue = {}) {
+  return {
+    ...buildCloseProjectionPayload(issue),
+    actor: issue.closed_by || issue.created_by || 'beads',
+  };
+}
+
 function buildForgeProjectionMetadata(issue = {}, closeMetadata = {}) {
   const metadata = parseMetadataObject(issue.metadata);
   metadata[FORGE_PROJECTION_METADATA_KEY] = {
@@ -308,7 +317,7 @@ function buildForgeProjectionMetadata(issue = {}, closeMetadata = {}) {
     entity_type: 'issue',
     entity_id: issue.id,
     entity_revision: normalizeEntityRevision(issue.entity_revision),
-    payload_hash: JSON.stringify(buildCloseProjectionPayload(closeMetadata)),
+    payload_hash: JSON.stringify(buildCloseProjectionFingerprint({ ...issue, ...closeMetadata })),
   };
   return metadata;
 }
@@ -423,7 +432,7 @@ function buildCloseEvent(issue, importedAt) {
 
   const createdAt = issue.closed_at || issue.updated_at || importedAt;
   const payload = buildCloseProjectionPayload(issue);
-  const projectionOrigin = getForgeProjectionOrigin(issue, payload);
+  const projectionOrigin = getForgeProjectionOrigin(issue, buildCloseProjectionFingerprint(issue));
   if (projectionOrigin) {
     payload.projection_origin = projectionOrigin;
   }

--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const BEADS_EXPORT_FILES = ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl'];
+const FORGE_PROJECTION_METADATA_KEY = 'forge_projection';
 const UNSUPPORTED_ISSUE_FIELDS = Object.freeze([
   ['acceptance_criteria', 'no Kernel acceptance criteria column in schema v1'],
   ['assignee', 'no Kernel assignee column in schema v1'],
@@ -237,6 +238,54 @@ function hasBeadsFieldValue(value) {
   return true;
 }
 
+function parseMetadataObject(value) {
+  if (value === null || value === undefined || value === '') return {};
+  if (typeof value === 'object' && !Array.isArray(value)) return { ...value };
+  if (typeof value !== 'string') return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (_error) {
+    return {};
+  }
+}
+
+function getForgeProjectionOrigin(issue = {}) {
+  const metadata = parseMetadataObject(issue.metadata);
+  const projection = metadata[FORGE_PROJECTION_METADATA_KEY];
+  if (!projection || typeof projection !== 'object') return null;
+  if (projection.source !== 'forge-kernel' || projection.target !== 'beads') return null;
+  if (projection.entity_type !== 'issue' || projection.entity_id !== issue.id) return null;
+
+  return {
+    source: 'forge-kernel',
+    target: 'beads',
+    entity_type: 'issue',
+    entity_id: issue.id,
+    entity_revision: normalizeEntityRevision(projection.entity_revision),
+  };
+}
+
+function hasUnsupportedBeadsMetadata(value) {
+  if (!hasBeadsFieldValue(value)) return false;
+  if (typeof value !== 'string' && (typeof value !== 'object' || Array.isArray(value))) return true;
+  const metadata = parseMetadataObject(value);
+  const keys = Object.keys(metadata);
+  return keys.length === 0 || keys.some(key => key !== FORGE_PROJECTION_METADATA_KEY);
+}
+
+function buildForgeProjectionMetadata(issue = {}) {
+  const metadata = parseMetadataObject(issue.metadata);
+  metadata[FORGE_PROJECTION_METADATA_KEY] = {
+    source: 'forge-kernel',
+    target: 'beads',
+    entity_type: 'issue',
+    entity_id: issue.id,
+    entity_revision: normalizeEntityRevision(issue.entity_revision),
+  };
+  return metadata;
+}
+
 function buildFidelityReport({ kernel, gaps }) {
   return {
     summary: {
@@ -262,7 +311,7 @@ function mapBeadsIssueToKernel(issue, importedAt, gaps, seenGaps) {
   if (Array.isArray(issue.labels) && issue.labels.length > 0) {
     addGap(gaps, seenGaps, 'issues.labels', 'no Kernel labels table in schema v1');
   }
-  if (issue.metadata && issue.metadata !== '{}') {
+  if (hasUnsupportedBeadsMetadata(issue.metadata)) {
     addGap(gaps, seenGaps, 'issues.metadata', 'no Kernel issue metadata column in schema v1');
   }
   for (const [field, reason] of UNSUPPORTED_ISSUE_FIELDS) {
@@ -346,19 +395,25 @@ function buildCloseEvent(issue, importedAt) {
   }
 
   const createdAt = issue.closed_at || issue.updated_at || importedAt;
+  const projectionOrigin = getForgeProjectionOrigin(issue);
+  const payload = {
+    closed_at: issue.closed_at || null,
+    close_reason: issue.close_reason || null,
+  };
+  if (projectionOrigin) {
+    payload.projection_origin = projectionOrigin;
+  }
+
   return {
     id: `beads-close-${encodedIdPart(issue.id)}`,
     entity_type: 'issue',
     entity_id: issue.id,
     event_type: 'beads.issue.closed',
     idempotency_key: `beads-close:${issue.id}:${createdAt}`,
-    expected_revision: normalizeEntityRevision(issue.entity_revision),
+    expected_revision: normalizeEntityRevision(projectionOrigin?.entity_revision ?? issue.entity_revision),
     actor: issue.closed_by || issue.created_by || 'beads',
     origin: 'beads_import',
-    payload_json: JSON.stringify({
-      closed_at: issue.closed_at || null,
-      close_reason: issue.close_reason || null,
-    }),
+    payload_json: JSON.stringify(payload),
     created_at: createdAt,
   };
 }
@@ -478,6 +533,7 @@ function mapKernelIssueToBeads(issue, dependenciesByIssue, dependentsByIssue, cl
   if (issue.created_by) {
     exported.created_by = issue.created_by;
   }
+  exported.metadata = JSON.stringify(buildForgeProjectionMetadata(issue));
 
   if (closeMetadata.closed_at) {
     exported.closed_at = closeMetadata.closed_at;

--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -250,13 +250,20 @@ function parseMetadataObject(value) {
   }
 }
 
+function hasFiniteRevisionValue(value) {
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  return trimmed !== '' && Number.isFinite(Number(trimmed));
+}
+
 function isValidForgeProjection(projection, issueId) {
   if (!projection || typeof projection !== 'object' || Array.isArray(projection)) return false;
   return projection.source === 'forge-kernel'
     && projection.target === 'beads'
     && projection.entity_type === 'issue'
     && projection.entity_id === issueId
-    && Number.isFinite(Number(projection.entity_revision))
+    && hasFiniteRevisionValue(projection.entity_revision)
     && typeof projection.payload_hash === 'string'
     && projection.payload_hash !== '';
 }

--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -51,6 +51,20 @@ function stringifyJsonl(records = []) {
   return `${records.map(record => JSON.stringify(record)).join('\n')}\n`;
 }
 
+function stableStringify(value) {
+  if (value === undefined) return '{}';
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  return `{${Object.keys(value).sort((left, right) => left.localeCompare(right))
+    .map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+    .join(',')}}`;
+}
+
 function readJsonlIfPresent(filePath) {
   if (!fs.existsSync(filePath)) {
     return [];
@@ -250,12 +264,21 @@ function parseMetadataObject(value) {
   }
 }
 
-function getForgeProjectionOrigin(issue = {}) {
+function isValidForgeProjection(projection, issueId) {
+  if (!projection || typeof projection !== 'object' || Array.isArray(projection)) return false;
+  return projection.source === 'forge-kernel'
+    && projection.target === 'beads'
+    && projection.entity_type === 'issue'
+    && projection.entity_id === issueId
+    && Number.isFinite(Number(projection.entity_revision))
+    && typeof projection.payload_hash === 'string'
+    && projection.payload_hash !== '';
+}
+
+function getForgeProjectionOrigin(issue = {}, currentPayload = {}) {
   const metadata = parseMetadataObject(issue.metadata);
   const projection = metadata[FORGE_PROJECTION_METADATA_KEY];
-  if (!projection || typeof projection !== 'object') return null;
-  if (projection.source !== 'forge-kernel' || projection.target !== 'beads') return null;
-  if (projection.entity_type !== 'issue' || projection.entity_id !== issue.id) return null;
+  if (!isValidForgeProjection(projection, issue.id)) return null;
 
   return {
     source: 'forge-kernel',
@@ -263,18 +286,28 @@ function getForgeProjectionOrigin(issue = {}) {
     entity_type: 'issue',
     entity_id: issue.id,
     entity_revision: normalizeEntityRevision(projection.entity_revision),
+    payload_hash: projection.payload_hash,
+    imported_payload_hash: stableStringify(currentPayload),
   };
 }
 
-function hasUnsupportedBeadsMetadata(value) {
+function hasUnsupportedBeadsMetadata(value, issueId) {
   if (!hasBeadsFieldValue(value)) return false;
   if (typeof value !== 'string' && (typeof value !== 'object' || Array.isArray(value))) return true;
   const metadata = parseMetadataObject(value);
   const keys = Object.keys(metadata);
-  return keys.length === 0 || keys.some(key => key !== FORGE_PROJECTION_METADATA_KEY);
+  if (keys.length !== 1 || keys[0] !== FORGE_PROJECTION_METADATA_KEY) return true;
+  return !isValidForgeProjection(metadata[FORGE_PROJECTION_METADATA_KEY], issueId);
 }
 
-function buildForgeProjectionMetadata(issue = {}) {
+function buildCloseProjectionPayload(closeMetadata = {}) {
+  return {
+    closed_at: closeMetadata.closed_at || null,
+    close_reason: closeMetadata.close_reason || null,
+  };
+}
+
+function buildForgeProjectionMetadata(issue = {}, closeMetadata = {}) {
   const metadata = parseMetadataObject(issue.metadata);
   metadata[FORGE_PROJECTION_METADATA_KEY] = {
     source: 'forge-kernel',
@@ -282,6 +315,7 @@ function buildForgeProjectionMetadata(issue = {}) {
     entity_type: 'issue',
     entity_id: issue.id,
     entity_revision: normalizeEntityRevision(issue.entity_revision),
+    payload_hash: stableStringify(buildCloseProjectionPayload(closeMetadata)),
   };
   return metadata;
 }
@@ -311,7 +345,7 @@ function mapBeadsIssueToKernel(issue, importedAt, gaps, seenGaps) {
   if (Array.isArray(issue.labels) && issue.labels.length > 0) {
     addGap(gaps, seenGaps, 'issues.labels', 'no Kernel labels table in schema v1');
   }
-  if (hasUnsupportedBeadsMetadata(issue.metadata)) {
+  if (hasUnsupportedBeadsMetadata(issue.metadata, issue.id)) {
     addGap(gaps, seenGaps, 'issues.metadata', 'no Kernel issue metadata column in schema v1');
   }
   for (const [field, reason] of UNSUPPORTED_ISSUE_FIELDS) {
@@ -395,11 +429,8 @@ function buildCloseEvent(issue, importedAt) {
   }
 
   const createdAt = issue.closed_at || issue.updated_at || importedAt;
-  const projectionOrigin = getForgeProjectionOrigin(issue);
-  const payload = {
-    closed_at: issue.closed_at || null,
-    close_reason: issue.close_reason || null,
-  };
+  const payload = buildCloseProjectionPayload(issue);
+  const projectionOrigin = getForgeProjectionOrigin(issue, payload);
   if (projectionOrigin) {
     payload.projection_origin = projectionOrigin;
   }
@@ -533,7 +564,7 @@ function mapKernelIssueToBeads(issue, dependenciesByIssue, dependentsByIssue, cl
   if (issue.created_by) {
     exported.created_by = issue.created_by;
   }
-  exported.metadata = JSON.stringify(buildForgeProjectionMetadata(issue));
+  exported.metadata = JSON.stringify(buildForgeProjectionMetadata(issue, closeMetadata));
 
   if (closeMetadata.closed_at) {
     exported.closed_at = closeMetadata.closed_at;

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -37,6 +37,7 @@ function isForgeProjectionEcho(event, entity = {}) {
 	if (!projectionOrigin || typeof projectionOrigin !== 'object') return false;
 	if (projectionOrigin.source !== 'forge-kernel' || projectionOrigin.target !== 'beads') return false;
 	if (projectionOrigin.entity_type !== event.entity_type || projectionOrigin.entity_id !== event.entity_id) return false;
+	if (!projectionOrigin.payload_hash || projectionOrigin.payload_hash !== projectionOrigin.imported_payload_hash) return false;
 
 	const actualRevision = Number(entity.entity_revision || 0);
 	const projectedRevision = Number(projectionOrigin.entity_revision);

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -29,6 +29,20 @@ function payloadJsonFor(event) {
 	return stableStringify(normalizePayload(event));
 }
 
+function isForgeProjectionEcho(event, entity = {}) {
+	if (event.origin !== 'beads_import') return false;
+
+	const payload = normalizePayload(event);
+	const projectionOrigin = payload.projection_origin;
+	if (!projectionOrigin || typeof projectionOrigin !== 'object') return false;
+	if (projectionOrigin.source !== 'forge-kernel' || projectionOrigin.target !== 'beads') return false;
+	if (projectionOrigin.entity_type !== event.entity_type || projectionOrigin.entity_id !== event.entity_id) return false;
+
+	const actualRevision = Number(entity.entity_revision || 0);
+	const projectedRevision = Number(projectionOrigin.entity_revision);
+	return Number.isFinite(projectedRevision) && projectedRevision === actualRevision;
+}
+
 function findOriginalIdempotencyEvent(event, priorEvents = []) {
 	return priorEvents.find(priorEvent => priorEvent.idempotency_key === event.idempotency_key);
 }
@@ -125,6 +139,14 @@ function evaluateKernelEvent(input = {}) {
 			decision: 'dedupe',
 			reason: 'equivalent_write',
 			originalEvent: equivalentEvent,
+			projection: false,
+		};
+	}
+
+	if (isForgeProjectionEcho(event, input.entity)) {
+		return {
+			decision: 'projection_echo',
+			reason: 'forge_projection_echo',
 			projection: false,
 		};
 	}

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -38,6 +38,7 @@ function isForgeProjectionEcho(event, entity = {}) {
 	if (projectionOrigin.source !== 'forge-kernel' || projectionOrigin.target !== 'beads') return false;
 	if (projectionOrigin.entity_type !== event.entity_type || projectionOrigin.entity_id !== event.entity_id) return false;
 	if (!projectionOrigin.payload_hash || projectionOrigin.payload_hash !== projectionOrigin.imported_payload_hash) return false;
+	if (!entity || entity.entity_revision === undefined || entity.entity_revision === null) return false;
 
 	const actualRevision = Number(entity.entity_revision || 0);
 	const projectedRevision = Number(projectionOrigin.entity_revision);

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -285,6 +285,11 @@ describe('Beads Kernel compatibility adapter', () => {
 				target: 'beads',
 				entity_type: 'issue',
 				entity_id: 'forge-native',
+				entity_revision: null,
+				payload_hash: JSON.stringify({
+					closed_at: IMPORTED_AT,
+					close_reason: 'Done',
+				}),
 			},
 		});
 

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -23,6 +23,34 @@ function parseJsonl(content) {
 		.map(line => JSON.parse(line));
 }
 
+function exportClosedKernelIssue() {
+	return exportKernelToBeads({
+		issues: [{
+			id: 'forge-native',
+			title: 'Native Kernel issue',
+			body: 'Projected to Beads and imported back.',
+			status: 'closed',
+			priority: 'P1',
+			type: 'task',
+			entity_revision: 4,
+			created_at: IMPORTED_AT,
+			updated_at: IMPORTED_AT,
+		}],
+		dependencies: [],
+		comments: [],
+		events: [{
+			entity_type: 'issue',
+			entity_id: 'forge-native',
+			event_type: 'beads.issue.closed',
+			payload_json: JSON.stringify({
+				closed_at: IMPORTED_AT,
+				close_reason: 'Done',
+			}),
+			created_at: IMPORTED_AT,
+		}],
+	}, { dryRun: true });
+}
+
 describe('Beads Kernel compatibility adapter', () => {
 	test('normalizes generated identifier parts without regex backtracking', () => {
 		expect(safeIdPart('  Forge CHILD :: Closed!!! ')).toBe('forge-child-closed');
@@ -214,31 +242,7 @@ describe('Beads Kernel compatibility adapter', () => {
 	});
 
 	test('round-trips Forge projection provenance through Beads export and import', () => {
-		const exportResult = exportKernelToBeads({
-			issues: [{
-				id: 'forge-native',
-				title: 'Native Kernel issue',
-				body: 'Projected to Beads and imported back.',
-				status: 'closed',
-				priority: 'P1',
-				type: 'task',
-				entity_revision: 4,
-				created_at: IMPORTED_AT,
-				updated_at: IMPORTED_AT,
-			}],
-			dependencies: [],
-			comments: [],
-			events: [{
-				entity_type: 'issue',
-				entity_id: 'forge-native',
-				event_type: 'beads.issue.closed',
-				payload_json: JSON.stringify({
-					closed_at: IMPORTED_AT,
-					close_reason: 'Done',
-				}),
-				created_at: IMPORTED_AT,
-			}],
-		}, { dryRun: true });
+		const exportResult = exportClosedKernelIssue();
 
 		const [exportedIssue] = parseJsonl(exportResult.files['issues.jsonl']);
 		expect(JSON.parse(exportedIssue.metadata).forge_projection).toMatchObject({
@@ -272,31 +276,7 @@ describe('Beads Kernel compatibility adapter', () => {
 	});
 
 	test('reports malformed Forge projection metadata as unsupported', () => {
-		const exportResult = exportKernelToBeads({
-			issues: [{
-				id: 'forge-native',
-				title: 'Native Kernel issue',
-				body: 'Projected to Beads and imported back.',
-				status: 'closed',
-				priority: 'P1',
-				type: 'task',
-				entity_revision: 4,
-				created_at: IMPORTED_AT,
-				updated_at: IMPORTED_AT,
-			}],
-			dependencies: [],
-			comments: [],
-			events: [{
-				entity_type: 'issue',
-				entity_id: 'forge-native',
-				event_type: 'beads.issue.closed',
-				payload_json: JSON.stringify({
-					closed_at: IMPORTED_AT,
-					close_reason: 'Done',
-				}),
-				created_at: IMPORTED_AT,
-			}],
-		}, { dryRun: true });
+		const exportResult = exportClosedKernelIssue();
 
 		const [exportedIssue] = parseJsonl(exportResult.files['issues.jsonl']);
 		exportedIssue.metadata = JSON.stringify({

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -271,6 +271,56 @@ describe('Beads Kernel compatibility adapter', () => {
 		});
 	});
 
+	test('reports malformed Forge projection metadata as unsupported', () => {
+		const exportResult = exportKernelToBeads({
+			issues: [{
+				id: 'forge-native',
+				title: 'Native Kernel issue',
+				body: 'Projected to Beads and imported back.',
+				status: 'closed',
+				priority: 'P1',
+				type: 'task',
+				entity_revision: 4,
+				created_at: IMPORTED_AT,
+				updated_at: IMPORTED_AT,
+			}],
+			dependencies: [],
+			comments: [],
+			events: [{
+				entity_type: 'issue',
+				entity_id: 'forge-native',
+				event_type: 'beads.issue.closed',
+				payload_json: JSON.stringify({
+					closed_at: IMPORTED_AT,
+					close_reason: 'Done',
+				}),
+				created_at: IMPORTED_AT,
+			}],
+		}, { dryRun: true });
+
+		const [exportedIssue] = parseJsonl(exportResult.files['issues.jsonl']);
+		exportedIssue.metadata = JSON.stringify({
+			forge_projection: {
+				source: 'forge-kernel',
+				target: 'beads',
+				entity_type: 'issue',
+				entity_id: 'forge-native',
+			},
+		});
+
+		const importResult = importBeadsSnapshot({
+			issues: [exportedIssue],
+			comments: [],
+			dependencies: [],
+		}, { importedAt: IMPORTED_AT });
+		const [closeEvent] = importResult.kernel.events;
+
+		expect(importResult.report.gaps).toEqual(expect.arrayContaining([
+			expect.objectContaining({ field: 'issues.metadata' }),
+		]));
+		expect(JSON.parse(closeEvent.payload_json).projection_origin).toBeUndefined();
+	});
+
 	test('counts only blocking dependency edges on Beads export', () => {
 		const exportResult = exportKernelToBeads({
 			issues: [

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -213,6 +213,64 @@ describe('Beads Kernel compatibility adapter', () => {
 		expect(issue.created_by).toBeUndefined();
 	});
 
+	test('round-trips Forge projection provenance through Beads export and import', () => {
+		const exportResult = exportKernelToBeads({
+			issues: [{
+				id: 'forge-native',
+				title: 'Native Kernel issue',
+				body: 'Projected to Beads and imported back.',
+				status: 'closed',
+				priority: 'P1',
+				type: 'task',
+				entity_revision: 4,
+				created_at: IMPORTED_AT,
+				updated_at: IMPORTED_AT,
+			}],
+			dependencies: [],
+			comments: [],
+			events: [{
+				entity_type: 'issue',
+				entity_id: 'forge-native',
+				event_type: 'beads.issue.closed',
+				payload_json: JSON.stringify({
+					closed_at: IMPORTED_AT,
+					close_reason: 'Done',
+				}),
+				created_at: IMPORTED_AT,
+			}],
+		}, { dryRun: true });
+
+		const [exportedIssue] = parseJsonl(exportResult.files['issues.jsonl']);
+		expect(JSON.parse(exportedIssue.metadata).forge_projection).toMatchObject({
+			source: 'forge-kernel',
+			target: 'beads',
+			entity_type: 'issue',
+			entity_id: 'forge-native',
+			entity_revision: 4,
+		});
+
+		const importResult = importBeadsSnapshot({
+			issues: [exportedIssue],
+			comments: [],
+			dependencies: [],
+		}, { importedAt: IMPORTED_AT });
+		const [closeEvent] = importResult.kernel.events;
+
+		expect(closeEvent).toMatchObject({
+			entity_type: 'issue',
+			entity_id: 'forge-native',
+			origin: 'beads_import',
+			expected_revision: 4,
+		});
+		expect(JSON.parse(closeEvent.payload_json).projection_origin).toMatchObject({
+			source: 'forge-kernel',
+			target: 'beads',
+			entity_type: 'issue',
+			entity_id: 'forge-native',
+			entity_revision: 4,
+		});
+	});
+
 	test('counts only blocking dependency edges on Beads export', () => {
 		const exportResult = exportKernelToBeads({
 			issues: [

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -306,6 +306,22 @@ describe('Beads Kernel compatibility adapter', () => {
 		expect(JSON.parse(closeEvent.payload_json).projection_origin).toBeUndefined();
 	});
 
+	test('does not apply projection origin when close actor drifts after export', () => {
+		const exportResult = exportClosedKernelIssue();
+		const [exportedIssue] = parseJsonl(exportResult.files['issues.jsonl']);
+		exportedIssue.closed_by = 'External Beads User';
+
+		const importResult = importBeadsSnapshot({
+			issues: [exportedIssue],
+			comments: [],
+			dependencies: [],
+		}, { importedAt: IMPORTED_AT });
+		const [closeEvent] = importResult.kernel.events;
+
+		expect(closeEvent.actor).toBe('External Beads User');
+		expect(JSON.parse(closeEvent.payload_json).projection_origin).toBeUndefined();
+	});
+
 	test('counts only blocking dependency edges on Beads export', () => {
 		const exportResult = exportKernelToBeads({
 			issues: [

--- a/test/kernel/evaluators.test.js
+++ b/test/kernel/evaluators.test.js
@@ -182,6 +182,37 @@ describe('Kernel conflict evaluators', () => {
 		expect(result.projection).toBe(true);
 	});
 
+	test('does not suppress Beads imports when the authority entity is missing', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'issue',
+				entity_id: 'forge-1',
+				event_type: 'issue.update',
+				idempotency_key: 'beads-import:forge-1:missing-entity',
+				expected_revision: 0,
+				origin: 'beads_import',
+				payload: {
+					title: 'Projected title',
+					projection_origin: {
+						source: 'forge-kernel',
+						target: 'beads',
+						entity_type: 'issue',
+						entity_id: 'forge-1',
+						entity_revision: 0,
+						payload_hash: '{"title":"Projected title"}',
+						imported_payload_hash: '{"title":"Projected title"}',
+					},
+				},
+			},
+			entity: null,
+		});
+
+		expect(result.decision).toBe('accept');
+		expect(result.projection).toBe(true);
+	});
+
 	test('quarantines dependency writes that would create a cycle', () => {
 		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
 

--- a/test/kernel/evaluators.test.js
+++ b/test/kernel/evaluators.test.js
@@ -116,6 +116,38 @@ describe('Kernel conflict evaluators', () => {
 		expect(result.projection).toBe(true);
 	});
 
+	test('suppresses Beads imports that echo a Forge projection', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'issue',
+				entity_id: 'forge-1',
+				event_type: 'issue.update',
+				idempotency_key: 'beads-import:forge-1:projected-rev-4',
+				expected_revision: 4,
+				origin: 'beads_import',
+				payload: {
+					title: 'Projected title',
+					projection_origin: {
+						source: 'forge-kernel',
+						target: 'beads',
+						entity_type: 'issue',
+						entity_id: 'forge-1',
+						entity_revision: 4,
+					},
+				},
+			},
+			entity: { entity_revision: 4 },
+		});
+
+		expect(result).toMatchObject({
+			decision: 'projection_echo',
+			reason: 'forge_projection_echo',
+			projection: false,
+		});
+	});
+
 	test('quarantines dependency writes that would create a cycle', () => {
 		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
 

--- a/test/kernel/evaluators.test.js
+++ b/test/kernel/evaluators.test.js
@@ -135,6 +135,8 @@ describe('Kernel conflict evaluators', () => {
 						entity_type: 'issue',
 						entity_id: 'forge-1',
 						entity_revision: 4,
+						payload_hash: '{"title":"Projected title"}',
+						imported_payload_hash: '{"title":"Projected title"}',
 					},
 				},
 			},
@@ -146,6 +148,38 @@ describe('Kernel conflict evaluators', () => {
 			reason: 'forge_projection_echo',
 			projection: false,
 		});
+	});
+
+	test('does not suppress Beads imports when projected payload differs', () => {
+		const { evaluateKernelEvent } = require('../../lib/kernel/evaluators');
+
+		const result = evaluateKernelEvent({
+			event: {
+				entity_type: 'issue',
+				entity_id: 'forge-1',
+				event_type: 'issue.update',
+				idempotency_key: 'beads-import:forge-1:changed-payload',
+				expected_revision: 4,
+				origin: 'beads_import',
+				payload: {
+					title: 'Changed in Beads',
+					projection_origin: {
+						source: 'forge-kernel',
+						target: 'beads',
+						entity_type: 'issue',
+						entity_id: 'forge-1',
+						entity_revision: 4,
+						payload_hash: '{"title":"Projected title"}',
+						imported_payload_hash: '{"title":"Changed in Beads"}',
+					},
+				},
+			},
+			entity: { entity_revision: 4 },
+		});
+
+		expect(result.decision).not.toBe('projection_echo');
+		expect(result.decision).toBe('accept');
+		expect(result.projection).toBe(true);
 	});
 
 	test('quarantines dependency writes that would create a cycle', () => {


### PR DESCRIPTION
## Summary
- add Forge-to-Beads projection provenance metadata to Beads export records
- preserve that provenance on imported Beads close events
- suppress Beads imports that echo Forge's own projection at the current entity revision, so they are not accepted or projected as new authoritative Kernel mutations

## Dependency
Draft until #205 merges. After #205 merges, rebase this branch on the updated `origin/master` before marking ready.

## Validation
- `bun test test/kernel/evaluators.test.js --timeout 15000` (red first, then green)
- `bun test test/adapters/beads-kernel-compat.test.js --timeout 15000`
- `bun test test/kernel/evaluators.test.js test/adapters/beads-kernel-compat.test.js --timeout 15000`
- `bunx eslint lib/kernel/evaluators.js lib/adapters/beads-kernel-compat.js test/kernel/evaluators.test.js test/adapters/beads-kernel-compat.test.js --max-warnings 0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export and record Forge projection provenance as serialized projection metadata on exported issues; rebuilt close-event construction to include projection-origin when valid and set expected revision (with fallback).
  * Deterministic payload fingerprints/hashes to validate projection payloads.

* **Bug Fixes**
  * Suppress import echoes by matching projection hashes and revisions to avoid re-applying mirrored changes.
  * More accurate detection of unsupported/malformed metadata and omission of projection data when provenance is invalid.

* **Tests**
  * End-to-end and unit tests for round-trip projection preservation, malformed-projection handling, echo suppression, and unsupported-metadata detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->