### PR TITLE
feat(hermes): add Hermes harness adapter consuming forge orient/recap

### DIFF
--- a/docs/reference/HERMES_INTEGRATION.md
+++ b/docs/reference/HERMES_INTEGRATION.md
@@ -42,9 +42,16 @@ from.
 ### What lives in Forge Kernel state
 
 Anything that is a **project fact**: issue records, decisions, evidence,
-design-snapshot content, ready queues, and active claims. These are emitted —
-bounded and cited — by `forge orient` and `forge recap`, and are written back
+design-snapshot content, ready queues, and active claims — all written back
 exclusively through Forge CLI commands.
+
+Not all of that state is surfaced by the bounded `forge orient` / `forge recap`
+envelope. Today the envelope emits the project design snapshot, active-work
+artifacts (`docs/work`), and — for `forge recap <issue-id>` — an issue summary;
+ready queue and active claims currently appear as forward-looking kernel
+placeholders. Issue **evidence/comments are not in the envelope** — read them
+from the issue record itself (e.g. `forge show <id>`). Treat orient/recap as the
+bounded entry point, not the exhaustive store.
 
 ### What lives in Hermes-native memory
 

--- a/docs/reference/HERMES_INTEGRATION.md
+++ b/docs/reference/HERMES_INTEGRATION.md
@@ -35,7 +35,7 @@ from.
 | **Scope** | The project — shared across all harnesses | One Hermes session / profile |
 | **Authority** | Source of truth | Convenience cache, never authoritative |
 | **Read path** | `forge orient` / `forge recap` (bounded, cited JSON) | Hermes' own store |
-| **Write path** | Forge CLI only (`forge audit`, `forge issue …`) | Hermes' own store |
+| **Write path** | Forge CLI only (`forge comment`, `forge update`) | Hermes' own store |
 | **Contains** | Issues, decisions, evidence, design snapshots, claims, queues | Prompts, session scratch, user preferences, Hermes profile data |
 | **Provenance** | Every fact carries `{ path, source_kind, authority, role }` | Not part of the Forge provenance graph |
 
@@ -65,9 +65,12 @@ silently choosing.
 Evidence and decisions discovered in a Hermes session flow back into the Forge
 Kernel **only** through Forge CLI commands:
 
-- `forge audit …` — append evidence to the kernel audit log.
-- `forge issue comment <id> …` — attach a decision or note to an issue.
-- `forge issue update <id> …` — update issue state.
+- `forge comment <id> <body...>` — attach evidence, a decision, or a note to an issue.
+- `forge update <id...> [flags]` — update issue state/fields.
+- `forge create [title] [flags]` — open a follow-up issue.
+
+(`forge audit` is verify-only — `forge audit verify` — and is not an
+evidence-append path; record evidence as an issue comment.)
 
 Because the write path and the read path share the same authority, anything
 Hermes writes through the CLI is exactly what a later `forge orient` /

--- a/docs/reference/HERMES_INTEGRATION.md
+++ b/docs/reference/HERMES_INTEGRATION.md
@@ -72,9 +72,13 @@ Kernel **only** through Forge CLI commands:
 (`forge audit` is verify-only — `forge audit verify` — and is not an
 evidence-append path; record evidence as an issue comment.)
 
-Because the write path and the read path share the same authority, anything
-Hermes writes through the CLI is exactly what a later `forge orient` /
-`forge recap` reads back, with full provenance intact.
+These writes land in the Forge Kernel issue store and become part of the issue's
+durable history. Note the read/write asymmetry: the bounded `forge orient` /
+`forge recap` envelope is assembled from project docs, `docs/work` artifacts, and
+the issue summary — it surfaces issue/design/decision state but does **not** echo
+individual issue comments back. Evidence added via `forge comment` lives in the
+issue history (reachable from the issue record), not necessarily in the next
+orient/recap payload.
 
 ## The no-profile-write guard
 

--- a/docs/reference/HERMES_INTEGRATION.md
+++ b/docs/reference/HERMES_INTEGRATION.md
@@ -97,10 +97,11 @@ Forge CLI so it becomes part of the shared, cited source of truth.
 
 ## Token-budget & truncation expectations
 
-`forge orient` / `forge recap` are deterministically bounded (default ~2000
-estimated tokens, `chars_per_token: 4`). Truncation follows the published
-`token_budget.truncation_order`, marks trimmed sections with
-`[truncated deterministically by token budget]`, and sets `truncated: true`.
+`forge orient` and `forge recap <issue-id>` emit the deterministically bounded
+envelope (default ~2000 estimated tokens, `chars_per_token: 4`). Truncation
+follows the published `token_budget.truncation_order`, marks trimmed sections
+with `[truncated deterministically by token budget]`, and sets `truncated: true`.
 Hermes treats truncated sections as incomplete and re-requests with a higher
-`--budget` when completeness matters. See the skill for the full envelope and
-provenance model.
+`--budget` when completeness matters. (Bare `forge recap` — no issue id —
+returns the legacy activity summary, which is not the bounded envelope.) See the
+skill for the full envelope and provenance model.

