### PR TITLE
feat(kernel): JSONL portability projection (D16)

### DIFF
--- a/docs/work/2026-06-17-kernel-jsonl-projection-d16/design.md
+++ b/docs/work/2026-06-17-kernel-jsonl-projection-d16/design.md
@@ -1,0 +1,90 @@
+# Kernel JSONL Portability Projection (D16)
+
+**Roadmap:** forge-2agy.9.6.x — Beads/Dolt retirement portability prerequisite.
+**Decision:** [D16](../2026-06-06-kernel-backlog-memory-roadmap/decisions.md) — "Kernel JSONL portability projection".
+**Gates:** `forge-2agy.9.1.8` (Dolt hot-path retirement). Adjacent to D22 `fresh-clone-no-beads-acceptance`.
+
+## Problem
+
+Today `.beads/issues.jsonl` in git is what makes the backlog clone with the repo, diff in
+PRs, and survive disk loss. `kernel.sqlite` is a local binary that does none of that. There
+is currently **no consumer** that reads `kernel_outbox` (target `jsonl`) and writes a
+git-tracked, deterministic JSONL export. Without a Kernel-owned export/import replacement,
+retiring Beads silently deletes the portability/bootstrap story.
+
+## Design intent (from D16)
+
+- The Kernel owns **deterministic-order** JSONL export/import artifacts for intentionally
+  published clone/bootstrap and reviewable portability snapshots.
+- Exports are **explicit projections** — NOT auto-exported on routine mutation or push, and
+  NOT the durability mechanism for close/verify state (that stays in local SQLite / server
+  authority).
+- The projection is the **Kernel's own surface**, not a "Beads compatibility" feature.
+
+## Decisions
+
+### D16-a — Kernel-native JSONL schema (not Beads-shaped)
+The projection records mirror the Kernel authority columns directly, not the Beads export
+shape (`_type`, `depends_on_id`, numeric priority). We reuse only the *pure* JSONL helpers
+(`parseJsonl`/`stringifyJsonl`) from `lib/adapters/beads-kernel-compat.js`. Record shapes:
+
+- `issues.jsonl`: `{ kind, id, title, body, type, status, priority, priority_rank, created_at, updated_at, entity_revision }`
+- `comments.jsonl`: `{ kind, id, issue_id, body, actor, visibility, created_at }`
+- `dependencies.jsonl`: `{ kind, id, issue_id, blocks_issue_id, dependency_type, created_at }`
+- `manifest.json`: `{ schema_version, source, counts, content_sha256 }` (timestamp-free → deterministic)
+
+### D16-b — Write location: `.forge/kernel/` (git-tracked, NOT `.beads/`)
+`.forge/` is the established Kernel-owned, git-tracked directory. `.beads/` is gitignored and
+must stay out of the write path (dolt-hot-path-retirement & github-projection acceptance).
+
+### D16-c — Determinism contract
+Records are normalized to the canonical key set/types, then sorted by stable byte-order keys:
+issues by `id`; comments by `(issue_id, created_at, id)`; dependencies by
+`(issue_id, blocks_issue_id, dependency_type, id)`. JSON keys are emitted in fixed insertion
+order. Same logical state → byte-identical files. `manifest.content_sha256` is the sha256 of
+the three concatenated JSONL files.
+
+### D16-d — Outbox-driven consumer, full-snapshot rebuild
+`kernel_outbox` entries for target `jsonl` are **dirty markers**. Draining them performs ONE
+full-snapshot write covering all of them (idempotent rebuild). On success, every drained
+entry is marked `done`. On write failure the batch increments `attempts`; entries below
+`maxAttempts` return to `pending` with a backoff `next_attempt_at`; entries at/above
+`maxAttempts` are dead-lettered (`kernel_dead_letters` row + outbox `status=dead`). Projection
+failure never mutates Kernel authority.
+
+### D16-e — No `schema.js` change
+`kernel_outbox` already has `next_attempt_at`; `kernel_dead_letters` already exists; `target`
+is free TEXT so `'jsonl'` needs no migration. This also avoids the PR 5 (taxonomy) conflict on
+`schema.js`.
+
+### D16-f — Additive broker methods only
+broker.js gains read/update outbox methods (`listProjectionOutbox`, `loadProjectionModel`,
+`markProjectionDelivered`, `recordProjectionFailure`, `deadLetterProjection`) delegating to new
+driver methods. The append/CAS path (`enqueueKernelProjection`/`insertKernelEvent`/
+`runGuardedEvent`) is untouched — PR 3 owns it (parallel-safe).
+
+### D16-g — Dedicated `forge export` command; `sync.js` NOT auto-wired
+A standalone `lib/commands/export.js` (export + `--import` bootstrap). `sync` is deliberately
+NOT modified to auto-export, because D16 forbids auto-export "on routine mutation or push".
+Portability artifacts are git-tracked, so ordinary `git`/`forge sync` already carries them.
+
+## Round-trip / bootstrap
+
+`importProjection(writeProjection(model))` deep-equals the normalized model. Bootstrap path:
+fresh clone → `forge export --import` reads `.forge/kernel/*.jsonl` → Kernel model for status.
+The manifest hash is verified on import (integrity).
+
+## Security (OWASP)
+
+- A01/A03: projection dir is resolved and constrained under the project root; no shell-out, no
+  `bd`; `execFileSync`-free. JSONL parsing wraps `JSON.parse` with line-scoped errors.
+- A08: manifest sha256 integrity check on import detects tampered/corrupt snapshots.
+- No secrets are projected (only issue/comment/dependency authority columns).
+
+## Files
+
+- create: `lib/kernel/projection-jsonl-writer.js`, `lib/commands/export.js`,
+  `test/kernel/projection-jsonl-writer.test.js`, `test/kernel/broker-projection-outbox.test.js`,
+  `test/commands/export.test.js`, `test/fixtures/kernel-projection/*`
+- modify: `lib/kernel/broker.js` (additive outbox read/update methods)
+- not modified (by design): `lib/kernel/schema.js` (D16-e), `lib/commands/sync.js` (D16-g)

--- a/docs/work/2026-06-17-kernel-jsonl-projection-d16/tasks.md
+++ b/docs/work/2026-06-17-kernel-jsonl-projection-d16/tasks.md
@@ -1,0 +1,33 @@
+# Tasks — Kernel JSONL Portability Projection (D16)
+
+TDD-first. Each task: RED (failing test) → GREEN (impl) → REFACTOR. Run
+`bun test test/kernel/ test/commands/` and `bunx eslint <files> --max-warnings 0`.
+
+## Wave 1 — pure serialization core (no deps)
+- [ ] T1. `projection-jsonl-writer.js`: `normalizeProjectionModel`, `buildProjectionSnapshot`
+  (deterministic sort + canonical records), `serializeProjection` (→ files map + manifest).
+  Tests: determinism (shuffled input → identical bytes), fixture byte-match.
+- [ ] T2. `importProjection` (parse files → model) + manifest integrity check. Test: write→read
+  round-trip deep-equals normalized model; tampered manifest throws.
+
+## Wave 2 — fs write + consumer (depends on Wave 1)
+- [ ] T3. `writeProjection({ model, projectionDir })` atomic write + rollback snapshot; default
+  dir `.forge/kernel`. Test: writes 4 files, returns writes/bytes, re-import round-trip.
+- [ ] T4. `runJsonlProjectionConsumer({ broker, projectionDir, now, maxAttempts, writer })`:
+  drain pending → one write → mark delivered; no pending → no write; write-fail → attempts++
+  + backoff; exceed maxAttempts → dead-letter. Tests cover all four paths with a mock broker.
+
+## Wave 3 — broker methods (depends on Wave 2 contract; additive only)
+- [ ] T5. broker.js: `listProjectionOutbox`, `loadProjectionModel`, `markProjectionDelivered`,
+  `recordProjectionFailure`, `deadLetterProjection` delegating to driver methods. Tests in
+  `broker-projection-outbox.test.js` with mock drivers. Do NOT touch append/CAS path.
+
+## Wave 4 — command (depends on Waves 1-3)
+- [ ] T6. `lib/commands/export.js`: `forge export [--dir] [--dry-run] [--json] [--import]`.
+  DI via `opts` (`_broker`, `_writer`, `_now`). Graceful skip when no Kernel broker available.
+  Tests in `test/commands/export.test.js`.
+
+## Wave 5 — finalize
+- [ ] T7. Fixtures committed under `test/fixtures/kernel-projection/`.
+- [ ] T8. Regenerate D20 kill-list; confirm `bun test test/commands/release.test.js` passes.
+- [ ] T9. Full `bun test test/kernel/ test/commands/ test/adapters/`; lint clean.

--- a/lib/commands/export.js
+++ b/lib/commands/export.js
@@ -9,7 +9,16 @@ const {
 	DEFAULT_PROJECTION_TARGET,
 } = require('../kernel/projection-jsonl-writer');
 
