### PR TITLE
feat: select builtin Kernel SQLite driver

### DIFF
--- a/docs/reference/FORGE_KERNEL_STORAGE_MODEL.md
+++ b/docs/reference/FORGE_KERNEL_STORAGE_MODEL.md
@@ -73,6 +73,12 @@ Local mode may work without a server. It must still prevent two local worktrees 
 
 Local mode is intentionally local-only. Closing an issue, recording a run, updating a claim, or saving project knowledge in local mode must not require a Git commit or push. If the user wants another machine or teammate to see that state, Forge must use team mode server authority or an explicit export/import operation.
 
+### SQLite Runtime Driver
+
+Forge Kernel local mode uses a builtin SQLite runtime driver. Driver selection must feature-detect `bun:sqlite` first and `node:sqlite` second, and must not add a native-compile SQLite package as the default install path.
+
+The selected driver must pass conformance checks for WAL mode, `busy_timeout`, transactions, WAL checkpointing, backup creation, and FTS5 before Forge claims real local SQLite authority behavior.
+
 ## Team Mode
 
 Team mode requires server authority.

--- a/docs/reference/FORGE_KERNEL_STORAGE_MODEL.md
+++ b/docs/reference/FORGE_KERNEL_STORAGE_MODEL.md
@@ -75,7 +75,7 @@ Local mode is intentionally local-only. Closing an issue, recording a run, updat
 
 ### SQLite Runtime Driver
 
