### PR TITLE
feat(kernel): D18 taxonomy read-model + validation layer

### DIFF
--- a/docs/reference/KERNEL_TAXONOMY_VALIDATION.md
+++ b/docs/reference/KERNEL_TAXONOMY_VALIDATION.md
@@ -48,8 +48,9 @@ transition leaves them.
 
 `ready` and `blocked` are **derived read-model facts, never stored statuses** (D18). A
 blocker that clears makes the issue ready again in whatever stored status it held — there
-is no "preserve previous status" hack. "Backlog" is simply `open` with readiness
-conditions unmet.
+is no "preserve previous status" hack. `backlog` is the fallback summary state when an
+issue is neither terminal nor ready/blocked/gated/deferred/claimed/disabled — for example
+`open` with readiness conditions unmet, or a non-workable status such as `review`.
 
 `deriveReadiness(issue, context)` returns:
 

--- a/docs/reference/KERNEL_TAXONOMY_VALIDATION.md
+++ b/docs/reference/KERNEL_TAXONOMY_VALIDATION.md
@@ -1,0 +1,160 @@
+# Kernel Taxonomy, Readiness, and Validation
+
+Reference for the Forge Kernel issue taxonomy collapse and its read-model/validation
+layer, implemented per **D18** (see
+[`docs/work/2026-06-06-kernel-backlog-memory-roadmap/decisions.md`](../work/2026-06-06-kernel-backlog-memory-roadmap/decisions.md))
+and roadmap items `forge-2agy.9.2.1`, `.9.2.2`, `.9.2.6`, `.9.2.7`, `.9.2.8`, `.9.2.9`.
+
+The four planning axes are kept **separate** (D5): stored **status**, parent/child
+**hierarchy**, sprint/release planning **bucket**, and workflow **stage** execution. A
+task can be in a sprint, have a parent epic, be derived-ready, and currently sit in the
+`validate` stage — these are not the same field.
+
+---
+
+## 1. Issue types (4) — `lib/kernel/taxonomy-validator.js`
+
+A type only earns existence if it changes Kernel behavior (routing, gates, board
+grouping, rollup). `feature`, `story`, `chore`, and `spike` are **labels**, not types.
+
+| Type | `canParent` | `claimable` | `blocksOthers` | `rollup` | Board group |
+| --- | --- | --- | --- | --- | --- |
+| `epic` | ✅ (only container) | ❌ | ❌ | ✅ | `roadmap` |
+| `task` | ❌ | ✅ | ❌ | ❌ | `backlog` |
+| `bug` | ❌ | ✅ | ❌ | ❌ | `backlog` |
+| `decision` | ❌ | ❌ | ✅ (gates dependents) | ❌ | `decisions` |
+
+`TYPE_BEHAVIORS` is the single source of truth for these mappings. Enums are enforced at
+the **validation layer**, not as DB constraints, so label-based extensibility and derived
+readiness stay outside the stored column set.
+
+## 2. Status lifecycle (5 stored)
+
+Stored statuses: `open`, `in_progress`, `review`, `done`, `cancelled`.
+
+```text
+open ──► in_progress ──► review ──► done
+ ▲           │             │
+ └───────────┘             │   (rework: review ──► in_progress, in_progress ──► open)
+open / in_progress / review ──► cancelled        (done, cancelled are terminal)
+```
+
+`STATUS_TRANSITIONS` encodes the legal moves. `validateStatusTransition(from, to)` throws
+a `TaxonomyValidationError` for illegal moves and unknown statuses; a same-status
+transition is treated as an idempotent no-op. `done` and `cancelled` are terminal — no
+transition leaves them.
+
+## 3. Derived readiness — `lib/kernel/readiness-model.js`
+
+`ready` and `blocked` are **derived read-model facts, never stored statuses** (D18). A
+blocker that clears makes the issue ready again in whatever stored status it held — there
+is no "preserve previous status" hack. "Backlog" is simply `open` with readiness
+conditions unmet.
+
+`deriveReadiness(issue, context)` returns:
+
+```json
+{
+  "id": "forge-1",
+  "status": "open",
+  "ready": true,
+  "blocked": false,
+  "blocked_by": [],
+  "reasons": [],
+  "state": "ready"
+}
+```
+
+Readiness policy considers: blocking dependencies (upstream not in a terminal status —
+`done` and `cancelled` both clear, so a cancelled blocker never wedges a dependent),
+unresolved decision dependencies, projection **quarantine**/conflicts, required workflow
+**gates**, **defer** windows, **policy-disabled** work, and an **active conflicting
+claim** by another actor. Reason codes (`READINESS_REASONS`): `dependency` (carries a
+`decision: true` flag when the blocker is a decision issue), `quarantine`, `conflict`,
+`gate`, `claimed`, `deferred`, `policy_disabled`.
+
+**Acceptance-criteria and due-date readiness** are modeled through the generic `gates`
+input (an acceptance/definition-of-ready gate, or a due-window gate the caller supplies),
+not as separate hardcoded field checks — so the policy stays open to caller-defined gates
+without the read model owning every "definition of ready" rule.
+
+Summary `state` (precedence high→low): `closed` → `blocked` → `gated` → `deferred` →
+`claimed` → `disabled` → `ready` → `backlog`. `blocked` (dependencies/quarantine/conflict)
+always outranks softer not-ready reasons. Because the single `state` collapses multiple
+conditions, consumers picking next work should read the full `reasons[]` — e.g. a claim
+hidden behind a defer window is in `reasons[]` even when `state` reports `deferred`.
+Terminal issues are `closed` — neither ready nor blocked.
+
+`buildReadinessIndex({ issues, dependencies, claims, conflicts, gates, now, actor,
+policyDisabledIds })` computes readiness for a whole board, resolving each dependency's
+status from the issue set and returning a `readyQueue` ordered by authoritative numeric
+rank then id, plus the `blocked` id list. The ready-work queue excludes terminal,
+deferred, gated, policy-disabled, and claimed-by-other issues.
+
+## 4. Validation layer — `lib/kernel/taxonomy-validator.js`
+
+| Function | Enforces |
+| --- | --- |
+| `validateIssueTaxonomy(issue)` | type/status enum membership; rejects self-parent |
+| `validateStatusTransition(from, to)` | status lifecycle rules (throws) |
+| `findDependencyCycles(deps)` / `assertAcyclicDependencies(deps)` | dependency graph acyclicity (only `blocks` edges) |
+| `validateParentChild(issue, parent)` | parent exists, parent type `canParent`, no self-parent |
+| `findParentCycle(issuesById, startId)` | parent-chain cycle detection |
+| `validateClaim(claim, { now, issueType })` | actor present, valid claim state, claimable type, lease not expired |
+| `validateActiveClaimUniqueness(claims)` | at most one active claim per issue |
+
+These complement (do not replace) the broker/DB claim-lease invariants enforced
+elsewhere; the validation layer is the pure, storage-agnostic checker.
+
+## 5. Priority rank vs P0–P4 projection
+
+A single numeric rank is authoritative for ordering; **P0–P4 is a display projection
+only** (D18). `rankForPriorityLabel(label)` ingests a label/number to the authoritative
+rank; `priorityLabelForRank(rank)` projects a rank to a display label clamped to `P0..P4`;
+`normalizeRank(value)` coerces to a non-negative integer.
+
+## 6. Planning bucket entities — `lib/kernel/planning-buckets-schema.js`
+
+Sprint, release, and milestone are first-class Kernel entities (`forge-2agy.9.2.7`), not
+string fields on issues. Each table (`kernel_sprint`, `kernel_release`,
+`kernel_milestone`) carries `id`, `name`, `state`, `rank`, owner/goal, dates,
+`entity_revision`, and **read-model rollup counters** (`total_count`, `completed_count`).
+The schema reuses the shared `lib/kernel/schema.js` builders and passes
+`validateKernelSchema`; `getPlanningBucketsSchema()` is migration-renderable through the
+existing `buildSchemaMigration` renderer.
+
+State vocabularies:
+
+- Sprint: `planned`, `active`, `completed`, `cancelled`
+- Release: `planned`, `in_progress`, `released`, `cancelled`
+- Milestone: `planned`, `reached`, `missed`, `cancelled`
+
+The extended `kernel_issues` columns wire issues to these buckets and to hierarchy and
+stage: `parent_id` (self-referencing), `sprint_id`, `release_id`, `stage_state`,
+`labels`, `acceptance_criteria`, `estimate`.
+
+## 7. Board rank and mutation event model
+
+Frontend drag/drop and assignment operations must produce Kernel events carrying
+`expected_revision` and `idempotency_key` (`forge-2agy.9.2.6`). `BOARD_MUTATION_EVENT_TYPES`:
+
+- `issue.reordered` — board rank change. Per D18 there is a **single** authoritative
+  numeric ordering rank (`priority_rank`); P0–P4 is its display projection. There is no
+  separate board-only rank column.
+- `issue.status_changed`
+- `issue.sprint_assigned`
+- `issue.release_assigned`
+- `issue.blocked` / `issue.unblocked` — recorded transitions of the derived readiness
+  edge, emitted for audit; readiness itself remains computed, not stored
+- `issue.type_changed`
+
+Each event is validated optimistically against the entity's current revision and is
+idempotent on replay, consistent with the Kernel event/outbox contract.
+
+## Board views (frontend implications)
+
+- **Backlog board** — group by `type`, `priority`, `parent_id`, `release_id`.
+- **Sprint board** — group by `sprint_id` and status.
+- **Ready-work queue** — `buildReadinessIndex(...).readyQueue` (derived).
+- **Agent work view** — filter by claim actor, lease, worktree/session, and `stage_state`.
+- **Roadmap view** — group epics by release/milestone with child rollups.

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -13,6 +13,12 @@ const ISSUE_COMMAND_EXIT_CODES = Object.freeze({
 	validation: 6,
 });
 