-const PROJECTION_BROKER_METHODS = ['listProjectionOutbox', 'loadProjectionModel', 'markProjectionDelivered'];
+// Full set the consumer may call — including the retry (recordProjectionFailure)
+// and dead-letter (deadLetterProjection) paths — so a partially-implemented
+// broker is skipped cleanly instead of failing mid-run.
+const PROJECTION_BROKER_METHODS = [
+	'listProjectionOutbox',
+	'loadProjectionModel',
+	'markProjectionDelivered',
+	'recordProjectionFailure',
+	'deadLetterProjection',
+];
 
 /**
  * Parse `forge export` options from positional args (and a parsed flags object
@@ -29,7 +38,14 @@ function parseExportOptions(args = [], flags = {}) {
 		else if (arg === '--dry-run') options.dryRun = true;
 		else if (arg === '--json') options.json = true;
 		else if (arg.startsWith('--dir=')) options.dir = arg.slice('--dir='.length);
-		else if (arg === '--dir') { options.dir = args[i + 1]; i += 1; }
+		else if (arg === '--dir') {
+			// only consume the next token when it is a real value, not another flag
+			const next = args[i + 1];
+			if (next && !next.startsWith('--')) {
+				options.dir = next;
+				i += 1;
+			}
+		}
 	}
 
 	return options;
@@ -147,6 +163,21 @@ module.exports = {
 
 		try {
 			const run = await runJsonlProjectionConsumer({ broker, projectionDir, projectRoot, now, writer });
+
+			// A write failure leaves entries retried/dead-lettered without a snapshot;
+			// surface it as a failure rather than silently reporting success.
+			if (!run.written && run.error) {
+				return finalize(options, {
+					success: false,
+					exported: false,
+					error: run.error,
+					drained: run.drained,
+					retried: run.retried,
+					dead: run.dead,
+					dir: resolveProjectionDir(projectionDir, projectRoot),
+				});
+			}
+
 			return finalize(options, {
 				success: true,
 				exported: run.written,

--- a/lib/commands/export.js
+++ b/lib/commands/export.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const path = require('node:path');
+const {
+	runJsonlProjectionConsumer,
+	readProjection,
+	resolveProjectionDir,
+	writeProjection,
+	DEFAULT_PROJECTION_TARGET,
+} = require('../kernel/projection-jsonl-writer');
+
+const PROJECTION_BROKER_METHODS = ['listProjectionOutbox', 'loadProjectionModel', 'markProjectionDelivered'];
+
+/**
+ * Parse `forge export` options from positional args (and a parsed flags object
+ * as a fallback). Supported: --import, --dry-run, --json, --dir=<path> / --dir <path>.
+ */
+function parseExportOptions(args = [], flags = {}) {
+	const options = {
+		import: Boolean(flags.import),
+		dryRun: Boolean(flags['dry-run'] || flags.dryRun),
+		json: Boolean(flags.json),
+		dir: flags.dir,
+	};
+
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (arg === '--import') options.import = true;
+		else if (arg === '--dry-run') options.dryRun = true;
+		else if (arg === '--json') options.json = true;
+		else if (arg.startsWith('--dir=')) options.dir = arg.slice('--dir='.length);
+		else if (arg === '--dir') { options.dir = args[i + 1]; i += 1; }
+	}
+
+	return options;
+}
+
+function brokerSupportsProjection(broker) {
+	return Boolean(broker) && PROJECTION_BROKER_METHODS.every(method => typeof broker[method] === 'function');
+}
+
+function resolveDirArg(dirArg, projectRoot) {
+	if (!dirArg) return undefined;
+	return path.resolve(projectRoot || process.cwd(), dirArg);
+}
+
+function renderHuman(payload) {
+	if (payload.error) return `forge export failed: ${payload.error}`;
+	if (payload.imported === true) {
+		const { issues, comments, dependencies } = payload.counts;
+		return `Imported Kernel projection from ${payload.dir} (${issues} issues, ${comments} comments, ${dependencies} dependencies)`;
+	}
+	if (payload.imported === false) return payload.message;
+	if (payload.dryRun) return `${payload.pending} pending projection entr${payload.pending === 1 ? 'y' : 'ies'} → ${payload.dir} (dry run, nothing written)`;
+	if (payload.skipped) return payload.message;
+	if (payload.exported) return `Exported Kernel projection to ${payload.dir} (drained ${payload.drained})`;
+	return payload.message || 'Nothing to export';
+}
+
+function finalize(options, payload) {
+	const output = options.json ? JSON.stringify(payload, null, 2) : renderHuman(payload);
+	return { ...payload, output, json: Boolean(options.json) };
+}
+
+/**
+ * Forge Export Command (D16 — Kernel JSONL portability projection).
+ *
+ * Explicit, Kernel-owned projection of issues/comments/dependencies to
+ * deterministic git-tracked JSONL under `.forge/kernel/`. This is NOT auto-run on
+ * mutation/push (D16 forbids that); it is an on-demand portability/bootstrap
+ * surface. The `--import` path reads a committed snapshot back from disk (no
+ * broker required) and verifies its manifest integrity.
+ *
+ * @module commands/export
+ */
+module.exports = {
+	name: 'export',
+	description: 'Export the Kernel backlog to deterministic git-tracked JSONL (D16 portability projection)',
+	usage: 'forge export [--dir <path>] [--dry-run] [--json] [--import]',
+	flags: {},
+
+	/**
+	 * @param {string[]} args - Positional arguments / flags
+	 * @param {object} flags - Parsed CLI flags (fallback source)
+	 * @param {string} projectRoot - Project root path
+	 * @param {object} [opts] - Dependency injection: _broker, _writer, _now, _fs
+	 */
+	async handler(args = [], flags = {}, projectRoot, opts = {}) {
+		const options = parseExportOptions(args, flags || {});
+		const now = opts._now || new Date().toISOString();
+		const writer = opts._writer || writeProjection;
+		const fsImpl = opts._fs;
+		const projectionDir = resolveDirArg(options.dir, projectRoot);
+
+		// --- Import / bootstrap (no broker required) -------------------------
+		if (options.import) {
+			try {
+				const result = readProjection({ projectionDir, projectRoot, fsImpl });
+				if (!result) {
+					return finalize(options, {
+						success: true,
+						imported: false,
+						dir: resolveProjectionDir(projectionDir, projectRoot),
+						message: 'No projection snapshot found to import',
+					});
+				}
+				return finalize(options, {
+					success: true,
+					imported: true,
+					dir: result.dir,
+					counts: {
+						issues: result.model.issues.length,
+						comments: result.model.comments.length,
+						dependencies: result.model.dependencies.length,
+					},
+				});
+			} catch (error) {
+				return finalize(options, { success: false, imported: false, error: error.message });
+			}
+		}
+
+		// --- Export (requires a projection-capable Kernel broker) ------------
+		const broker = opts._broker || null;
+		if (!brokerSupportsProjection(broker)) {
+			return finalize(options, {
+				success: true,
+				exported: false,
+				skipped: true,
+				message: 'No Kernel broker available — nothing to export',
+			});
+		}
+
+		if (options.dryRun) {
+			const pending = (await broker.listProjectionOutbox({
+				target: DEFAULT_PROJECTION_TARGET,
+				status: 'pending',
+				now,
+			})) || [];
+			return finalize(options, {
+				success: true,
+				exported: false,
+				dryRun: true,
+				pending: pending.length,
+				dir: resolveProjectionDir(projectionDir, projectRoot),
+			});
+		}
+
+		try {
+			const run = await runJsonlProjectionConsumer({ broker, projectionDir, projectRoot, now, writer });
+			return finalize(options, {
+				success: true,
+				exported: run.written,
+				drained: run.drained,
+				delivered: run.delivered,
+				retried: run.retried,
+				dead: run.dead,
+				dir: run.write ? run.write.dir : resolveProjectionDir(projectionDir, projectRoot),
+				files: run.write ? run.write.files : [],
+			});
+		} catch (error) {
+			return finalize(options, { success: false, exported: false, error: error.message });
+		}
+	},
+};

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -236,6 +236,36 @@ function createLocalBroker(options = {}) {
 				outboxEntry,
 			};
 		},
+
+		// --- Projection-outbox read/update surface (D16) -----------------------
+		// Additive read/update methods for projection consumers. These never touch
+		// the append/CAS path above (runGuardedEvent / enqueueKernelProjection);
+		// they only read and update existing outbox rows or dead-letter them.
+
+		async listProjectionOutbox(filter = {}, context = {}) {
+			requireDriverMethod(driver, 'listProjectionOutbox');
+			return driver.listProjectionOutbox(filter, context, getConfig());
+		},
+
+		async loadProjectionModel(context = {}) {
+			requireDriverMethod(driver, 'loadProjectionModel');
+			return driver.loadProjectionModel(context, getConfig());
+		},
+
+		async markProjectionDelivered(ids, meta = {}, context = {}) {
+			requireDriverMethod(driver, 'markProjectionDelivered');
+			return driver.markProjectionDelivered(ids, meta, context, getConfig());
+		},
+
+		async recordProjectionFailure(record, context = {}) {
+			requireDriverMethod(driver, 'recordProjectionFailure');
+			return driver.recordProjectionFailure(record, context, getConfig());
+		},
+
+		async deadLetterProjection(record, context = {}) {
+			requireDriverMethod(driver, 'deadLetterProjection');
+			return driver.deadLetterProjection(record, context, getConfig());
+		},
 	};
 }
 

--- a/lib/kernel/projection-jsonl-writer.js
+++ b/lib/kernel/projection-jsonl-writer.js
@@ -12,6 +12,9 @@ const SCHEMA_VERSION = 1;
 // effectively the commit marker for the snapshot).
 const PROJECTION_FILE_ORDER = ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl', 'manifest.json'];
 const DEFAULT_PROJECTION_DIR = path.join('.forge', 'kernel');
+// Exclusive publish lock filename (transient — written and removed within a single
+// writeProjection call) that serializes the rename phase across concurrent exports.
+const PROJECTION_LOCK_FILE = '.export.lock';
 
 // Fixed key insertion order per D16-a and D16-c
 const ISSUE_KEYS = ['kind', 'id', 'title', 'body', 'type', 'status', 'priority', 'priority_rank', 'created_at', 'updated_at', 'entity_revision'];