-Forge Kernel local mode uses a builtin SQLite runtime driver. Driver selection must feature-detect `bun:sqlite` first and `node:sqlite` second, and must not add a native-compile SQLite package as the default install path.
+Forge Kernel local mode uses a builtin SQLite runtime driver. Driver selection must feature-detect `bun:sqlite` first and backup-capable `node:sqlite` second, and must not add a native-compile SQLite package as the default install path.
 
 The selected driver must pass conformance checks for WAL mode, `busy_timeout`, transactions, WAL checkpointing, backup creation, and FTS5 before Forge claims real local SQLite authority behavior.
 

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -296,8 +296,10 @@ async function validateBackup(runtime, db, backupPath) {
 async function validateBuiltinSQLiteRuntimeDriver(options = {}, deps = {}) {
 	const runtime = options.runtime || selectBuiltinSQLiteRuntime(deps);
 	let tempDir = options.tempDir;
+	let ownsTempDir = false;
 	if (!tempDir && !options.databasePath && !options.backupPath) {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-sqlite-'));
+		ownsTempDir = true;
 	}
 	const databasePath = options.databasePath
 		|| (tempDir ? path.join(tempDir, 'kernel.sqlite') : `${options.backupPath}.source.sqlite`);
@@ -329,6 +331,9 @@ async function validateBuiltinSQLiteRuntimeDriver(options = {}, deps = {}) {
 		};
 	} finally {
 		closeDatabase(db);
+		if (ownsTempDir) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	}
 }
 

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -120,7 +120,15 @@ function createDriver(runtime, configuredDatabasePath) {
 	let openedDatabasePath;
 
 	function resolveDatabasePath(config) {
-		const databasePath = configuredDatabasePath || (config && config.databasePath);
+		const brokerDatabasePath = config && config.databasePath;
+		if (configuredDatabasePath && brokerDatabasePath && configuredDatabasePath !== brokerDatabasePath) {
+			throw new Error([
+				'Kernel SQLite driver databasePath mismatch:',
+				`driver is configured for ${configuredDatabasePath}`,
+				`but broker config uses ${brokerDatabasePath}`,
+			].join(' '));
+		}
+		const databasePath = brokerDatabasePath || configuredDatabasePath;
 		if (!databasePath) {
 			throw new Error('Kernel SQLite driver requires a databasePath or broker config databasePath');
 		}

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -310,9 +310,10 @@ async function validateBuiltinSQLiteRuntimeDriver(options = {}, deps = {}) {
 		|| (tempDir ? path.join(tempDir, 'kernel.sqlite') : `${options.backupPath}.source.sqlite`);
 	const backupPath = options.backupPath
 		|| (tempDir ? path.join(tempDir, 'kernel.backup.sqlite') : `${databasePath}.backup.sqlite`);
-	const db = createDatabase(runtime, databasePath);
+	let db;
 
 	try {
+		db = createDatabase(runtime, databasePath);
 		const capabilities = {
 			wal: assertCapability(runtime, 'WAL', validateWal(runtime, db)),
 			busyTimeout: assertCapability(runtime, 'busy_timeout', validateBusyTimeout(runtime, db)),

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -1,0 +1,277 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const BUILTIN_SQLITE_RUNTIME_ORDER = Object.freeze(['bun:sqlite', 'node:sqlite']);
+
+function isModuleUnavailable(error) {
+	return error && (
+		error.code === 'MODULE_NOT_FOUND'
+		|| error.code === 'ERR_UNKNOWN_BUILTIN_MODULE'
+		|| /Cannot find module|No such built-in module/i.test(String(error.message || error))
+	);
+}
+
+function loadRuntimeDescriptor(id, sqliteModule) {
+	if (id === 'bun:sqlite') {
+		if (typeof sqliteModule.Database !== 'function') {
+			throw new Error('bun:sqlite is present but does not expose Database');
+		}
+		return {
+			id,
+			module: sqliteModule,
+			databaseClassName: 'Database',
+			nativeCompileDependency: false,
+			experimental: false,
+		};
+	}
+
+	if (id === 'node:sqlite') {
+		if (typeof sqliteModule.DatabaseSync !== 'function') {
+			throw new Error('node:sqlite is present but does not expose DatabaseSync');
+		}
+		return {
+			id,
+			module: sqliteModule,
+			databaseClassName: 'DatabaseSync',
+			nativeCompileDependency: false,
+			experimental: true,
+		};
+	}
+
+	throw new Error(`Unsupported builtin SQLite runtime: ${id}`);
+}
+
+function selectBuiltinSQLiteRuntime(deps = {}) {
+	const requireModule = deps.requireModule || require;
+	const unavailable = [];
+
+	for (const id of BUILTIN_SQLITE_RUNTIME_ORDER) {
+		try {
+			return loadRuntimeDescriptor(id, requireModule(id));
+		} catch (error) {
+			if (!isModuleUnavailable(error)) {
+				throw error;
+			}
+			unavailable.push(`${id}: ${error.message || error}`);
+		}
+	}
+
+	throw new Error([
+		'Forge Kernel requires a builtin SQLite runtime: bun:sqlite or node:sqlite.',
+		'Install/run Forge with Bun >= 1.2 or Node >= 22.5 built with node:sqlite support.',
+		'No native-compile SQLite package is installed by default.',
+		`Detection failures: ${unavailable.join('; ')}`,
+	].join(' '));
+}
+
+function createDatabase(runtime, databasePath) {
+	if (runtime.id === 'bun:sqlite') {
+		return new runtime.module.Database(databasePath, { create: true });
+	}
+	if (runtime.id === 'node:sqlite') {
+		return new runtime.module.DatabaseSync(databasePath);
+	}
+	throw new Error(`Unsupported builtin SQLite runtime: ${runtime.id}`);
+}
+
+function execSql(runtime, db, sql) {
+	if (runtime.id === 'bun:sqlite') {
+		db.exec(sql);
+		return;
+	}
+	db.exec(sql);
+}
+
+function queryAll(runtime, db, sql) {
+	if (runtime.id === 'bun:sqlite') {
+		return db.query(sql).all();
+	}
+	return db.prepare(sql).all();
+}
+
+function queryOne(runtime, db, sql) {
+	return queryAll(runtime, db, sql)[0] || {};
+}
+
+function closeDatabase(db) {
+	if (db && typeof db.close === 'function') {
+		db.close();
+	}
+}
+
+function createDriver(runtime, databasePath) {
+	let db;
+
+	function getDatabase() {
+		if (!db) {
+			db = createDatabase(runtime, databasePath);
+		}
+		return db;
+	}
+
+	return {
+		runtime: {
+			id: runtime.id,
+			databaseClassName: runtime.databaseClassName,
+			nativeCompileDependency: runtime.nativeCompileDependency,
+			experimental: runtime.experimental,
+		},
+		databasePath,
+		async exec(statement) {
+			execSql(runtime, getDatabase(), statement);
+		},
+		queryAll(statement) {
+			return queryAll(runtime, getDatabase(), statement);
+		},
+		close() {
+			closeDatabase(db);
+			db = null;
+		},
+	};
+}
+
+function assertCapability(runtime, capability, detail) {
+	if (!detail.ok) {
+		throw new Error(`Builtin SQLite runtime ${runtime.id} failed ${capability} validation: ${detail.reason}`);
+	}
+	return true;
+}
+
+function validateWal(runtime, db) {
+	const row = queryOne(runtime, db, 'PRAGMA journal_mode=WAL;');
+	const mode = String(row.journal_mode || '').toLowerCase();
+	return { ok: mode === 'wal', reason: `journal_mode=${mode || 'unknown'}` };
+}
+
+function validateBusyTimeout(runtime, db) {
+	const row = queryOne(runtime, db, 'PRAGMA busy_timeout=5000;');
+	const timeout = Number(row.timeout);
+	return { ok: timeout === 5000, reason: `timeout=${Number.isNaN(timeout) ? 'unknown' : timeout}` };
+}
+
+function validateTransactions(runtime, db) {
+	try {
+		execSql(runtime, db, [
+			'BEGIN IMMEDIATE;',
+			'CREATE TABLE forge_transaction_probe (id INTEGER PRIMARY KEY, value TEXT NOT NULL);',
+			"INSERT INTO forge_transaction_probe (value) VALUES ('ok');",
+			'COMMIT;',
+		].join('\n'));
+		const row = queryOne(runtime, db, 'SELECT value FROM forge_transaction_probe WHERE id = 1;');
+		return { ok: row.value === 'ok', reason: `value=${row.value || 'missing'}` };
+	} catch (error) {
+		try {
+			execSql(runtime, db, 'ROLLBACK;');
+		} catch {
+			// Ignore rollback errors from runtimes that already closed the failed transaction.
+		}
+		return { ok: false, reason: error.message || String(error) };
+	}
+}
+
+function validateFts5(runtime, db) {
+	try {
+		execSql(runtime, db, 'CREATE VIRTUAL TABLE forge_fts_probe USING fts5(content);');
+		execSql(runtime, db, "INSERT INTO forge_fts_probe (content) VALUES ('kernel sqlite driver');");
+		const row = queryOne(runtime, db, "SELECT count(*) AS count FROM forge_fts_probe WHERE forge_fts_probe MATCH 'sqlite';");
+		return { ok: Number(row.count) === 1, reason: `count=${row.count || 0}` };
+	} catch (error) {
+		return { ok: false, reason: error.message || String(error) };
+	}
+}
+
+function validateCheckpoint(runtime, db) {
+	try {
+		const row = queryOne(runtime, db, 'PRAGMA wal_checkpoint(TRUNCATE);');
+		return { ok: Number(row.busy) === 0, reason: `busy=${row.busy}` };
+	} catch (error) {
+		return { ok: false, reason: error.message || String(error) };
+	}
+}
+
+async function createBackup(runtime, db, backupPath) {
+	if (runtime.id === 'node:sqlite') {
+		if (typeof runtime.module.backup !== 'function') {
+			throw new Error('node:sqlite backup() is unavailable');
+		}
+		await runtime.module.backup(db, backupPath);
+		return;
+	}
+
+	if (runtime.id === 'bun:sqlite') {
+		if (typeof db.serialize !== 'function') {
+			throw new Error('bun:sqlite Database.serialize() is unavailable');
+		}
+		fs.writeFileSync(backupPath, db.serialize());
+		return;
+	}
+
+	throw new Error(`Unsupported builtin SQLite runtime: ${runtime.id}`);
+}
+
+async function validateBackup(runtime, db, backupPath) {
+	try {
+		await createBackup(runtime, db, backupPath);
+		const backupDb = createDatabase(runtime, backupPath);
+		try {
+			const row = queryOne(runtime, backupDb, 'SELECT value FROM forge_transaction_probe WHERE id = 1;');
+			return {
+				ok: row.value === 'ok' && fs.existsSync(backupPath),
+				reason: `value=${row.value || 'missing'}`,
+			};
+		} finally {
+			closeDatabase(backupDb);
+		}
+	} catch (error) {
+		return { ok: false, reason: error.message || String(error) };
+	}
+}
+
+async function validateBuiltinSQLiteRuntimeDriver(options = {}, deps = {}) {
+	const runtime = options.runtime || selectBuiltinSQLiteRuntime(deps);
+	const tempDir = options.tempDir || fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-sqlite-'));
+	const databasePath = options.databasePath || path.join(tempDir, 'kernel.sqlite');
+	const backupPath = options.backupPath || path.join(tempDir, 'kernel.backup.sqlite');
+	const db = createDatabase(runtime, databasePath);
+
+	try {
+		const capabilities = {
+			wal: assertCapability(runtime, 'WAL', validateWal(runtime, db)),
+			busyTimeout: assertCapability(runtime, 'busy_timeout', validateBusyTimeout(runtime, db)),
+			transactions: assertCapability(runtime, 'transaction', validateTransactions(runtime, db)),
+			fts5: assertCapability(runtime, 'FTS5', validateFts5(runtime, db)),
+			checkpoint: assertCapability(runtime, 'checkpoint', validateCheckpoint(runtime, db)),
+			backup: assertCapability(runtime, 'backup', await validateBackup(runtime, db, backupPath)),
+			nativeCompileDependency: runtime.nativeCompileDependency,
+		};
+
+		return {
+			runtime: {
+				id: runtime.id,
+				databaseClassName: runtime.databaseClassName,
+				nativeCompileDependency: runtime.nativeCompileDependency,
+				experimental: runtime.experimental,
+			},
+			databasePath,
+			backupPath,
+			capabilities,
+		};
+	} finally {
+		closeDatabase(db);
+	}
+}
+
+function createBuiltinSQLiteDriver(options = {}, deps = {}) {
+	const runtime = options.runtime || selectBuiltinSQLiteRuntime(deps);
+	return createDriver(runtime, options.databasePath || ':memory:');
+}
+
+module.exports = {
+	BUILTIN_SQLITE_RUNTIME_ORDER,
+	createBuiltinSQLiteDriver,
+	selectBuiltinSQLiteRuntime,
+	validateBuiltinSQLiteRuntimeDriver,
+};

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -110,12 +110,25 @@ function closeDatabase(db) {
 	}
 }
 
-function createDriver(runtime, databasePath) {
+function createDriver(runtime, configuredDatabasePath) {
 	let db;
+	let openedDatabasePath;
 
-	function getDatabase() {
+	function resolveDatabasePath(config) {
+		const databasePath = configuredDatabasePath || (config && config.databasePath);
+		if (!databasePath) {
+			throw new Error('Kernel SQLite driver requires a databasePath or broker config databasePath');
+		}
+		return databasePath;
+	}
+
+	function getDatabase(config) {
+		const databasePath = resolveDatabasePath(config);
 		if (!db) {
 			db = createDatabase(runtime, databasePath);
+			openedDatabasePath = databasePath;
+		} else if (openedDatabasePath !== databasePath) {
+			throw new Error(`Kernel SQLite driver is already open for ${openedDatabasePath}`);
 		}
 		return db;
 	}
@@ -127,16 +140,17 @@ function createDriver(runtime, databasePath) {
 			nativeCompileDependency: runtime.nativeCompileDependency,
 			experimental: runtime.experimental,
 		},
-		databasePath,
-		async exec(statement) {
-			execSql(runtime, getDatabase(), statement);
+		databasePath: configuredDatabasePath,
+		async exec(statement, config) {
+			execSql(runtime, getDatabase(config), statement);
 		},
-		async queryAll(statement) {
-			return queryAll(runtime, getDatabase(), statement);
+		async queryAll(statement, config) {
+			return queryAll(runtime, getDatabase(config), statement);
 		},
 		close() {
 			closeDatabase(db);
 			db = null;
+			openedDatabasePath = null;
 		},
 	};
 }
@@ -320,7 +334,7 @@ async function validateBuiltinSQLiteRuntimeDriver(options = {}, deps = {}) {
 
 function createBuiltinSQLiteDriver(options = {}, deps = {}) {
 	const runtime = options.runtime || selectBuiltinSQLiteRuntime(deps);
-	return createDriver(runtime, options.databasePath || ':memory:');
+	return createDriver(runtime, options.databasePath);
 }
 
 module.exports = {

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -5,6 +5,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const BUILTIN_SQLITE_RUNTIME_ORDER = Object.freeze(['bun:sqlite', 'node:sqlite']);
+let probeCounter = 0;
 
 function isModuleUnavailable(error) {
 	return error && (
@@ -77,11 +78,7 @@ function createDatabase(runtime, databasePath) {
 	throw new Error(`Unsupported builtin SQLite runtime: ${runtime.id}`);
 }
 
-function execSql(runtime, db, sql) {
-	if (runtime.id === 'bun:sqlite') {
-		db.exec(sql);
-		return;
-	}
+function execSql(_runtime, db, sql) {
 	db.exec(sql);
 }
 
@@ -123,7 +120,7 @@ function createDriver(runtime, databasePath) {
 		async exec(statement) {
 			execSql(runtime, getDatabase(), statement);
 		},
-		queryAll(statement) {
+		async queryAll(statement) {
 			return queryAll(runtime, getDatabase(), statement);
 		},
 		close() {
@@ -152,34 +149,57 @@ function validateBusyTimeout(runtime, db) {
 	return { ok: timeout === 5000, reason: `timeout=${Number.isNaN(timeout) ? 'unknown' : timeout}` };
 }
 
+function createProbeTableName(prefix) {
+	probeCounter += 1;
+	return `${prefix}_${process.pid}_${probeCounter}`;
+}
+
 function validateTransactions(runtime, db) {
+	const tableName = createProbeTableName('forge_transaction_probe');
+	let committed = false;
 	try {
 		execSql(runtime, db, [
 			'BEGIN IMMEDIATE;',
-			'CREATE TABLE forge_transaction_probe (id INTEGER PRIMARY KEY, value TEXT NOT NULL);',
-			"INSERT INTO forge_transaction_probe (value) VALUES ('ok');",
+			`CREATE TABLE ${tableName} (id INTEGER PRIMARY KEY, value TEXT NOT NULL);`,
+			`INSERT INTO ${tableName} (value) VALUES ('ok');`,
 			'COMMIT;',
 		].join('\n'));
-		const row = queryOne(runtime, db, 'SELECT value FROM forge_transaction_probe WHERE id = 1;');
+		committed = true;
+		const row = queryOne(runtime, db, `SELECT value FROM ${tableName} WHERE id = 1;`);
 		return { ok: row.value === 'ok', reason: `value=${row.value || 'missing'}` };
 	} catch (error) {
-		try {
-			execSql(runtime, db, 'ROLLBACK;');
-		} catch {
-			// Ignore rollback errors from runtimes that already closed the failed transaction.
+		if (!committed) {
+			try {
+				execSql(runtime, db, 'ROLLBACK;');
+			} catch {
+				// Ignore rollback errors from runtimes that already closed the failed transaction.
+			}
 		}
 		return { ok: false, reason: error.message || String(error) };
+	} finally {
+		try {
+			execSql(runtime, db, `DROP TABLE IF EXISTS ${tableName};`);
+		} catch {
+			// Probe cleanup must not hide the original capability result.
+		}
 	}
 }
 
 function validateFts5(runtime, db) {
+	const tableName = createProbeTableName('forge_fts_probe');
 	try {
-		execSql(runtime, db, 'CREATE VIRTUAL TABLE forge_fts_probe USING fts5(content);');
-		execSql(runtime, db, "INSERT INTO forge_fts_probe (content) VALUES ('kernel sqlite driver');");
-		const row = queryOne(runtime, db, "SELECT count(*) AS count FROM forge_fts_probe WHERE forge_fts_probe MATCH 'sqlite';");
+		execSql(runtime, db, `CREATE VIRTUAL TABLE ${tableName} USING fts5(content);`);
+		execSql(runtime, db, `INSERT INTO ${tableName} (content) VALUES ('kernel sqlite driver');`);
+		const row = queryOne(runtime, db, `SELECT count(*) AS count FROM ${tableName} WHERE ${tableName} MATCH 'sqlite';`);
 		return { ok: Number(row.count) === 1, reason: `count=${row.count || 0}` };
 	} catch (error) {
 		return { ok: false, reason: error.message || String(error) };
+	} finally {
+		try {
+			execSql(runtime, db, `DROP TABLE IF EXISTS ${tableName};`);
+		} catch {
+			// Probe cleanup must not hide the original capability result.
+		}
 	}
 }
 
@@ -193,12 +213,20 @@ function validateCheckpoint(runtime, db) {
 }
 
 async function createBackup(runtime, db, backupPath) {
+	if (fs.existsSync(backupPath)) {
+		fs.rmSync(backupPath, { force: true });
+	}
+
 	if (runtime.id === 'node:sqlite') {
-		if (typeof runtime.module.backup !== 'function') {
-			throw new Error('node:sqlite backup() is unavailable');
+		if (typeof runtime.module.backup === 'function') {
+			await runtime.module.backup(db, backupPath);
+			return;
 		}
-		await runtime.module.backup(db, backupPath);
-		return;
+		if (typeof db.backup === 'function') {
+			await db.backup(backupPath);
+			return;
+		}
+		throw new Error('node:sqlite backup API is unavailable');
 	}
 
 	if (runtime.id === 'bun:sqlite') {
@@ -213,11 +241,14 @@ async function createBackup(runtime, db, backupPath) {
 }
 
 async function validateBackup(runtime, db, backupPath) {
+	const tableName = createProbeTableName('forge_backup_probe');
 	try {
+		execSql(runtime, db, `CREATE TABLE ${tableName} (id INTEGER PRIMARY KEY, value TEXT NOT NULL);`);
+		execSql(runtime, db, `INSERT INTO ${tableName} (value) VALUES ('ok');`);
 		await createBackup(runtime, db, backupPath);
 		const backupDb = createDatabase(runtime, backupPath);
 		try {
-			const row = queryOne(runtime, backupDb, 'SELECT value FROM forge_transaction_probe WHERE id = 1;');
+			const row = queryOne(runtime, backupDb, `SELECT value FROM ${tableName} WHERE id = 1;`);
 			return {
 				ok: row.value === 'ok' && fs.existsSync(backupPath),
 				reason: `value=${row.value || 'missing'}`,
@@ -227,14 +258,25 @@ async function validateBackup(runtime, db, backupPath) {
 		}
 	} catch (error) {
 		return { ok: false, reason: error.message || String(error) };
+	} finally {
+		try {
+			execSql(runtime, db, `DROP TABLE IF EXISTS ${tableName};`);
+		} catch {
+			// Probe cleanup must not hide the original capability result.
+		}
 	}
 }
 
 async function validateBuiltinSQLiteRuntimeDriver(options = {}, deps = {}) {
 	const runtime = options.runtime || selectBuiltinSQLiteRuntime(deps);
-	const tempDir = options.tempDir || fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-sqlite-'));
-	const databasePath = options.databasePath || path.join(tempDir, 'kernel.sqlite');
-	const backupPath = options.backupPath || path.join(tempDir, 'kernel.backup.sqlite');
+	let tempDir = options.tempDir;
+	if (!tempDir && !options.databasePath && !options.backupPath) {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-sqlite-'));
+	}
+	const databasePath = options.databasePath
+		|| (tempDir ? path.join(tempDir, 'kernel.sqlite') : `${options.backupPath}.source.sqlite`);
+	const backupPath = options.backupPath
+		|| (tempDir ? path.join(tempDir, 'kernel.backup.sqlite') : `${databasePath}.backup.sqlite`);
 	const db = createDatabase(runtime, databasePath);
 
 	try {

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -68,7 +68,18 @@ function selectBuiltinSQLiteRuntime(deps = {}) {
 	].join(' '));
 }
 
+function ensureFileBackedDatabaseDirectory(databasePath) {
+	if (!databasePath || databasePath === ':memory:' || String(databasePath).startsWith('file:')) {
+		return;
+	}
+	const databaseDir = path.dirname(databasePath);
+	if (databaseDir && databaseDir !== '.') {
+		fs.mkdirSync(databaseDir, { recursive: true });
+	}
+}
+
 function createDatabase(runtime, databasePath) {
+	ensureFileBackedDatabaseDirectory(databasePath);
 	if (runtime.id === 'bun:sqlite') {
 		return new runtime.module.Database(databasePath, { create: true });
 	}
@@ -213,6 +224,7 @@ function validateCheckpoint(runtime, db) {
 }
 
 async function createBackup(runtime, db, backupPath) {
+	ensureFileBackedDatabaseDirectory(backupPath);
 	if (fs.existsSync(backupPath)) {
 		fs.rmSync(backupPath, { force: true });
 	}

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -33,6 +33,11 @@ function loadRuntimeDescriptor(id, sqliteModule) {
 		if (typeof sqliteModule.DatabaseSync !== 'function') {
 			throw new Error('node:sqlite is present but does not expose DatabaseSync');
 		}
+		const hasBackupApi = typeof sqliteModule.backup === 'function'
+			|| typeof sqliteModule.DatabaseSync.prototype.backup === 'function';
+		if (!hasBackupApi) {
+			throw new Error('node:sqlite is present but does not expose backup support; run with Node >= 22.16 or Bun >= 1.2');
+		}
 		return {
 			id,
 			module: sqliteModule,
@@ -62,7 +67,7 @@ function selectBuiltinSQLiteRuntime(deps = {}) {
 
 	throw new Error([
 		'Forge Kernel requires a builtin SQLite runtime: bun:sqlite or node:sqlite.',
-		'Install/run Forge with Bun >= 1.2 or Node >= 22.5 built with node:sqlite support.',
+		'Install/run Forge with Bun >= 1.2 or Node >= 22.16 with node:sqlite backup support.',
 		'No native-compile SQLite package is installed by default.',
 		`Detection failures: ${unavailable.join('; ')}`,
 	].join(' '));

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -98,4 +98,25 @@ describe('Kernel SQLite runtime driver selection', () => {
 		expect(result.databasePath).toBe(databasePath);
 		expect(fs.existsSync(result.backupPath)).toBe(true);
 	});
+
+	test('can rerun real validation against the same database without leaving probe tables', async () => {
+		const { Database } = require('bun:sqlite');
+		const { validateBuiltinSQLiteRuntimeDriver } = require('../../lib/kernel/sqlite-driver');
+		const databasePath = path.join(makeTempDir(), 'kernel.sqlite');
+
+		await validateBuiltinSQLiteRuntimeDriver({ databasePath });
+		await validateBuiltinSQLiteRuntimeDriver({ databasePath });
+
+		const db = new Database(databasePath);
+		try {
+			const probeTables = db.query([
+				"SELECT name FROM sqlite_master WHERE type = 'table'",
+				"AND name LIKE 'forge_%_probe_%'",
+				'ORDER BY name;',
+			].join(' ')).all();
+			expect(probeTables).toEqual([]);
+		} finally {
+			db.close();
+		}
+	});
 });

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -113,6 +113,31 @@ describe('Kernel SQLite runtime driver selection', () => {
 		expect(fs.existsSync(databasePath)).toBe(true);
 	});
 
+	test('derives the database path from broker config instead of opening memory', async () => {
+		const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+		const databasePath = path.join(makeTempDir(), 'git-common-dir', 'forge', 'kernel.sqlite');
+		const driver = createBuiltinSQLiteDriver();
+
+		try {
+			await driver.exec('CREATE TABLE broker_config_probe (id INTEGER PRIMARY KEY);', { databasePath });
+		} finally {
+			driver.close();
+		}
+
+		expect(fs.existsSync(databasePath)).toBe(true);
+	});
+
+	test('fails clearly when the driver has no database path or broker config', async () => {
+		const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+		const driver = createBuiltinSQLiteDriver();
+
+		try {
+			await expect(driver.exec('SELECT 1;')).rejects.toThrow(/requires a databasePath/);
+		} finally {
+			driver.close();
+		}
+	});
+
 	test('can rerun real validation against the same database without leaving probe tables', async () => {
 		const { Database } = require('bun:sqlite');
 		const { validateBuiltinSQLiteRuntimeDriver } = require('../../lib/kernel/sqlite-driver');

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -99,6 +99,20 @@ describe('Kernel SQLite runtime driver selection', () => {
 		expect(fs.existsSync(result.backupPath)).toBe(true);
 	});
 
+	test('removes internally-created validation temp directories', async () => {
+		const { validateBuiltinSQLiteRuntimeDriver } = require('../../lib/kernel/sqlite-driver');
+		const before = new Set(
+			fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('forge-kernel-sqlite-')),
+		);
+
+		await validateBuiltinSQLiteRuntimeDriver();
+
+		const leaked = fs.readdirSync(os.tmpdir())
+			.filter((name) => name.startsWith('forge-kernel-sqlite-'))
+			.filter((name) => !before.has(name));
+		expect(leaked).toEqual([]);
+	});
+
 	test('creates parent directories for fresh file-backed broker databases', async () => {
 		const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
 		const databasePath = path.join(makeTempDir(), 'git-common-dir', 'forge', 'kernel.sqlite');

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -67,6 +67,23 @@ describe('Kernel SQLite runtime driver selection', () => {
 		});
 	});
 
+	test('rejects node:sqlite runtimes without backup support', () => {
+		const { selectBuiltinSQLiteRuntime } = require('../../lib/kernel/sqlite-driver');
+
+		expect(() => selectBuiltinSQLiteRuntime({
+			requireModule(name) {
+				if (name === 'node:sqlite') {
+					return {
+						DatabaseSync: function DatabaseSync() {},
+					};
+				}
+				const error = new Error(`Cannot find module ${name}`);
+				error.code = 'MODULE_NOT_FOUND';
+				throw error;
+			},
+		})).toThrow(/node:sqlite is present but does not expose backup/);
+	});
+
 	test('fails with a clear remediation when no builtin SQLite runtime exists', () => {
 		const { selectBuiltinSQLiteRuntime } = require('../../lib/kernel/sqlite-driver');
 

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -130,6 +130,31 @@ describe('Kernel SQLite runtime driver selection', () => {
 		expect(leaked).toEqual([]);
 	});
 
+	test('removes internally-created validation temp directories when database open fails', async () => {
+		const { validateBuiltinSQLiteRuntimeDriver } = require('../../lib/kernel/sqlite-driver');
+		const before = new Set(
+			fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('forge-kernel-sqlite-')),
+		);
+		const runtime = {
+			id: 'bun:sqlite',
+			module: {
+				Database: function Database() {
+					throw new Error('open failed');
+				},
+			},
+			databaseClassName: 'Database',
+			nativeCompileDependency: false,
+			experimental: false,
+		};
+
+		await expect(validateBuiltinSQLiteRuntimeDriver({ runtime })).rejects.toThrow(/open failed/);
+
+		const leaked = fs.readdirSync(os.tmpdir())
+			.filter((name) => name.startsWith('forge-kernel-sqlite-'))
+			.filter((name) => !before.has(name));
+		expect(leaked).toEqual([]);
+	});
+
 	test('creates parent directories for fresh file-backed broker databases', async () => {
 		const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
 		const databasePath = path.join(makeTempDir(), 'git-common-dir', 'forge', 'kernel.sqlite');

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -1,0 +1,101 @@
+const { afterEach, describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const tmpDirs = [];
+
+function makeTempDir() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-sqlite-'));
+	tmpDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	while (tmpDirs.length > 0) {
+		fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+	}
+});
+
+describe('Kernel SQLite runtime driver selection', () => {
+	test('selects the first builtin SQLite runtime without native package dependencies', () => {
+		const { selectBuiltinSQLiteRuntime } = require('../../lib/kernel/sqlite-driver');
+		const calls = [];
+
+		const selected = selectBuiltinSQLiteRuntime({
+			requireModule(name) {
+				calls.push(name);
+				if (name === 'bun:sqlite') {
+					return {
+						Database: function Database() {},
+					};
+				}
+				throw new Error(`unexpected module ${name}`);
+			},
+		});
+
+		expect(selected).toMatchObject({
+			id: 'bun:sqlite',
+			databaseClassName: 'Database',
+			nativeCompileDependency: false,
+			experimental: false,
+		});
+		expect(calls).toEqual(['bun:sqlite']);
+	});
+
+	test('falls back to node:sqlite when bun:sqlite is not available', () => {
+		const { selectBuiltinSQLiteRuntime } = require('../../lib/kernel/sqlite-driver');
+		const selected = selectBuiltinSQLiteRuntime({
+			requireModule(name) {
+				if (name === 'node:sqlite') {
+					return {
+						DatabaseSync: function DatabaseSync() {},
+						backup: async () => {},
+					};
+				}
+				const error = new Error(`Cannot find module ${name}`);
+				error.code = 'MODULE_NOT_FOUND';
+				throw error;
+			},
+		});
+
+		expect(selected).toMatchObject({
+			id: 'node:sqlite',
+			databaseClassName: 'DatabaseSync',
+			nativeCompileDependency: false,
+			experimental: true,
+		});
+	});
+
+	test('fails with a clear remediation when no builtin SQLite runtime exists', () => {
+		const { selectBuiltinSQLiteRuntime } = require('../../lib/kernel/sqlite-driver');
+
+		expect(() => selectBuiltinSQLiteRuntime({
+			requireModule(name) {
+				const error = new Error(`Cannot find module ${name}`);
+				error.code = 'MODULE_NOT_FOUND';
+				throw error;
+			},
+		})).toThrow(/Forge Kernel requires a builtin SQLite runtime/);
+	});
+
+	test('validates the real builtin driver against WAL, busy_timeout, checkpoint, backup, and FTS5', async () => {
+		const { validateBuiltinSQLiteRuntimeDriver } = require('../../lib/kernel/sqlite-driver');
+		const databasePath = path.join(makeTempDir(), 'kernel.sqlite');
+
+		const result = await validateBuiltinSQLiteRuntimeDriver({ databasePath });
+
+		expect(result.runtime.id).toBe('bun:sqlite');
+		expect(result.capabilities).toMatchObject({
+			wal: true,
+			busyTimeout: true,
+			transactions: true,
+			checkpoint: true,
+			backup: true,
+			fts5: true,
+			nativeCompileDependency: false,
+		});
+		expect(result.databasePath).toBe(databasePath);
+		expect(fs.existsSync(result.backupPath)).toBe(true);
+	});
+});

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -183,6 +183,22 @@ describe('Kernel SQLite runtime driver selection', () => {
 		expect(fs.existsSync(databasePath)).toBe(true);
 	});
 
+	test('rejects mismatched configured and broker database paths', async () => {
+		const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+		const driverDatabasePath = path.join(makeTempDir(), 'driver', 'kernel.sqlite');
+		const brokerDatabasePath = path.join(makeTempDir(), 'broker', 'kernel.sqlite');
+		const driver = createBuiltinSQLiteDriver({ databasePath: driverDatabasePath });
+
+		try {
+			await expect(driver.exec(
+				'CREATE TABLE broker_mismatch_probe (id INTEGER PRIMARY KEY);',
+				{ databasePath: brokerDatabasePath },
+			)).rejects.toThrow(/databasePath mismatch/);
+		} finally {
+			driver.close();
+		}
+	});
+
 	test('fails clearly when the driver has no database path or broker config', async () => {
 		const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
 		const driver = createBuiltinSQLiteDriver();

--- a/test/kernel/sqlite-driver.test.js
+++ b/test/kernel/sqlite-driver.test.js
@@ -99,6 +99,20 @@ describe('Kernel SQLite runtime driver selection', () => {
 		expect(fs.existsSync(result.backupPath)).toBe(true);
 	});
 
+	test('creates parent directories for fresh file-backed broker databases', async () => {
+		const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+		const databasePath = path.join(makeTempDir(), 'git-common-dir', 'forge', 'kernel.sqlite');
+		const driver = createBuiltinSQLiteDriver({ databasePath });
+
+		try {
+			await driver.exec('CREATE TABLE broker_directory_probe (id INTEGER PRIMARY KEY);');
+		} finally {
+			driver.close();
+		}
+
+		expect(fs.existsSync(databasePath)).toBe(true);
+	});
+
 	test('can rerun real validation against the same database without leaving probe tables', async () => {
 		const { Database } = require('bun:sqlite');
 		const { validateBuiltinSQLiteRuntimeDriver } = require('../../lib/kernel/sqlite-driver');


### PR DESCRIPTION
﻿## Problem
Forge Kernel local authority needs a real SQLite runtime driver path before later broker/concurrency work can make safety claims. The open roadmap requires builtin `bun:sqlite` and/or `node:sqlite` feature detection with no default native-compile dependency.

Dependency update: #205 merged on 2026-06-13 and this branch has been rebased onto its merge commit.

## Root Cause
The Kernel broker already accepted an injected SQLite-style driver and applied WAL/busy pragmas, but the repo did not have a real builtin runtime selector or conformance probe for WAL, busy timeout, transactions, checkpoint, backup, and FTS5 behavior.

## Fix
Add a narrow `lib/kernel/sqlite-driver.js` module that selects builtin SQLite runtimes in order: `bun:sqlite`, then `node:sqlite`. It exposes driver creation and a real conformance validator without adding a native SQLite dependency. Add focused tests for detection, fallback, clear failure behavior, and real `bun:sqlite` conformance on Windows.

## Value
This gives the Kernel implementation an evidence-backed runtime driver path while keeping later Kernel state, broker transaction, local contention, and Beads projection safety work out of this PR.

## Beads
Closes forge-2agy.9.5.7
Dependency #205 satisfied

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: 4 focused driver tests, 13 focused Kernel tests, 889 full-suite tests passing in `bun run check`
- Scenarios covered: builtin driver selection, `node:sqlite` fallback, no-driver failure message, real driver validation for WAL, `busy_timeout`, transactions, checkpoint, backup, and FTS5

### Security Review
- OWASP Top 10: no auth/data exposure changes; dependency posture unchanged because no native SQLite package was added
- Automated scan: `bun run check` reported one existing moderate `qs` advisory via `@stryker-mutator/core`; project gate treats moderate/low audit findings as non-blocking and completed successfully

### Design Doc
See: `docs/work/2026-06-06-kernel-backlog-memory-roadmap/plan.md`
See: `docs/work/2026-06-06-kernel-backlog-memory-roadmap/revised-safety-gates.md`
See: `docs/reference/FORGE_KERNEL_STORAGE_MODEL.md`

### Key Decisions
- Prefer builtin `bun:sqlite` when available because Forge validation runs under Bun and the roadmap accepted builtin SQLite runtime detection.
- Fall back to builtin `node:sqlite` when `bun:sqlite` is unavailable; `node:sqlite` is marked experimental in the runtime descriptor.
- Do not add `better-sqlite3`, `sqlite3`, or any other native-compile dependency as the default path.
- Keep broker transaction semantics and multi-process contention tests for follow-up Kernel issues.

### Documentation Updated
- `docs/reference/FORGE_KERNEL_STORAGE_MODEL.md` documents the selected builtin-runtime policy and required conformance capabilities.

### Validation
- [x] Type check passing (`bun run check`; project reports no TypeScript and skips)
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing (`bun run check`: 889 pass, 22 skip, 0 fail)
- [x] Security review completed (`bun run check` audit completed; existing moderate advisory non-blocking)

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bun run lint` via `bun run check` and pre-push)
- [x] All tests pass locally (`bun run check`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (or documented in migration guide)
- [x] TDD compliance: All source files have corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local mode now auto-selects a built-in SQLite runtime with fallback, lazy single-connection driver instances, and clearer errors when no runtime is available.
  * Runtime validation now verifies WAL, busy timeout, transactional behavior, checkpointing, backup persistence, and FTS5.

* **Bug Fixes**
  * Ensures temp directories and probe artifacts are cleaned up and validates backup persistence.

* **Documentation**
  * Added a SQLite Runtime Driver subsection to the storage model reference.

* **Tests**
  * Added comprehensive tests for selection, validation, filesystem behavior, and regression cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
