### PR TITLE
fix: exclude .claude/worktrees from WORKFLOW.md removal test collector

### DIFF
--- a/test/setup-workflow-removal.test.js
+++ b/test/setup-workflow-removal.test.js
@@ -27,7 +27,11 @@ const ACTIVE_SOURCE_PATHS = [
 function collectWorkflowReferences(rootDir) {
   const matches = [];
   const allowedExtensions = new Set(['.js', '.sh', '.md', '.json']);
-  const excludedDirs = new Set(['node_modules', '.worktrees', '.git']);
+  // Exclude both worktree container conventions: '.worktrees' (forge worktree
+  // create, at repo root) and 'worktrees' (Claude Code session worktrees under
+  // .claude/worktrees/). Stray worktrees hold full nested repo checkouts whose
+  // CHANGELOG/docs legitimately reference removed files and must not be scanned.
+  const excludedDirs = new Set(['node_modules', '.worktrees', 'worktrees', '.git']);
   const stack = ACTIVE_SOURCE_PATHS
     .map((relativePath) => path.join(rootDir, relativePath))
     .filter((absolutePath) => fs.existsSync(absolutePath));


### PR DESCRIPTION
## Summary

Hotfix for a false local-test failure. `test/setup-workflow-removal.test.js` walks the filesystem under `.claude` looking for live `WORKFLOW.md` references. Its `excludedDirs` set skipped `.worktrees` (the `forge worktree create` convention at repo root) but **not** `worktrees` — the directory name Claude Code uses for session worktrees under `.claude/worktrees/`.

A stray Claude Code worktree (`.claude/worktrees/<slug>/`) holds a full nested repo checkout (its own `CHANGELOG.md`, `docs/**`). The collector descended into it, matched `WORKFLOW.md`, and failed the local full suite + the pre-push test gate. CI never saw it because worktrees are gitignored, so this only bit local runs.

## Fix

Add `'worktrees'` to `excludedDirs` alongside `.worktrees`, with a comment documenting both conventions. Now stray Claude Code worktrees can't cause false failures.

## Testing

- `bun test test/setup-workflow-removal.test.js` → 5 pass, 0 fail
- `eslint . --max-warnings 0` → clean (via `forge push`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test helper to improve accuracy when scanning for workflow references by better handling directory exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->