--- a/docs/reference/HERMES_INTEGRATION.md
+++ b/docs/reference/HERMES_INTEGRATION.md
@@ -1,0 +1,103 @@
+# Hermes Integration
+
+> Roadmap lane: `forge-2agy.9.7.x` (Hermes adapter)
+
+This document defines how the **Hermes** harness integrates with a Forge
+project, and — most importantly — the boundary between **Forge Kernel state**
+(shared, authoritative, cited) and **Hermes-native memory** (private to a Hermes
+session or profile).
+
+The consumption contract that Hermes sessions follow lives in
+[skills/hermes-forge/SKILL.md](../../skills/hermes-forge/SKILL.md). The storage
+model Hermes reads against is described in
+[FORGE_KERNEL_STORAGE_MODEL.md](FORGE_KERNEL_STORAGE_MODEL.md), and the
+writeback surface in
+[forge-kernel-issue-command-contract.md](forge-kernel-issue-command-contract.md).
+
+## Why a boundary is needed
+
+Hermes carries its own conversational/profile memory. Forge carries the
+project's durable, provenance-tracked state. If Hermes were allowed to write its
+private memory into Forge state, the two would drift: Forge would accumulate
+Hermes-specific context that other harnesses (Claude Code, Codex, Cursor) cannot
+interpret, and the "single source of truth" guarantee behind `forge orient` /
+`forge recap` would erode.
+
+The integration therefore makes Forge state the authority and Hermes a
+**consumer** that writes back only through the same audited CLI surface it reads
+from.
+
+## The two memory tiers
+
+| | Forge Kernel state | Hermes-native memory |
+| --- | --- | --- |
+| **Owner** | Forge | Hermes |
+| **Scope** | The project — shared across all harnesses | One Hermes session / profile |
+| **Authority** | Source of truth | Convenience cache, never authoritative |
+| **Read path** | `forge orient` / `forge recap` (bounded, cited JSON) | Hermes' own store |
+| **Write path** | Forge CLI only (`forge audit`, `forge issue …`) | Hermes' own store |
+| **Contains** | Issues, decisions, evidence, design snapshots, claims, queues | Prompts, session scratch, user preferences, Hermes profile data |
+| **Provenance** | Every fact carries `{ path, source_kind, authority, role }` | Not part of the Forge provenance graph |
+
+### What lives in Forge Kernel state
+
+Anything that is a **project fact**: issue records, decisions, evidence,
+design-snapshot content, ready queues, and active claims. These are emitted —
+bounded and cited — by `forge orient` and `forge recap`, and are written back
+exclusively through Forge CLI commands.
+
+### What lives in Hermes-native memory
+
+Anything that only matters to **Hermes**: conversational history, session
+scratchpads, per-user preferences, and the Hermes profile itself. None of this
+belongs in Forge Kernel state.
+
+## Authority rule
+
+Forge Kernel state is the single source of truth. When Hermes needs project
+state it MUST obtain it from `forge orient` / `forge recap` (JSON form) rather
+than reconstructing it from raw files or kernel internals. When two sources
+conflict, prefer the higher `authority` and surface the conflict instead of
+silently choosing.
+
+## Writeback rule
+
+Evidence and decisions discovered in a Hermes session flow back into the Forge
+Kernel **only** through Forge CLI commands:
+
+- `forge audit …` — append evidence to the kernel audit log.
+- `forge issue comment <id> …` — attach a decision or note to an issue.
+- `forge issue update <id> …` — update issue state.
+
+Because the write path and the read path share the same authority, anything
+Hermes writes through the CLI is exactly what a later `forge orient` /
+`forge recap` reads back, with full provenance intact.
+
+## The no-profile-write guard
+
+The hard boundary, enforced as a contract in the `hermes-forge` skill and
+guarded by tests:
+
+> **Hermes MUST NOT write Hermes profile state into Forge Kernel state.**
+
+Concretely, a Hermes session must never:
+
+- Persist Hermes profile or session memory into Forge Kernel storage.
+- Edit Forge state files (design, decision, issue stores) directly to record
+  Hermes-side context.
+- Use the Forge issue/evidence backend as a dumping ground for
+  Hermes-only data.
+
+If a piece of context only matters to Hermes, it stays in Hermes-native memory.
+If it is a project fact, decision, or evidence item, it is written through the
+Forge CLI so it becomes part of the shared, cited source of truth.
+
+## Token-budget & truncation expectations
+
+`forge orient` / `forge recap` are deterministically bounded (default ~2000
+estimated tokens, `chars_per_token: 4`). Truncation follows the published
+`token_budget.truncation_order`, marks trimmed sections with
+`[truncated deterministically by token budget]`, and sets `truncated: true`.
+Hermes treats truncated sections as incomplete and re-requests with a higher
+`--budget` when completeness matters. See the skill for the full envelope and
+provenance model.

--- a/lib/agents/hermes.plugin.json
+++ b/lib/agents/hermes.plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "hermes",
+  "name": "Hermes",
+  "version": "1.0.0",
+  "description": "Hermes harness adapter — consumes Forge project state through the forge orient / forge recap CLI surface and treats the Forge Kernel as the single source of truth.",
+  "capabilities": {
+    "skills": true
+  },
+  "directories": {
+    "skills": ".hermes/skills/forge-workflow"
+  },
+  "files": {
+    "skillDefinition": ".hermes/skills/forge-workflow/SKILL.md"
+  },
+  "setup": {
+    "createSkill": true
+  },
+  "support": {
+    "status": "supported",
+    "surface": "hybrid",
+    "install": {
+      "required": false
+    }
+  }
+}

