### PR TITLE
ci: make Tests artifact-upload steps resilient to transient flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Upload matrix artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-full-matrix-${{ matrix.os }}-node${{ matrix.node-version }}
           path: test-results/
@@ -121,6 +122,7 @@ jobs:
       - name: Upload unit shard artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-unit-shard-${{ matrix.shard-index }}
           path: test-results/
@@ -159,6 +161,7 @@ jobs:
       - name: Upload Windows smoke artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-windows-smoke
           path: test-results/
@@ -197,6 +200,7 @@ jobs:
       - name: Upload macOS smoke artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-macos-smoke
           path: test-results/
@@ -312,6 +316,7 @@ jobs:
       - name: Upload followup artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-followup-${{ matrix.label }}
           path: test-results/
@@ -351,6 +356,7 @@ jobs:
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-coverage
           path: |
@@ -403,6 +409,7 @@ jobs:
       - name: Upload E2E artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-e2e
           path: test-results/
@@ -443,6 +450,7 @@ jobs:
       - name: Upload Beads integration artifacts
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: test-artifacts-beads-integration
           path: test-results/
@@ -472,6 +480,7 @@ jobs:
       - name: Upload mutation report
         uses: actions/upload-artifact@v7
         if: always()
+        continue-on-error: true
         with:
           name: mutation-report
           path: stryker-report/
@@ -495,6 +504,7 @@ jobs:
         run: node scripts/test-dashboard.js --profiles-dir test-results/downloaded
       - name: Upload dashboard
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: test-dashboard
           path: test-dashboard.json
@@ -525,6 +535,7 @@ jobs:
         run: node scripts/test-dashboard.js --profiles-dir test-results/downloaded
       - name: Upload dashboard
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: test-dashboard
           path: test-dashboard.json


### PR DESCRIPTION
## Problem
The **Tests** GitHub Actions workflow intermittently fails at artifact-upload steps (e.g. "Upload matrix artifacts") even when the test run reports **0 failures**. On master commit `695441b`, the `macos-latest` / Node 24 *Full Matrix* shard passed all tests but the artifact-upload step errored, marking the entire Tests gate red. This is a transient GitHub artifact-service / upload-action hiccup — not a code failure.

## Root Cause
The artifact-upload steps used `actions/upload-artifact@v7` with `if: always()` but no failure tolerance. A transient upload error therefore propagated as step failure → job failure → red Tests gate, despite the tests themselves passing.

## Fix
Add `continue-on-error: true` to all 11 `actions/upload-artifact@v7` steps in `.github/workflows/test.yml` (full-matrix, unit-shard, windows/macos smoke, followup, coverage, e2e, beads-integration, mutation report, and both dashboard uploads). A transient upload failure no longer fails the job or the gate. On success, uploads run exactly as before — `continue-on-error` only suppresses job failure when the upload step itself errors. The `@v7` pin is unchanged and no retry was added (upload-artifact has no native retry input), keeping the change minimal and scoped to upload resilience.

## Value
The Tests gate stops flaking red on transient artifact-service hiccups when the actual test run is green — removing false-negative gate failures and the manual re-run churn they cause. Successful uploads are unaffected, so artifacts remain available for the dashboard jobs.

## Beads
N/A — CI infrastructure hotfix; no Beads issue tracked for this change.

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Tests: **3641 passing** (full suite; 0 fail, 58 skip)
- Scenarios covered: `test/ci-workflow.test.js` asserts `actions/upload-artifact@v7` presence and workflow structure; the edited YAML was validated with a `js-yaml` parse (11 jobs intact) and a `continue-on-error` count of 11.

### Security Review
- OWASP Top 10: N/A — CI YAML configuration change only; no application code, inputs, or dependencies added.
- Automated scan: `bun audit` reports 4 pre-existing transitive dev-dependency advisories (3 moderate, 1 low — js-yaml via `@commitlint` / `@forge/skills`). These exist on master and are unrelated to this change.

### Design Doc
N/A — single-step CI resilience fix; no `/plan` design doc.

### Key Decisions
- Chose `continue-on-error: true` over a version bump/retry — it directly satisfies "a transient upload failure must not fail the gate" with the smallest diff.
- Applied to **all** upload-artifact steps, not just the matrix one — every job's upload carries the same flake risk, and any one of them failing turns the whole Tests gate red.
- Kept the `@v7` pin — already the repo standard; changing versions would widen scope unnecessarily.

### Documentation Updated
None — no doc-facing changes.

### Validation
- [x] Type check passing (no-op — no TypeScript in project)
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing (3641 pass / 0 fail)
- [x] Security review completed (pre-existing dep advisories only, unrelated to this change)

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff (11 `continue-on-error: true` insertions, one per upload-artifact step)
- [x] No debug code (console.log, commented code, temporary changes)
- [x] ESLint passes with zero warnings (`bunx eslint .`)
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes
- [x] TDD compliance: CI workflow change covered by `test/ci-workflow.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