+// Canonical D18 taxonomy. Types and statuses are enforced at the validation layer
+// (see taxonomy-validator), not as DB constraints, so label-based extensibility and
+// derived readiness (ready/blocked) stay outside the stored status set.
+const ISSUE_TYPES = Object.freeze(['epic', 'task', 'bug', 'decision']);
+const ISSUE_STATUSES = Object.freeze(['open', 'in_progress', 'review', 'done', 'cancelled']);
+
 function deepFreeze(value) {
 	if (!value || typeof value !== 'object') return value;
 	Object.freeze(value);
@@ -29,8 +35,8 @@ const ISSUE_SUMMARY_SCHEMA = {
 		id: { type: 'string' },
 		title: { type: 'string' },
 		body: { type: ['string', 'null'] },
-		type: { enum: ['epic', 'task', 'bug', 'decision'] },
-		status: { enum: ['open', 'in_progress', 'review', 'done', 'cancelled'] },
+		type: { enum: [...ISSUE_TYPES] },
+		status: { enum: [...ISSUE_STATUSES] },
 		priority: { type: 'string' },
 		rank: { type: 'number' },
 		revision: { type: 'integer', minimum: 0 },
@@ -257,6 +263,8 @@ module.exports = {
 	ISSUE_COMMAND_EXIT_CODES,
 	ISSUE_COMMAND_RESPONSE_SCHEMAS,
 	ISSUE_COMMAND_SCHEMA_VERSION,
+	ISSUE_STATUSES,
+	ISSUE_TYPES,
 	formatIssueCommandError,
 	getIssueCommandContract,
 };

--- a/lib/kernel/planning-buckets-schema.js
+++ b/lib/kernel/planning-buckets-schema.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { cloneTableList, deepFreeze, field, index, table, validateKernelSchema } = require('./schema');
+
+// Planning buckets are first-class entities, not string fields on issues (D5/D18,
+// forge-2agy.9.2.7). Sprint/release/milestone each carry id, name, state, dates,
+// owner/goal, ordering rank, completion rollups, and an entity revision.
+const SPRINT_STATES = Object.freeze(['planned', 'active', 'completed', 'cancelled']);
+const RELEASE_STATES = Object.freeze(['planned', 'in_progress', 'released', 'cancelled']);
+const MILESTONE_STATES = Object.freeze(['planned', 'reached', 'missed', 'cancelled']);
+
+// Board drag/drop and assignment operations emit Kernel events carrying
+// expected_revision + idempotency_key (board rank / mutation event model,
+// forge-2agy.9.2.6). See docs/reference/KERNEL_TAXONOMY_VALIDATION.md.
+const BOARD_MUTATION_EVENT_TYPES = Object.freeze([
+	'issue.reordered',
+	'issue.status_changed',
+	'issue.sprint_assigned',
+	'issue.release_assigned',
+	'issue.blocked',
+	'issue.unblocked',
+	'issue.type_changed',
+]);
+
+const ROLLUP = Object.freeze({ storageClass: 'read_model' });
+
+const PLANNING_BUCKET_TABLE_LIST = deepFreeze([
+	table('sprint', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('name', 'TEXT', { notNull: true }),
+		field('state', 'TEXT', { notNull: true, default: "'planned'" }),
+		field('goal', 'TEXT'),
+		field('owner', 'TEXT'),
+		field('start_date', 'TEXT'),
+		field('end_date', 'TEXT'),
+		field('capacity', 'INTEGER'),
+		field('rank', 'INTEGER', { notNull: true, default: '0' }),
+		field('total_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
+		field('completed_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
+		field('created_at', 'TEXT', { notNull: true }),
+		field('updated_at', 'TEXT', { notNull: true }),
+		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
+	], [
+		index('idx_kernel_sprint_state', ['state']),
+		index('idx_kernel_sprint_rank', ['rank']),
+	]),
+	table('release', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('name', 'TEXT', { notNull: true }),
+		field('state', 'TEXT', { notNull: true, default: "'planned'" }),
+		field('goal', 'TEXT'),
+		field('owner', 'TEXT'),
+		field('target_date', 'TEXT'),
+		field('released_at', 'TEXT'),
+		field('rank', 'INTEGER', { notNull: true, default: '0' }),
+		field('total_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
+		field('completed_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
+		field('created_at', 'TEXT', { notNull: true }),
+		field('updated_at', 'TEXT', { notNull: true }),
+		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
+	], [
+		index('idx_kernel_release_state', ['state']),
+		index('idx_kernel_release_rank', ['rank']),
+	]),
+	table('milestone', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('name', 'TEXT', { notNull: true }),
+		field('state', 'TEXT', { notNull: true, default: "'planned'" }),
+		field('release_id', 'TEXT'),
+		field('goal', 'TEXT'),
+		field('owner', 'TEXT'),
+		field('target_date', 'TEXT'),
+		field('reached_at', 'TEXT'),
+		field('rank', 'INTEGER', { notNull: true, default: '0' }),
+		field('total_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
+		field('completed_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
+		field('created_at', 'TEXT', { notNull: true }),
+		field('updated_at', 'TEXT', { notNull: true }),
+		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
+	], [
+		index('idx_kernel_milestone_state', ['state']),
+		index('idx_kernel_milestone_release', ['release_id']),
+	]),
+]);
+
+const PLANNING_BUCKET_TABLES = deepFreeze(
+	Object.fromEntries(PLANNING_BUCKET_TABLE_LIST.map(definition => [definition.name, definition])),
+);
+
+function getPlanningBucketsSchema() {
+	return {
+		version: 1,
+		tables: cloneTableList(PLANNING_BUCKET_TABLE_LIST),
+	};
+}
+
+function validatePlanningBucketsSchema(schema = getPlanningBucketsSchema()) {
+	return validateKernelSchema(schema);
+}
+
+module.exports = {
+	BOARD_MUTATION_EVENT_TYPES,
+	MILESTONE_STATES,
+	PLANNING_BUCKET_TABLES,
+	RELEASE_STATES,
+	SPRINT_STATES,
+	getPlanningBucketsSchema,
+	validatePlanningBucketsSchema,
+};

--- a/lib/kernel/planning-buckets-schema.js
+++ b/lib/kernel/planning-buckets-schema.js
@@ -24,59 +24,46 @@ const BOARD_MUTATION_EVENT_TYPES = Object.freeze([
 
 const ROLLUP = Object.freeze({ storageClass: 'read_model' });
 
-const PLANNING_BUCKET_TABLE_LIST = deepFreeze([
-	table('sprint', 'authority', [
+// All three planning buckets share the same envelope (identity, state, ownership,
+// ordering rank, completion rollups, and revision). `specificFields` carries the
+// bucket-specific scheduling columns; this keeps the shared shape defined once.
+function planningBucketTable(name, specificFields, indexes) {
+	return table(name, 'authority', [
 		field('id', 'TEXT', { primaryKey: true }),
 		field('name', 'TEXT', { notNull: true }),
 		field('state', 'TEXT', { notNull: true, default: "'planned'" }),
 		field('goal', 'TEXT'),
 		field('owner', 'TEXT'),
-		field('start_date', 'TEXT'),
-		field('end_date', 'TEXT'),
-		field('capacity', 'INTEGER'),
+		...specificFields,
 		field('rank', 'INTEGER', { notNull: true, default: '0' }),
 		field('total_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
 		field('completed_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
 		field('created_at', 'TEXT', { notNull: true }),
 		field('updated_at', 'TEXT', { notNull: true }),
 		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
+	], indexes);
+}
+
+const PLANNING_BUCKET_TABLE_LIST = deepFreeze([
+	planningBucketTable('sprint', [
+		field('start_date', 'TEXT'),
+		field('end_date', 'TEXT'),
+		field('capacity', 'INTEGER'),
 	], [
 		index('idx_kernel_sprint_state', ['state']),
 		index('idx_kernel_sprint_rank', ['rank']),
 	]),
-	table('release', 'authority', [
-		field('id', 'TEXT', { primaryKey: true }),
-		field('name', 'TEXT', { notNull: true }),
-		field('state', 'TEXT', { notNull: true, default: "'planned'" }),
-		field('goal', 'TEXT'),
-		field('owner', 'TEXT'),
+	planningBucketTable('release', [
 		field('target_date', 'TEXT'),
 		field('released_at', 'TEXT'),
-		field('rank', 'INTEGER', { notNull: true, default: '0' }),
-		field('total_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
-		field('completed_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
-		field('created_at', 'TEXT', { notNull: true }),
-		field('updated_at', 'TEXT', { notNull: true }),
-		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
 	], [
 		index('idx_kernel_release_state', ['state']),
 		index('idx_kernel_release_rank', ['rank']),
 	]),
-	table('milestone', 'authority', [
-		field('id', 'TEXT', { primaryKey: true }),
-		field('name', 'TEXT', { notNull: true }),
-		field('state', 'TEXT', { notNull: true, default: "'planned'" }),
+	planningBucketTable('milestone', [
 		field('release_id', 'TEXT'),
-		field('goal', 'TEXT'),
-		field('owner', 'TEXT'),
 		field('target_date', 'TEXT'),
 		field('reached_at', 'TEXT'),
-		field('rank', 'INTEGER', { notNull: true, default: '0' }),
-		field('total_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
-		field('completed_count', 'INTEGER', { notNull: true, default: '0', ...ROLLUP }),
-		field('created_at', 'TEXT', { notNull: true }),
-		field('updated_at', 'TEXT', { notNull: true }),
-		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
 	], [
 		index('idx_kernel_milestone_state', ['state']),
 		index('idx_kernel_milestone_release', ['release_id']),
@@ -87,6 +74,7 @@ const PLANNING_BUCKET_TABLES = deepFreeze(
 	Object.fromEntries(PLANNING_BUCKET_TABLE_LIST.map(definition => [definition.name, definition])),
 );
 
+/** @returns {{version: number, tables: object[]}} an isolated, deep-cloned copy of the planning-bucket schema. */
 function getPlanningBucketsSchema() {
 	return {
 		version: 1,
@@ -94,6 +82,10 @@ function getPlanningBucketsSchema() {
 	};
 }
 
+/**
+ * Validate the planning-bucket schema through the shared Kernel schema validator.
+ * @returns {true} when storage classes and authorities are valid.
+ */
 function validatePlanningBucketsSchema(schema = getPlanningBucketsSchema()) {
 	return validateKernelSchema(schema);
 }

--- a/lib/kernel/planning-buckets-schema.js
+++ b/lib/kernel/planning-buckets-schema.js
@@ -83,10 +83,18 @@ function getPlanningBucketsSchema() {
 }
 
 /**
- * Validate the planning-bucket schema through the shared Kernel schema validator.
- * @returns {true} when storage classes and authorities are valid.
+ * Validate the planning-bucket schema: enforce that the sprint/release/milestone tables are
+ * present, then run the shared Kernel structural validator.
+ * @throws {Error} if a required planning bucket table is missing.
+ * @returns {true} when membership, storage classes, and authorities are valid.
  */
 function validatePlanningBucketsSchema(schema = getPlanningBucketsSchema()) {
+	const present = new Set((schema.tables || []).map(tableDefinition => tableDefinition.name));
+	for (const required of ['sprint', 'release', 'milestone']) {
+		if (!present.has(required)) {
+			throw new Error(`Missing planning bucket table: ${required}`);
+		}
+	}
 	return validateKernelSchema(schema);
 }
 

--- a/lib/kernel/readiness-model.js
+++ b/lib/kernel/readiness-model.js
@@ -28,6 +28,7 @@ const READINESS_STATES = Object.freeze([
 
 const WORKABLE_STATUSES = Object.freeze(['open', 'in_progress']);
 
+/** @returns {boolean} true if `status` is a pickable working status (open/in_progress). */
 function isWorkableStatus(status) {
 	return WORKABLE_STATUSES.includes(status);
 }
@@ -107,6 +108,12 @@ function deriveState(flags) {
 	return 'backlog';
 }
 
+/**
+ * Derive an issue's readiness (a read model, never stored) from its context.
+ * @param {object} issue stored issue fields (id, status, defer_until, ...).
+ * @param {object} context { now, actor, dependencyStatuses[], conflicts[], gates[], claims[], policyDisabled }.
+ * @returns {{id, status, ready: boolean, blocked: boolean, blocked_by: string[], reasons: object[], state: string}}
+ */
 function deriveReadiness(issue = {}, context = {}) {
 	const id = issue.id;
 	const status = issue.status;
@@ -167,6 +174,11 @@ function groupBy(items, keyFn) {
 	return grouped;
 }
 
+/**
+ * Compute readiness for a whole board, resolving each dependency's status from the issue set.
+ * @param {object} input { issues[], dependencies[], conflicts[], claims[], gates[], policyDisabledIds[], now, actor }.
+ * @returns {{readinessById: object, readyQueue: string[], blocked: string[]}} readyQueue is ranked by the single numeric rank.
+ */
 function buildReadinessIndex(input = {}) {
 	const issues = input.issues || [];
 	const statusById = new Map(issues.map(issue => [issue.id, issue.status]));

--- a/lib/kernel/readiness-model.js
+++ b/lib/kernel/readiness-model.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const { isTerminalStatus, normalizeRank, toEpochMillis } = require('./taxonomy-validator');
+
+// Readiness is a DERIVED read model (D18). `ready`/`blocked` are computed on demand
+// from dependencies, claims, quarantine/conflicts, gates, defer windows, and policy —
+// they are NEVER stored as issue status values.
+const READINESS_REASONS = Object.freeze({
+	DEPENDENCY: 'dependency',
+	QUARANTINE: 'quarantine',
+	CONFLICT: 'conflict',
+	GATE: 'gate',
+	CLAIM: 'claimed',
+	DEFERRED: 'deferred',
+	POLICY: 'policy_disabled',
+});
+
+const READINESS_STATES = Object.freeze([
+	'ready',
+	'blocked',
+	'gated',
+	'deferred',
+	'claimed',
+	'disabled',
+	'closed',
+	'backlog',
+]);
+
+const WORKABLE_STATUSES = Object.freeze(['open', 'in_progress']);
+
+function isWorkableStatus(status) {
+	return WORKABLE_STATUSES.includes(status);
+}
+
+// Edge-only blocking test: keys off the dependency RELATIONSHIP (dependency_type),
+// NOT the blocking issue's type. Distinct from taxonomy-validator's isBlockingDependency,
+// which also falls back to `.type`; do not merge them (see readiness decision-dependency).
+function isBlockingDependencyEdge(dependency) {
+	return (dependency.dependency_type || 'blocks') === 'blocks';
+}
+
+function isDeferred(issue, now) {
+	if (!issue.defer_until) return false;
+	const deferMillis = toEpochMillis(issue.defer_until);
+	const nowMillis = toEpochMillis(now);
+	if (deferMillis === null || nowMillis === null) return false;
+	return deferMillis > nowMillis;
+}
+
+function findConflictingClaim(issueId, claims, actor) {
+	for (const claim of claims || []) {
+		if (claim.issue_id !== issueId) continue;
+		if ((claim.state || 'active') !== 'active') continue;
+		if (actor && claim.actor === actor) continue; // the requesting actor's own claim does not block them
+		return claim;
+	}
+	return null;
+}
+
+function collectDependencyBlockers(context, reasons, blockedBy) {
+	for (const dependency of context.dependencyStatuses || []) {
+		if (!isBlockingDependencyEdge(dependency)) continue;
+		// A terminal (done OR cancelled) blocker will never complete again, so it no longer
+		// blocks — a cancelled dependency must not wedge the dependent as permanently blocked.
+		if (isTerminalStatus(dependency.status)) continue;
+		blockedBy.push(dependency.id);
+		const reason = { code: READINESS_REASONS.DEPENDENCY, issue_id: dependency.id, status: dependency.status };
+		if (dependency.type === 'decision') {
+			reason.decision = true;
+		}
+		reasons.push(reason);
+	}
+}
+
+function collectConflictBlockers(issue, context, reasons) {
+	let hasConflict = false;
+	for (const conflict of context.conflicts || []) {
+		if (conflict.entity_id && issue.id && conflict.entity_id !== issue.id) continue;
+		hasConflict = true;
+		const status = conflict.status || 'quarantined';
+		const code = status === 'quarantined' ? READINESS_REASONS.QUARANTINE : READINESS_REASONS.CONFLICT;
+		reasons.push({ code, status });
+	}
+	return hasConflict;
+}
+
+function collectGateBlockers(context, reasons) {
+	let hasGate = false;
+	for (const gate of context.gates || []) {
+		if (gate.satisfied) continue;
+		hasGate = true;
+		reasons.push({ code: READINESS_REASONS.GATE, gate: gate.name });
+	}
+	return hasGate;
+}
+
+// Precedence high→low. `blocked` (dependencies/quarantine/conflict) always outranks the
+// softer not-ready reasons; consumers picking next work should read the full reasons[]
+// because a claim hidden behind a defer window is not reflected in this single summary.
+function deriveState(flags) {
+	if (flags.blocked) return 'blocked';
+	if (flags.hasGate) return 'gated';
+	if (flags.deferred) return 'deferred';
+	if (flags.hasClaim) return 'claimed';
+	if (flags.policyDisabled) return 'disabled';
+	if (flags.ready) return 'ready';
+	return 'backlog';
+}
+
+function deriveReadiness(issue = {}, context = {}) {
+	const id = issue.id;
+	const status = issue.status;
+
+	if (isTerminalStatus(status)) {
+		return { id, status, ready: false, blocked: false, blocked_by: [], reasons: [], state: 'closed' };
+	}
+
+	const reasons = [];
+	const blockedBy = [];
+
+	collectDependencyBlockers(context, reasons, blockedBy);
+	const hasConflict = collectConflictBlockers(issue, context, reasons);
+	const hasGate = collectGateBlockers(context, reasons);
+
+	const deferred = isDeferred(issue, context.now);
+	if (deferred) {
+		reasons.push({ code: READINESS_REASONS.DEFERRED, until: issue.defer_until });
+	}
+
+	const policyDisabled = Boolean(context.policyDisabled);
+	if (policyDisabled) {
+		reasons.push({ code: READINESS_REASONS.POLICY });
+	}
+
+	const conflictingClaim = findConflictingClaim(id, context.claims, context.actor);
+	if (conflictingClaim) {
+		reasons.push({ code: READINESS_REASONS.CLAIM, actor: conflictingClaim.actor });
+	}
+
+	const blocked = blockedBy.length > 0 || hasConflict;
+	const ready = !blocked
+		&& !hasGate
+		&& !deferred
+		&& !policyDisabled
+		&& !conflictingClaim
+		&& isWorkableStatus(status);
+
+	const state = deriveState({
+		blocked,
+		hasGate,
+		deferred,
+		hasClaim: Boolean(conflictingClaim),
+		policyDisabled,
+		ready,
+	});
+
+	return { id, status, ready, blocked, blocked_by: blockedBy, reasons, state };
+}
+
+function groupBy(items, keyFn) {
+	const grouped = new Map();
+	for (const item of items || []) {
+		const key = keyFn(item);
+		if (!grouped.has(key)) grouped.set(key, []);
+		grouped.get(key).push(item);
+	}
+	return grouped;
+}
+
+function buildReadinessIndex(input = {}) {
+	const issues = input.issues || [];
+	const statusById = new Map(issues.map(issue => [issue.id, issue.status]));
+	const typeById = new Map(issues.map(issue => [issue.id, issue.type]));
+
+	const dependencyStatusesByIssue = new Map();
+	for (const dependency of input.dependencies || []) {
+		if (!dependencyStatusesByIssue.has(dependency.issue_id)) {
+			dependencyStatusesByIssue.set(dependency.issue_id, []);
+		}
+		dependencyStatusesByIssue.get(dependency.issue_id).push({
+			id: dependency.blocks_issue_id,
+			status: statusById.get(dependency.blocks_issue_id),
+			type: typeById.get(dependency.blocks_issue_id),
+			dependency_type: dependency.dependency_type,
+		});
+	}
+
+	const conflictsByIssue = groupBy(input.conflicts, conflict => conflict.entity_id);
+	const claimsByIssue = groupBy(input.claims, claim => claim.issue_id);
+	const gatesByIssue = groupBy(input.gates, gate => gate.issue_id);
+	const policyDisabledIds = new Set(input.policyDisabledIds || []);
+
+	const readinessById = {};
+	for (const issue of issues) {
+		readinessById[issue.id] = deriveReadiness(issue, {
+			now: input.now,
+			actor: input.actor,
+			dependencyStatuses: dependencyStatusesByIssue.get(issue.id) || [],
+			conflicts: conflictsByIssue.get(issue.id) || [],
+			claims: claimsByIssue.get(issue.id) || [],
+			gates: gatesByIssue.get(issue.id) || [],
+			policyDisabled: policyDisabledIds.has(issue.id),
+		});
+	}
+
+	const readyIssues = issues.filter(issue => readinessById[issue.id].ready);
+	readyIssues.sort((left, right) => (
+		(normalizeRank(left.priority_rank) - normalizeRank(right.priority_rank))
+		|| String(left.id).localeCompare(String(right.id))
+	));
+
+	return {
+		readinessById,
+		readyQueue: readyIssues.map(issue => issue.id),
+		blocked: issues.filter(issue => readinessById[issue.id].blocked).map(issue => issue.id),
+	};
+}
+
+module.exports = {
+	READINESS_REASONS,
+	READINESS_STATES,
+	buildReadinessIndex,
+	deriveReadiness,
+	isWorkableStatus,
+};

--- a/lib/kernel/readiness-model.js
+++ b/lib/kernel/readiness-model.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isTerminalStatus, normalizeRank, toEpochMillis } = require('./taxonomy-validator');
+const { getTypeBehavior, isTerminalStatus, normalizeRank, toEpochMillis } = require('./taxonomy-validator');
 
 // Readiness is a DERIVED read model (D18). `ready`/`blocked` are computed on demand
 // from dependencies, claims, quarantine/conflicts, gates, defer windows, and policy —
@@ -31,6 +31,14 @@ const WORKABLE_STATUSES = Object.freeze(['open', 'in_progress']);
 /** @returns {boolean} true if `status` is a pickable working status (open/in_progress). */
 function isWorkableStatus(status) {
 	return WORKABLE_STATUSES.includes(status);
+}
+
+// Ready work must be claimable: epics (containers) and decisions are claimable:false, so they
+// never belong in the ready queue even when unblocked. A known non-claimable type is excluded;
+// an unknown/unspecified type is not penalised (callers may omit `type`).
+function isReadyEligibleType(type) {
+	const behavior = getTypeBehavior(type);
+	return behavior ? behavior.claimable : true;
 }
 
 // Edge-only blocking test: keys off the dependency RELATIONSHIP (dependency_type),
@@ -160,7 +168,8 @@ function deriveReadiness(issue = {}, context = {}) {
 		&& !deferred
 		&& !policyDisabled
 		&& !conflictingClaim
-		&& isWorkableStatus(status);
+		&& isWorkableStatus(status)
+		&& isReadyEligibleType(issue.type);
 
 	const state = deriveState({
 		blocked,

--- a/lib/kernel/readiness-model.js
+++ b/lib/kernel/readiness-model.js
@@ -94,6 +94,10 @@ function collectDependencyBlockers(context, reasons, blockedBy) {
 function collectConflictBlockers(issue, context, reasons) {
 	let hasConflict = false;
 	for (const conflict of context.conflicts || []) {
+		// Conflicts are keyed by (entity_type, entity_id). Only issue-scoped conflicts block an
+		// issue; a quarantined dependency/release/sprint that happens to share the id string must
+		// not. Absent entity_type is treated as legacy issue-scoped.
+		if (conflict.entity_type && conflict.entity_type !== 'issue') continue;
 		if (conflict.entity_id && issue.id && conflict.entity_id !== issue.id) continue;
 		hasConflict = true;
 		const status = conflict.status || 'quarantined';

--- a/lib/kernel/readiness-model.js
+++ b/lib/kernel/readiness-model.js
@@ -52,11 +52,17 @@ function isDeferred(issue, now) {
 	return deferMillis > nowMillis;
 }
 
-function findConflictingClaim(issueId, claims, actor) {
+function findConflictingClaim(issueId, claims, actor, now) {
+	const nowMillis = toEpochMillis(now);
 	for (const claim of claims || []) {
 		if (claim.issue_id !== issueId) continue;
 		if ((claim.state || 'active') !== 'active') continue;
 		if (actor && claim.actor === actor) continue; // the requesting actor's own claim does not block them
+		// An active row whose lease has elapsed is dead (validateClaim agrees) — it must not
+		// keep the issue out of the ready queue for other actors. If `now` is unknown we cannot
+		// confirm expiry, so the claim still blocks (conservative).
+		const expiresMillis = toEpochMillis(claim.expires_at);
+		if (expiresMillis !== null && nowMillis !== null && expiresMillis <= nowMillis) continue;
 		return claim;
 	}
 	return null;
@@ -143,7 +149,7 @@ function deriveReadiness(issue = {}, context = {}) {
 		reasons.push({ code: READINESS_REASONS.POLICY });
 	}
 
-	const conflictingClaim = findConflictingClaim(id, context.claims, context.actor);
+	const conflictingClaim = findConflictingClaim(id, context.claims, context.actor, context.now);
 	if (conflictingClaim) {
 		reasons.push({ code: READINESS_REASONS.CLAIM, actor: conflictingClaim.actor });
 	}

--- a/lib/kernel/readiness-model.js
+++ b/lib/kernel/readiness-model.js
@@ -43,8 +43,12 @@ function isBlockingDependencyEdge(dependency) {
 function isDeferred(issue, now) {
 	if (!issue.defer_until) return false;
 	const deferMillis = toEpochMillis(issue.defer_until);
+	if (deferMillis === null) return false; // an unparseable defer window is not a defer
 	const nowMillis = toEpochMillis(now);
-	if (deferMillis === null || nowMillis === null) return false;
+	// Fail closed: without a usable clock we cannot confirm the window elapsed, so a deferred
+	// issue stays deferred rather than incorrectly surfacing as ready. Keeps the model pure
+	// (caller supplies `now`) instead of reaching for a wall clock.
+	if (nowMillis === null) return true;
 	return deferMillis > nowMillis;
 }
 
@@ -202,7 +206,9 @@ function buildReadinessIndex(input = {}) {
 	const gatesByIssue = groupBy(input.gates, gate => gate.issue_id);
 	const policyDisabledIds = new Set(input.policyDisabledIds || []);
 
-	const readinessById = {};
+	// Null-prototype map: issue ids are unconstrained external strings, so a literal `{}`
+	// keyed by them would be a prototype-pollution vector (e.g. an id of `__proto__`).
+	const readinessById = Object.create(null);
 	for (const issue of issues) {
 		readinessById[issue.id] = deriveReadiness(issue, {
 			now: input.now,

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -71,9 +71,21 @@ const TABLE_LIST = deepFreeze([
 		field('created_at', 'TEXT', { notNull: true }),
 		field('updated_at', 'TEXT', { notNull: true }),
 		field('entity_revision', 'INTEGER', { notNull: true, default: '0' }),
+		// D18 taxonomy: hierarchy, planning buckets, and execution stage are separate
+		// axes from status. ready/blocked stay derived (readiness-model), never stored.
+		field('parent_id', 'TEXT', { references: 'issues.id' }),
+		field('sprint_id', 'TEXT'),
+		field('release_id', 'TEXT'),
+		field('stage_state', 'TEXT'),
+		field('labels', 'TEXT'),
+		field('acceptance_criteria', 'TEXT'),
+		field('estimate', 'TEXT'),
 	], [
 		index('idx_kernel_issues_status_priority', ['status', 'priority_rank']),
 		index('idx_kernel_issues_updated_at', ['updated_at']),
+		index('idx_kernel_issues_parent', ['parent_id']),
+		index('idx_kernel_issues_sprint', ['sprint_id']),
+		index('idx_kernel_issues_release', ['release_id']),
 	]),
 	table('dependencies', 'authority', [
 		field('id', 'TEXT', { primaryKey: true }),
@@ -271,17 +283,21 @@ function validateKernelSchema(schema = getKernelSchema()) {
 	return true;
 }
 
+function cloneTableList(tableList) {
+	return tableList.map(tableDefinition => ({
+		...tableDefinition,
+		fields: tableDefinition.fields.map(fieldDefinition => ({ ...fieldDefinition })),
+		indexes: tableDefinition.indexes.map(indexDefinition => ({
+			...indexDefinition,
+			columns: [...indexDefinition.columns],
+		})),
+	}));
+}
+
 function getKernelSchema() {
 	return {
 		version: 1,
-		tables: TABLE_LIST.map(tableDefinition => ({
-			...tableDefinition,
-			fields: tableDefinition.fields.map(fieldDefinition => ({ ...fieldDefinition })),
-			indexes: tableDefinition.indexes.map(indexDefinition => ({
-				...indexDefinition,
-				columns: [...indexDefinition.columns],
-			})),
-		})),
+		tables: cloneTableList(TABLE_LIST),
 	};
 }
 
@@ -290,6 +306,11 @@ module.exports = {
 	KERNEL_STORAGE_CLASSES,
 	KERNEL_TABLES,
 	classifyKernelStorage,
+	cloneTableList,
+	deepFreeze,
+	field,
 	getKernelSchema,
+	index,
+	table,
 	validateKernelSchema,
 };

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -283,6 +283,7 @@ function validateKernelSchema(schema = getKernelSchema()) {
 	return true;
 }
 
+/** Deep-clone a table list so callers receive isolated, mutation-safe schema definitions. */
 function cloneTableList(tableList) {
 	return tableList.map(tableDefinition => ({
 		...tableDefinition,

--- a/lib/kernel/taxonomy-validator.js
+++ b/lib/kernel/taxonomy-validator.js
@@ -39,27 +39,33 @@ class TaxonomyValidationError extends Error {
 	}
 }
 
+/** @returns {boolean} true if `type` is one of the four canonical issue types. */
 function isValidIssueType(type) {
 	return ISSUE_TYPES.includes(type);
 }
 
+/** @returns {boolean} true if `status` is one of the five stored statuses (ready/blocked are derived, not stored). */
 function isValidIssueStatus(status) {
 	return ISSUE_STATUSES.includes(status);
 }
 
+/** @returns {boolean} true if `status` is terminal (done/cancelled). */
 function isTerminalStatus(status) {
 	return TERMINAL_STATUSES.includes(status);
 }
 
+/** @returns {object|null} the behavior mapping for `type`, or null for unknown types. */
 function getTypeBehavior(type) {
-	return Object.prototype.hasOwnProperty.call(TYPE_BEHAVIORS, type) ? TYPE_BEHAVIORS[type] : null;
+	return Object.hasOwn(TYPE_BEHAVIORS, type) ? TYPE_BEHAVIORS[type] : null;
 }
 
+/** @returns {boolean} true if issues of `type` may carry an active claim (task/bug). */
 function isClaimableType(type) {
 	const behavior = getTypeBehavior(type);
-	return Boolean(behavior && behavior.claimable);
+	return Boolean(behavior?.claimable);
 }
 
+/** @returns {boolean} true if `from`->`to` is a legal status move (same status is an idempotent no-op). */
 function isValidStatusTransition(from, to) {
 	if (!isValidIssueStatus(from) || !isValidIssueStatus(to)) {
 		return false;
@@ -70,6 +76,11 @@ function isValidStatusTransition(from, to) {
 	return STATUS_TRANSITIONS[from].includes(to);
 }
 
+/**
+ * Assert a status transition is legal.
+ * @throws {TaxonomyValidationError} on an unknown status or an illegal move.
+ * @returns {true} when the transition is allowed.
+ */
 function validateStatusTransition(from, to) {
 	if (!isValidIssueStatus(from)) {
 		throw new TaxonomyValidationError(`Unknown source status: ${from}`, { code: 'unknown_status', field: 'status' });
@@ -94,6 +105,10 @@ function selfParentError() {
 	return { code: 'self_parent', field: 'parent_id', message: 'An issue cannot be its own parent' };
 }
 
+/**
+ * Validate an issue's type/status enums and self-parent rule.
+ * @returns {{valid: boolean, errors: Array<{code: string, field: string, message: string}>}}
+ */
 function validateIssueTaxonomy(issue = {}) {
 	const errors = [];
 	if (!isValidIssueType(issue.type)) {
@@ -143,51 +158,65 @@ const NODE_WHITE = 0;
 const NODE_GRAY = 1;
 const NODE_BLACK = 2;
 
+function recordBackEdgeCycle(path, reentryNode, accumulator) {
+	const startIndex = path.indexOf(reentryNode);
+	if (startIndex < 0) return;
+	const cycle = canonicalRotation(path.slice(startIndex));
+	const key = cycle.join(' ');
+	if (accumulator.seen.has(key)) return;
+	accumulator.seen.add(key);
+	accumulator.cycles.push(cycle);
+}
+
+function exploreFromRoot(root, adjacency, color, accumulator) {
+	const path = [root];
+	const frames = [{ node: root, neighborIndex: 0 }];
+	color.set(root, NODE_GRAY);
+
+	while (frames.length > 0) {
+		const frame = frames.at(-1);
+		const neighbors = adjacency.get(frame.node) || [];
+		if (frame.neighborIndex >= neighbors.length) {
+			color.set(frame.node, NODE_BLACK);
+			frames.pop();
+			path.pop();
+			continue;
+		}
+		const next = neighbors[frame.neighborIndex];
+		frame.neighborIndex += 1;
+		const nextColor = color.get(next) || NODE_WHITE;
+		if (nextColor === NODE_GRAY) {
+			recordBackEdgeCycle(path, next, accumulator);
+		} else if (nextColor === NODE_WHITE) {
+			color.set(next, NODE_GRAY);
+			path.push(next);
+			frames.push({ node: next, neighborIndex: 0 });
+		}
+	}
+}
+
+/**
+ * Find dependency cycles among `blocks` edges using an iterative (stack-safe) DFS.
+ * @param {Array<{issue_id: string, blocks_issue_id: string, dependency_type?: string}>} dependencies
+ * @returns {string[][]} each detected cycle, canonically rotated (smallest id first), deduplicated.
+ */
 function findDependencyCycles(dependencies) {
 	const adjacency = buildDependencyAdjacency(dependencies);
 	const color = new Map();
-	const cycles = [];
-	const seenCycleKeys = new Set();
-
+	const accumulator = { cycles: [], seen: new Set() };
 	for (const root of adjacency.keys()) {
-		if ((color.get(root) || NODE_WHITE) !== NODE_WHITE) continue;
-
-		const path = [root];
-		const frames = [{ node: root, neighborIndex: 0 }];
-		color.set(root, NODE_GRAY);
-
-		while (frames.length > 0) {
-			const frame = frames[frames.length - 1];
-			const neighbors = adjacency.get(frame.node) || [];
-			if (frame.neighborIndex < neighbors.length) {
-				const next = neighbors[frame.neighborIndex];
-				frame.neighborIndex += 1;
-				const nextColor = color.get(next) || NODE_WHITE;
-				if (nextColor === NODE_GRAY) {
-					const startIndex = path.indexOf(next);
-					if (startIndex >= 0) {
-						const cycle = canonicalRotation(path.slice(startIndex));
-						const key = cycle.join(' ');
-						if (!seenCycleKeys.has(key)) {
-							seenCycleKeys.add(key);
-							cycles.push(cycle);
-						}
-					}
-				} else if (nextColor === NODE_WHITE) {
-					color.set(next, NODE_GRAY);
-					path.push(next);
-					frames.push({ node: next, neighborIndex: 0 });
-				}
-			} else {
-				color.set(frame.node, NODE_BLACK);
-				frames.pop();
-				path.pop();
-			}
+		if ((color.get(root) || NODE_WHITE) === NODE_WHITE) {
+			exploreFromRoot(root, adjacency, color, accumulator);
 		}
 	}
-	return cycles;
+	return accumulator.cycles;
 }
 
+/**
+ * Assert the dependency graph is acyclic.
+ * @throws {TaxonomyValidationError} with the first detected cycle.
+ * @returns {true} when no cycle exists.
+ */
 function assertAcyclicDependencies(dependencies) {
 	const cycles = findDependencyCycles(dependencies);
 	if (cycles.length > 0) {
@@ -199,6 +228,10 @@ function assertAcyclicDependencies(dependencies) {
 	return true;
 }
 
+/**
+ * Validate a child issue against its resolved parent (existence, container type, no self-parent).
+ * @returns {{valid: boolean, errors: Array<{code: string, field: string, message: string}>}}
+ */
 function validateParentChild(issue = {}, parent = null) {
 	const errors = [];
 	if (!issue.parent_id) {
@@ -213,7 +246,7 @@ function validateParentChild(issue = {}, parent = null) {
 		return { valid: false, errors };
 	}
 	const behavior = getTypeBehavior(parent.type);
-	if (!behavior || !behavior.canParent) {
+	if (!behavior?.canParent) {
 		errors.push({
 			code: 'invalid_parent_type',
 			field: 'parent_id',
@@ -223,27 +256,38 @@ function validateParentChild(issue = {}, parent = null) {
 	return { valid: errors.length === 0, errors };
 }
 
-function findParentCycle(issuesById = {}, startId) {
+/**
+ * Walk the parent_id chain from `startId`, detecting a cycle.
+ * @returns {string[]} the cycle path if one exists, otherwise an empty array.
+ */
+function findParentCycle(issuesById, startId) {
+	const nodes = issuesById || {};
 	const visited = [];
 	const seen = new Set();
 	let current = startId;
-	while (current && issuesById[current]) {
+	while (current && nodes[current]) {
 		if (seen.has(current)) {
 			return visited.slice(visited.indexOf(current));
 		}
 		seen.add(current);
 		visited.push(current);
-		current = issuesById[current].parent_id;
+		current = nodes[current].parent_id;
 	}
 	return [];
 }
 
+/** @returns {number|null} epoch millis for a date-ish value, or null if absent/unparseable. */
 function toEpochMillis(value) {
 	if (value === null || value === undefined) return null;
 	const millis = new Date(value).getTime();
 	return Number.isFinite(millis) ? millis : null;
 }
 
+/**
+ * Validate claim-lease invariants (actor, state, claimable type, lease expiry). Fails closed on
+ * an unparseable expiry. Complements — does not replace — broker/DB lease enforcement.
+ * @returns {{valid: boolean, errors: Array<{code: string, field: string, message: string}>}}
+ */
 function validateClaim(claim = {}, options = {}) {
 	const errors = [];
 	if (!claim.actor || String(claim.actor).trim() === '') {
@@ -271,6 +315,10 @@ function validateClaim(claim = {}, options = {}) {
 	return { valid: errors.length === 0, errors };
 }
 
+/**
+ * Check that no issue has more than one active claim.
+ * @returns {{valid: boolean, errors: object[], conflictingIssueIds: string[]}}
+ */
 function validateActiveClaimUniqueness(claims = []) {
 	const activeByIssue = new Map();
 	for (const claim of claims) {
@@ -289,22 +337,25 @@ function validateActiveClaimUniqueness(claims = []) {
 	return { valid: conflictingIssueIds.length === 0, errors, conflictingIssueIds };
 }
 
+/** @returns {number} `value` coerced to a non-negative integer rank (0 for non-numeric). */
 function normalizeRank(value) {
 	const numeric = Number(value);
 	if (!Number.isFinite(numeric)) return 0;
 	return Math.max(0, Math.trunc(numeric));
 }
 
+/** @returns {number} the authoritative numeric rank for a priority label/number (default rank for unknown labels). */
 function rankForPriorityLabel(label) {
 	if (typeof label === 'number' && Number.isFinite(label)) {
 		return normalizeRank(label);
 	}
 	const raw = String(label ?? '').trim().toUpperCase();
-	const match = raw.match(/^P?(\d+)$/);
+	const match = /^P?(\d+)$/.exec(raw);
 	if (!match) return DEFAULT_PRIORITY_RANK;
 	return normalizeRank(match[1]);
 }
 
+/** @returns {string} the P0-P4 display label projected from a numeric rank (clamped for display). */
 function priorityLabelForRank(rank) {
 	const clamped = Math.min(normalizeRank(rank), MAX_DISPLAY_PRIORITY_RANK);
 	return `P${clamped}`;

--- a/lib/kernel/taxonomy-validator.js
+++ b/lib/kernel/taxonomy-validator.js
@@ -1,0 +1,339 @@
+'use strict';
+
+const { ISSUE_TYPES, ISSUE_STATUSES } = require('./issue-command-contract');
+
+// done/cancelled are terminal: no transitions leave them, and the readiness model
+// reports them as `closed` rather than ready/blocked.
+const TERMINAL_STATUSES = Object.freeze(['done', 'cancelled']);
+
+// A type only earns existence if it changes Kernel behavior (routing, gates, board
+// grouping, rollup) — D18. `feature`/`story`/`chore`/`spike` are labels, not types.
+const TYPE_BEHAVIORS = Object.freeze({
+	epic: Object.freeze({ container: true, canParent: true, claimable: false, rollup: true, blocksOthers: false, board: 'roadmap' }),
+	task: Object.freeze({ container: false, canParent: false, claimable: true, rollup: false, blocksOthers: false, board: 'backlog' }),
+	bug: Object.freeze({ container: false, canParent: false, claimable: true, rollup: false, blocksOthers: false, board: 'backlog' }),
+	decision: Object.freeze({ container: false, canParent: false, claimable: false, rollup: false, blocksOthers: true, board: 'decisions' }),
+});
+
+// Stored status lifecycle. Forward path plus rework (backward) and cancellation.
+// ready/blocked are NEVER here — they are derived facts (see readiness-model).
+const STATUS_TRANSITIONS = Object.freeze({
+	open: Object.freeze(['in_progress', 'cancelled']),
+	in_progress: Object.freeze(['review', 'open', 'cancelled']),
+	review: Object.freeze(['done', 'in_progress', 'cancelled']),
+	done: Object.freeze([]),
+	cancelled: Object.freeze([]),
+});
+
+const CLAIM_STATES = Object.freeze(['active', 'released', 'expired']);
+
+const DEFAULT_PRIORITY_RANK = 2;
+const MAX_DISPLAY_PRIORITY_RANK = 4;
+
+class TaxonomyValidationError extends Error {
+	constructor(message, details = {}) {
+		super(message);
+		this.name = 'TaxonomyValidationError';
+		this.code = details.code || 'taxonomy_validation_error';
+		this.field = details.field;
+	}
+}
+
+function isValidIssueType(type) {
+	return ISSUE_TYPES.includes(type);
+}
+
+function isValidIssueStatus(status) {
+	return ISSUE_STATUSES.includes(status);
+}
+
+function isTerminalStatus(status) {
+	return TERMINAL_STATUSES.includes(status);
+}
+
+function getTypeBehavior(type) {
+	return Object.prototype.hasOwnProperty.call(TYPE_BEHAVIORS, type) ? TYPE_BEHAVIORS[type] : null;
+}
+
+function isClaimableType(type) {
+	const behavior = getTypeBehavior(type);
+	return Boolean(behavior && behavior.claimable);
+}
+
+function isValidStatusTransition(from, to) {
+	if (!isValidIssueStatus(from) || !isValidIssueStatus(to)) {
+		return false;
+	}
+	if (from === to) {
+		return true; // idempotent no-op
+	}
+	return STATUS_TRANSITIONS[from].includes(to);
+}
+
+function validateStatusTransition(from, to) {
+	if (!isValidIssueStatus(from)) {
+		throw new TaxonomyValidationError(`Unknown source status: ${from}`, { code: 'unknown_status', field: 'status' });
+	}
+	if (!isValidIssueStatus(to)) {
+		throw new TaxonomyValidationError(`Unknown target status: ${to}`, { code: 'unknown_status', field: 'status' });
+	}
+	if (!isValidStatusTransition(from, to)) {
+		throw new TaxonomyValidationError(`Illegal status transition: ${from} -> ${to}`, {
+			code: 'illegal_transition',
+			field: 'status',
+		});
+	}
+	return true;
+}
+
+function isSelfParent(issue) {
+	return Boolean(issue.parent_id) && issue.parent_id === issue.id;
+}
+
+function selfParentError() {
+	return { code: 'self_parent', field: 'parent_id', message: 'An issue cannot be its own parent' };
+}
+
+function validateIssueTaxonomy(issue = {}) {
+	const errors = [];
+	if (!isValidIssueType(issue.type)) {
+		errors.push({ code: 'invalid_type', field: 'type', message: `Unknown issue type: ${issue.type}` });
+	}
+	if (!isValidIssueStatus(issue.status)) {
+		errors.push({ code: 'invalid_status', field: 'status', message: `Unknown issue status: ${issue.status}` });
+	}
+	if (isSelfParent(issue)) {
+		errors.push(selfParentError());
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+function isBlockingDependency(dependency) {
+	const type = dependency.dependency_type || dependency.type || 'blocks';
+	return type === 'blocks';
+}
+
+function buildDependencyAdjacency(dependencies) {
+	const adjacency = new Map();
+	for (const dependency of dependencies || []) {
+		if (!isBlockingDependency(dependency)) continue;
+		const from = dependency.issue_id;
+		const to = dependency.blocks_issue_id;
+		if (!from || !to) continue;
+		if (!adjacency.has(from)) adjacency.set(from, []);
+		adjacency.get(from).push(to);
+	}
+	return adjacency;
+}
+
+// Rotate a cycle so its smallest member leads: a deterministic, entry-point
+// independent representation used for both deduplication and the returned cycle.
+function canonicalRotation(cycle) {
+	let minIndex = 0;
+	for (let i = 1; i < cycle.length; i += 1) {
+		if (cycle[i] < cycle[minIndex]) minIndex = i;
+	}
+	return [...cycle.slice(minIndex), ...cycle.slice(0, minIndex)];
+}
+
+// Iterative (explicit-stack) DFS with white/gray/black coloring. Iterative — not
+// recursive — so a deep dependency chain (thousands of nodes, or a crafted import)
+// cannot overflow the call stack while computing the readiness/validation read model.
+const NODE_WHITE = 0;
+const NODE_GRAY = 1;
+const NODE_BLACK = 2;
+
+function findDependencyCycles(dependencies) {
+	const adjacency = buildDependencyAdjacency(dependencies);
+	const color = new Map();
+	const cycles = [];
+	const seenCycleKeys = new Set();
+
+	for (const root of adjacency.keys()) {
+		if ((color.get(root) || NODE_WHITE) !== NODE_WHITE) continue;
+
+		const path = [root];
+		const frames = [{ node: root, neighborIndex: 0 }];
+		color.set(root, NODE_GRAY);
+
+		while (frames.length > 0) {
+			const frame = frames[frames.length - 1];
+			const neighbors = adjacency.get(frame.node) || [];
+			if (frame.neighborIndex < neighbors.length) {
+				const next = neighbors[frame.neighborIndex];
+				frame.neighborIndex += 1;
+				const nextColor = color.get(next) || NODE_WHITE;
+				if (nextColor === NODE_GRAY) {
+					const startIndex = path.indexOf(next);
+					if (startIndex >= 0) {
+						const cycle = canonicalRotation(path.slice(startIndex));
+						const key = cycle.join(' ');
+						if (!seenCycleKeys.has(key)) {
+							seenCycleKeys.add(key);
+							cycles.push(cycle);
+						}
+					}
+				} else if (nextColor === NODE_WHITE) {
+					color.set(next, NODE_GRAY);
+					path.push(next);
+					frames.push({ node: next, neighborIndex: 0 });
+				}
+			} else {
+				color.set(frame.node, NODE_BLACK);
+				frames.pop();
+				path.pop();
+			}
+		}
+	}
+	return cycles;
+}
+
+function assertAcyclicDependencies(dependencies) {
+	const cycles = findDependencyCycles(dependencies);
+	if (cycles.length > 0) {
+		throw new TaxonomyValidationError(`Dependency cycle detected: ${cycles[0].join(' -> ')}`, {
+			code: 'dependency_cycle',
+			field: 'dependencies',
+		});
+	}
+	return true;
+}
+
+function validateParentChild(issue = {}, parent = null) {
+	const errors = [];
+	if (!issue.parent_id) {
+		return { valid: true, errors };
+	}
+	if (isSelfParent(issue)) {
+		errors.push(selfParentError());
+		return { valid: false, errors };
+	}
+	if (!parent) {
+		errors.push({ code: 'missing_parent', field: 'parent_id', message: `Parent ${issue.parent_id} not found` });
+		return { valid: false, errors };
+	}
+	const behavior = getTypeBehavior(parent.type);
+	if (!behavior || !behavior.canParent) {
+		errors.push({
+			code: 'invalid_parent_type',
+			field: 'parent_id',
+			message: `Type ${parent.type} cannot contain children`,
+		});
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+function findParentCycle(issuesById = {}, startId) {
+	const visited = [];
+	const seen = new Set();
+	let current = startId;
+	while (current && issuesById[current]) {
+		if (seen.has(current)) {
+			return visited.slice(visited.indexOf(current));
+		}
+		seen.add(current);
+		visited.push(current);
+		current = issuesById[current].parent_id;
+	}
+	return [];
+}
+
+function toEpochMillis(value) {
+	if (value === null || value === undefined) return null;
+	const millis = new Date(value).getTime();
+	return Number.isFinite(millis) ? millis : null;
+}
+
+function validateClaim(claim = {}, options = {}) {
+	const errors = [];
+	if (!claim.actor || String(claim.actor).trim() === '') {
+		errors.push({ code: 'missing_actor', field: 'actor', message: 'Claim requires an actor' });
+	}
+	const state = claim.state || 'active';
+	if (!CLAIM_STATES.includes(state)) {
+		errors.push({ code: 'invalid_claim_state', field: 'state', message: `Unknown claim state: ${state}` });
+	}
+	if (options.issueType && !isClaimableType(options.issueType)) {
+		errors.push({ code: 'unclaimable_type', field: 'issue_type', message: `Type ${options.issueType} is not claimable` });
+	}
+	const expiresMillis = toEpochMillis(claim.expires_at);
+	const hasExpiry = claim.expires_at !== null && claim.expires_at !== undefined;
+	if (hasExpiry && expiresMillis === null) {
+		// Fail closed: a lease invariant cannot accept an unparseable expiry date.
+		errors.push({ code: 'invalid_lease_date', field: 'expires_at', message: `Unparseable lease expiry: ${claim.expires_at}` });
+	}
+	const nowMillis = toEpochMillis(options.now);
+	if (state === 'active' && nowMillis !== null && expiresMillis !== null && expiresMillis <= nowMillis) {
+		// Inclusive boundary: a lease whose expiry instant has arrived is expired, so the
+		// issue is released to others rather than held by a just-elapsed lease.
+		errors.push({ code: 'lease_expired', field: 'expires_at', message: 'Active claim lease has expired' });
+	}
+	return { valid: errors.length === 0, errors };
+}
+
+function validateActiveClaimUniqueness(claims = []) {
+	const activeByIssue = new Map();
+	for (const claim of claims) {
+		if ((claim.state || 'active') !== 'active') continue;
+		activeByIssue.set(claim.issue_id, (activeByIssue.get(claim.issue_id) || 0) + 1);
+	}
+	const conflictingIssueIds = [];
+	for (const [issueId, count] of activeByIssue) {
+		if (count > 1) conflictingIssueIds.push(issueId);
+	}
+	const errors = conflictingIssueIds.map(issueId => ({
+		code: 'multiple_active_claims',
+		field: 'issue_id',
+		message: `Issue ${issueId} has more than one active claim`,
+	}));
+	return { valid: conflictingIssueIds.length === 0, errors, conflictingIssueIds };
+}
+
+function normalizeRank(value) {
+	const numeric = Number(value);
+	if (!Number.isFinite(numeric)) return 0;
+	return Math.max(0, Math.trunc(numeric));
+}
+
+function rankForPriorityLabel(label) {
+	if (typeof label === 'number' && Number.isFinite(label)) {
+		return normalizeRank(label);
+	}
+	const raw = String(label ?? '').trim().toUpperCase();
+	const match = raw.match(/^P?(\d+)$/);
+	if (!match) return DEFAULT_PRIORITY_RANK;
+	return normalizeRank(match[1]);
+}
+
+function priorityLabelForRank(rank) {
+	const clamped = Math.min(normalizeRank(rank), MAX_DISPLAY_PRIORITY_RANK);
+	return `P${clamped}`;
+}
+
+module.exports = {
+	CLAIM_STATES,
+	STATUS_TRANSITIONS,
+	TERMINAL_STATUSES,
+	TYPE_BEHAVIORS,
+	TaxonomyValidationError,
+	ISSUE_STATUSES,
+	ISSUE_TYPES,
+	assertAcyclicDependencies,
+	findDependencyCycles,
+	findParentCycle,
+	getTypeBehavior,
+	isClaimableType,
+	isTerminalStatus,
+	isValidIssueStatus,
+	isValidIssueType,
+	isValidStatusTransition,
+	normalizeRank,
+	priorityLabelForRank,
+	rankForPriorityLabel,
+	toEpochMillis,
+	validateActiveClaimUniqueness,
+	validateClaim,
+	validateIssueTaxonomy,
+	validateParentChild,
+	validateStatusTransition,
+};

--- a/test/kernel/broker.test.js
+++ b/test/kernel/broker.test.js
@@ -59,7 +59,7 @@ describe('local Kernel broker contract', () => {
 			'PRAGMA foreign_keys=ON;',
 			'PRAGMA busy_timeout=5000;',
 		]);
-		expect(statements).toContain('CREATE TABLE IF NOT EXISTS kernel_issues (\n  id TEXT NOT NULL PRIMARY KEY,\n  title TEXT NOT NULL,\n  body TEXT,\n  type TEXT NOT NULL DEFAULT \'task\',\n  status TEXT NOT NULL DEFAULT \'open\',\n  priority TEXT NOT NULL DEFAULT \'P2\',\n  priority_rank INTEGER NOT NULL DEFAULT 0,\n  created_at TEXT NOT NULL,\n  updated_at TEXT NOT NULL,\n  entity_revision INTEGER NOT NULL DEFAULT 0\n);');
+		expect(statements).toContain('CREATE TABLE IF NOT EXISTS kernel_issues (\n  id TEXT NOT NULL PRIMARY KEY,\n  title TEXT NOT NULL,\n  body TEXT,\n  type TEXT NOT NULL DEFAULT \'task\',\n  status TEXT NOT NULL DEFAULT \'open\',\n  priority TEXT NOT NULL DEFAULT \'P2\',\n  priority_rank INTEGER NOT NULL DEFAULT 0,\n  created_at TEXT NOT NULL,\n  updated_at TEXT NOT NULL,\n  entity_revision INTEGER NOT NULL DEFAULT 0,\n  parent_id TEXT REFERENCES kernel_issues(id),\n  sprint_id TEXT,\n  release_id TEXT,\n  stage_state TEXT,\n  labels TEXT,\n  acceptance_criteria TEXT,\n  estimate TEXT\n);');
 	});
 
 	test('does not fail when the expected revision column migration is replayed', async () => {

--- a/test/kernel/planning-buckets-schema.test.js
+++ b/test/kernel/planning-buckets-schema.test.js
@@ -55,6 +55,12 @@ describe('planning bucket entities (forge-2agy.9.2.7)', () => {
 		expect(validatePlanningBucketsSchema()).toBe(true);
 	});
 
+	test('rejects a schema missing a required planning bucket table', () => {
+		const schema = getPlanningBucketsSchema();
+		schema.tables = schema.tables.filter(table => table.name !== 'milestone');
+		expect(() => validatePlanningBucketsSchema(schema)).toThrow(/milestone/);
+	});
+
 	test('returns isolated, migration-renderable schema definitions', () => {
 		const schema = getPlanningBucketsSchema();
 		schema.tables[0].fields[0].name = 'mutated';

--- a/test/kernel/planning-buckets-schema.test.js
+++ b/test/kernel/planning-buckets-schema.test.js
@@ -1,0 +1,83 @@
+const { describe, expect, test } = require('bun:test');
+
+const { buildSchemaMigration } = require('../../lib/kernel/migrations');
+const {
+	PLANNING_BUCKET_TABLES,
+	SPRINT_STATES,
+	RELEASE_STATES,
+	MILESTONE_STATES,
+	BOARD_MUTATION_EVENT_TYPES,
+	getPlanningBucketsSchema,
+	validatePlanningBucketsSchema,
+} = require('../../lib/kernel/planning-buckets-schema');
+
+describe('planning bucket entities (forge-2agy.9.2.7)', () => {
+	test('defines sprint, release, and milestone entity tables', () => {
+		expect(PLANNING_BUCKET_TABLES.sprint).toBeDefined();
+		expect(PLANNING_BUCKET_TABLES.release).toBeDefined();
+		expect(PLANNING_BUCKET_TABLES.milestone).toBeDefined();
+		expect(PLANNING_BUCKET_TABLES.sprint.sqlName).toBe('kernel_sprint');
+	});
+
+	test('each bucket carries id, name, state, ordering, rollup, and revision', () => {
+		for (const name of ['sprint', 'release', 'milestone']) {
+			const fields = PLANNING_BUCKET_TABLES[name].fields.map(field => field.name);
+			expect(fields).toContain('id');
+			expect(fields).toContain('name');
+			expect(fields).toContain('state');
+			expect(fields).toContain('rank');
+			expect(fields).toContain('entity_revision');
+			// rollup read-model counters
+			expect(fields).toContain('total_count');
+			expect(fields).toContain('completed_count');
+		}
+	});
+
+	test('every bucket carries an owner field for parity', () => {
+		for (const name of ['sprint', 'release', 'milestone']) {
+			const fields = PLANNING_BUCKET_TABLES[name].fields.map(field => field.name);
+			expect(fields).toContain('owner');
+		}
+	});
+
+	test('marks rollup counters as derived read-model storage', () => {
+		const total = PLANNING_BUCKET_TABLES.sprint.fields.find(field => field.name === 'total_count');
+		expect(total.storageClass).toBe('read_model');
+	});
+
+	test('exposes bucket state vocabularies', () => {
+		expect(SPRINT_STATES).toContain('active');
+		expect(RELEASE_STATES).toContain('released');
+		expect(MILESTONE_STATES).toContain('reached');
+	});
+
+	test('passes the shared Kernel schema validator', () => {
+		expect(validatePlanningBucketsSchema()).toBe(true);
+	});
+
+	test('returns isolated, migration-renderable schema definitions', () => {
+		const schema = getPlanningBucketsSchema();
+		schema.tables[0].fields[0].name = 'mutated';
+		expect(getPlanningBucketsSchema().tables[0].fields[0].name).toBe('id');
+
+		const migration = buildSchemaMigration(getPlanningBucketsSchema());
+		const sql = migration.apply.join('\n');
+		expect(sql).toContain('CREATE TABLE IF NOT EXISTS kernel_sprint');
+		expect(sql).toContain('CREATE TABLE IF NOT EXISTS kernel_release');
+		expect(sql).toContain('CREATE TABLE IF NOT EXISTS kernel_milestone');
+	});
+
+	test('defines the board rank mutation event vocabulary', () => {
+		for (const eventType of [
+			'issue.reordered',
+			'issue.status_changed',
+			'issue.sprint_assigned',
+			'issue.release_assigned',
+			'issue.blocked',
+			'issue.unblocked',
+			'issue.type_changed',
+		]) {
+			expect(BOARD_MUTATION_EVENT_TYPES).toContain(eventType);
+		}
+	});
+});

--- a/test/kernel/readiness-model.test.js
+++ b/test/kernel/readiness-model.test.js
@@ -278,6 +278,15 @@ describe('deriveReadiness — additional branches', () => {
 		expect(result.ready).toBe(true);
 	});
 
+	test('a non-issue conflict sharing the id string does not block the issue', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, conflicts: [{ entity_type: 'dependency', entity_id: 'a', status: 'quarantined' }] },
+		);
+		expect(result.blocked).toBe(false);
+		expect(result.ready).toBe(true);
+	});
+
 	test('a non-active claim by another actor does not make the issue claimed', () => {
 		const result = deriveReadiness(
 			{ id: 'a', status: 'open' },

--- a/test/kernel/readiness-model.test.js
+++ b/test/kernel/readiness-model.test.js
@@ -113,6 +113,19 @@ describe('deriveReadiness — derived facts, never stored', () => {
 		expect(result.reasons.map(reason => reason.code)).toContain('claimed');
 	});
 
+	test('an active claim whose lease has expired no longer blocks other actors', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{
+				now: NOW,
+				claims: [{ issue_id: 'a', actor: 'other', state: 'active', expires_at: '2026-06-16T00:00:00.000Z' }],
+				actor: 'me',
+			},
+		);
+		expect(result.ready).toBe(true);
+		expect(result.state).not.toBe('claimed');
+	});
+
 	test('an issue claimed by the requesting actor is still ready for that actor', () => {
 		const result = deriveReadiness(
 			{ id: 'a', status: 'open' },

--- a/test/kernel/readiness-model.test.js
+++ b/test/kernel/readiness-model.test.js
@@ -296,6 +296,20 @@ describe('deriveReadiness — additional branches', () => {
 		expect(decisionReason.decision).toBe(true);
 	});
 
+	test('an open epic/decision is not ready work (unclaimable types are excluded)', () => {
+		const epic = deriveReadiness({ id: 'e', status: 'open', type: 'epic' }, { now: NOW });
+		expect(epic.ready).toBe(false);
+		expect(epic.blocked).toBe(false);
+		expect(epic.state).toBe('backlog');
+
+		const decision = deriveReadiness({ id: 'd', status: 'open', type: 'decision' }, { now: NOW });
+		expect(decision.ready).toBe(false);
+
+		// a claimable task with the same conditions is ready
+		const task = deriveReadiness({ id: 't', status: 'open', type: 'task' }, { now: NOW });
+		expect(task.ready).toBe(true);
+	});
+
 	test('a cancelled dependency is terminal and no longer blocks', () => {
 		const result = deriveReadiness(
 			{ id: 'a', status: 'open' },

--- a/test/kernel/readiness-model.test.js
+++ b/test/kernel/readiness-model.test.js
@@ -131,6 +131,15 @@ describe('deriveReadiness — derived facts, never stored', () => {
 		expect(result.reasons.map(reason => reason.code)).toContain('deferred');
 	});
 
+	test('a deferred issue stays deferred (fail closed) when now is unavailable', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open', defer_until: '2026-12-01T00:00:00.000Z' },
+			{},
+		);
+		expect(result.ready).toBe(false);
+		expect(result.state).toBe('deferred');
+	});
+
 	test('a past defer window is no longer deferring', () => {
 		const result = deriveReadiness(
 			{ id: 'a', status: 'open', defer_until: '2026-01-01T00:00:00.000Z' },

--- a/test/kernel/readiness-model.test.js
+++ b/test/kernel/readiness-model.test.js
@@ -1,0 +1,285 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+	READINESS_REASONS,
+	READINESS_STATES,
+	isWorkableStatus,
+	deriveReadiness,
+	buildReadinessIndex,
+} = require('../../lib/kernel/readiness-model');
+
+const NOW = '2026-06-17T00:00:00.000Z';
+
+describe('readiness reason and state vocabularies', () => {
+	test('exposes stable reason codes', () => {
+		expect(READINESS_REASONS.DEPENDENCY).toBe('dependency');
+		expect(READINESS_REASONS.CLAIM).toBe('claimed');
+		expect(READINESS_REASONS.QUARANTINE).toBe('quarantine');
+		expect(READINESS_REASONS.GATE).toBe('gate');
+		expect(READINESS_REASONS.DEFERRED).toBe('deferred');
+		expect(READINESS_REASONS.POLICY).toBe('policy_disabled');
+	});
+
+	test('exposes the derived state vocabulary including ready and blocked', () => {
+		expect(READINESS_STATES).toContain('ready');
+		expect(READINESS_STATES).toContain('blocked');
+		expect(READINESS_STATES).toContain('closed');
+	});
+
+	test('classifies workable statuses', () => {
+		expect(isWorkableStatus('open')).toBe(true);
+		expect(isWorkableStatus('in_progress')).toBe(true);
+		expect(isWorkableStatus('done')).toBe(false);
+		expect(isWorkableStatus('cancelled')).toBe(false);
+	});
+});
+
+describe('deriveReadiness — derived facts, never stored', () => {
+	test('an open issue with no blockers is ready', () => {
+		const result = deriveReadiness({ id: 'a', status: 'open' }, { now: NOW });
+		expect(result.ready).toBe(true);
+		expect(result.blocked).toBe(false);
+		expect(result.blocked_by).toEqual([]);
+		expect(result.state).toBe('ready');
+		// derived output must not leak back as a stored status field
+		expect(result.status).toBe('open');
+	});
+
+	test('an unmet dependency blocks the issue', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, dependencyStatuses: [{ id: 'b', status: 'in_progress' }] },
+		);
+		expect(result.ready).toBe(false);
+		expect(result.blocked).toBe(true);
+		expect(result.blocked_by).toContain('b');
+		expect(result.state).toBe('blocked');
+		expect(result.reasons.map(reason => reason.code)).toContain('dependency');
+	});
+
+	test('a satisfied (done) dependency does not block', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, dependencyStatuses: [{ id: 'b', status: 'done' }] },
+		);
+		expect(result.ready).toBe(true);
+		expect(result.blocked).toBe(false);
+	});
+
+	test('non-blocking dependency types are ignored', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, dependencyStatuses: [{ id: 'b', status: 'open', dependency_type: 'related' }] },
+		);
+		expect(result.blocked).toBe(false);
+	});
+
+	test('an unresolved decision dependency blocks the issue', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, dependencyStatuses: [{ id: 'd', status: 'open', type: 'decision' }] },
+		);
+		expect(result.blocked).toBe(true);
+		expect(result.blocked_by).toContain('d');
+	});
+
+	test('a quarantine/conflict marks the issue blocked', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, conflicts: [{ entity_id: 'a', status: 'quarantined' }] },
+		);
+		expect(result.blocked).toBe(true);
+		expect(result.reasons.map(reason => reason.code)).toContain('quarantine');
+	});
+
+	test('an unsatisfied required gate makes the issue not ready (gated)', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, gates: [{ name: 'design_approved', satisfied: false }] },
+		);
+		expect(result.ready).toBe(false);
+		expect(result.state).toBe('gated');
+		expect(result.reasons.map(reason => reason.code)).toContain('gate');
+	});
+
+	test('an active claim by another actor makes the issue not ready (claimed)', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, claims: [{ issue_id: 'a', actor: 'other', state: 'active' }], actor: 'me' },
+		);
+		expect(result.ready).toBe(false);
+		expect(result.blocked).toBe(false);
+		expect(result.state).toBe('claimed');
+		expect(result.reasons.map(reason => reason.code)).toContain('claimed');
+	});
+
+	test('an issue claimed by the requesting actor is still ready for that actor', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, claims: [{ issue_id: 'a', actor: 'me', state: 'active' }], actor: 'me' },
+		);
+		expect(result.ready).toBe(true);
+	});
+
+	test('a future defer window makes the issue not ready (deferred)', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open', defer_until: '2026-12-01T00:00:00.000Z' },
+			{ now: NOW },
+		);
+		expect(result.ready).toBe(false);
+		expect(result.state).toBe('deferred');
+		expect(result.reasons.map(reason => reason.code)).toContain('deferred');
+	});
+
+	test('a past defer window is no longer deferring', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open', defer_until: '2026-01-01T00:00:00.000Z' },
+			{ now: NOW },
+		);
+		expect(result.ready).toBe(true);
+	});
+
+	test('a policy-disabled issue is not ready', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, policyDisabled: true },
+		);
+		expect(result.ready).toBe(false);
+		expect(result.state).toBe('disabled');
+	});
+
+	test('a terminal issue is closed, neither ready nor blocked', () => {
+		const done = deriveReadiness({ id: 'a', status: 'done' }, { now: NOW });
+		expect(done.ready).toBe(false);
+		expect(done.blocked).toBe(false);
+		expect(done.state).toBe('closed');
+
+		const cancelled = deriveReadiness({ id: 'a', status: 'cancelled' }, { now: NOW });
+		expect(cancelled.state).toBe('closed');
+	});
+
+	test('blocked takes precedence over claimed in the summary state', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{
+				now: NOW,
+				dependencyStatuses: [{ id: 'b', status: 'open' }],
+				claims: [{ issue_id: 'a', actor: 'other', state: 'active' }],
+				actor: 'me',
+			},
+		);
+		expect(result.blocked).toBe(true);
+		expect(result.state).toBe('blocked');
+	});
+
+	test('never mutates the input issue', () => {
+		const issue = { id: 'a', status: 'open' };
+		const frozen = Object.freeze({ ...issue });
+		expect(() => deriveReadiness(frozen, { now: NOW })).not.toThrow();
+	});
+});
+
+describe('buildReadinessIndex — board read model', () => {
+	test('resolves dependency statuses from the issue set and ranks the ready queue', () => {
+		const index = buildReadinessIndex({
+			now: NOW,
+			issues: [
+				{ id: 'a', status: 'open', priority_rank: 2 },
+				{ id: 'b', status: 'open', priority_rank: 0 },
+				{ id: 'c', status: 'open', priority_rank: 1 },
+			],
+			dependencies: [
+				{ issue_id: 'a', blocks_issue_id: 'b' }, // a depends on b
+			],
+		});
+
+		// b is unfinished, so a is blocked; b and c are ready, ordered by rank (0 before 1)
+		expect(index.readinessById.a.blocked).toBe(true);
+		expect(index.blocked).toContain('a');
+		expect(index.readyQueue).toEqual(['b', 'c']);
+	});
+
+	test('excludes terminal and claimed-by-other issues from the ready queue', () => {
+		const index = buildReadinessIndex({
+			now: NOW,
+			actor: 'me',
+			issues: [
+				{ id: 'a', status: 'done', priority_rank: 0 },
+				{ id: 'b', status: 'open', priority_rank: 1 },
+				{ id: 'c', status: 'open', priority_rank: 2 },
+			],
+			claims: [{ issue_id: 'c', actor: 'other', state: 'active' }],
+		});
+
+		expect(index.readyQueue).toEqual(['b']);
+		expect(index.readinessById.a.state).toBe('closed');
+		expect(index.readinessById.c.state).toBe('claimed');
+	});
+
+	test('wires gates, conflicts, and policyDisabledIds into per-issue readiness', () => {
+		const index = buildReadinessIndex({
+			now: NOW,
+			issues: [
+				{ id: 'g', status: 'open', priority_rank: 0 },
+				{ id: 'q', status: 'open', priority_rank: 1 },
+				{ id: 'p', status: 'open', priority_rank: 2 },
+				{ id: 'ok', status: 'open', priority_rank: 3 },
+			],
+			gates: [{ issue_id: 'g', name: 'design_approved', satisfied: false }],
+			conflicts: [{ entity_id: 'q', status: 'quarantined' }],
+			policyDisabledIds: ['p'],
+		});
+
+		expect(index.readinessById.g.state).toBe('gated');
+		expect(index.readinessById.q.state).toBe('blocked');
+		expect(index.readinessById.p.state).toBe('disabled');
+		expect(index.readinessById.ok.ready).toBe(true);
+		expect(index.readyQueue).toEqual(['ok']);
+		expect(index.blocked).toEqual(['q']);
+	});
+});
+
+describe('deriveReadiness — additional branches', () => {
+	test('a non-workable, non-terminal status with no blockers falls through to backlog', () => {
+		const result = deriveReadiness({ id: 'a', status: 'review' }, { now: NOW });
+		expect(result.ready).toBe(false);
+		expect(result.blocked).toBe(false);
+		expect(result.state).toBe('backlog');
+	});
+
+	test('a conflict for a different entity does not block this issue', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, conflicts: [{ entity_id: 'other', status: 'quarantined' }] },
+		);
+		expect(result.blocked).toBe(false);
+		expect(result.ready).toBe(true);
+	});
+
+	test('a non-active claim by another actor does not make the issue claimed', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, claims: [{ issue_id: 'a', actor: 'other', state: 'released' }], actor: 'me' },
+		);
+		expect(result.ready).toBe(true);
+		expect(result.state).not.toBe('claimed');
+	});
+
+	test('a decision blocker carries the decision marker', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, dependencyStatuses: [{ id: 'd', status: 'open', type: 'decision' }] },
+		);
+		const decisionReason = result.reasons.find(reason => reason.issue_id === 'd');
+		expect(decisionReason.decision).toBe(true);
+	});
+
+	test('a cancelled dependency is terminal and no longer blocks', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, dependencyStatuses: [{ id: 'b', status: 'cancelled' }] },
+		);
+		expect(result.blocked).toBe(false);
+		expect(result.ready).toBe(true);
+	});
+});

--- a/test/kernel/taxonomy-validator.test.js
+++ b/test/kernel/taxonomy-validator.test.js
@@ -1,0 +1,424 @@
+const { describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { getKernelSchema, KERNEL_TABLES } = require('../../lib/kernel/schema');
+const { buildSchemaMigration } = require('../../lib/kernel/migrations');
+const {
+	ISSUE_TYPES,
+	ISSUE_STATUSES,
+} = require('../../lib/kernel/issue-command-contract');
+const {
+	TERMINAL_STATUSES,
+	TYPE_BEHAVIORS,
+	STATUS_TRANSITIONS,
+	TaxonomyValidationError,
+	isValidIssueType,
+	isValidIssueStatus,
+	getTypeBehavior,
+	isClaimableType,
+	isTerminalStatus,
+	isValidStatusTransition,
+	validateStatusTransition,
+	validateIssueTaxonomy,
+	findDependencyCycles,
+	assertAcyclicDependencies,
+	validateParentChild,
+	findParentCycle,
+	validateClaim,
+	validateActiveClaimUniqueness,
+	rankForPriorityLabel,
+	priorityLabelForRank,
+	normalizeRank,
+} = require('../../lib/kernel/taxonomy-validator');
+
+describe('D18 issue schema taxonomy extensions', () => {
+	test('extends the issues table with planning and execution columns', () => {
+		const issues = getKernelSchema().tables.find(table => table.name === 'issues');
+		const fieldNames = issues.fields.map(field => field.name);
+
+		for (const column of [
+			'parent_id',
+			'sprint_id',
+			'release_id',
+			'stage_state',
+			'labels',
+			'acceptance_criteria',
+			'estimate',
+		]) {
+			expect(fieldNames).toContain(column);
+		}
+	});
+
+	test('keeps stored issue columns separate from derived readiness', () => {
+		const fieldNames = KERNEL_TABLES.issues.fields.map(field => field.name);
+		// ready/blocked are derived read-model facts, never stored columns (D18).
+		expect(fieldNames).not.toContain('ready');
+		expect(fieldNames).not.toContain('blocked');
+	});
+
+	test('parent_id self-references the issues table and stays nullable', () => {
+		const parent = KERNEL_TABLES.issues.fields.find(field => field.name === 'parent_id');
+		expect(parent.references).toBe('issues.id');
+		expect(parent.notNull).toBe(false);
+	});
+
+	test('renders valid DDL for the extended issues table', () => {
+		const migration = buildSchemaMigration(getKernelSchema());
+		const sql = migration.apply.join('\n');
+		expect(sql).toContain('CREATE TABLE IF NOT EXISTS kernel_issues');
+		expect(sql).toContain('parent_id TEXT REFERENCES kernel_issues(id)');
+		expect(sql).toContain('CREATE INDEX IF NOT EXISTS idx_kernel_issues_parent');
+	});
+});
+
+describe('canonical issue enums', () => {
+	test('exposes the 4-type and 5-status taxonomy from the contract', () => {
+		expect(ISSUE_TYPES).toEqual(['epic', 'task', 'bug', 'decision']);
+		expect(ISSUE_STATUSES).toEqual(['open', 'in_progress', 'review', 'done', 'cancelled']);
+		expect(TERMINAL_STATUSES).toEqual(['done', 'cancelled']);
+	});
+
+	test('validates membership without DB constraints', () => {
+		expect(isValidIssueType('task')).toBe(true);
+		expect(isValidIssueType('feature')).toBe(false); // feature is a label, not a type
+		expect(isValidIssueType('story')).toBe(false);
+		expect(isValidIssueStatus('review')).toBe(true);
+		expect(isValidIssueStatus('ready')).toBe(false); // ready is derived, not a status
+		expect(isValidIssueStatus('blocked')).toBe(false);
+	});
+});
+
+describe('type to behavior mapping', () => {
+	test('every type maps to a distinct Kernel behavior', () => {
+		for (const type of ISSUE_TYPES) {
+			expect(TYPE_BEHAVIORS[type]).toBeDefined();
+			expect(getTypeBehavior(type)).toBe(TYPE_BEHAVIORS[type]);
+		}
+		// epic is the only container that can parent and roll up children.
+		expect(TYPE_BEHAVIORS.epic.canParent).toBe(true);
+		expect(TYPE_BEHAVIORS.task.canParent).toBe(false);
+		expect(TYPE_BEHAVIORS.bug.canParent).toBe(false);
+		// decisions block dependents; epics/decisions are not directly claimable.
+		expect(TYPE_BEHAVIORS.decision.blocksOthers).toBe(true);
+		expect(isClaimableType('task')).toBe(true);
+		expect(isClaimableType('bug')).toBe(true);
+		expect(isClaimableType('epic')).toBe(false);
+		expect(isClaimableType('decision')).toBe(false);
+	});
+
+	test('unknown type has no behavior', () => {
+		expect(getTypeBehavior('feature')).toBeNull();
+	});
+});
+
+describe('status lifecycle rules', () => {
+	test('allows the forward lifecycle and cancellation', () => {
+		expect(isValidStatusTransition('open', 'in_progress')).toBe(true);
+		expect(isValidStatusTransition('in_progress', 'review')).toBe(true);
+		expect(isValidStatusTransition('review', 'done')).toBe(true);
+		expect(isValidStatusTransition('open', 'cancelled')).toBe(true);
+		expect(isValidStatusTransition('review', 'cancelled')).toBe(true);
+	});
+
+	test('allows rework transitions backward but not out of terminal states', () => {
+		expect(isValidStatusTransition('review', 'in_progress')).toBe(true);
+		expect(isValidStatusTransition('in_progress', 'open')).toBe(true);
+		expect(isValidStatusTransition('done', 'in_progress')).toBe(false);
+		expect(isValidStatusTransition('cancelled', 'open')).toBe(false);
+		expect(STATUS_TRANSITIONS.done).toEqual([]);
+		expect(STATUS_TRANSITIONS.cancelled).toEqual([]);
+	});
+
+	test('treats a same-status transition as an idempotent no-op', () => {
+		expect(isValidStatusTransition('open', 'open')).toBe(true);
+	});
+
+	test('rejects illegal transitions and unknown statuses by throwing', () => {
+		expect(isValidStatusTransition('open', 'done')).toBe(false);
+		expect(() => validateStatusTransition('open', 'done')).toThrow(TaxonomyValidationError);
+		expect(() => validateStatusTransition('open', 'flying')).toThrow(/unknown/i);
+	});
+});
+
+describe('issue taxonomy validation', () => {
+	test('accepts a well-formed issue', () => {
+		const result = validateIssueTaxonomy({
+			id: 'forge-1',
+			type: 'task',
+			status: 'open',
+			priority: 'P2',
+		});
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+
+	test('reports invalid type and status with field-scoped error codes', () => {
+		const result = validateIssueTaxonomy({ id: 'forge-1', type: 'feature', status: 'ready' });
+		expect(result.valid).toBe(false);
+		const codes = result.errors.map(error => error.code);
+		expect(codes).toContain('invalid_type');
+		expect(codes).toContain('invalid_status');
+	});
+
+	test('rejects an issue that is its own parent', () => {
+		const result = validateIssueTaxonomy({ id: 'forge-1', type: 'task', status: 'open', parent_id: 'forge-1' });
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('self_parent');
+	});
+});
+
+describe('dependency cycle detection', () => {
+	test('returns no cycles for an acyclic graph', () => {
+		const deps = [
+			{ issue_id: 'a', blocks_issue_id: 'b' },
+			{ issue_id: 'b', blocks_issue_id: 'c' },
+		];
+		expect(findDependencyCycles(deps)).toEqual([]);
+		expect(() => assertAcyclicDependencies(deps)).not.toThrow();
+	});
+
+	test('detects a direct cycle', () => {
+		const deps = [
+			{ issue_id: 'a', blocks_issue_id: 'b' },
+			{ issue_id: 'b', blocks_issue_id: 'a' },
+		];
+		const cycles = findDependencyCycles(deps);
+		expect(cycles.length).toBeGreaterThan(0);
+		expect(cycles[0]).toContain('a');
+		expect(cycles[0]).toContain('b');
+		expect(() => assertAcyclicDependencies(deps)).toThrow(TaxonomyValidationError);
+	});
+
+	test('ignores non-blocking dependency types', () => {
+		const deps = [
+			{ issue_id: 'a', blocks_issue_id: 'b', dependency_type: 'related' },
+			{ issue_id: 'b', blocks_issue_id: 'a', dependency_type: 'related' },
+		];
+		expect(findDependencyCycles(deps)).toEqual([]);
+	});
+});
+
+describe('dependency cycle detection — robustness', () => {
+	test('detects an indirect 3-node cycle and returns it canonically (smallest id first)', () => {
+		const cycles = findDependencyCycles([
+			{ issue_id: 'b', blocks_issue_id: 'c' },
+			{ issue_id: 'c', blocks_issue_id: 'a' },
+			{ issue_id: 'a', blocks_issue_id: 'b' },
+		]);
+		expect(cycles).toEqual([['a', 'b', 'c']]);
+	});
+
+	test('reports a shared cycle once regardless of entry point (dedup)', () => {
+		const cycles = findDependencyCycles([
+			{ issue_id: 'a', blocks_issue_id: 'b' },
+			{ issue_id: 'b', blocks_issue_id: 'a' },
+			{ issue_id: 'x', blocks_issue_id: 'a' }, // extra entry edge into the same cycle
+		]);
+		expect(cycles).toEqual([['a', 'b']]);
+	});
+
+	test('does not overflow the stack on a deep acyclic chain', () => {
+		const deep = [];
+		for (let i = 0; i < 20000; i += 1) {
+			deep.push({ issue_id: `n${i}`, blocks_issue_id: `n${i + 1}` });
+		}
+		expect(findDependencyCycles(deep)).toEqual([]);
+		expect(() => assertAcyclicDependencies(deep)).not.toThrow();
+	});
+});
+
+describe('parent-child consistency', () => {
+	test('accepts a task parented under an epic', () => {
+		const result = validateParentChild(
+			{ id: 'child', type: 'task', parent_id: 'epic-1' },
+			{ id: 'epic-1', type: 'epic' },
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	test('rejects a parent whose type cannot contain children', () => {
+		const result = validateParentChild(
+			{ id: 'child', type: 'task', parent_id: 'task-1' },
+			{ id: 'task-1', type: 'task' },
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('invalid_parent_type');
+	});
+
+	test('rejects a missing parent referenced by parent_id', () => {
+		const result = validateParentChild({ id: 'child', type: 'task', parent_id: 'epic-1' }, null);
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('missing_parent');
+	});
+
+	test('detects a parent chain cycle', () => {
+		const byId = {
+			a: { id: 'a', parent_id: 'b' },
+			b: { id: 'b', parent_id: 'a' },
+		};
+		expect(findParentCycle(byId, 'a')).toContain('a');
+	});
+});
+
+describe('parent cycle detection — non-cycle paths', () => {
+	test('returns empty for an acyclic parent chain', () => {
+		const byId = {
+			a: { id: 'a', parent_id: 'b' },
+			b: { id: 'b', parent_id: 'c' },
+			c: { id: 'c' },
+		};
+		expect(findParentCycle(byId, 'a')).toEqual([]);
+	});
+
+	test('returns empty for an unknown start id', () => {
+		expect(findParentCycle({}, 'missing')).toEqual([]);
+	});
+});
+
+describe('parent-child validator — extra branches', () => {
+	test('a root issue with no parent is trivially valid', () => {
+		const result = validateParentChild({ id: 'a', type: 'task' });
+		expect(result.valid).toBe(true);
+	});
+
+	test('rejects an issue that is its own parent', () => {
+		const result = validateParentChild({ id: 'a', type: 'task', parent_id: 'a' });
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('self_parent');
+	});
+});
+
+describe('claim-lease invariants (validation layer)', () => {
+	const now = '2026-06-17T00:00:00.000Z';
+
+	test('accepts an active unexpired claim on a claimable issue', () => {
+		const result = validateClaim(
+			{ issue_id: 'forge-1', actor: 'agent-a', state: 'active', claimed_at: now, expires_at: '2026-06-17T01:00:00.000Z' },
+			{ now, issueType: 'task' },
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	test('flags an active claim whose lease already expired', () => {
+		const result = validateClaim(
+			{ issue_id: 'forge-1', actor: 'agent-a', state: 'active', claimed_at: now, expires_at: '2026-06-16T00:00:00.000Z' },
+			{ now, issueType: 'task' },
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('lease_expired');
+	});
+
+	test('rejects a claim with no actor', () => {
+		const result = validateClaim({ issue_id: 'forge-1', actor: '', state: 'active', claimed_at: now }, { now });
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('missing_actor');
+	});
+
+	test('rejects claiming an unclaimable issue type', () => {
+		const result = validateClaim(
+			{ issue_id: 'epic-1', actor: 'agent-a', state: 'active', claimed_at: now },
+			{ now, issueType: 'epic' },
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('unclaimable_type');
+	});
+
+	test('detects more than one active claim per issue', () => {
+		const result = validateActiveClaimUniqueness([
+			{ issue_id: 'forge-1', actor: 'a', state: 'active' },
+			{ issue_id: 'forge-1', actor: 'b', state: 'active' },
+			{ issue_id: 'forge-2', actor: 'c', state: 'active' },
+		]);
+		expect(result.valid).toBe(false);
+		expect(result.conflictingIssueIds).toContain('forge-1');
+		expect(result.conflictingIssueIds).not.toContain('forge-2');
+	});
+});
+
+describe('claim validator — extra branches', () => {
+	const now = '2026-06-17T00:00:00.000Z';
+
+	test('rejects an unknown claim state', () => {
+		const result = validateClaim({ issue_id: 'forge-1', actor: 'a', state: 'paused' }, { now });
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('invalid_claim_state');
+	});
+
+	test('fails closed on an unparseable expiry date', () => {
+		const result = validateClaim(
+			{ issue_id: 'forge-1', actor: 'a', state: 'active', expires_at: 'not-a-date' },
+			{ now, issueType: 'task' },
+		);
+		expect(result.valid).toBe(false);
+		expect(result.errors.map(error => error.code)).toContain('invalid_lease_date');
+	});
+
+	test('does not count released claims toward active-claim conflicts', () => {
+		const result = validateActiveClaimUniqueness([
+			{ issue_id: 'forge-1', actor: 'a', state: 'active' },
+			{ issue_id: 'forge-1', actor: 'b', state: 'released' },
+		]);
+		expect(result.valid).toBe(true);
+		expect(result.conflictingIssueIds).toEqual([]);
+	});
+});
+
+describe('priority rank projection', () => {
+	test('treats numeric rank as authoritative and P0-P4 as a display projection', () => {
+		expect(rankForPriorityLabel('P0')).toBe(0);
+		expect(rankForPriorityLabel('P3')).toBe(3);
+		expect(rankForPriorityLabel('p2')).toBe(2);
+		expect(rankForPriorityLabel(4)).toBe(4);
+		expect(rankForPriorityLabel('high')).toBe(2); // unknown label falls back to default rank
+	});
+
+	test('projects rank back to a clamped display label', () => {
+		expect(priorityLabelForRank(0)).toBe('P0');
+		expect(priorityLabelForRank(4)).toBe('P4');
+		expect(priorityLabelForRank(9)).toBe('P4'); // display clamps to P4
+		expect(priorityLabelForRank(-1)).toBe('P0');
+	});
+
+	test('normalizes ranks to non-negative integers', () => {
+		expect(normalizeRank(2.9)).toBe(2);
+		expect(normalizeRank(-5)).toBe(0);
+		expect(normalizeRank('3')).toBe(3);
+		expect(normalizeRank(undefined)).toBe(0);
+	});
+});
+
+describe('terminal status predicate', () => {
+	test('identifies terminal statuses directly', () => {
+		expect(isTerminalStatus('done')).toBe(true);
+		expect(isTerminalStatus('cancelled')).toBe(true);
+		expect(isTerminalStatus('open')).toBe(false);
+		expect(isTerminalStatus('review')).toBe(false);
+	});
+});
+
+describe('status transition validator (throwing wrapper)', () => {
+	test('returns true for a legal transition', () => {
+		expect(validateStatusTransition('open', 'in_progress')).toBe(true);
+	});
+
+	test('throws on an unknown source status', () => {
+		expect(() => validateStatusTransition('flying', 'open')).toThrow(/unknown/i);
+	});
+});
+
+describe('taxonomy documentation', () => {
+	test('documents backlog vs sprint vs task vs stage and derived readiness', () => {
+		const doc = fs.readFileSync(
+			path.join(__dirname, '..', '..', 'docs', 'reference', 'KERNEL_TAXONOMY_VALIDATION.md'),
+			'utf8',
+		);
+		expect(doc).toContain('D18');
+		expect(doc).toMatch(/backlog/i);
+		expect(doc).toMatch(/sprint/i);
+		expect(doc).toMatch(/stage/i);
+		expect(doc).toMatch(/derived/i);
+		expect(doc).toContain('ready');
+		expect(doc).toContain('blocked');
+	});
+});


### PR DESCRIPTION
## Summary

Implements **D18** (taxonomy collapse: 4 types, 5 statuses, single rank) plus the derived **readiness read-model** and the **validation layer** for the Forge Kernel. Roadmap: `forge-2agy.9.2.1/.9.2.2/.9.2.6/.9.2.7/.9.2.8/.9.2.9`.

See [docs/reference/KERNEL_TAXONOMY_VALIDATION.md](docs/reference/KERNEL_TAXONOMY_VALIDATION.md) for the full reference.

## What changed

**Schema (additive only — coordinates with PR 4 on `lib/kernel/schema.js`)**
- `kernel_issues` gains `parent_id` (self-ref), `sprint_id`, `release_id`, `stage_state`, `labels`, `acceptance_criteria`, `estimate` + board indexes (parent/sprint/release).
- New `lib/kernel/planning-buckets-schema.js`: `kernel_sprint` / `kernel_release` / `kernel_milestone` first-class entities with state, ordering rank, owner/goal/dates, `entity_revision`, and read-model rollup counters (`total_count`, `completed_count`).
- Exported shared schema builders (`field`/`table`/`index`/`deepFreeze`/`cloneTableList`) so planning buckets reuse them.

**Validation layer — `lib/kernel/taxonomy-validator.js` (enforced at the validation layer, NOT DB constraints, to keep label-based extensibility)**
- Canonical `ISSUE_TYPES` (epic/task/bug/decision) + `ISSUE_STATUSES` (open/in_progress/review/done/cancelled) on the command contract; `feature`/`story`/`chore`/`spike` are labels.
- Type→behavior mapping (only `epic` can parent + rolls up; `decision` blocks dependents; epic/decision not claimable), status lifecycle rules, **iterative** dependency cycle detection (no recursion → safe on deep chains), parent-child consistency + parent-cycle detection, claim-lease invariants (fails closed on unparseable expiry).
- Single numeric rank is authoritative; **P0–P4 is a display projection**.

**Readiness read-model — `lib/kernel/readiness-model.js`**
- `ready`/`blocked` are **DERIVED, never stored** — computed from blocking dependencies (terminal deps clear), quarantine/conflicts, required gates, defer windows, policy, and conflicting claims. `buildReadinessIndex` ranks the ready queue by the single rank.

## Testing
- New source-matched kernel suites: `taxonomy-validator.test.js`, `readiness-model.test.js`, `planning-buckets-schema.test.js` (+ updated `broker.test.js` DDL snapshot for the additive columns).
- `bun test test/kernel/` → **129 pass / 0 fail**; full suite **0 fail**; ESLint `--max-warnings 0` clean; D20 kill-list unchanged; `test/commands/release.test.js` passes.
- Hardened via an adversarial multi-lens review pass (stack-overflow-safe cycle detection, fail-closed lease validation, dedup'd helpers, +coverage tests).

## Notes
- `lib/kernel/schema.js` edits are additive/minimal; expect a small merge coordination with PR 4 (JSONL projection).
- `ready`/`blocked` are intentionally absent from stored columns/statuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added planning buckets for sprints, releases, and milestones, including rollup fields and board mutation event support.
  * Expanded issue schema with planning/metadata fields (including acceptance criteria, labels, and estimates) and added related indexes.
  * Introduced a readiness model that derives issue states such as ready/blocked/gated/deferred/claimed/disabled from dependencies, gates, claims, and policy.
  * Added kernel taxonomy validation covering allowed status transitions, dependency consistency, and claim rules.
* **Documentation**
  * Published a comprehensive reference for taxonomy validation and readiness/read-model behavior.
* **Tests**
  * Added Bun test suites for planning buckets, readiness derivation/indexing, taxonomy validation, and updated migration/schema expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->