--- a/lib/agents/hermes.plugin.json
+++ b/lib/agents/hermes.plugin.json
@@ -7,13 +7,10 @@
     "skills": true
   },
   "directories": {
-    "skills": ".hermes/skills/forge-workflow"
+    "skills": ".hermes/skills"
   },
   "files": {
-    "skillDefinition": ".hermes/skills/forge-workflow/SKILL.md"
-  },
-  "setup": {
-    "createSkill": true
+    "skillDefinition": ".hermes/skills/hermes-forge/SKILL.md"
   },
   "support": {
     "status": "supported",

--- a/packages/skills/src/commands/sync.js
+++ b/packages/skills/src/commands/sync.js
@@ -31,7 +31,7 @@ export async function syncCommand(options) {
     const enabledAgents = detectAgents();
     if (enabledAgents.length === 0) {
       console.log(chalk.yellow('No agents detected'));
-      console.log(chalk.gray('Supported: claude (.claude), codex (.codex), cursor (.cursor)'));
+      console.log(chalk.gray('Supported: claude (.claude), codex (.codex), cursor (.cursor), hermes (.hermes)'));
       return;
     }
 

--- a/packages/skills/src/lib/agents.js
+++ b/packages/skills/src/lib/agents.js
@@ -12,7 +12,7 @@ import { join } from 'node:path';
  *
  * All agents are enabled: true — directory existence already gates syncing.
  *
- * Forge currently supports Claude Code, Codex, and Cursor.
+ * Forge currently supports Claude Code, Codex, Cursor, and Hermes.
  * Dropped agents: aider, antigravity, cline, continue, github-copilot,
  * kilocode, opencode, roo, windsurf
  */
@@ -20,6 +20,7 @@ const AGENT_DEFINITIONS = [
   { name: 'claude',      directory: '.claude',   description: 'Claude Code (Anthropic)',   enabled: true },
   { name: 'codex',       directory: '.codex',    description: 'Codex CLI (OpenAI)',        enabled: true },
   { name: 'cursor',      directory: '.cursor',   description: 'Cursor AI Code Editor',     enabled: true },
+  { name: 'hermes',      directory: '.hermes',   description: 'Hermes harness',            enabled: true },
 ];
 
 /**

--- a/packages/skills/test/agents.test.js
+++ b/packages/skills/test/agents.test.js
@@ -69,19 +69,32 @@ describe('Agent Detection', () => {
     expect(agents[0].enabled).toBe(true);
   });
 
+  test('detectAgents finds Hermes agent', () => {
+    mkdirSync('.hermes', { recursive: true });
+
+    const agents = detectAgents();
+
+    expect(agents.length).toBe(1);
+    expect(agents[0].name).toBe('hermes');
+    expect(agents[0].path).toBe('.hermes/skills');
+    expect(agents[0].enabled).toBe(true);
+  });
+
   test('detectAgents finds multiple agents', () => {
     mkdirSync('.cursor', { recursive: true });
     mkdirSync('.claude', { recursive: true });
     mkdirSync('.codex', { recursive: true });
+    mkdirSync('.hermes', { recursive: true });
 
     const agents = detectAgents();
 
-    expect(agents.length).toBe(3);
+    expect(agents.length).toBe(4);
 
     const agentNames = agents.map(a => a.name);
     expect(agentNames).toContain('cursor');
     expect(agentNames).toContain('claude');
     expect(agentNames).toContain('codex');
+    expect(agentNames).toContain('hermes');
   });
 
   test('detectAgents returns agents in consistent order', () => {

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -109,14 +109,16 @@ section as exhaustive; if completeness matters, re-request with a higher
 Evidence and decisions discovered during a Hermes session flow back into the
 Forge Kernel **only** through Forge CLI commands — the same authority that
 orient/recap read from. Use the issue command surface documented in
-[docs/reference/forge-kernel-issue-command-contract.md](../../docs/reference/forge-kernel-issue-command-contract.md)
-and the evidence/audit command:
+[docs/reference/forge-kernel-issue-command-contract.md](../../docs/reference/forge-kernel-issue-command-contract.md):
 
 ```bash
-forge audit ...                # append evidence to the kernel audit log
-forge issue comment <id> ...   # attach a decision/comment to an issue
-forge issue update <id> ...    # update issue state
+forge comment <id> <body...>   # attach evidence, a decision, or a note to an issue
+forge update <id...> [flags]   # update issue state/fields
+forge create [title] [flags]   # open a new issue for follow-up work
 ```
+
+> Note: `forge audit` is verify-only (`forge audit verify`) and does **not**
+> append evidence — record evidence as an issue comment via `forge comment`.
 
 This keeps the read model and the write model consistent: what Hermes writes
 through the CLI is exactly what a later `forge orient` / `forge recap` will read
@@ -130,7 +132,7 @@ into design/decision files, not into the issue backend. Hermes-native memory
 stays in Hermes' own store.
 
 - ✅ Read state via `forge orient` / `forge recap`.
-- ✅ Write evidence/decisions via `forge audit` / `forge issue …`.
+- ✅ Write evidence/decisions via `forge comment` / `forge update`.
 - ❌ Never persist Hermes profile/session memory into Forge Kernel state.
 - ❌ Never edit Forge state files directly to record Hermes-side context.
 

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -110,8 +110,14 @@ whole payload.
 
 Truncation is deterministic, never random:
 
-- Preserved sections are kept whole. Non-preserved sections are trimmed first,
-  in the published `token_budget.truncation_order`.
+- Non-preserved sections are allocated budget in ascending numeric `priority`
+  order (lower `priority` first); when the budget is exhausted, the
+  later/higher-`priority` sections are the ones trimmed. Preserved sections are
+  kept whole and trimmed only as a last resort if the payload is still over
+  budget. The authoritative per-section signal is each section's `truncated`
+  flag plus its `priority`/`estimated_tokens` — not the nominal
+  `token_budget.truncation_order` list, which is a static hint and may not match
+  the priority-driven trim order.
 - A trimmed section ends with the literal marker
   `[truncated deterministically by token budget]` and has `truncated: true`.
 - `token_budget.truncated === true` means the payload as a whole was trimmed.

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -7,7 +7,7 @@ description: >
   deterministic truncation policy, and write evidence or decisions back ONLY
   through Forge CLI commands. Hermes-native profile memory never leaks into
   Forge Kernel state.
-compatibility: Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Read-only orientation works anywhere; writeback requires a Forge Kernel issue backend. CLI-only — no direct file or profile writes into Forge state.
+compatibility: Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Install path — like every Forge skill pack (e.g. parallel-deep-research, sonarcloud-analysis) this is delivered by the unified Skills CLI: run `skills sync` to install it into `.hermes/skills/hermes-forge/`. (`forge setup` initializes the skills registry via `skills init` but does not sync packs to agents.) Read-only orientation works anywhere; writeback requires a Forge Kernel issue backend. CLI-only — no direct file or profile writes into Forge state.
 metadata:
   author: forge
   version: "1.0.0"

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: hermes-forge
+description: >
+  Consumption contract for the Hermes harness on a Forge project. Treat
+  `forge orient` and `forge recap` as the authoritative, token-bounded source
+  of project state, cite every surfaced fact by its provenance, honor the
+  deterministic truncation policy, and write evidence or decisions back ONLY
+  through Forge CLI commands. Hermes-native profile memory never leaks into
+  Forge Kernel state.
+compatibility: Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Read-only orientation works anywhere; writeback requires a Forge Kernel issue backend. CLI-only — no direct file or profile writes into Forge state.
+metadata:
+  author: forge
+  version: "1.0.0"
+  roadmap: forge-2agy.9.7.x
+---
+
+# Hermes ⇄ Forge consumption contract
+
+Hermes is a *consumer* of Forge project state, not an owner of it. This skill
+defines how a Hermes session reads, cites, and writes back to a Forge project
+without ever becoming a second source of truth.
+
+The boundary between what Forge owns and what Hermes owns is specified in
+[docs/reference/HERMES_INTEGRATION.md](../../docs/reference/HERMES_INTEGRATION.md).
+
+## When to use
+
+- At the start of any Hermes session on a Forge repo (orientation).
+- Before acting on a specific issue (issue recap).
+- Whenever you need current project state — never reconstruct it from raw files.
+
+## Authority: orient / recap are the only state source
+
+The Forge Kernel is the single source of truth. Hermes obtains project state
+**exclusively** through two thin CLI wrappers and must not infer state by
+reading `.beads`-style stores, design files, or kernel internals directly:
+
+```bash
+forge orient --json            # bounded project orientation
+forge orient --budget 4000 --json
+forge recap --json             # recent work / evidence / review outcomes
+forge recap <issue-id> --json  # per-issue recap
+```
+
+Both emit a deterministic JSON envelope (assembly
+`deterministic-file-assembly-v1`). Parse the JSON; do not screen-scrape the
+human text form.
+
+### Envelope shape
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Contract version (currently `1`). Reject unknown majors. |
+| `kind` | `orientation`, `issue_recap`, or `prime`. |
+| `generated_at` | Assembly timestamp. |
+| `assembly` | `deterministic-file-assembly-v1` — same inputs ⇒ same output. |
+| `token_budget` | Budget accounting (see below). |
+| `sections[]` | Ordered content blocks, each independently cited. |
+| `sources[]` | Deduplicated provenance across all sections. |
+| `next_commands[]` | Suggested follow-up `forge` commands. Prefer these for navigation. |
+
+Each `sections[]` entry: `{ id, title, content, sources, truncated, estimated_tokens }`.
+
+## Token budget
+
+`forge orient` / `forge recap` are bounded so they fit a context window
+deterministically.
+
+- Default budget: **2000** estimated tokens. Minimum honored: **40**.
+- Estimation is approximate: `token_budget.approximate === true`,
+  `token_budget.chars_per_token === 4`.
+- `token_budget.requested` is what you asked for; `token_budget.used` is the
+  estimate actually emitted.
+- Raise the ceiling with `--budget N` when you need more depth; do not retry
+  blindly — request a specific larger budget.
+
+## Citation & provenance model
+
+Every fact Hermes surfaces to a user MUST be attributable. Each section carries
+`sources: [{ path, source_kind, authority, role }]`:
+
+- `path` — the file the content came from.
+- `source_kind` — the kind of artifact (e.g. design, decision, claim, queue).
+- `authority` — how authoritative the source is. Prefer higher-authority
+  sources when two sources conflict; surface the conflict rather than silently
+  picking one.
+- `role` — the role the source plays in the section.
+
+When Hermes states a project fact, cite at least the `path` and `authority` of
+the backing source. The top-level `sources[]` is the deduplicated set for the
+whole payload.
+
+## Truncation policy
+
+Truncation is deterministic, never random:
+
+- Preserved sections are kept whole. Non-preserved sections are trimmed first,
+  in the published `token_budget.truncation_order`.
+- A trimmed section ends with the literal marker
+  `[truncated deterministically by token budget]` and has `truncated: true`.
+- `token_budget.truncated === true` means the payload as a whole was trimmed.
+
+Treat any `truncated` section as **incomplete**. Do not present a truncated
+section as exhaustive; if completeness matters, re-request with a higher
+`--budget` or recap the specific issue.
+
+## Writeback path: Hermes → Forge Kernel
+
+Evidence and decisions discovered during a Hermes session flow back into the
+Forge Kernel **only** through Forge CLI commands — the same authority that
+orient/recap read from. Use the issue command surface documented in
+[docs/reference/forge-kernel-issue-command-contract.md](../../docs/reference/forge-kernel-issue-command-contract.md)
+and the evidence/audit command:
+
+```bash
+forge audit ...                # append evidence to the kernel audit log
+forge issue comment <id> ...   # attach a decision/comment to an issue
+forge issue update <id> ...    # update issue state
+```
+
+This keeps the read model and the write model consistent: what Hermes writes
+through the CLI is exactly what a later `forge orient` / `forge recap` will read
+back, with full provenance.
+
+## No-profile-write guard (hard boundary)
+
+Hermes **MUST NOT write Hermes profile** state, conversation memory, or any
+Hermes-native artifact into Forge Kernel state — not into kernel storage, not
+into design/decision files, not into the issue backend. Hermes-native memory
+stays in Hermes' own store.
+
+- ✅ Read state via `forge orient` / `forge recap`.
+- ✅ Write evidence/decisions via `forge audit` / `forge issue …`.
+- ❌ Never persist Hermes profile/session memory into Forge Kernel state.
+- ❌ Never edit Forge state files directly to record Hermes-side context.
+
+If a piece of context only matters to Hermes, it belongs in Hermes-native
+memory. If it is a project fact, decision, or evidence item, write it through
+the Forge CLI so it becomes part of the shared, cited source of truth.

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -28,8 +28,10 @@ Hermes is a *consumer* of Forge project state, not an owner of it. This skill
 defines how a Hermes session reads, cites, and writes back to a Forge project
 without ever becoming a second source of truth.
 
-The boundary between what Forge owns and what Hermes owns is specified in
-[docs/reference/HERMES_INTEGRATION.md](../../docs/reference/HERMES_INTEGRATION.md).
+The boundary between what Forge owns and what Hermes owns is specified in the
+Forge repo at `docs/reference/HERMES_INTEGRATION.md` (repo-relative path — this
+skill is synced to `.hermes/skills/hermes-forge/`, so relative links would not
+resolve from the installed location).
 
 ## When to use
 
@@ -121,9 +123,9 @@ section as exhaustive; if completeness matters, re-request with a higher
 ## Writeback path: Hermes → Forge Kernel
 
 Evidence and decisions discovered during a Hermes session flow back into the
-Forge Kernel **only** through Forge CLI commands — the same authority that
-orient/recap read from. Use the issue command surface documented in
-[docs/reference/forge-kernel-issue-command-contract.md](../../docs/reference/forge-kernel-issue-command-contract.md):
+Forge Kernel **only** through Forge CLI commands. Use the issue command surface
+documented in the Forge repo at
+`docs/reference/forge-kernel-issue-command-contract.md`:
 
 ```bash
 forge comment <id> <body...>   # attach evidence, a decision, or a note to an issue
@@ -134,9 +136,14 @@ forge create [title] [flags]   # open a new issue for follow-up work
 > Note: `forge audit` is verify-only (`forge audit verify`) and does **not**
 > append evidence — record evidence as an issue comment via `forge comment`.
 
-This keeps the read model and the write model consistent: what Hermes writes
-through the CLI is exactly what a later `forge orient` / `forge recap` will read
-back, with full provenance.
+These writes land in the Forge Kernel issue store, where they become part of the
+issue's durable history (view them via the issue itself, e.g. `forge show <id>`).
+Note the read/write asymmetry: the bounded `forge orient` / `forge recap`
+envelope is assembled from project docs, `docs/work` artifacts, and the issue
+summary — it surfaces issue/design/decision state but does **not** echo
+individual issue comments back. Do not assume evidence added via `forge comment`
+reappears verbatim in the next orient/recap payload; it lives in the issue
+history, reachable from the issue record.
 
 ## No-profile-write guard (hard boundary)
 

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -36,15 +36,21 @@ The Forge Kernel is the single source of truth. Hermes obtains project state
 reading `.beads`-style stores, design files, or kernel internals directly:
 
 ```bash
-forge orient --json            # bounded project orientation
+forge orient --json                # bounded project orientation (envelope)
 forge orient --budget 4000 --json
-forge recap --json             # recent work / evidence / review outcomes
-forge recap <issue-id> --json  # per-issue recap
+forge recap <issue-id> --json      # bounded per-issue recap (envelope)
+forge recap --json                 # legacy activity summary (NOT the envelope)
 ```
 
-Both emit a deterministic JSON envelope (assembly
-`deterministic-file-assembly-v1`). Parse the JSON; do not screen-scrape the
-human text form.
+`forge orient` and `forge recap <issue-id>` emit the deterministic JSON envelope
+described below (assembly `deterministic-file-assembly-v1`). Parse the JSON; do
+not screen-scrape the human text form.
+
+> Note: bare `forge recap --json` (no issue id) returns the legacy activity
+> summary (`generatedAt`, `issueSummary`, `reviewOutcomes`, `recentIssues`,
+> `insights`) — it does **not** carry `schema_version`, `sections`,
+> `token_budget`, or `assembly`. For the envelope contract, use `forge orient`
+> or `forge recap <issue-id>`.
 
 ### Envelope shape
 
@@ -63,8 +69,8 @@ Each `sections[]` entry: `{ id, title, content, sources, truncated, estimated_to
 
 ## Token budget
 
-`forge orient` / `forge recap` are bounded so they fit a context window
-deterministically.
+`forge orient` / `forge recap <issue-id>` are bounded so they fit a context
+window deterministically.
 
 - Default budget: **2000** estimated tokens. Minimum honored: **40**.
 - Estimation is approximate: `token_budget.approximate === true`,

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -7,7 +7,15 @@ description: >
   deterministic truncation policy, and write evidence or decisions back ONLY
   through Forge CLI commands. Hermes-native profile memory never leaks into
   Forge Kernel state.
-compatibility: Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Install path — like every Forge skill pack (e.g. parallel-deep-research, sonarcloud-analysis) this is delivered by the unified Skills CLI: run `skills sync` to install it into `.hermes/skills/hermes-forge/`. (`forge setup` initializes the skills registry via `skills init` but does not sync packs to agents.) Read-only orientation works anywhere; writeback requires a Forge Kernel issue backend. CLI-only — no direct file or profile writes into Forge state.
+compatibility: >
+  Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Install
+  path — like every Forge skill pack (e.g. parallel-deep-research,
+  sonarcloud-analysis) this is delivered by the unified Skills CLI; run
+  `skills sync` to install it into `.hermes/skills/hermes-forge/`. (`forge setup`
+  initializes the skills registry via `skills init` but does not sync packs to
+  agents.) Read-only orientation works anywhere; writeback requires a Forge
+  Kernel issue backend. CLI-only — no direct file or profile writes into Forge
+  state.
 metadata:
   author: forge
   version: "1.0.0"

--- a/test/beads-setup.test.js
+++ b/test/beads-setup.test.js
@@ -159,6 +159,49 @@ describe('writeBeadsGitignore', () => {
 // ---------------------------------------------------------------------------
 describe('ensureBeadsGitExclude', () => {
   let tmpDir;
+  let gitHome;
+  let savedGitEnv;
+
+  // These tests exercise the real `git` plumbing in `ensureBeadsGitExclude`, so
+  // each one spawns several git subprocesses (init/add here, plus the rev-parse,
+  // ls-files and rm --cached the function shells out to — each prefixed by a
+  // `where`/`which` lookup inside secureExecFileSync). On Windows under
+  // full-suite load that runs 5-8s per test, which intermittently blew bun's
+  // per-test timeout and produced nondeterministic timeout failures across the
+  // whole block (not just the two `git init` tests). The default per-test
+  // timeout is 5000ms: bunfig.toml's `timeout` is NOT honored, so any run that
+  // does not pass `--timeout` on the CLI (e.g. a plain `bun test`) uses 5000ms.
+  //
+  // Primary fix: an explicit, generous per-test timeout (GIT_TEST_TIMEOUT_MS,
+  // applied as the 3rd arg to each test) that overrides the suite default no
+  // matter how `bun test` is invoked.
+  const GIT_TEST_TIMEOUT_MS = 30000;
+
+  // Secondary measure: run every git invocation hermetically. The tests (and
+  // `ensureBeadsGitExclude`, which inherits process.env) otherwise read the
+  // developer's shared global/system git config and any inherited GIT_* repo
+  // pointers. Pointing HOME/global config at a per-test temp dir, skipping
+  // system config, and scrubbing GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE removes
+  // that shared-state dependency so timing and behavior stay consistent.
+  //
+  // Mutating process.env here is safe: this suite runs sequentially (no
+  // concurrentTestGlob match), and afterEach restores the prior values exactly.
+  const GIT_ENV_KEYS = [
+    'HOME',
+    'USERPROFILE',
+    'GIT_CONFIG_GLOBAL',
+    'GIT_CONFIG_SYSTEM',
+    'GIT_CONFIG_NOSYSTEM',
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_TERMINAL_PROMPT',
+    'GIT_AUTHOR_NAME',
+    'GIT_AUTHOR_EMAIL',
+    'GIT_COMMITTER_NAME',
+    'GIT_COMMITTER_EMAIL'
+  ];
+
   function gitInTmp(args, options = {}) {
     return execFileSync('git', [
       '-c',
@@ -175,9 +218,52 @@ describe('ensureBeadsGitExclude', () => {
   beforeEach(() => {
     tmpDir = makeTmpDir();
     fs.mkdirSync(path.join(tmpDir, '.git', 'info'), { recursive: true });
+
+    // Per-test isolated HOME with a minimal, deterministic global git config so
+    // no git subprocess reads or contends on the shared developer/system config.
+    gitHome = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-setup-home-'));
+    const globalConfig = path.join(gitHome, '.gitconfig');
+    fs.writeFileSync(
+      globalConfig,
+      '[user]\n'
+        + '\tname = Forge Test\n'
+        + '\temail = forge-test@example.invalid\n'
+        + '[init]\n'
+        + '\tdefaultBranch = main\n',
+      'utf8'
+    );
+
+    savedGitEnv = {};
+    for (const key of GIT_ENV_KEYS) {
+      savedGitEnv[key] = process.env[key];
+    }
+
+    process.env.HOME = gitHome;
+    process.env.USERPROFILE = gitHome;
+    process.env.GIT_CONFIG_GLOBAL = globalConfig;
+    process.env.GIT_CONFIG_NOSYSTEM = '1';
+    delete process.env.GIT_CONFIG_SYSTEM;
+    delete process.env.GIT_DIR;
+    delete process.env.GIT_WORK_TREE;
+    delete process.env.GIT_INDEX_FILE;
+    process.env.GIT_TERMINAL_PROMPT = '0';
+    process.env.GIT_AUTHOR_NAME = 'Forge Test';
+    process.env.GIT_AUTHOR_EMAIL = 'forge-test@example.invalid';
+    process.env.GIT_COMMITTER_NAME = 'Forge Test';
+    process.env.GIT_COMMITTER_EMAIL = 'forge-test@example.invalid';
   });
   afterEach(() => {
+    for (const key of GIT_ENV_KEYS) {
+      if (savedGitEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedGitEnv[key];
+      }
+    }
     rmrf(tmpDir);
+    if (gitHome) {
+      rmrf(gitHome);
+    }
   });
 
   test('adds local exclude rules for Beads state without touching tracked ignore files', () => {
@@ -191,7 +277,7 @@ describe('ensureBeadsGitExclude', () => {
     expect(content).toContain('.dolt/');
     expect(content).toContain('.beads-credential-key');
     expect(fs.existsSync(path.join(tmpDir, '.gitignore'))).toBe(false);
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 
   test('is idempotent when local exclude rules already exist', () => {
     ensureBeadsGitExclude(tmpDir);
@@ -202,7 +288,7 @@ describe('ensureBeadsGitExclude', () => {
 
     expect(content.match(/# Forge local Beads state/g)).toHaveLength(1);
     expect(content.match(/\.beads\//g)).toHaveLength(1);
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 
   test('untracks previously committed Beads state without deleting local files', () => {
     gitInTmp(['init'], { stdio: 'pipe' });
@@ -218,7 +304,7 @@ describe('ensureBeadsGitExclude', () => {
     expect(fs.readFileSync(beadsFile, 'utf8')).toBe('{"id":"forge-test"}\n');
     expect(gitInTmp(['ls-files', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
     expect(gitInTmp(['status', '--short', '--', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 
   test('untracks staged Beads state even when the working file diverged', () => {
     gitInTmp(['init'], { stdio: 'pipe' });
@@ -233,7 +319,7 @@ describe('ensureBeadsGitExclude', () => {
     expect(fs.readFileSync(beadsFile, 'utf8')).toBe('{"id":"working"}\n');
     expect(gitInTmp(['ls-files', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
     expect(gitInTmp(['status', '--short', '--', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 });
 
 // ---------------------------------------------------------------------------

--- a/test/plugin-manager.test.js
+++ b/test/plugin-manager.test.js
@@ -12,11 +12,12 @@ describe("plugin-manager supported agent catalog", () => {
     .filter((file) => file.endsWith(".plugin.json"))
     .sort();
 
-  it("contains exactly the supported harness catalogs (claude, codex, cursor)", () => {
+  it("contains exactly the supported harness catalogs (claude, codex, cursor, hermes)", () => {
     expect(catalogFiles).toEqual([
       "claude.plugin.json",
       "codex.plugin.json",
       "cursor.plugin.json",
+      "hermes.plugin.json",
     ]);
   });
 

--- a/test/plugins/hermes-plugin.test.js
+++ b/test/plugins/hermes-plugin.test.js
@@ -1,0 +1,103 @@
+/**
+ * Hermes adapter lane (roadmap forge-2agy.9.7.x).
+ *
+ * Hermes is a harness that consumes Forge project state through the
+ * `forge orient` / `forge recap` CLI surface. It is intentionally NOT a
+ * command-sync target (no entry in scripts/sync-commands AGENT_ADAPTERS), so
+ * its plugin manifest must declare skills wiring WITHOUT declaring
+ * `capabilities.commands` — otherwise scripts/check-agents.js fails because
+ * there is no Forge sync adapter for it.
+ *
+ * These tests lock that contract plus the consumption-skill invariants
+ * (orient/recap as authority, no direct Forge-state profile writes).
+ */
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { validatePluginSchema } = require('../../lib/plugin-manager');
+const { checkAgents } = require('../../scripts/check-agents');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const pluginPath = path.join(repoRoot, 'lib', 'agents', 'hermes.plugin.json');
+const skillPath = path.join(repoRoot, 'skills', 'hermes-forge', 'SKILL.md');
+const integrationDocPath = path.join(repoRoot, 'docs', 'reference', 'HERMES_INTEGRATION.md');
+
+function loadHermesPlugin() {
+  return JSON.parse(fs.readFileSync(pluginPath, 'utf8'));
+}
+
+describe('hermes.plugin.json — manifest contract', () => {
+  test('manifest exists and parses as JSON', () => {
+    expect(fs.existsSync(pluginPath)).toBe(true);
+    expect(loadHermesPlugin()).toBeTruthy();
+  });
+
+  test('declares the hermes identity', () => {
+    const plugin = loadHermesPlugin();
+    expect(plugin.id).toBe('hermes');
+    expect(typeof plugin.name).toBe('string');
+    expect(typeof plugin.version).toBe('string');
+  });
+
+  test('does NOT declare commands capability (no Forge sync adapter exists)', () => {
+    const plugin = loadHermesPlugin();
+    expect(plugin.capabilities.commands).toBeFalsy();
+  });
+
+  test('wires a skills directory for the consumption skill', () => {
+    const plugin = loadHermesPlugin();
+    expect(plugin.capabilities.skills).toBe(true);
+    expect(typeof plugin.directories.skills).toBe('string');
+    expect(plugin.directories.skills.length).toBeGreaterThan(0);
+  });
+
+  test('declares a valid support status and surface', () => {
+    const plugin = loadHermesPlugin();
+    expect(['first-class', 'supported', 'compatibility']).toContain(plugin.support.status);
+    expect(typeof plugin.support.surface).toBe('string');
+  });
+
+  test('passes validatePluginSchema with no errors', () => {
+    const result = validatePluginSchema(loadHermesPlugin());
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  test('introduces no agent-parity errors in checkAgents', () => {
+    const { errors } = checkAgents(repoRoot);
+    const hermesErrors = errors.filter((error) => /hermes/i.test(error));
+    expect(hermesErrors).toEqual([]);
+  });
+});
+
+describe('skills/hermes-forge/SKILL.md — consumption contract', () => {
+  test('skill template exists with hermes-forge frontmatter', () => {
+    expect(fs.existsSync(skillPath)).toBe(true);
+    const body = fs.readFileSync(skillPath, 'utf8');
+    expect(body.startsWith('---')).toBe(true);
+    expect(body).toContain('name: hermes-forge');
+  });
+
+  test('treats forge orient / forge recap as project-state authority', () => {
+    const body = fs.readFileSync(skillPath, 'utf8');
+    expect(body).toContain('forge orient');
+    expect(body).toContain('forge recap');
+  });
+
+  test('forbids writing Hermes-native profile state into Forge state', () => {
+    const body = fs.readFileSync(skillPath, 'utf8');
+    // Stable invariant phrase — guards the no-profile-write boundary.
+    expect(body).toContain('MUST NOT write Hermes profile');
+  });
+});
+
+describe('docs/reference/HERMES_INTEGRATION.md — memory boundary', () => {
+  test('documents the Forge-Kernel vs Hermes-native memory boundary', () => {
+    expect(fs.existsSync(integrationDocPath)).toBe(true);
+    const body = fs.readFileSync(integrationDocPath, 'utf8');
+    expect(body).toContain('Forge Kernel');
+    expect(body).toContain('Hermes');
+  });
+});

--- a/test/plugins/hermes-plugin.test.js
+++ b/test/plugins/hermes-plugin.test.js
@@ -43,7 +43,9 @@ describe('hermes.plugin.json — manifest contract', () => {
 
   test('does NOT declare commands capability (no Forge sync adapter exists)', () => {
     const plugin = loadHermesPlugin();
-    expect(plugin.capabilities.commands).toBeFalsy();
+    // Assert true omission, not just a falsy value — the contract is that
+    // `commands` is absent, since Hermes has no Forge command-sync adapter.
+    expect(Object.prototype.hasOwnProperty.call(plugin.capabilities, 'commands')).toBe(false);
   });
 
   test('wires a skills directory for the consumption skill', () => {
@@ -53,10 +55,11 @@ describe('hermes.plugin.json — manifest contract', () => {
     expect(plugin.directories.skills.length).toBeGreaterThan(0);
   });
 
-  test('declares a valid support status and surface', () => {
+  test('declares the exact Hermes support status and surface', () => {
     const plugin = loadHermesPlugin();
-    expect(['first-class', 'supported', 'compatibility']).toContain(plugin.support.status);
-    expect(typeof plugin.support.surface).toBe('string');
+    // Pin the declared contract values rather than accepting any valid enum.
+    expect(plugin.support.status).toBe('supported');
+    expect(plugin.support.surface).toBe('hybrid');
   });
 
   test('passes validatePluginSchema with no errors', () => {

--- a/test/skills-structure.test.js
+++ b/test/skills-structure.test.js
@@ -1,4 +1,4 @@
-const { describe, test, expect } = require('bun:test');
+const { describe, test, expect } = require('bun:test');
 const fs = require('node:fs');
 const path = require('node:path');
 
@@ -44,6 +44,7 @@ describe('skills/ directory structure', () => {
   });
 
   const requiredSkills = [
+    'hermes-forge',
     'parallel-deep-research',
     'sonarcloud-analysis',
   ];
@@ -110,7 +111,7 @@ describe('skills/ directory structure', () => {
     test('skills/ contains exactly the expected skill directories', () => {
       const dirs = fs.readdirSync(path.join(ROOT, 'skills'))
         .filter(d => fs.statSync(path.join(ROOT, 'skills', d)).isDirectory());
-      expect(dirs.sort()).toEqual(['parallel-deep-research', 'sonarcloud-analysis'].sort());
+      expect(dirs.sort()).toEqual(['hermes-forge', 'parallel-deep-research', 'sonarcloud-analysis'].sort());
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements the **Hermes adapter lane** (roadmap `forge-2agy.9.7.x`), scoped strictly to `agents/skills/docs` — no `lib/kernel/**` changes. Hermes is wired as a *consumer* of Forge project state through the `forge orient` / `forge recap` CLI surface, with the Forge Kernel as the single source of truth.

## What changed

- **`lib/agents/hermes.plugin.json`** — Hermes harness config wiring the consumption-skill directory. Declares `skills` capability but **not** `commands` (Hermes is intentionally not a Forge command-sync target — there is no `AGENT_ADAPTERS` entry, so declaring `commands` would fail `check-agents`). `support.status: "supported"`, `support.surface: "hybrid"`.
- **`skills/hermes-forge/SKILL.md`** — the consumption contract:
  - `forge orient` / `forge recap --json` are the authoritative, token-bounded project-state source (no raw-file reconstruction).
  - Documents the envelope (`schema_version`, `kind`, `token_budget`, `sections[]`, `sources[]`, `next_commands[]`).
  - Token budget (default 2000, `chars_per_token: 4`), citation/provenance model (`{path, source_kind, authority, role}`), deterministic truncation policy.
  - Evidence/decision **writeback path** Hermes→Forge Kernel via Forge CLI only.
  - **No-profile-write guard**: Hermes-native memory never enters Forge Kernel state.
- **`docs/reference/HERMES_INTEGRATION.md`** — defines the Forge-Kernel-authority vs Hermes-native-memory boundary (two-tier memory model).
- **`test/plugins/hermes-plugin.test.js`** — locks the manifest contract (`validatePluginSchema`, `checkAgents` parity, no-commands guard, skills wiring) and the skill/doc consumption invariants.
- **Companion catalog updates** — `test/plugin-manager.test.js` and `test/skills-structure.test.js` now include the new supported harness + skill directory. (The large churn in `skills-structure.test.js` is CRLF→LF normalization to repo standard; the only semantic change is adding `hermes-forge`.)

## Test plan

- TDD: RED (10 failing) → GREEN (11 passing) for `test/plugins/hermes-plugin.test.js`.
- Full suite: `bun test` green (one Beads/dolt-timing flake in `scripts/preflight.test.js` that passes in isolation — unrelated to this lane).
- `bunx eslint … --max-warnings 0` clean.
- `node scripts/check-agents.js` → "All agent checks passed."
- D20 kill-list artifact regenerated → no diff (no new `bd`/`.beads`/`dolt` call-sites introduced).

Closes forge-0k6z

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Hermes adapter support with a dedicated Hermes-Forge skill and a plugin manifest.
  * Hermes is now recognized in agent detection and is included in sync “Supported” output when applicable.

* **Documentation**
  * Added an integration reference defining authority handling, deterministic JSON envelopes, token budgeting/truncation rules, and strict guardrails for Hermes state writeback.

* **Tests**
  * Added/updated tests to enforce Hermes plugin/skill/doc parity, include Hermes in agent detection checks, and improved Git test isolation with explicit timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->