@@ -158,7 +161,11 @@ function assertRecordKind(records, expectedKind, file) {
 }
 
 function assertManifestCounts(counts, parsed) {
-	if (!counts) return;
+	if (!counts) {
+		// A manifest with a valid hash but no counts would otherwise skip the
+		// per-file binding check entirely — treat the missing field as corruption.
+		throw new Error('Manifest is missing the required counts field');
+	}
 	for (const key of ['issues', 'comments', 'dependencies']) {
 		if (typeof counts[key] === 'number' && counts[key] !== parsed[key].length) {
 			throw new Error(
@@ -188,6 +195,13 @@ function resolveProjectionDir(projectionDir, projectRoot) {
 // throws, restore the snapshot (rewrite prior content or delete files that did
 // not previously exist) and clean up temps before rethrowing. A projection write
 // failure must never leave a half-applied snapshot on disk.
+//
+// The per-file renames are not individually atomic across files, so the publish
+// phase is guarded by an exclusive directory lock: a concurrent export to the
+// same dir fails fast instead of interleaving renames into a mixed snapshot whose
+// manifest hash no longer matches. The lock is always released in `finally`, so
+// only an abnormal crash mid-publish (a sub-millisecond window) could leave a
+// stale lock — the error message tells the operator how to clear it.
 function writeProjection({ model, projectionDir, projectRoot, fsImpl } = {}) {
 	const io = fsImpl || fs;
 	const dir = resolveProjectionDir(projectionDir, projectRoot);
@@ -209,24 +223,32 @@ function writeProjection({ model, projectionDir, projectRoot, fsImpl } = {}) {
 		bytes += Buffer.byteLength(content, 'utf8');
 	}
 
-	const snapshots = [];
-	const renamed = [];
+	const lockPath = path.join(dir, PROJECTION_LOCK_FILE);
+	let lockHeld = false;
 	try {
-		for (let i = 0; i < PROJECTION_FILE_ORDER.length; i += 1) {
-			const name = PROJECTION_FILE_ORDER[i];
-			const target = path.join(dir, name);
-			const existed = io.existsSync(target);
-			snapshots.push({ target, existed, content: existed ? io.readFileSync(target) : null });
-			io.renameSync(tempPaths[i], target);
-			renamed.push(target);
-		}
-	} catch (error) {
-		rollbackProjectionWrite(io, snapshots, renamed);
-		cleanupTempFiles(io, tempPaths);
-		throw error;
-	}
+		acquireProjectionLock(io, lockPath);
+		lockHeld = true;
 
-	cleanupTempFiles(io, tempPaths);
+		const snapshots = [];
+		const renamed = [];
+		try {
+			for (let i = 0; i < PROJECTION_FILE_ORDER.length; i += 1) {
+				const name = PROJECTION_FILE_ORDER[i];
+				const target = path.join(dir, name);
+				const existed = io.existsSync(target);
+				snapshots.push({ target, existed, content: existed ? io.readFileSync(target) : null });
+				io.renameSync(tempPaths[i], target);
+				renamed.push(target);
+			}
+		} catch (error) {
+			rollbackProjectionWrite(io, snapshots, renamed);
+			throw error;
+		}
+	} finally {
+		// only release a lock we actually acquired (never delete a foreign lock)
+		if (lockHeld) removeIfPresent(io, lockPath);
+		cleanupTempFiles(io, tempPaths);
+	}
 
 	return {
 		dir,
@@ -234,6 +256,22 @@ function writeProjection({ model, projectionDir, projectRoot, fsImpl } = {}) {
 		bytes,
 		files: [...PROJECTION_FILE_ORDER],
 	};
+}
+
+// Acquire an exclusive publish lock via O_EXCL (flag 'wx'): fails if the lock
+// already exists. Translates the raw EEXIST into an actionable message.
+function acquireProjectionLock(io, lockPath) {
+	try {
+		io.writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+	} catch (error) {
+		if (error && error.code === 'EEXIST') {
+			throw new Error(
+				`Another forge export is already publishing to this directory (lock: ${lockPath}). `
+				+ 'Retry once it finishes, or remove the lock file if it is stale.',
+			);
+		}
+		throw error;
+	}
 }
 
 function rollbackProjectionWrite(io, snapshots, renamed) {
@@ -292,6 +330,12 @@ const DEFAULT_BASE_BACKOFF_MS = 5000;
 
 function computeBackoff(now, attempts, baseBackoffMs) {
 	const start = Date.parse(now);
+	if (Number.isNaN(start)) {
+		// Without this guard, new Date(NaN).toISOString() throws a bare
+		// "Invalid time value" RangeError inside the consumer's catch block,
+		// masking the original write error. Fail with an attributable message.
+		throw new RangeError(`computeBackoff: invalid 'now' timestamp: ${now}`);
+	}
 	const delay = baseBackoffMs * 2 ** Math.max(0, attempts - 1);
 	return new Date(start + delay).toISOString();
 }
@@ -357,9 +401,11 @@ async function runJsonlProjectionConsumer({
 }
 
 module.exports = {
+	SCHEMA_VERSION,
 	DEFAULT_PROJECTION_DIR,
 	DEFAULT_PROJECTION_TARGET,
 	DEFAULT_MAX_ATTEMPTS,
+	DEFAULT_BASE_BACKOFF_MS,
 	PROJECTION_FILE_ORDER,
 	normalizeProjectionModel,
 	buildProjectionSnapshot,

--- a/lib/kernel/projection-jsonl-writer.js
+++ b/lib/kernel/projection-jsonl-writer.js
@@ -1,0 +1,315 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const { parseJsonl, stringifyJsonl } = require('../adapters/beads-kernel-compat');
+
+const SCHEMA_VERSION = 1;
+
+// Deterministic write/rename order. manifest.json is renamed last so a partial
+// write never leaves a manifest pointing at incomplete JSONL (the manifest is
+// effectively the commit marker for the snapshot).
+const PROJECTION_FILE_ORDER = ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl', 'manifest.json'];
+const DEFAULT_PROJECTION_DIR = path.join('.forge', 'kernel');
+
+// Fixed key insertion order per D16-a and D16-c
+const ISSUE_KEYS = ['kind', 'id', 'title', 'body', 'type', 'status', 'priority', 'priority_rank', 'created_at', 'updated_at', 'entity_revision'];
+const COMMENT_KEYS = ['kind', 'id', 'issue_id', 'body', 'actor', 'visibility', 'created_at'];
+const DEP_KEYS = ['kind', 'id', 'issue_id', 'blocks_issue_id', 'dependency_type', 'created_at'];
+
+function pickKeys(record, keys) {
+	const out = {};
+	for (const key of keys) {
+		out[key] = Object.prototype.hasOwnProperty.call(record, key) ? record[key] : null;
+	}
+	return out;
+}
+
+function normalizeIssue(raw) {
+	return pickKeys({ ...raw, kind: 'issue', body: raw.body ?? null }, ISSUE_KEYS);
+}
+
+function normalizeComment(raw) {
+	return pickKeys({ ...raw, kind: 'comment' }, COMMENT_KEYS);
+}
+
+function normalizeDependency(raw) {
+	return pickKeys({ ...raw, kind: 'dependency' }, DEP_KEYS);
+}
+
+function normalizeProjectionModel(model) {
+	return {
+		issues: (model.issues || []).map(normalizeIssue),
+		comments: (model.comments || []).map(normalizeComment),
+		dependencies: (model.dependencies || []).map(normalizeDependency),
+	};
+}
+
+function cmp(a, b) {
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+}
+
+function buildProjectionSnapshot(model) {
+	const issues = [...model.issues].sort((a, b) => cmp(a.id, b.id));
+
+	const comments = [...model.comments].sort((a, b) =>
+		cmp(a.issue_id, b.issue_id) || cmp(a.created_at, b.created_at) || cmp(a.id, b.id),
+	);
+
+	const dependencies = [...model.dependencies].sort((a, b) =>
+		cmp(a.issue_id, b.issue_id) ||
+		cmp(a.blocks_issue_id, b.blocks_issue_id) ||
+		cmp(a.dependency_type, b.dependency_type) ||
+		cmp(a.id, b.id),
+	);
+
+	return { issues, comments, dependencies };
+}
+
+function serializeProjection(model) {
+	const snap = buildProjectionSnapshot(model);
+
+	const issuesJsonl = stringifyJsonl(snap.issues);
+	const commentsJsonl = stringifyJsonl(snap.comments);
+	const depsJsonl = stringifyJsonl(snap.dependencies);
+
+	const contentSha256 = crypto
+		.createHash('sha256')
+		.update(issuesJsonl)
+		.update(commentsJsonl)
+		.update(depsJsonl)
+		.digest('hex');
+
+	const manifest = {
+		schema_version: SCHEMA_VERSION,
+		source: 'kernel',
+		counts: {
+			issues: snap.issues.length,
+			comments: snap.comments.length,
+			dependencies: snap.dependencies.length,
+		},
+		content_sha256: contentSha256,
+	};
+
+	return {
+		files: {
+			'issues.jsonl': issuesJsonl,
+			'comments.jsonl': commentsJsonl,
+			'dependencies.jsonl': depsJsonl,
+			'manifest.json': JSON.stringify(manifest, null, 2) + '\n',
+		},
+	};
+}
+
+function importProjection(files) {
+	if (!files['manifest.json']) {
+		throw new Error('Missing manifest.json in projection files');
+	}
+
+	const manifest = JSON.parse(files['manifest.json']);
+
+	const issuesJsonl = files['issues.jsonl'] || '';
+	const commentsJsonl = files['comments.jsonl'] || '';
+	const depsJsonl = files['dependencies.jsonl'] || '';
+
+	const actualSha256 = crypto
+		.createHash('sha256')
+		.update(issuesJsonl)
+		.update(commentsJsonl)
+		.update(depsJsonl)
+		.digest('hex');
+
+	if (actualSha256 !== manifest.content_sha256) {
+		throw new Error(
+			`sha256 mismatch: manifest has ${manifest.content_sha256}, computed ${actualSha256}`,
+		);
+	}
+
+	return {
+		issues: issuesJsonl ? parseJsonl(issuesJsonl, 'issues.jsonl') : [],
+		comments: commentsJsonl ? parseJsonl(commentsJsonl, 'comments.jsonl') : [],
+		dependencies: depsJsonl ? parseJsonl(depsJsonl, 'dependencies.jsonl') : [],
+	};
+}
+
+function resolveProjectionDir(projectionDir, projectRoot) {
+	const resolved = path.resolve(projectionDir || (projectRoot ? path.join(projectRoot, DEFAULT_PROJECTION_DIR) : DEFAULT_PROJECTION_DIR));
+
+	if (projectRoot) {
+		const root = path.resolve(projectRoot);
+		const relative = path.relative(root, resolved);
+		const escapes = relative.startsWith('..') || path.isAbsolute(relative);
+		if (escapes) {
+			throw new Error(`Projection directory escapes the project root: ${resolved}`);
+		}
+	}
+
+	return resolved;
+}
+
+// Atomic-ish multi-file write: render every file to a sibling temp, snapshot the
+// existing targets, then rename temps into place in a fixed order. If any rename
+// throws, restore the snapshot (rewrite prior content or delete files that did
+// not previously exist) and clean up temps before rethrowing. A projection write
+// failure must never leave a half-applied snapshot on disk.
+function writeProjection({ model, projectionDir, projectRoot, fsImpl } = {}) {
+	const io = fsImpl || fs;
+	const dir = resolveProjectionDir(projectionDir, projectRoot);
+	const { files } = serializeProjection(model);
+
+	io.mkdirSync(dir, { recursive: true });
+
+	const tempPaths = [];
+	let bytes = 0;
+	for (const name of PROJECTION_FILE_ORDER) {
+		const content = files[name];
+		const tempPath = path.join(dir, `.tmp-${name}`);
+		io.writeFileSync(tempPath, content);
+		tempPaths.push(tempPath);
+		bytes += Buffer.byteLength(content, 'utf8');
+	}
+
+	const snapshots = [];
+	const renamed = [];
+	try {
+		for (let i = 0; i < PROJECTION_FILE_ORDER.length; i += 1) {
+			const name = PROJECTION_FILE_ORDER[i];
+			const target = path.join(dir, name);
+			const existed = io.existsSync(target);
+			snapshots.push({ target, existed, content: existed ? io.readFileSync(target) : null });
+			io.renameSync(tempPaths[i], target);
+			renamed.push(target);
+		}
+	} catch (error) {
+		rollbackProjectionWrite(io, snapshots, renamed);
+		cleanupTempFiles(io, tempPaths);
+		throw error;
+	}
+
+	cleanupTempFiles(io, tempPaths);
+
+	return {
+		dir,
+		writes: PROJECTION_FILE_ORDER.length,
+		bytes,
+		files: [...PROJECTION_FILE_ORDER],
+	};
+}
+
+function rollbackProjectionWrite(io, snapshots, renamed) {
+	const renamedSet = new Set(renamed);
+	for (const snapshot of snapshots) {
+		if (!renamedSet.has(snapshot.target)) {
+			continue;
+		}
+		if (snapshot.existed) {
+			io.writeFileSync(snapshot.target, snapshot.content);
+		} else {
+			removeIfPresent(io, snapshot.target);
+		}
+	}
+}
+
+function cleanupTempFiles(io, tempPaths) {
+	for (const tempPath of tempPaths) {
+		removeIfPresent(io, tempPath);
+	}
+}
+
+function removeIfPresent(io, target) {
+	try {
+		if (io.existsSync(target)) {
+			io.rmSync(target, { force: true });
+		}
+	} catch {
+		// best-effort cleanup; never mask the original failure
+	}
+}
+
+const DEFAULT_PROJECTION_TARGET = 'jsonl';
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_BASE_BACKOFF_MS = 5000;
+
+function computeBackoff(now, attempts, baseBackoffMs) {
+	const start = Date.parse(now);
+	const delay = baseBackoffMs * 2 ** Math.max(0, attempts - 1);
+	return new Date(start + delay).toISOString();
+}
+
+// Outbox-driven JSONL consumer. Pending kernel_outbox rows for the projection
+// target are dirty markers; draining them performs ONE full-snapshot write that
+// covers all of them. On success every drained row is marked delivered. On write
+// failure each row increments its attempt count: rows below maxAttempts return to
+// pending with an exponential backoff; rows that reach maxAttempts are
+// dead-lettered. A projection failure never mutates Kernel authority.
+async function runJsonlProjectionConsumer({
+	broker,
+	projectionDir,
+	projectRoot,
+	now = new Date().toISOString(),
+	maxAttempts = DEFAULT_MAX_ATTEMPTS,
+	baseBackoffMs = DEFAULT_BASE_BACKOFF_MS,
+	target = DEFAULT_PROJECTION_TARGET,
+	writer = writeProjection,
+} = {}) {
+	const pending = (await broker.listProjectionOutbox({ target, status: 'pending', now })) || [];
+	if (pending.length === 0) {
+		return { drained: 0, written: false, delivered: [], retried: [], dead: [] };
+	}
+
+	const model = await broker.loadProjectionModel();
+
+	let write;
+	try {
+		write = writer({ model, projectionDir, projectRoot });
+	} catch (error) {
+		const retried = [];
+		const dead = [];
+		for (const entry of pending) {
+			const attempts = (entry.attempts || 0) + 1;
+			if (attempts >= maxAttempts) {
+				await broker.deadLetterProjection({
+					outbox_id: entry.id,
+					target,
+					error: error.message,
+					payload_json: JSON.stringify({ event_id: entry.event_id, attempts }),
+					now,
+				});
+				dead.push(entry.id);
+			} else {
+				await broker.recordProjectionFailure({
+					id: entry.id,
+					attempts,
+					next_attempt_at: computeBackoff(now, attempts, baseBackoffMs),
+					error: error.message,
+					now,
+				});
+				retried.push(entry.id);
+			}
+		}
+		return { drained: pending.length, written: false, error: error.message, delivered: [], retried, dead };
+	}
+
+	const delivered = pending.map(entry => entry.id);
+	await broker.markProjectionDelivered(delivered, { now });
+
+	return { drained: pending.length, written: true, write, delivered, retried: [], dead: [] };
+}
+
+module.exports = {
+	DEFAULT_PROJECTION_DIR,
+	DEFAULT_PROJECTION_TARGET,
+	DEFAULT_MAX_ATTEMPTS,
+	PROJECTION_FILE_ORDER,
+	normalizeProjectionModel,
+	buildProjectionSnapshot,
+	serializeProjection,
+	importProjection,
+	resolveProjectionDir,
+	writeProjection,
+	computeBackoff,
+	runJsonlProjectionConsumer,
+};

--- a/lib/kernel/projection-jsonl-writer.js
+++ b/lib/kernel/projection-jsonl-writer.js
@@ -70,7 +70,10 @@ function buildProjectionSnapshot(model) {
 }
 
 function serializeProjection(model) {
-	const snap = buildProjectionSnapshot(model);
+	// Normalize defensively: callers (including the outbox consumer) may pass raw
+	// driver rows that lack `kind`/canonical key order. normalizeProjectionModel is
+	// idempotent, so pre-normalized snapshots are unaffected.
+	const snap = buildProjectionSnapshot(normalizeProjectionModel(model));
 
 	const issuesJsonl = stringifyJsonl(snap.issues);
 	const commentsJsonl = stringifyJsonl(snap.comments);
@@ -128,11 +131,41 @@ function importProjection(files) {
 		);
 	}
 
-	return {
-		issues: issuesJsonl ? parseJsonl(issuesJsonl, 'issues.jsonl') : [],
-		comments: commentsJsonl ? parseJsonl(commentsJsonl, 'comments.jsonl') : [],
-		dependencies: depsJsonl ? parseJsonl(depsJsonl, 'dependencies.jsonl') : [],
-	};
+	const issues = issuesJsonl ? parseJsonl(issuesJsonl, 'issues.jsonl') : [];
+	const comments = commentsJsonl ? parseJsonl(commentsJsonl, 'comments.jsonl') : [];
+	const dependencies = depsJsonl ? parseJsonl(depsJsonl, 'dependencies.jsonl') : [];
+
+	// The content hash binds only the concatenated byte stream, not file
+	// boundaries — moving a line between files leaves the stream unchanged. Bind
+	// records to their files (kind) and to the manifest (counts) so a relocated or
+	// dropped record is rejected even when the hash still matches.
+	assertRecordKind(issues, 'issue', 'issues.jsonl');
+	assertRecordKind(comments, 'comment', 'comments.jsonl');
+	assertRecordKind(dependencies, 'dependency', 'dependencies.jsonl');
+	assertManifestCounts(manifest.counts, { issues, comments, dependencies });
+
+	return { issues, comments, dependencies };
+}
+
+function assertRecordKind(records, expectedKind, file) {
+	for (let i = 0; i < records.length; i += 1) {
+		if (records[i].kind !== expectedKind) {
+			throw new Error(
+				`Invalid record in ${file} at line ${i + 1}: kind "${records[i].kind}", expected "${expectedKind}"`,
+			);
+		}
+	}
+}
+
+function assertManifestCounts(counts, parsed) {
+	if (!counts) return;
+	for (const key of ['issues', 'comments', 'dependencies']) {
+		if (typeof counts[key] === 'number' && counts[key] !== parsed[key].length) {
+			throw new Error(
+				`Manifest count mismatch for ${key}: manifest says ${counts[key]}, found ${parsed[key].length}`,
+			);
+		}
+	}
 }
 
 function resolveProjectionDir(projectionDir, projectRoot) {

--- a/lib/kernel/projection-jsonl-writer.js
+++ b/lib/kernel/projection-jsonl-writer.js
@@ -224,8 +224,8 @@ function removeIfPresent(io, target) {
 		if (io.existsSync(target)) {
 			io.rmSync(target, { force: true });
 		}
-	} catch {
-		// best-effort cleanup; never mask the original failure
+	} catch { /* intentional: best-effort cleanup, never mask the original failure */ // NOSONAR S2486
+		// no-op
 	}
 }
 

--- a/lib/kernel/projection-jsonl-writer.js
+++ b/lib/kernel/projection-jsonl-writer.js
@@ -229,6 +229,26 @@ function removeIfPresent(io, target) {
 	}
 }
 
+// Symmetric on-disk read of a projection snapshot. Returns null when no snapshot
+// exists (no manifest), otherwise the imported model with its integrity verified
+// by importProjection (throws on a tampered/corrupt manifest hash).
+function readProjection({ projectionDir, projectRoot, fsImpl } = {}) {
+	const io = fsImpl || fs;
+	const dir = resolveProjectionDir(projectionDir, projectRoot);
+	const manifestPath = path.join(dir, 'manifest.json');
+	if (!io.existsSync(manifestPath)) {
+		return null;
+	}
+
+	const files = {};
+	for (const name of PROJECTION_FILE_ORDER) {
+		const target = path.join(dir, name);
+		files[name] = io.existsSync(target) ? io.readFileSync(target, 'utf8') : '';
+	}
+
+	return { dir, model: importProjection(files) };
+}
+
 const DEFAULT_PROJECTION_TARGET = 'jsonl';
 const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_BASE_BACKOFF_MS = 5000;
@@ -310,6 +330,7 @@ module.exports = {
 	importProjection,
 	resolveProjectionDir,
 	writeProjection,
+	readProjection,
 	computeBackoff,
 	runJsonlProjectionConsumer,
 };

--- a/lib/kernel/projection-jsonl-writer.js
+++ b/lib/kernel/projection-jsonl-writer.js
@@ -195,11 +195,15 @@ function writeProjection({ model, projectionDir, projectRoot, fsImpl } = {}) {
 
 	io.mkdirSync(dir, { recursive: true });
 
+	// Per-write unique tag so concurrent exports to the same dir never collide on
+	// each other's temp files (which would corrupt snapshots / rollback). pid +
+	// random bytes is unique without depending on wall-clock time.
+	const tempTag = `${process.pid}-${crypto.randomBytes(8).toString('hex')}`;
 	const tempPaths = [];
 	let bytes = 0;
 	for (const name of PROJECTION_FILE_ORDER) {
 		const content = files[name];
-		const tempPath = path.join(dir, `.tmp-${name}`);
+		const tempPath = path.join(dir, `.tmp-${tempTag}-${name}`);
 		io.writeFileSync(tempPath, content);
 		tempPaths.push(tempPath);
 		bytes += Buffer.byteLength(content, 'utf8');

--- a/test/commands/export.test.js
+++ b/test/commands/export.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const exportCommand = require('../../lib/commands/export');
+const {
+	normalizeProjectionModel,
+	writeProjection,
+} = require('../../lib/kernel/projection-jsonl-writer');
+
+const NOW = '2026-06-18T00:00:00.000Z';
+
+function tmpRoot() {
+	return fs.mkdtempSync(path.join(os.tmpdir(), 'forge-export-'));
+}
+
+function makeBroker({ pending = [], model = { issues: [], comments: [], dependencies: [] } } = {}) {
+	const calls = { delivered: [], listed: 0 };
+	return {
+		calls,
+		async listProjectionOutbox() { calls.listed += 1; return pending; },
+		async loadProjectionModel() { return model; },
+		async markProjectionDelivered(ids) { calls.delivered.push(ids); },
+		async recordProjectionFailure() {},
+		async deadLetterProjection() {},
+	};
+}
+
+describe('forge export command contract', () => {
+	test('has the registry-required shape', () => {
+		expect(exportCommand.name).toBe('export');
+		expect(typeof exportCommand.description).toBe('string');
+		expect(typeof exportCommand.handler).toBe('function');
+	});
+});
+
+describe('forge export — graceful skip', () => {
+	test('skips when no Kernel broker is available', async () => {
+		const root = tmpRoot();
+		const result = await exportCommand.handler([], {}, root, { _now: NOW });
+		expect(result.success).toBe(true);
+		expect(result.exported).toBe(false);
+		expect(result.skipped).toBe(true);
+		expect(result.message).toMatch(/no kernel broker/i);
+	});
+});
+
+describe('forge export — export path (DI broker)', () => {
+	test('drains pending entries and writes the snapshot to .forge/kernel', async () => {
+		const root = tmpRoot();
+		const model = { issues: [{ id: 'forge-1', title: 'T', created_at: NOW, updated_at: NOW }], comments: [], dependencies: [] };
+		const pending = [{ id: 'ob-1', event_id: 'ev-1', target: 'jsonl', status: 'pending', attempts: 0 }];
+		const broker = makeBroker({ pending, model });
+
+		const result = await exportCommand.handler([], {}, root, { _broker: broker, _now: NOW });
+
+		expect(result.success).toBe(true);
+		expect(result.exported).toBe(true);
+		expect(result.drained).toBe(1);
+		expect(broker.calls.delivered[0]).toEqual(['ob-1']);
+		expect(result.dir).toBe(path.resolve(root, '.forge', 'kernel'));
+		expect(fs.existsSync(path.join(root, '.forge', 'kernel', 'manifest.json'))).toBe(true);
+	});
+
+	test('honors --dir override (resolved under the project root)', async () => {
+		const root = tmpRoot();
+		const pending = [{ id: 'ob-1', event_id: 'ev-1', target: 'jsonl', status: 'pending', attempts: 0 }];
+		const broker = makeBroker({ pending });
+
+		const result = await exportCommand.handler(['--dir=snapshots/kernel'], {}, root, { _broker: broker, _now: NOW });
+
+		expect(result.dir).toBe(path.resolve(root, 'snapshots', 'kernel'));
+		expect(fs.existsSync(path.join(root, 'snapshots', 'kernel', 'manifest.json'))).toBe(true);
+	});
+
+	test('--dry-run reports pending count without writing', async () => {
+		const root = tmpRoot();
+		const pending = [
+			{ id: 'ob-1', event_id: 'ev-1', target: 'jsonl', status: 'pending', attempts: 0 },
+			{ id: 'ob-2', event_id: 'ev-2', target: 'jsonl', status: 'pending', attempts: 0 },
+		];
+		const broker = makeBroker({ pending });
+
+		const result = await exportCommand.handler(['--dry-run'], {}, root, { _broker: broker, _now: NOW });
+
+		expect(result.dryRun).toBe(true);
+		expect(result.exported).toBe(false);
+		expect(result.pending).toBe(2);
+		expect(broker.calls.delivered).toEqual([]);
+		expect(fs.existsSync(path.join(root, '.forge', 'kernel', 'manifest.json'))).toBe(false);
+	});
+
+	test('--json emits a JSON output string', async () => {
+		const root = tmpRoot();
+		const broker = makeBroker({ pending: [] });
+
+		const result = await exportCommand.handler(['--json'], {}, root, { _broker: broker, _now: NOW });
+
+		expect(result.json).toBe(true);
+		expect(() => JSON.parse(result.output)).not.toThrow();
+	});
+});
+
+describe('forge export — import / bootstrap path', () => {
+	test('--import reads a committed snapshot from disk', async () => {
+		const root = tmpRoot();
+		const dir = path.join(root, '.forge', 'kernel');
+		const model = normalizeProjectionModel({
+			issues: [{ id: 'forge-1', title: 'T', type: 'task', status: 'open', priority: 'P2', priority_rank: 0, created_at: NOW, updated_at: NOW, entity_revision: 1 }],
+			comments: [],
+			dependencies: [],
+		});
+		writeProjection({ model, projectionDir: dir });
+
+		const result = await exportCommand.handler(['--import'], {}, root, { _now: NOW });
+
+		expect(result.success).toBe(true);
+		expect(result.imported).toBe(true);
+		expect(result.counts).toEqual({ issues: 1, comments: 0, dependencies: 0 });
+		expect(result.dir).toBe(path.resolve(dir));
+	});
+
+	test('--import is a graceful no-op when no snapshot exists', async () => {
+		const root = tmpRoot();
+		const result = await exportCommand.handler(['--import'], {}, root, { _now: NOW });
+
+		expect(result.success).toBe(true);
+		expect(result.imported).toBe(false);
+		expect(result.message).toMatch(/no projection snapshot/i);
+	});
+
+	test('--import surfaces an integrity error on a tampered snapshot', async () => {
+		const root = tmpRoot();
+		const dir = path.join(root, '.forge', 'kernel');
+		const model = normalizeProjectionModel({ issues: [], comments: [], dependencies: [] });
+		writeProjection({ model, projectionDir: dir });
+		const manifestPath = path.join(dir, 'manifest.json');
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+		manifest.content_sha256 = 'c'.repeat(64);
+		fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+		const result = await exportCommand.handler(['--import'], {}, root, { _now: NOW });
+
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/sha256/i);
+	});
+});

--- a/test/commands/export.test.js
+++ b/test/commands/export.test.js
@@ -104,6 +104,47 @@ describe('forge export — export path (DI broker)', () => {
 	});
 });
 
+describe('forge export — robustness hardening', () => {
+	test('skips cleanly when the broker lacks failure-path methods', async () => {
+		const root = tmpRoot();
+		// only the happy-path trio; missing recordProjectionFailure + deadLetterProjection
+		const partial = {
+			async listProjectionOutbox() { return []; },
+			async loadProjectionModel() { return { issues: [], comments: [], dependencies: [] }; },
+			async markProjectionDelivered() {},
+		};
+
+		const result = await exportCommand.handler([], {}, root, { _broker: partial, _now: NOW });
+
+		expect(result.skipped).toBe(true);
+		expect(result.exported).toBe(false);
+	});
+
+	test('--dir without a value does not consume the next flag token', async () => {
+		const root = tmpRoot();
+		const broker = makeBroker({ pending: [] });
+
+		const result = await exportCommand.handler(['--dir', '--json'], {}, root, { _broker: broker, _now: NOW });
+
+		// --json must still be honored, and dir must not become "--json"
+		expect(result.json).toBe(true);
+		expect(result.dir).toBe(path.resolve(root, '.forge', 'kernel'));
+	});
+
+	test('reports failure (success:false) when the projection write fails', async () => {
+		const root = tmpRoot();
+		const pending = [{ id: 'ob-1', event_id: 'ev-1', target: 'jsonl', status: 'pending', attempts: 0 }];
+		const broker = makeBroker({ pending });
+		const failingWriter = () => { throw new Error('disk full'); };
+
+		const result = await exportCommand.handler([], {}, root, { _broker: broker, _now: NOW, _writer: failingWriter });
+
+		expect(result.success).toBe(false);
+		expect(result.exported).toBe(false);
+		expect(result.error).toMatch(/disk full/);
+	});
+});
+
 describe('forge export — import / bootstrap path', () => {
 	test('--import reads a committed snapshot from disk', async () => {
 		const root = tmpRoot();

--- a/test/fixtures/kernel-projection/comments.jsonl
+++ b/test/fixtures/kernel-projection/comments.jsonl
@@ -1,0 +1,2 @@
+{"kind":"comment","id":"c-1","issue_id":"forge-1","body":"First comment","actor":"author","visibility":"public","created_at":"2026-01-01T01:00:00.000Z"}
+{"kind":"comment","id":"c-2","issue_id":"forge-1","body":"Second comment","actor":"reviewer","visibility":"public","created_at":"2026-01-01T02:00:00.000Z"}

--- a/test/fixtures/kernel-projection/dependencies.jsonl
+++ b/test/fixtures/kernel-projection/dependencies.jsonl
@@ -1,0 +1,1 @@
+{"kind":"dependency","id":"dep-1","issue_id":"forge-2","blocks_issue_id":"forge-1","dependency_type":"blocks","created_at":"2026-01-02T00:00:00.000Z"}

--- a/test/fixtures/kernel-projection/issues.jsonl
+++ b/test/fixtures/kernel-projection/issues.jsonl
@@ -1,0 +1,2 @@
+{"kind":"issue","id":"forge-1","title":"First issue","body":"Body text","type":"task","status":"open","priority":"P2","priority_rank":0,"created_at":"2026-01-01T00:00:00.000Z","updated_at":"2026-01-01T00:00:00.000Z","entity_revision":1}
+{"kind":"issue","id":"forge-2","title":"Second issue","body":null,"type":"bug","status":"closed","priority":"P1","priority_rank":10,"created_at":"2026-01-02T00:00:00.000Z","updated_at":"2026-01-02T08:30:00.000Z","entity_revision":3}

--- a/test/fixtures/kernel-projection/manifest.json
+++ b/test/fixtures/kernel-projection/manifest.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "source": "kernel",
+  "counts": {
+    "issues": 2,
+    "comments": 2,
+    "dependencies": 1
+  },
+  "content_sha256": "47b97a734f182f75a2c7b9e8cf6891802c58e846d5f416e1509b4e7d20cc004e"
+}

--- a/test/fixtures/kernel-projection/model.json
+++ b/test/fixtures/kernel-projection/model.json
@@ -1,0 +1,55 @@
+{
+  "issues": [
+    {
+      "id": "forge-2",
+      "title": "Second issue",
+      "body": null,
+      "type": "bug",
+      "status": "closed",
+      "priority": "P1",
+      "priority_rank": 10,
+      "created_at": "2026-01-02T00:00:00.000Z",
+      "updated_at": "2026-01-02T08:30:00.000Z",
+      "entity_revision": 3
+    },
+    {
+      "id": "forge-1",
+      "title": "First issue",
+      "body": "Body text",
+      "type": "task",
+      "status": "open",
+      "priority": "P2",
+      "priority_rank": 0,
+      "created_at": "2026-01-01T00:00:00.000Z",
+      "updated_at": "2026-01-01T00:00:00.000Z",
+      "entity_revision": 1
+    }
+  ],
+  "comments": [
+    {
+      "id": "c-2",
+      "issue_id": "forge-1",
+      "body": "Second comment",
+      "actor": "reviewer",
+      "visibility": "public",
+      "created_at": "2026-01-01T02:00:00.000Z"
+    },
+    {
+      "id": "c-1",
+      "issue_id": "forge-1",
+      "body": "First comment",
+      "actor": "author",
+      "visibility": "public",
+      "created_at": "2026-01-01T01:00:00.000Z"
+    }
+  ],
+  "dependencies": [
+    {
+      "id": "dep-1",
+      "issue_id": "forge-2",
+      "blocks_issue_id": "forge-1",
+      "dependency_type": "blocks",
+      "created_at": "2026-01-02T00:00:00.000Z"
+    }
+  ]
+}

--- a/test/kernel/broker-projection-outbox.test.js
+++ b/test/kernel/broker-projection-outbox.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+
+function makeBroker(driver) {
+	const { createLocalBroker } = require('../../lib/kernel/broker');
+	return createLocalBroker({
+		projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+		gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
+		driver,
+	});
+}
+
+describe('local Kernel broker projection-outbox methods', () => {
+	test('listProjectionOutbox delegates filter, context, and config to the driver', async () => {
+		const calls = [];
+		const rows = [{ id: 'ob-1' }];
+		const broker = makeBroker({
+			async listProjectionOutbox(filter, context, config) {
+				calls.push({ filter, context, config });
+				return rows;
+			},
+		});
+
+		const result = await broker.listProjectionOutbox(
+			{ target: 'jsonl', status: 'pending', now: 'NOW' },
+			{ actor: 'consumer' },
+		);
+
+		expect(result).toBe(rows);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].filter).toEqual({ target: 'jsonl', status: 'pending', now: 'NOW' });
+		expect(calls[0].context).toEqual({ actor: 'consumer' });
+		expect(calls[0].config).toMatchObject({ mode: 'local' });
+	});
+
+	test('listProjectionOutbox throws when the driver lacks the method', async () => {
+		const broker = makeBroker({});
+		await expect(broker.listProjectionOutbox({ target: 'jsonl' })).rejects.toThrow(/listProjectionOutbox/);
+	});
+
+	test('loadProjectionModel delegates to the driver with config', async () => {
+		const model = { issues: [], comments: [], dependencies: [] };
+		const calls = [];
+		const broker = makeBroker({
+			async loadProjectionModel(context, config) {
+				calls.push({ context, config });
+				return model;
+			},
+		});
+
+		const result = await broker.loadProjectionModel({ actor: 'x' });
+
+		expect(result).toBe(model);
+		expect(calls[0].context).toEqual({ actor: 'x' });
+		expect(calls[0].config).toMatchObject({ mode: 'local' });
+	});
+
+	test('markProjectionDelivered delegates ids and meta', async () => {
+		const calls = [];
+		const broker = makeBroker({
+			async markProjectionDelivered(ids, meta, context, config) {
+				calls.push({ ids, meta, context, config });
+				return { updated: ids.length };
+			},
+		});
+
+		const result = await broker.markProjectionDelivered(['ob-1', 'ob-2'], { now: 'NOW' });
+
+		expect(result).toEqual({ updated: 2 });
+		expect(calls[0].ids).toEqual(['ob-1', 'ob-2']);
+		expect(calls[0].meta).toEqual({ now: 'NOW' });
+		expect(calls[0].config).toMatchObject({ mode: 'local' });
+	});
+
+	test('recordProjectionFailure delegates the failure record', async () => {
+		const calls = [];
+		const broker = makeBroker({
+			async recordProjectionFailure(record, context, config) {
+				calls.push({ record, context, config });
+			},
+		});
+
+		await broker.recordProjectionFailure({
+			id: 'ob-1', attempts: 1, next_attempt_at: 'LATER', error: 'boom',
+		});
+
+		expect(calls[0].record).toEqual({ id: 'ob-1', attempts: 1, next_attempt_at: 'LATER', error: 'boom' });
+		expect(calls[0].config).toMatchObject({ mode: 'local' });
+	});
+
+	test('deadLetterProjection delegates the dead-letter record', async () => {
+		const calls = [];
+		const broker = makeBroker({
+			async deadLetterProjection(record, context, config) {
+				calls.push({ record, context, config });
+				return { id: 'dl-1' };
+			},
+		});
+
+		const result = await broker.deadLetterProjection({
+			outbox_id: 'ob-1', target: 'jsonl', error: 'boom', payload_json: '{}', now: 'NOW',
+		});
+
+		expect(result).toEqual({ id: 'dl-1' });
+		expect(calls[0].record.outbox_id).toBe('ob-1');
+		expect(calls[0].record.target).toBe('jsonl');
+		expect(calls[0].config).toMatchObject({ mode: 'local' });
+	});
+
+	test('read/update methods never invoke the append/CAS path', async () => {
+		const forbidden = [];
+		const broker = makeBroker({
+			async listProjectionOutbox() { return []; },
+			async loadProjectionModel() { return { issues: [], comments: [], dependencies: [] }; },
+			async markProjectionDelivered() {},
+			async enqueueKernelProjection() { forbidden.push('enqueueKernelProjection'); },
+			async insertKernelEvent() { forbidden.push('insertKernelEvent'); },
+		});
+
+		await broker.listProjectionOutbox({ target: 'jsonl' });
+		await broker.loadProjectionModel();
+		await broker.markProjectionDelivered(['ob-1'], { now: 'NOW' });
+
+		expect(forbidden).toEqual([]);
+	});
+});

--- a/test/kernel/projection-jsonl-writer.test.js
+++ b/test/kernel/projection-jsonl-writer.test.js
@@ -305,6 +305,34 @@ describe('writeProjection', () => {
 		expect(stray).toEqual([]);
 	});
 
+	test('uses per-write unique temp filenames to avoid concurrent collisions', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+
+		function capturingFs() {
+			const temps = [];
+			const io = {
+				...fs,
+				writeFileSync(target, data) {
+					if (String(target).includes('.tmp-')) temps.push(path.basename(target));
+					return fs.writeFileSync(target, data);
+				},
+			};
+			return { io, temps };
+		}
+
+		const first = capturingFs();
+		const second = capturingFs();
+		writeProjection({ model, projectionDir: dir, fsImpl: first.io });
+		writeProjection({ model, projectionDir: dir, fsImpl: second.io });
+
+		// no predictable static name that two concurrent writers would share
+		expect(first.temps).not.toContain('.tmp-issues.jsonl');
+		// the two writes must not reuse the same temp basenames
+		const shared = first.temps.filter(name => second.temps.includes(name));
+		expect(shared).toEqual([]);
+	});
+
 	test('rejects a projectionDir outside projectRoot', () => {
 		const root = tmpDir();
 		const outside = path.join(os.tmpdir(), `evil-${path.basename(root)}`);

--- a/test/kernel/projection-jsonl-writer.test.js
+++ b/test/kernel/projection-jsonl-writer.test.js
@@ -1,0 +1,429 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+	normalizeProjectionModel,
+	buildProjectionSnapshot,
+	serializeProjection,
+	importProjection,
+	writeProjection,
+	runJsonlProjectionConsumer,
+} = require('../../lib/kernel/projection-jsonl-writer');
+
+// Minimal fixtures
+const ISSUE_RAW = {
+	id: 'forge-1',
+	title: 'First issue',
+	body: 'Body text',
+	type: 'task',
+	status: 'open',
+	priority: 'P2',
+	priority_rank: 0,
+	created_at: '2026-01-01T00:00:00.000Z',
+	updated_at: '2026-01-01T00:00:00.000Z',
+	entity_revision: 1,
+	extra_field: 'should be stripped',
+};
+
+const ISSUE_RAW_2 = {
+	id: 'forge-2',
+	title: 'Second issue',
+	body: null,
+	type: 'bug',
+	status: 'closed',
+	priority: 'P1',
+	priority_rank: 10,
+	created_at: '2026-01-02T00:00:00.000Z',
+	updated_at: '2026-01-02T00:00:00.000Z',
+	entity_revision: 2,
+};
+
+const COMMENT_RAW = {
+	id: 'c-1',
+	issue_id: 'forge-1',
+	body: 'A comment',
+	actor: 'tester',
+	visibility: 'public',
+	created_at: '2026-01-01T01:00:00.000Z',
+	noise: 'stripped',
+};
+
+const DEP_RAW = {
+	id: 'dep-1',
+	issue_id: 'forge-2',
+	blocks_issue_id: 'forge-1',
+	dependency_type: 'blocks',
+	created_at: '2026-01-01T00:00:00.000Z',
+	extra: 'stripped',
+};
+
+describe('normalizeProjectionModel', () => {
+	test('strips extra fields and adds kind to issues', () => {
+		const { issues } = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		expect(issues).toHaveLength(1);
+		const issue = issues[0];
+		expect(issue.kind).toBe('issue');
+		expect(issue.id).toBe('forge-1');
+		expect(issue.extra_field).toBeUndefined();
+		expect(Object.keys(issue)).toEqual([
+			'kind', 'id', 'title', 'body', 'type', 'status',
+			'priority', 'priority_rank', 'created_at', 'updated_at', 'entity_revision',
+		]);
+	});
+
+	test('strips extra fields and adds kind to comments', () => {
+		const { comments } = normalizeProjectionModel({ issues: [], comments: [COMMENT_RAW], dependencies: [] });
+		expect(comments).toHaveLength(1);
+		const comment = comments[0];
+		expect(comment.kind).toBe('comment');
+		expect(comment.noise).toBeUndefined();
+		expect(Object.keys(comment)).toEqual([
+			'kind', 'id', 'issue_id', 'body', 'actor', 'visibility', 'created_at',
+		]);
+	});
+
+	test('strips extra fields and adds kind to dependencies', () => {
+		const { dependencies } = normalizeProjectionModel({ issues: [], comments: [], dependencies: [DEP_RAW] });
+		expect(dependencies).toHaveLength(1);
+		const dep = dependencies[0];
+		expect(dep.kind).toBe('dependency');
+		expect(dep.extra).toBeUndefined();
+		expect(Object.keys(dep)).toEqual([
+			'kind', 'id', 'issue_id', 'blocks_issue_id', 'dependency_type', 'created_at',
+		]);
+	});
+
+	test('handles empty model', () => {
+		const result = normalizeProjectionModel({ issues: [], comments: [], dependencies: [] });
+		expect(result).toEqual({ issues: [], comments: [], dependencies: [] });
+	});
+
+	test('defaults body to null when missing', () => {
+		const raw = { ...ISSUE_RAW };
+		delete raw.body;
+		const { issues } = normalizeProjectionModel({ issues: [raw], comments: [], dependencies: [] });
+		expect(issues[0].body).toBeNull();
+	});
+});
+
+describe('buildProjectionSnapshot', () => {
+	test('sorts issues by id', () => {
+		const model = normalizeProjectionModel({
+			issues: [ISSUE_RAW_2, ISSUE_RAW],
+			comments: [],
+			dependencies: [],
+		});
+		const snap = buildProjectionSnapshot(model);
+		expect(snap.issues.map(i => i.id)).toEqual(['forge-1', 'forge-2']);
+	});
+
+	test('sorts comments by (issue_id, created_at, id)', () => {
+		const c1 = { ...COMMENT_RAW, id: 'c-1', issue_id: 'forge-2', created_at: '2026-01-01T01:00:00.000Z' };
+		const c2 = { ...COMMENT_RAW, id: 'c-2', issue_id: 'forge-1', created_at: '2026-01-01T02:00:00.000Z' };
+		const c3 = { ...COMMENT_RAW, id: 'c-3', issue_id: 'forge-1', created_at: '2026-01-01T01:00:00.000Z' };
+		const model = normalizeProjectionModel({ issues: [], comments: [c1, c2, c3], dependencies: [] });
+		const snap = buildProjectionSnapshot(model);
+		expect(snap.comments.map(c => c.id)).toEqual(['c-3', 'c-2', 'c-1']);
+	});
+
+	test('sorts dependencies by (issue_id, blocks_issue_id, dependency_type, id)', () => {
+		const d1 = { ...DEP_RAW, id: 'd-1', issue_id: 'forge-2', blocks_issue_id: 'forge-1', dependency_type: 'blocks' };
+		const d2 = { ...DEP_RAW, id: 'd-2', issue_id: 'forge-1', blocks_issue_id: 'forge-3', dependency_type: 'blocks' };
+		const model = normalizeProjectionModel({ issues: [], comments: [], dependencies: [d1, d2] });
+		const snap = buildProjectionSnapshot(model);
+		expect(snap.dependencies.map(d => d.id)).toEqual(['d-2', 'd-1']);
+	});
+
+	test('produces same result regardless of input order (determinism)', () => {
+		const model1 = normalizeProjectionModel({ issues: [ISSUE_RAW, ISSUE_RAW_2], comments: [COMMENT_RAW], dependencies: [DEP_RAW] });
+		const model2 = normalizeProjectionModel({ issues: [ISSUE_RAW_2, ISSUE_RAW], comments: [COMMENT_RAW], dependencies: [DEP_RAW] });
+		expect(buildProjectionSnapshot(model1)).toEqual(buildProjectionSnapshot(model2));
+	});
+});
+
+describe('serializeProjection', () => {
+	test('produces exactly four file keys', () => {
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [COMMENT_RAW], dependencies: [DEP_RAW] });
+		const { files } = serializeProjection(model);
+		expect(Object.keys(files).sort()).toEqual(['comments.jsonl', 'dependencies.jsonl', 'issues.jsonl', 'manifest.json']);
+	});
+
+	test('manifest has schema_version, source, counts, content_sha256 — no timestamp', () => {
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		const { files } = serializeProjection(model);
+		const manifest = JSON.parse(files['manifest.json']);
+		expect(manifest.schema_version).toBe(1);
+		expect(manifest.source).toBe('kernel');
+		expect(manifest.counts).toEqual({ issues: 1, comments: 0, dependencies: 0 });
+		expect(typeof manifest.content_sha256).toBe('string');
+		expect(manifest.content_sha256).toHaveLength(64);
+		expect(manifest.exported_at).toBeUndefined();
+	});
+
+	test('byte-identical output for same logical state regardless of input order', () => {
+		const m1 = normalizeProjectionModel({ issues: [ISSUE_RAW, ISSUE_RAW_2], comments: [COMMENT_RAW], dependencies: [DEP_RAW] });
+		const m2 = normalizeProjectionModel({ issues: [ISSUE_RAW_2, ISSUE_RAW], comments: [COMMENT_RAW], dependencies: [DEP_RAW] });
+		const s1 = serializeProjection(m1);
+		const s2 = serializeProjection(m2);
+		expect(s1.files['issues.jsonl']).toBe(s2.files['issues.jsonl']);
+		expect(s1.files['manifest.json']).toBe(s2.files['manifest.json']);
+	});
+
+	test('sha256 changes when content changes', () => {
+		const m1 = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		const m2 = normalizeProjectionModel({ issues: [ISSUE_RAW_2], comments: [], dependencies: [] });
+		const s1 = serializeProjection(m1);
+		const s2 = serializeProjection(m2);
+		const manifest1 = JSON.parse(s1.files['manifest.json']);
+		const manifest2 = JSON.parse(s2.files['manifest.json']);
+		expect(manifest1.content_sha256).not.toBe(manifest2.content_sha256);
+	});
+
+	test('JSONL files end with newline', () => {
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		const { files } = serializeProjection(model);
+		expect(files['issues.jsonl'].endsWith('\n')).toBe(true);
+	});
+
+	test('empty collections produce empty JSONL string', () => {
+		const model = normalizeProjectionModel({ issues: [], comments: [], dependencies: [] });
+		const { files } = serializeProjection(model);
+		expect(files['issues.jsonl']).toBe('');
+		expect(files['comments.jsonl']).toBe('');
+		expect(files['dependencies.jsonl']).toBe('');
+	});
+});
+
+describe('importProjection', () => {
+	test('round-trip: importProjection(serializeProjection(model)) deep-equals normalized model', () => {
+		const model = normalizeProjectionModel({
+			issues: [ISSUE_RAW, ISSUE_RAW_2],
+			comments: [COMMENT_RAW],
+			dependencies: [DEP_RAW],
+		});
+		const snap = buildProjectionSnapshot(model);
+		const { files } = serializeProjection(snap);
+		const imported = importProjection(files);
+		expect(imported).toEqual(snap);
+	});
+
+	test('throws on tampered manifest hash', () => {
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		const { files } = serializeProjection(model);
+		const manifest = JSON.parse(files['manifest.json']);
+		manifest.content_sha256 = 'a'.repeat(64);
+		const tampered = { ...files, 'manifest.json': JSON.stringify(manifest) };
+		expect(() => importProjection(tampered)).toThrow(/sha256/i);
+	});
+
+	test('throws on missing manifest', () => {
+		const { 'manifest.json': _removed, ...noManifest } = {
+			'issues.jsonl': '',
+			'comments.jsonl': '',
+			'dependencies.jsonl': '',
+			'manifest.json': '',
+		};
+		expect(() => importProjection(noManifest)).toThrow(/manifest/i);
+	});
+});
+
+describe('writeProjection', () => {
+	function tmpDir() {
+		return fs.mkdtempSync(path.join(os.tmpdir(), 'forge-proj-'));
+	}
+
+	test('writes four files to projectionDir and returns stats', () => {
+		const root = tmpDir();
+		const dir = path.join(root, '.forge', 'kernel');
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [COMMENT_RAW], dependencies: [DEP_RAW] });
+
+		const result = writeProjection({ model, projectionDir: dir });
+
+		expect(result.writes).toBe(4);
+		expect(result.bytes).toBeGreaterThan(0);
+		expect(result.dir).toBe(path.resolve(dir));
+		expect(result.files.slice().sort()).toEqual([
+			'comments.jsonl', 'dependencies.jsonl', 'issues.jsonl', 'manifest.json',
+		]);
+		expect(fs.existsSync(path.join(dir, 'issues.jsonl'))).toBe(true);
+		expect(fs.existsSync(path.join(dir, 'manifest.json'))).toBe(true);
+	});
+
+	test('creates nested projectionDir when missing', () => {
+		const dir = path.join(tmpDir(), 'a', 'b', 'c');
+		const model = normalizeProjectionModel({ issues: [], comments: [], dependencies: [] });
+
+		writeProjection({ model, projectionDir: dir });
+
+		expect(fs.existsSync(path.join(dir, 'manifest.json'))).toBe(true);
+	});
+
+	test('written files re-import to the same snapshot (on-disk round-trip)', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		const model = normalizeProjectionModel({
+			issues: [ISSUE_RAW, ISSUE_RAW_2],
+			comments: [COMMENT_RAW],
+			dependencies: [DEP_RAW],
+		});
+		const snap = buildProjectionSnapshot(model);
+
+		writeProjection({ model, projectionDir: dir });
+
+		const files = {};
+		for (const name of ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl', 'manifest.json']) {
+			files[name] = fs.readFileSync(path.join(dir, name), 'utf8');
+		}
+		expect(importProjection(files)).toEqual(snap);
+	});
+
+	test('rolls back prior file contents when a rename fails mid-write', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, 'issues.jsonl'), 'OLD-ISSUES\n');
+
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		const failingFs = {
+			...fs,
+			renameSync(src, dest) {
+				if (String(dest).includes('manifest.json')) {
+					throw new Error('simulated rename failure');
+				}
+				return fs.renameSync(src, dest);
+			},
+		};
+
+		expect(() => writeProjection({ model, projectionDir: dir, fsImpl: failingFs })).toThrow(/rename/i);
+		// issues.jsonl had already been renamed; rollback must restore old content.
+		expect(fs.readFileSync(path.join(dir, 'issues.jsonl'), 'utf8')).toBe('OLD-ISSUES\n');
+		// no stray temp files left behind
+		const stray = fs.readdirSync(dir).filter(name => name.includes('.tmp-'));
+		expect(stray).toEqual([]);
+	});
+
+	test('rejects a projectionDir outside projectRoot', () => {
+		const root = tmpDir();
+		const outside = path.join(os.tmpdir(), `evil-${path.basename(root)}`);
+		const model = normalizeProjectionModel({ issues: [], comments: [], dependencies: [] });
+
+		expect(() => writeProjection({ model, projectionDir: outside, projectRoot: root }))
+			.toThrow(/project root/i);
+	});
+});
+
+describe('runJsonlProjectionConsumer', () => {
+	const NOW = '2026-06-18T00:00:00.000Z';
+
+	function makeBroker(overrides = {}) {
+		const calls = {
+			listProjectionOutbox: [],
+			loadProjectionModel: 0,
+			markProjectionDelivered: [],
+			recordProjectionFailure: [],
+			deadLetterProjection: [],
+		};
+		const broker = {
+			async listProjectionOutbox(args) {
+				calls.listProjectionOutbox.push(args);
+				return overrides.pending || [];
+			},
+			async loadProjectionModel() {
+				calls.loadProjectionModel += 1;
+				return overrides.model || { issues: [], comments: [], dependencies: [] };
+			},
+			async markProjectionDelivered(ids, meta) {
+				calls.markProjectionDelivered.push({ ids, meta });
+			},
+			async recordProjectionFailure(args) {
+				calls.recordProjectionFailure.push(args);
+			},
+			async deadLetterProjection(args) {
+				calls.deadLetterProjection.push(args);
+			},
+		};
+		return { broker, calls };
+	}
+
+	test('drains pending entries, writes once, and marks delivered', async () => {
+		const pending = [
+			{ id: 'ob-1', event_id: 'ev-1', target: 'jsonl', status: 'pending', attempts: 0 },
+			{ id: 'ob-2', event_id: 'ev-2', target: 'jsonl', status: 'pending', attempts: 0 },
+		];
+		const model = { issues: [ISSUE_RAW], comments: [], dependencies: [] };
+		const { broker, calls } = makeBroker({ pending, model });
+		const writes = [];
+		const writer = args => {
+			writes.push(args);
+			return { dir: args.projectionDir, writes: 4, bytes: 10, files: ['issues.jsonl'] };
+		};
+
+		const result = await runJsonlProjectionConsumer({
+			broker, projectionDir: '.forge/kernel', projectRoot: '/repo', now: NOW, writer,
+		});
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0].model).toBe(model);
+		expect(writes[0].projectionDir).toBe('.forge/kernel');
+		expect(writes[0].projectRoot).toBe('/repo');
+		expect(calls.loadProjectionModel).toBe(1);
+		expect(calls.markProjectionDelivered).toHaveLength(1);
+		expect(calls.markProjectionDelivered[0].ids).toEqual(['ob-1', 'ob-2']);
+		expect(result.written).toBe(true);
+		expect(result.drained).toBe(2);
+		expect(result.delivered).toEqual(['ob-1', 'ob-2']);
+	});
+
+	test('does nothing when there are no pending entries', async () => {
+		const { broker, calls } = makeBroker({ pending: [] });
+		let writerCalled = false;
+		const writer = () => { writerCalled = true; };
+
+		const result = await runJsonlProjectionConsumer({ broker, now: NOW, writer });
+
+		expect(writerCalled).toBe(false);
+		expect(calls.loadProjectionModel).toBe(0);
+		expect(calls.markProjectionDelivered).toEqual([]);
+		expect(result).toMatchObject({ drained: 0, written: false });
+	});
+
+	test('on write failure below maxAttempts increments attempts with backoff', async () => {
+		const pending = [{ id: 'ob-1', event_id: 'ev-1', target: 'jsonl', status: 'pending', attempts: 0 }];
+		const { broker, calls } = makeBroker({ pending });
+		const writer = () => { throw new Error('disk full'); };
+
+		const result = await runJsonlProjectionConsumer({
+			broker, now: NOW, maxAttempts: 5, baseBackoffMs: 5000, writer,
+		});
+
+		expect(calls.recordProjectionFailure).toHaveLength(1);
+		const failure = calls.recordProjectionFailure[0];
+		expect(failure.id).toBe('ob-1');
+		expect(failure.attempts).toBe(1);
+		expect(failure.error).toMatch(/disk full/);
+		// backoff = now + base * 2^(attempts-1) = now + 5000ms
+		expect(Date.parse(failure.next_attempt_at)).toBe(Date.parse(NOW) + 5000);
+		expect(calls.deadLetterProjection).toEqual([]);
+		expect(result).toMatchObject({ written: false, retried: ['ob-1'], dead: [] });
+	});
+
+	test('dead-letters an entry once attempts reach maxAttempts', async () => {
+		const pending = [{ id: 'ob-1', event_id: 'ev-1', target: 'jsonl', status: 'pending', attempts: 4 }];
+		const { broker, calls } = makeBroker({ pending });
+		const writer = () => { throw new Error('still failing'); };
+
+		const result = await runJsonlProjectionConsumer({
+			broker, now: NOW, maxAttempts: 5, writer,
+		});
+
+		expect(calls.deadLetterProjection).toHaveLength(1);
+		const dead = calls.deadLetterProjection[0];
+		expect(dead.outbox_id).toBe('ob-1');
+		expect(dead.target).toBe('jsonl');
+		expect(dead.error).toMatch(/still failing/);
+		expect(calls.recordProjectionFailure).toEqual([]);
+		expect(result).toMatchObject({ written: false, dead: ['ob-1'], retried: [] });
+	});
+});

