### PR TITLE
fix(test): de-flake commitlint no-args exit-code test on Windows

### DIFF
--- a/scripts/commitlint.js
+++ b/scripts/commitlint.js
@@ -12,7 +12,9 @@ const isWindows = process.platform === 'win32';
 
 const commitMsgFile = process.argv[2];
 if (!commitMsgFile) {
-  console.error('❌ No commit message file provided');
+  // Write synchronously so the message is flushed before exit: on Windows the
+  // stderr pipe is async and process.exit() can otherwise truncate it.
+  require('node:fs').writeSync(2, '❌ No commit message file provided\n');
   process.exit(1);
 }
 

--- a/test/scripts/commitlint.test.js
+++ b/test/scripts/commitlint.test.js
@@ -57,7 +57,9 @@ function runWithNoArgs() {
     {
       cwd: PROJECT_ROOT,
       encoding: 'utf-8',
-      timeout: 10000,
+      // Generous timeout so a loaded CI runner can't kill the child early and
+      // surface a null exit status (matches runWithMessage's 30s).
+      timeout: 30000,
     }
   );
 }


### PR DESCRIPTION
## Problem
`scripts/commitlint.js > argument validation > exits with code 1 when no commit message file is provided` flaked on the **Windows / Node 22** CI shard while passing on every other shard (incl. Windows / Node 24) for the same commit — an `expect(received).toBe(expected)` on the child exit code.

## Root cause
Two Windows timing races:
1. `runWithNoArgs()` used a **10s** `spawnSync` timeout. Under a loaded Windows matrix runner the child could be killed at the timeout, returning a `null` exit status (≠ 1).
2. `scripts/commitlint.js` printed the no-args error via `console.error(...)` then `process.exit(1)`. On Windows the stderr pipe is async and `process.exit()` can truncate it (also flakes the sibling "prints error message" assertion).

## Fix
- Bump the no-args `spawnSync` timeout to **30s** (matches `runWithMessage()`), removing the timing race.
- Write the no-args error **synchronously** via `fs.writeSync(2, ...)` so it is flushed before exit.

## Verification
- 15 stress iterations of the no-args tests → 0 failures.
- Full `commitlint.test.js` suite → 32 pass.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for commit message validation to ensure error messages display properly across all environments and prevent potential truncation issues

* **Tests**
  * Updated test execution timeouts to improve continuous integration pipeline stability and prevent timeout-related failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->