--- a/test/kernel/projection-jsonl-writer.test.js
+++ b/test/kernel/projection-jsonl-writer.test.js
@@ -315,6 +315,35 @@ describe('writeProjection', () => {
 	});
 });
 
+describe('committed fixtures (byte-match + round-trip)', () => {
+	const FIXTURE_DIR = path.join(__dirname, '..', 'fixtures', 'kernel-projection');
+
+	function readFixture(name) {
+		return fs.readFileSync(path.join(FIXTURE_DIR, name), 'utf8');
+	}
+
+	test('serializing the fixture model reproduces the committed JSONL byte-for-byte', () => {
+		const raw = JSON.parse(readFixture('model.json'));
+		const model = normalizeProjectionModel(raw);
+		const { files } = serializeProjection(model);
+
+		for (const name of ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl', 'manifest.json']) {
+			// fixtures are stored with LF (enforced via .gitattributes eol=lf)
+			expect(files[name]).toBe(readFixture(name).replace(/\r\n/g, '\n'));
+		}
+	});
+
+	test('importing the committed fixtures reconstructs the sorted snapshot', () => {
+		const files = {};
+		for (const name of ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl', 'manifest.json']) {
+			files[name] = readFixture(name).replace(/\r\n/g, '\n');
+		}
+		const imported = importProjection(files);
+		const expected = buildProjectionSnapshot(normalizeProjectionModel(JSON.parse(readFixture('model.json'))));
+		expect(imported).toEqual(expected);
+	});
+});
+
 describe('readProjection', () => {
 	function tmpDir() {
 		return fs.mkdtempSync(path.join(os.tmpdir(), 'forge-proj-'));

--- a/test/kernel/projection-jsonl-writer.test.js
+++ b/test/kernel/projection-jsonl-writer.test.js
@@ -4,6 +4,7 @@ const { describe, expect, test } = require('bun:test');
 const os = require('node:os');
 const fs = require('node:fs');
 const path = require('node:path');
+const crypto = require('node:crypto');
 
 const {
 	normalizeProjectionModel,
@@ -13,6 +14,9 @@ const {
 	writeProjection,
 	readProjection,
 	runJsonlProjectionConsumer,
+	computeBackoff,
+	SCHEMA_VERSION,
+	DEFAULT_BASE_BACKOFF_MS,
 } = require('../../lib/kernel/projection-jsonl-writer');
 
 // Minimal fixtures
@@ -410,7 +414,6 @@ describe('projection integrity hardening', () => {
 		// recomputing the hash so we isolate the count check, not the hash check.
 		const oneIssue = files['issues.jsonl'].split('\n').filter(Boolean)[0] + '\n';
 		const manifest = JSON.parse(files['manifest.json']);
-		const crypto = require('node:crypto');
 		manifest.content_sha256 = crypto.createHash('sha256')
 			.update(oneIssue).update('').update('').digest('hex');
 		const tampered = {
@@ -575,5 +578,89 @@ describe('runJsonlProjectionConsumer', () => {
 		expect(dead.error).toMatch(/still failing/);
 		expect(calls.recordProjectionFailure).toEqual([]);
 		expect(result).toMatchObject({ written: false, dead: ['ob-1'], retried: [] });
+	});
+});
+
+describe('PR #218 review hardening', () => {
+	function tmpDir() {
+		return fs.mkdtempSync(path.join(os.tmpdir(), 'forge-proj-'));
+	}
+
+	test('exposes SCHEMA_VERSION and DEFAULT_BASE_BACKOFF_MS', () => {
+		expect(SCHEMA_VERSION).toBe(1);
+		expect(DEFAULT_BASE_BACKOFF_MS).toBe(5000);
+	});
+
+	test('computeBackoff throws a clear, attributable error for an invalid now', () => {
+		// must name `now` (not a bare RangeError "Invalid time value" that masks the
+		// real write error inside the consumer's catch block)
+		expect(() => computeBackoff('not-a-timestamp', 1, 5000)).toThrow(/now/i);
+	});
+
+	test('importProjection rejects a manifest with no counts field', () => {
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		const { files } = serializeProjection(model);
+		const manifest = JSON.parse(files['manifest.json']);
+		delete manifest.counts; // hash is over the JSONL bytes, so it still matches
+		const tampered = { ...files, 'manifest.json': JSON.stringify(manifest) };
+
+		expect(() => importProjection(tampered)).toThrow(/count/i);
+	});
+
+	test('writeProjection canonicalizes raw rows before persistence', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		const rawModel = { issues: [ISSUE_RAW], comments: [COMMENT_RAW], dependencies: [DEP_RAW] };
+
+		writeProjection({ model: rawModel, projectionDir: dir });
+		const result = readProjection({ projectionDir: dir });
+
+		expect(result.model.issues[0].kind).toBe('issue');
+		expect(result.model.issues[0].extra_field).toBeUndefined();
+		expect(Object.keys(result.model.issues[0])).toEqual([
+			'kind', 'id', 'title', 'body', 'type', 'status',
+			'priority', 'priority_rank', 'created_at', 'updated_at', 'entity_revision',
+		]);
+	});
+
+	test('rolls back cleanly when the first rename fails (nothing committed yet)', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, 'issues.jsonl'), 'OLD-ISSUES\n');
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		const failingFs = {
+			...fs,
+			renameSync(src, dest) {
+				if (String(dest).endsWith(`${path.sep}issues.jsonl`)) throw new Error('first rename failed');
+				return fs.renameSync(src, dest);
+			},
+		};
+
+		expect(() => writeProjection({ model, projectionDir: dir, fsImpl: failingFs })).toThrow(/first rename/);
+		// first rename failed → nothing committed → old content intact
+		expect(fs.readFileSync(path.join(dir, 'issues.jsonl'), 'utf8')).toBe('OLD-ISSUES\n');
+		expect(fs.readdirSync(dir).filter(name => name.includes('.tmp-'))).toEqual([]);
+		expect(fs.existsSync(path.join(dir, '.export.lock'))).toBe(false);
+	});
+
+	test('refuses to publish when another export holds the directory lock', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, '.export.lock'), 'held-by-other-pid');
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+
+		expect(() => writeProjection({ model, projectionDir: dir })).toThrow(/export.*(progress|lock)|lock/i);
+		// a pre-existing (foreign) lock must NOT be deleted by the loser
+		expect(fs.existsSync(path.join(dir, '.export.lock'))).toBe(true);
+		// and the loser must not leave its temp files behind
+		expect(fs.readdirSync(dir).filter(name => name.includes('.tmp-'))).toEqual([]);
+	});
+
+	test('releases the directory lock after a successful publish', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+
+		writeProjection({ model, projectionDir: dir });
+
+		expect(fs.existsSync(path.join(dir, '.export.lock'))).toBe(false);
 	});
 });

--- a/test/kernel/projection-jsonl-writer.test.js
+++ b/test/kernel/projection-jsonl-writer.test.js
@@ -345,6 +345,57 @@ describe('committed fixtures (byte-match + round-trip)', () => {
 	});
 });
 
+describe('projection integrity hardening', () => {
+	test('serializeProjection canonicalizes raw (un-normalized) rows defensively', () => {
+		// Raw rows as a DB driver would return them: extra columns, no `kind`,
+		// shuffled order. serializeProjection must still produce canonical,
+		// deterministic bytes identical to pre-normalized input.
+		const rawModel = { issues: [ISSUE_RAW_2, ISSUE_RAW], comments: [COMMENT_RAW], dependencies: [DEP_RAW] };
+		const fromRaw = serializeProjection(rawModel);
+		const fromNormalized = serializeProjection(normalizeProjectionModel(rawModel));
+
+		expect(fromRaw.files).toEqual(fromNormalized.files);
+
+		const firstIssue = JSON.parse(fromRaw.files['issues.jsonl'].split('\n')[0]);
+		expect(firstIssue.kind).toBe('issue');
+		expect(firstIssue.extra_field).toBeUndefined();
+	});
+
+	test('importProjection rejects a record whose kind does not match its file', () => {
+		// Move a comment line into issues.jsonl. Concatenation is byte-identical,
+		// so the sha256 still matches — only the per-file kind check catches this.
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [COMMENT_RAW], dependencies: [] });
+		const { files } = serializeProjection(model);
+		const tampered = {
+			...files,
+			'issues.jsonl': files['issues.jsonl'] + files['comments.jsonl'],
+			'comments.jsonl': '',
+		};
+
+		expect(() => importProjection(tampered)).toThrow(/kind|issues\.jsonl/i);
+	});
+
+	test('importProjection rejects per-file counts that disagree with the manifest', () => {
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW, ISSUE_RAW_2], comments: [], dependencies: [] });
+		const { files } = serializeProjection(model);
+		// drop one issue line but keep the manifest counts/hash inconsistent by
+		// recomputing the hash so we isolate the count check, not the hash check.
+		const oneIssue = files['issues.jsonl'].split('\n').filter(Boolean)[0] + '\n';
+		const manifest = JSON.parse(files['manifest.json']);
+		const crypto = require('node:crypto');
+		manifest.content_sha256 = crypto.createHash('sha256')
+			.update(oneIssue).update('').update('').digest('hex');
+		const tampered = {
+			'issues.jsonl': oneIssue,
+			'comments.jsonl': '',
+			'dependencies.jsonl': '',
+			'manifest.json': JSON.stringify(manifest),
+		};
+
+		expect(() => importProjection(tampered)).toThrow(/count/i);
+	});
+});
+
 describe('readProjection', () => {
 	function tmpDir() {
 		return fs.mkdtempSync(path.join(os.tmpdir(), 'forge-proj-'));

--- a/test/kernel/projection-jsonl-writer.test.js
+++ b/test/kernel/projection-jsonl-writer.test.js
@@ -328,15 +328,16 @@ describe('committed fixtures (byte-match + round-trip)', () => {
 		const { files } = serializeProjection(model);
 
 		for (const name of ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl', 'manifest.json']) {
-			// fixtures are stored with LF (enforced via .gitattributes eol=lf)
-			expect(files[name]).toBe(readFixture(name).replace(/\r\n/g, '\n'));
+			// fixtures are stored with LF (enforced via .gitattributes eol=lf); compare
+			// raw bytes so a CRLF regression on checkout is actually caught here.
+			expect(files[name]).toBe(readFixture(name));
 		}
 	});
 
 	test('importing the committed fixtures reconstructs the sorted snapshot', () => {
 		const files = {};
 		for (const name of ['issues.jsonl', 'comments.jsonl', 'dependencies.jsonl', 'manifest.json']) {
-			files[name] = readFixture(name).replace(/\r\n/g, '\n');
+			files[name] = readFixture(name);
 		}
 		const imported = importProjection(files);
 		const expected = buildProjectionSnapshot(normalizeProjectionModel(JSON.parse(readFixture('model.json'))));

--- a/test/kernel/projection-jsonl-writer.test.js
+++ b/test/kernel/projection-jsonl-writer.test.js
@@ -11,6 +11,7 @@ const {
 	serializeProjection,
 	importProjection,
 	writeProjection,
+	readProjection,
 	runJsonlProjectionConsumer,
 } = require('../../lib/kernel/projection-jsonl-writer');
 
@@ -311,6 +312,46 @@ describe('writeProjection', () => {
 
 		expect(() => writeProjection({ model, projectionDir: outside, projectRoot: root }))
 			.toThrow(/project root/i);
+	});
+});
+
+describe('readProjection', () => {
+	function tmpDir() {
+		return fs.mkdtempSync(path.join(os.tmpdir(), 'forge-proj-'));
+	}
+
+	test('returns null when no manifest is present', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		expect(readProjection({ projectionDir: dir })).toBeNull();
+	});
+
+	test('reads a written snapshot back to the same model', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		const model = normalizeProjectionModel({
+			issues: [ISSUE_RAW, ISSUE_RAW_2],
+			comments: [COMMENT_RAW],
+			dependencies: [DEP_RAW],
+		});
+		const snap = buildProjectionSnapshot(model);
+
+		writeProjection({ model, projectionDir: dir });
+		const result = readProjection({ projectionDir: dir });
+
+		expect(result.dir).toBe(path.resolve(dir));
+		expect(result.model).toEqual(snap);
+	});
+
+	test('throws when the on-disk manifest hash is tampered', () => {
+		const dir = path.join(tmpDir(), '.forge', 'kernel');
+		const model = normalizeProjectionModel({ issues: [ISSUE_RAW], comments: [], dependencies: [] });
+		writeProjection({ model, projectionDir: dir });
+
+		const manifestPath = path.join(dir, 'manifest.json');
+		const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+		manifest.content_sha256 = 'b'.repeat(64);
+		fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+		expect(() => readProjection({ projectionDir: dir })).toThrow(/sha256/i);
 	});
 });
 


### PR DESCRIPTION
## Summary

Implements **D16 — Kernel JSONL portability projection** (roadmap `forge-2agy.9.6.x`): the Kernel-owned, **explicit-only**, deterministic JSONL export/import projection for clone/bootstrap portability. This is the Beads/Dolt-retirement portability prerequisite that gates `forge-2agy.9.1.8` (Dolt hot-path retirement) and is adjacent to the D22 `fresh-clone-no-beads-acceptance`.

Design doc: [`docs/work/2026-06-17-kernel-jsonl-projection-d16/design.md`](docs/work/2026-06-17-kernel-jsonl-projection-d16/design.md)

## What's in this PR

- **`lib/kernel/projection-jsonl-writer.js`** — deterministic Kernel-native JSONL serialization (stable sort, fixed key order, timestamp-free `manifest.json` with `content_sha256`), atomic multi-file fs write with snapshot rollback, symmetric on-disk read with manifest-integrity verification, and an outbox-driven consumer (`drain → one snapshot write → mark delivered`; `write-fail → attempts++/backoff`; `exceed maxAttempts → dead-letter`). Projection failure never mutates Kernel authority.
- **`lib/kernel/broker.js`** — 5 **additive** outbox read/update methods (`listProjectionOutbox`, `loadProjectionModel`, `markProjectionDelivered`, `recordProjectionFailure`, `deadLetterProjection`). The append/CAS path (`runGuardedEvent`/`enqueueKernelProjection`/`insertKernelEvent`) is untouched — existing `broker-guards` tests stay green.
- **`lib/commands/export.js`** — standalone `forge export [--dir <path>] [--dry-run] [--json] [--import]`.
- **Deterministic committed fixtures** under `test/fixtures/kernel-projection/` + byte-match and import round-trip tests (LF pinned via `.gitattributes eol=lf`).

## Deliberate boundaries (by design — NOT regressions)

- **Export direction graceful-skips in production today.** The write direction requires a projection-capable Kernel broker; the production SQLite driver does not yet implement the outbox SQL methods, and the Kernel broker is feature-gated with a DI'd driver. Wiring the real driver belongs to the append-path lane (**PR 3**) — the same constraint that scopes this lane. Until then `forge export` skips with a clear message and is fully exercised via dependency injection in tests.
- **`--import` validates but does not yet hydrate the Kernel.** It reads `.forge/kernel/*.jsonl`, verifies manifest integrity (sha256), and reports counts — but does not load the model into Kernel authority, so `forge status` will not show an imported backlog yet (hydration needs the append path). **The round-trip proven here is serialization-level** (`writeProjection → readProjection` deep-equals the normalized snapshot), not the full D22 bootstrap-to-status acceptance.
- **No `schema.js` change** (D16-e): `kernel_outbox.next_attempt_at` and `kernel_dead_letters` already exist; `target` is free TEXT. This also avoids the PR 5 (taxonomy) conflict on `schema.js`.
- **`sync.js` not auto-wired** (D16-g): D16 forbids auto-export on routine mutation/push. Portability artifacts are git-tracked, so ordinary `git`/`forge sync` already carries them.

## Verification

- `.forge/kernel/` is **git-tracked** (only `.forge/eval-logs/` is ignored) — confirmed via `git check-ignore`.
- Local suites green: `test/kernel` + `test/adapters` 108/108; `test/commands` 452 pass / 31 skip / 0 fail; `test/commands/release.test.js` 6/6.
- CLI smoke-tested through the real registry: `forge export --dry-run`, `--import`, `--json`.
- D20 kill-list regenerated — no diff (no `bd` call-sites added).
- Lint clean (`eslint --max-warnings 0`); TDD RED→GREEN per task.

## Test plan

- [x] Deterministic serialization (shuffled input → byte-identical output)
- [x] Manifest integrity throws on tampered hash (import + on-disk)
- [x] Atomic write rollback on mid-write rename failure
- [x] Consumer: drain/write/deliver, no-pending no-op, backoff, dead-letter
- [x] Broker additive methods delegate; append/CAS path untouched
- [x] `forge export` skip / export / dry-run / json / import / tamper paths
- [x] Committed-fixture byte-match + round-trip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `forge export` for deterministic JSONL export/import of issues, comments, and dependencies, including `manifest.json` integrity verification.
  * Supports `--import` (import committed snapshot), `--dry-run` (report pending work), `--json` (machine-readable output), and `--dir` (custom output location).

* **Documentation**
  * Added design documentation and a TDD-first task plan for the kernel JSONL portability projection (D16).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->