### PR TITLE
feat(kernel): local broker safety proof — atomic events, idempotency & DB-enforced claim leases (9.5.x)

### DIFF
--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
@@ -51,9 +51,12 @@ are UTC ISO-8601 with trailing `Z` so lexicographic compare = chronological).
   **not** allowed to fall through as a non-claim event (the generic evaluator would
   otherwise accept and persist the event + outbox without ever creating a lease,
   leaving the issue claimable by a later caller). A claim is malformed when it has
-  no `issue_id`, or an `expires_at` that is not a valid UTC ISO-8601 `Z` timestamp
-  (a junk `expires_at` would make the lexicographic expiry comparison meaningless —
-  locking the issue forever or making a live lease look instantly reclaimable).
+  a non-string `issue_id`, or an `expires_at` that is not the exact canonical UTC
+  form (`YYYY-MM-DDTHH:MM:SS.mmmZ`, validated by round-tripping through
+  `Date#toISOString`). The lexicographic expiry comparison demands one canonical
+  spelling — a junk or non-canonical `expires_at` would otherwise lock the issue
+  forever or make a live lease look instantly reclaimable, and round-tripping also
+  rejects rollover dates that `Date.parse` silently normalises.
 
 **Payload consistency:** the claim scope, the inserted `kernel_claims` row, and the
 conflict record all read from the **same** `normalizePayload` (`payload_json`-first)

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
@@ -47,6 +47,11 @@ are UTC ISO-8601 with trailing `Z` so lexicographic compare = chronological).
   then insert the new active claim, atomically.
 - **Active claim, live** → **conflict** (quarantine, `reason='claim_conflict'`),
   regardless of who is asking.
+- **Malformed `claim.create`** (missing/invalid `payload.issue_id`, so no claim
+  scope) → quarantine, `reason='invalid_claim_scope'`. It is **not** allowed to
+  fall through as a non-claim event: the generic evaluator would otherwise accept
+  and persist the event + outbox without ever creating a lease, leaving the issue
+  claimable by a later caller.
 
 ### Ownership decision: conservative, no silent renewal
 

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
@@ -51,12 +51,17 @@ are UTC ISO-8601 with trailing `Z` so lexicographic compare = chronological).
   **not** allowed to fall through as a non-claim event (the generic evaluator would
   otherwise accept and persist the event + outbox without ever creating a lease,
   leaving the issue claimable by a later caller). A claim is malformed when it has
-  a non-string `issue_id`, or an `expires_at` that is not the exact canonical UTC
+  a non-string `issue_id`, an `expires_at` that is not the exact canonical UTC
   form (`YYYY-MM-DDTHH:MM:SS.mmmZ`, validated by round-tripping through
-  `Date#toISOString`). The lexicographic expiry comparison demands one canonical
-  spelling — a junk or non-canonical `expires_at` would otherwise lock the issue
-  forever or make a live lease look instantly reclaimable, and round-tripping also
-  rejects rollover dates that `Date.parse` silently normalises.
+  `Date#toISOString`), or an `entity_type` other than `claim` (a `claim.create`
+  carried on the wrong entity stream would insert a lease while the event/outbox
+  record a different entity). The lexicographic expiry comparison demands one
+  canonical spelling — a junk or non-canonical `expires_at` would otherwise lock
+  the issue forever or make a live lease look instantly reclaimable, and
+  round-tripping also rejects rollover dates that `Date.parse` silently normalises.
+  A retry of an already-accepted claim (same `idempotency_key`) still replays as a
+  duplicate even if *this* retry is malformed — the idempotency check runs before
+  the `invalid_claim_scope` quarantine.
 
 **Payload consistency:** the claim scope, the inserted `kernel_claims` row, and the
 conflict record all read from the **same** `normalizePayload` (`payload_json`-first)

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
@@ -83,6 +83,13 @@ make `issueOperation('claim'|'release')` emit guarded `claim.create` /
 `claim.release` events through `runGuardedEvent`, so the enforcement proven here
 becomes reachable end-to-end from the command surface.
 
+## Stage Exit Summary
+
+- **Summary:** The local broker enforces the claim-lease invariant atomically — a DB-level partial UNIQUE index plus transactional broker logic — proven under real multi-process SQLite (WAL) contention.
+- **Decisions:** (1) conservative ownership — a live lease blocks all new claims, no silent renewal while `actor` is not distinct per agent; (2) wiring deferral — the broker primitive is proven, the `forge claim` surface is a follow-up; (3) two-layer model — load-bearing DB index + optimization/recovery layer.
+- **Artifacts:** `lib/kernel/migrations.js` (partial UNIQUE index), `lib/kernel/lease-enforcer.js` (pure planners), `lib/kernel/broker.js` (transactional write path + quarantine/recovery), `test/kernel/broker-multiprocess.test.js` + `test/kernel/fixtures/claim-race-worker.js` (multi-process proof).
+- **Next:** implement a real higher-level Kernel driver; wire `issueOperation('claim'|'release')` to emit guarded events through `runGuardedEvent`; settle the owner-identity model for Slice 2 (release semantics + broad non-owner write guard).
+
 ## Slice 2 (deferred)
 
 - `claim.release`: owner releases → `state='released'` (accept); non-owner

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
@@ -47,11 +47,19 @@ are UTC ISO-8601 with trailing `Z` so lexicographic compare = chronological).
   then insert the new active claim, atomically.
 - **Active claim, live** → **conflict** (quarantine, `reason='claim_conflict'`),
   regardless of who is asking.
-- **Malformed `claim.create`** (missing/invalid `payload.issue_id`, so no claim
-  scope) → quarantine, `reason='invalid_claim_scope'`. It is **not** allowed to
-  fall through as a non-claim event: the generic evaluator would otherwise accept
-  and persist the event + outbox without ever creating a lease, leaving the issue
-  claimable by a later caller.
+- **Malformed `claim.create`** → quarantine, `reason='invalid_claim_scope'`. It is
+  **not** allowed to fall through as a non-claim event (the generic evaluator would
+  otherwise accept and persist the event + outbox without ever creating a lease,
+  leaving the issue claimable by a later caller). A claim is malformed when it has
+  no `issue_id`, or an `expires_at` that is not a valid UTC ISO-8601 `Z` timestamp
+  (a junk `expires_at` would make the lexicographic expiry comparison meaningless —
+  locking the issue forever or making a live lease look instantly reclaimable).
+
+**Payload consistency:** the claim scope, the inserted `kernel_claims` row, and the
+conflict record all read from the **same** `normalizePayload` (`payload_json`-first)
+that the evaluator uses to persist the event — so the lease can never describe a
+different issue than the accepted event/outbox when both `payload` and
+`payload_json` are present and disagree.
 
 ### Ownership decision: conservative, no silent renewal
 

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md
@@ -1,0 +1,94 @@
+# Local Broker Safety Proof — Claim Leases & Multi-Process Contention
+
+**Status:** Slice 1 complete (this PR). Slice 2 deferred (see below).
+**Tasks:** 9.5.1, 9.5.3, 9.5.6, 9.5.9, 9.5.10 (Phase B — Local Broker Proof).
+
+This PR proves the local Kernel broker enforces its concurrency invariants
+atomically and survives real multi-process contention on a single machine /
+git common-dir. It hardens the broker *primitive* (`runGuardedEvent`); wiring
+the user-facing `forge claim` command surface to emit guarded events is an
+explicit follow-up (see **Wiring deferral**).
+
+## What landed
+
+| Task | Guarantee | Where |
+| --- | --- | --- |
+| 9.5.6 | Event insert + projection-outbox enqueue commit atomically | `broker.js` `runGuardedEvent` `BEGIN IMMEDIATE…COMMIT`, ROLLBACK on failure |
+| 9.5.9 | Concurrent idempotency-key collisions resolve to a duplicate replay, not a raw error | `broker.js` catch-block re-reads the winner's event |
+| 9.5.10 | At most one **active** claim lease per issue | `migrations.js` partial UNIQUE index + `lease-enforcer.js` + `broker.js` |
+| 9.5.1 / 9.5.3 | The lease invariant holds under real concurrent OS processes | `test/kernel/broker-multiprocess.test.js` + worker fixture |
+
+## Enforcement model (two layers)
+
+1. **Hard invariant (load-bearing):** a partial UNIQUE index
+   `idx_kernel_claims_active_lease ON kernel_claims (issue_id) WHERE state='active'`
+   (migration 003). This is the *only* guarantee that survives a multi-process
+   race — a pre-read check cannot, because two writers can both read zero active
+   claims before either commits. It mirrors `idx_kernel_events_idempotency`.
+2. **Optimization + clean error path:** the pure `lease-enforcer.js`
+   (`isLeaseExpired` / `planClaimAcquisition` / `buildClaimConflict`) plus broker
+   integration. A live lease is detected pre-write and quarantined without
+   opening a transaction; a race that slips past the pre-read is caught when the
+   UNIQUE index throws, rolled back, and re-read into a `claim_conflict`
+   quarantine. This mirrors the idempotency-recovery architecture exactly.
+
+The pure evaluator (`evaluators.js`) is intentionally **unchanged**: claim
+conflict needs a fresh read of claim state, which a pure function cannot do, so
+it is decided in the broker transaction.
+
+## Lease semantics (Slice 1)
+
+A claim lease is a `kernel_claims` row with `state='active'`. A lease is **live**
+iff it is active and not expired (`expires_at` null = never expires; timestamps
+are UTC ISO-8601 with trailing `Z` so lexicographic compare = chronological).
+
+- **No active claim** → insert a new active claim.
+- **Active claim, expired** → reclaim: supersede the stale row to `reclaimable`,
+  then insert the new active claim, atomically.
+- **Active claim, live** → **conflict** (quarantine, `reason='claim_conflict'`),
+  regardless of who is asking.
+
+### Ownership decision: conservative, no silent renewal
+
+`actor` is **not** currently distinct per concurrent agent — it is not populated
+anywhere on the command path today (verified: no `actor` assignment in
+`lib/commands/` or `lib/adapters/`). Therefore Slice 1 does **no silent
+same-owner renewal**: a live lease blocks ALL new `claim.create` events, even
+one with a matching `actor`. A renewal branch keyed on `actor` would let two
+agents that share a git user identity silently steal each other's live lease —
+the exact race this PR exists to prevent.
+
+This is safe and non-disruptive because a genuine same-claim retry carries the
+same `idempotency_key` and is collapsed to a duplicate replay (9.5.9) *before*
+claim planning runs. Only a genuinely new claim against a live lease reaches the
+conflict path. In-place renewal can be added later once `actor`/`session_id`/
+`worktree_id` identity is reliably populated.
+
+## Wiring deferral (conscious decision)
+
+`runGuardedEvent` is currently a broker primitive exercised only by tests — the
+real `forge claim` path runs `runIssueOperation` → `driver.issueOperation('claim')`,
+a separate method, and there is no production higher-level driver implementing
+`insertKernelEvent` / `loadActiveKernelClaim` / `insertKernelClaim` yet (only
+test mocks and the low-level `sqlite-driver.js` `exec`/`queryAll`/`close`).
+
+This PR deliberately proves the primitive under contention rather than wiring
+the command surface, matching the stated scope ("broker safety **proof**"). The
+multi-process fixture therefore proves the **DB invariant** (the partial UNIQUE
+index) under real OS-process contention — the load-bearing guarantee — while the
+broker's plan/recover logic on top is proven with unit-level mocks.
+
+**Follow-up (not in this PR):** implement a real higher-level Kernel driver and
+make `issueOperation('claim'|'release')` emit guarded `claim.create` /
+`claim.release` events through `runGuardedEvent`, so the enforcement proven here
+becomes reachable end-to-end from the command surface.
+
+## Slice 2 (deferred)
+
+- `claim.release`: owner releases → `state='released'` (accept); non-owner
+  release of a live lease → `claim_conflict`. Requires the owner-identity model
+  above to be settled.
+- Broad non-owner write guard: extend claim-scope to `issue.update` / `issue.close`
+  so non-owner mutations of a claimed issue quarantine. This touches every
+  existing broker fixture (new `loadActiveKernelClaim` stubs), so it is a
+  separate change.

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -78,13 +78,16 @@ function isDuplicateColumnError(error) {
 }
 
 function isIdempotencyConflict(error) {
-	const msg = String(error && error.message ? error.message : error);
+	const msg = String(error?.message ?? error);
 	return /UNIQUE constraint failed/i.test(msg) && /idempotency_key/i.test(msg);
 }
 
+// Match ONLY the active-lease partial UNIQUE index (kernel_claims.issue_id), not
+// the table's primary key (kernel_claims.id): a duplicate-id violation is a
+// distinct bug and must not be misclassified as a lease conflict.
 function isClaimLeaseConflict(error) {
-	const msg = String(error && error.message ? error.message : error);
-	return /UNIQUE constraint failed/i.test(msg) && /kernel_claims/i.test(msg);
+	const msg = String(error?.message ?? error);
+	return /UNIQUE constraint failed/i.test(msg) && /kernel_claims\.issue_id/i.test(msg);
 }
 
 async function execMigrationStatement(driver, statement, config) {
@@ -278,7 +281,7 @@ function createLocalBroker(options = {}) {
 				}
 			}
 
-			await driver.exec('BEGIN IMMEDIATE;');
+			await driver.exec('BEGIN IMMEDIATE;', config);
 			let acceptedEvent, outboxEntry;
 			try {
 				if (claimPlan) {
@@ -298,10 +301,18 @@ function createLocalBroker(options = {}) {
 					context,
 					config,
 				);
-				await driver.exec('COMMIT;');
+				await driver.exec('COMMIT;', config);
 			} catch (err) {
-				await driver.exec('ROLLBACK;');
-				if (isIdempotencyConflict(err) && normalizedEvent.idempotency_key) {
+				await driver.exec('ROLLBACK;', config);
+				// A same-idempotency-key claim retry can trip EITHER unique index
+				// first: the claim insert precedes the event insert, so the
+				// active-lease index may throw before the events idempotency index.
+				// Prefer an idempotency replay whenever a committed winner exists,
+				// regardless of which index tripped, so legitimate retries are
+				// replayed as duplicates rather than quarantined as conflicts.
+				const isUniqueConflict = isIdempotencyConflict(err)
+					|| (claimScope && isClaimLeaseConflict(err));
+				if (isUniqueConflict && normalizedEvent.idempotency_key) {
 					const existingEvent = await driver.loadKernelEventByIdempotencyKey(
 						normalizedEvent.idempotency_key, context, config,
 					);

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -166,6 +166,7 @@ function createLocalBroker(options = {}) {
 
 		async runGuardedEvent(event, context = {}) {
 			for (const methodName of [
+				'exec',
 				'loadKernelEntity',
 				'listKernelEvents',
 				'loadKernelEventByIdempotencyKey',
@@ -220,15 +221,23 @@ function createLocalBroker(options = {}) {
 				return evaluation;
 			}
 
-			const acceptedEvent = await driver.insertKernelEvent({
-				...evaluation.event,
-				created_at: evaluation.event.created_at || now,
-			}, context, config);
-			const outboxEntry = await driver.enqueueKernelProjection(
-				buildProjectionOutboxEntry(acceptedEvent, context.projectionTarget || 'beads', now),
-				context,
-				config,
-			);
+			await driver.exec('BEGIN IMMEDIATE;');
+			let acceptedEvent, outboxEntry;
+			try {
+				acceptedEvent = await driver.insertKernelEvent({
+					...evaluation.event,
+					created_at: evaluation.event.created_at || now,
+				}, context, config);
+				outboxEntry = await driver.enqueueKernelProjection(
+					buildProjectionOutboxEntry(acceptedEvent, context.projectionTarget || 'beads', now),
+					context,
+					config,
+				);
+				await driver.exec('COMMIT;');
+			} catch (err) {
+				await driver.exec('ROLLBACK;');
+				throw err;
+			}
 
 			return {
 				...evaluation,

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -76,6 +76,11 @@ function isDuplicateColumnError(error) {
 	return /duplicate column name/i.test(String(error && error.message ? error.message : error));
 }
 
+function isIdempotencyConflict(error) {
+	const msg = String(error && error.message ? error.message : error);
+	return /UNIQUE constraint failed/i.test(msg) && /idempotency_key/i.test(msg);
+}
+
 async function execMigrationStatement(driver, statement, config) {
 	try {
 		await driver.exec(statement, config);
@@ -236,6 +241,19 @@ function createLocalBroker(options = {}) {
 				await driver.exec('COMMIT;');
 			} catch (err) {
 				await driver.exec('ROLLBACK;');
+				if (isIdempotencyConflict(err) && normalizedEvent.idempotency_key) {
+					const existingEvent = await driver.loadKernelEventByIdempotencyKey(
+						normalizedEvent.idempotency_key, context, config,
+					);
+					if (existingEvent) {
+						return {
+							decision: 'duplicate',
+							event: normalizedEvent,
+							originalEvent: existingEvent,
+							projection: false,
+						};
+					}
+				}
 				throw err;
 			}
 

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -4,6 +4,7 @@ const { execFileSync } = require('node:child_process');
 const path = require('node:path');
 const { evaluateKernelEvent } = require('./evaluators');
 const { buildKernelMigrationPlan } = require('./migrations');
+const { buildClaimConflict, planClaimAcquisition } = require('./lease-enforcer');
 
 const LOCAL_BROKER_PRAGMAS = Object.freeze([
 	'PRAGMA journal_mode=WAL;',
@@ -81,6 +82,11 @@ function isIdempotencyConflict(error) {
 	return /UNIQUE constraint failed/i.test(msg) && /idempotency_key/i.test(msg);
 }
 
+function isClaimLeaseConflict(error) {
+	const msg = String(error && error.message ? error.message : error);
+	return /UNIQUE constraint failed/i.test(msg) && /kernel_claims/i.test(msg);
+}
+
 async function execMigrationStatement(driver, statement, config) {
 	try {
 		await driver.exec(statement, config);
@@ -121,6 +127,20 @@ function buildDependencyScope(event) {
 		issue_id: payload.issue_id,
 		blocks_issue_id: payload.blocks_issue_id,
 		dependency_type: payload.dependency_type || 'blocks',
+		entity_type: event.entity_type,
+		entity_id: event.entity_id,
+	};
+}
+
+// A claim.create event targets entity_type='claim'/entity_id=<claim id>, so the
+// issue being claimed lives in the payload (exactly like dependency.add). Returns
+// null for non-claim events; getting this wrong silently disables enforcement.
+function buildClaimScope(event) {
+	if (event.event_type !== 'claim.create') return null;
+	const payload = parseEventPayload(event);
+	if (!payload.issue_id) return null;
+	return {
+		issue_id: payload.issue_id,
 		entity_type: event.entity_type,
 		entity_id: event.entity_id,
 	};
@@ -192,14 +212,22 @@ function createLocalBroker(options = {}) {
 			if (dependencyScope) {
 				requireDriverMethod(driver, 'listKernelDependencies');
 			}
+			const claimScope = buildClaimScope(normalizedEvent);
+			if (claimScope) {
+				requireDriverMethod(driver, 'loadActiveKernelClaim');
+				requireDriverMethod(driver, 'insertKernelClaim');
+			}
 
-			const [entity, entityEvents, idempotencyEvent, dependencies] = await Promise.all([
+			const [entity, entityEvents, idempotencyEvent, dependencies, activeClaim] = await Promise.all([
 				driver.loadKernelEntity(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
 				driver.listKernelEvents(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
 				driver.loadKernelEventByIdempotencyKey(normalizedEvent.idempotency_key, context, config),
 				dependencyScope
 					? driver.listKernelDependencies(dependencyScope, context, config)
 					: Promise.resolve([]),
+				claimScope
+					? driver.loadActiveKernelClaim(claimScope.issue_id, context, config)
+					: Promise.resolve(null),
 			]);
 			const priorEvents = idempotencyEvent
 				? [idempotencyEvent, ...entityEvents.filter(candidate => candidate.id !== idempotencyEvent.id)]
@@ -226,9 +254,41 @@ function createLocalBroker(options = {}) {
 				return evaluation;
 			}
 
+			async function quarantineClaimConflict(currentClaim) {
+				const conflict = await driver.insertKernelConflict({
+					...buildClaimConflict(normalizedEvent, currentClaim),
+					created_at: normalizedEvent.created_at || now,
+				}, context, config);
+				return {
+					decision: 'quarantine',
+					reason: 'claim_conflict',
+					conflict,
+					projection: false,
+				};
+			}
+
+			let claimPlan = null;
+			if (claimScope) {
+				claimPlan = planClaimAcquisition({ event: normalizedEvent, activeClaim, now });
+				if (claimPlan.action === 'conflict') {
+					return quarantineClaimConflict(activeClaim);
+				}
+				if (claimPlan.action === 'reclaim') {
+					requireDriverMethod(driver, 'updateKernelClaimState');
+				}
+			}
+
 			await driver.exec('BEGIN IMMEDIATE;');
 			let acceptedEvent, outboxEntry;
 			try {
+				if (claimPlan) {
+					if (claimPlan.action === 'reclaim') {
+						await driver.updateKernelClaimState(
+							claimPlan.supersede.claimId, claimPlan.supersede.toState, context, config,
+						);
+					}
+					await driver.insertKernelClaim(claimPlan.claim, context, config);
+				}
 				acceptedEvent = await driver.insertKernelEvent({
 					...evaluation.event,
 					created_at: evaluation.event.created_at || now,
@@ -253,6 +313,10 @@ function createLocalBroker(options = {}) {
 							projection: false,
 						};
 					}
+				}
+				if (claimScope && isClaimLeaseConflict(err)) {
+					const winner = await driver.loadActiveKernelClaim(claimScope.issue_id, context, config);
+					return quarantineClaimConflict(winner);
 				}
 				throw err;
 			}

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -159,6 +159,116 @@ function buildClaimScope(event) {
 	};
 }
 
+const GUARDED_DRIVER_METHODS = Object.freeze([
+	'exec',
+	'loadKernelEntity',
+	'listKernelEvents',
+	'loadKernelEventByIdempotencyKey',
+	'insertKernelConflict',
+	'insertKernelEvent',
+	'enqueueKernelProjection',
+]);
+
+function requireGuardedDriverMethods(driver) {
+	for (const methodName of GUARDED_DRIVER_METHODS) {
+		requireDriverMethod(driver, methodName);
+	}
+}
+
+// Insert a quarantined claim-conflict row and return the quarantine result.
+async function insertClaimConflictResult(driver, event, currentClaim, reason, context, config, now) {
+	const conflict = await driver.insertKernelConflict({
+		...buildClaimConflict(event, currentClaim, reason),
+		created_at: event.created_at || now,
+	}, context, config);
+	return { decision: 'quarantine', reason, conflict, projection: false };
+}
+
+// Re-read the idempotency key and, if a committed winner now exists, return a
+// duplicate replay. Used wherever a same-key retry might otherwise be misread as
+// a fresh conflict — the parallel guard reads are not a consistent snapshot, so
+// the idempotency lookup can miss a winner that a later read (or an insert
+// collision) then observes.
+async function replayDuplicateIfIdempotent(driver, event, context, config) {
+	if (!event.idempotency_key) return null;
+	const existingEvent = await driver.loadKernelEventByIdempotencyKey(event.idempotency_key, context, config);
+	if (!existingEvent) return null;
+	return { decision: 'duplicate', event, originalEvent: existingEvent, projection: false };
+}
+
+// Decide how an accepted claim.create maps to a claim row. Returns {terminal} to
+// short-circuit runGuardedEvent (duplicate replay or claim_conflict quarantine),
+// or {claimPlan} (possibly null for non-claim events) to proceed to the commit.
+async function resolveClaimAcquisition({ driver, event, claimScope, activeClaim, context, config, now }) {
+	if (!claimScope) return { claimPlan: null };
+	const claimPlan = planClaimAcquisition({ event, activeClaim, now });
+	if (claimPlan.action === 'conflict') {
+		// Split-read guard: the idempotency lookup may have run before the winner
+		// committed while the active-claim lookup ran after, so a legitimate
+		// same-key retry can reach here. Re-check before quarantining.
+		const terminal = (await replayDuplicateIfIdempotent(driver, event, context, config))
+			|| await insertClaimConflictResult(driver, event, activeClaim, 'claim_conflict', context, config, now);
+		return { terminal };
+	}
+	if (claimPlan.action === 'reclaim') {
+		requireDriverMethod(driver, 'updateKernelClaimState');
+	}
+	return { claimPlan };
+}
+
+// Recover from a failed accept transaction (after ROLLBACK). A committed
+// idempotency winner replays as a duplicate regardless of which unique index
+// tripped (the claim insert precedes the event insert, so the active-lease index
+// can throw before the events idempotency index); a genuine cross-owner lease
+// collision becomes a claim_conflict quarantine; anything else rethrows.
+async function recoverGuardedFailure({ driver, err, event, claimScope, context, config, now }) {
+	const isUniqueConflict = isIdempotencyConflict(err) || (claimScope && isClaimLeaseConflict(err));
+	if (isUniqueConflict) {
+		const replay = await replayDuplicateIfIdempotent(driver, event, context, config);
+		if (replay) return replay;
+	}
+	if (claimScope && isClaimLeaseConflict(err)) {
+		const winner = await driver.loadActiveKernelClaim(claimScope.issue_id, context, config);
+		return insertClaimConflictResult(driver, event, winner, 'claim_conflict', context, config, now);
+	}
+	throw err;
+}
+
+// Commit an accepted event: acquire/supersede the claim lease (if any), insert
+// the event, and enqueue the projection outbox entry — all inside one
+// BEGIN IMMEDIATE transaction, with ROLLBACK + recovery on failure.
+async function commitGuardedAccept({ driver, event, evaluation, claimScope, activeClaim, context, config, now }) {
+	const resolved = await resolveClaimAcquisition({ driver, event, claimScope, activeClaim, context, config, now });
+	if (resolved.terminal) return resolved.terminal;
+	const { claimPlan } = resolved;
+
+	await driver.exec('BEGIN IMMEDIATE;', config);
+	try {
+		if (claimPlan) {
+			if (claimPlan.action === 'reclaim') {
+				await driver.updateKernelClaimState(
+					claimPlan.supersede.claimId, claimPlan.supersede.toState, context, config,
+				);
+			}
+			await driver.insertKernelClaim(claimPlan.claim, context, config);
+		}
+		const acceptedEvent = await driver.insertKernelEvent({
+			...evaluation.event,
+			created_at: evaluation.event.created_at || now,
+		}, context, config);
+		const outboxEntry = await driver.enqueueKernelProjection(
+			buildProjectionOutboxEntry(acceptedEvent, context.projectionTarget || 'beads', now),
+			context,
+			config,
+		);
+		await driver.exec('COMMIT;', config);
+		return { ...evaluation, event: acceptedEvent, outboxEntry };
+	} catch (err) {
+		await driver.exec('ROLLBACK;', config);
+		return recoverGuardedFailure({ driver, err, event, claimScope, context, config, now });
+	}
+}
+
 function createLocalBroker(options = {}) {
 	const driver = options.driver;
 	let cachedConfig;
@@ -203,17 +313,7 @@ function createLocalBroker(options = {}) {
 		},
 
 		async runGuardedEvent(event, context = {}) {
-			for (const methodName of [
-				'exec',
-				'loadKernelEntity',
-				'listKernelEvents',
-				'loadKernelEventByIdempotencyKey',
-				'insertKernelConflict',
-				'insertKernelEvent',
-				'enqueueKernelProjection',
-			]) {
-				requireDriverMethod(driver, methodName);
-			}
+			requireGuardedDriverMethods(driver);
 
 			const config = getConfig();
 			const now = context.now || new Date().toISOString();
@@ -226,17 +326,13 @@ function createLocalBroker(options = {}) {
 				requireDriverMethod(driver, 'listKernelDependencies');
 			}
 			const claimScope = buildClaimScope(normalizedEvent);
-			// A claim.create with a missing/invalid payload.issue_id has no scope.
-			// Quarantine it instead of falling through as a non-claim event: the
-			// generic evaluator would otherwise accept and persist the event +
-			// outbox without ever creating a kernel_claims lease, so a later claim
-			// on the real issue would proceed as if nothing were claimed.
+			// A claim.create with a missing/invalid payload has no scope. Quarantine
+			// it instead of falling through as a non-claim event: the generic
+			// evaluator would otherwise accept and persist the event + outbox without
+			// ever creating a kernel_claims lease, so a later claim on the real issue
+			// would proceed as if nothing were claimed.
 			if (normalizedEvent.event_type === 'claim.create' && !claimScope) {
-				const conflict = await driver.insertKernelConflict({
-					...buildClaimConflict(normalizedEvent, null, 'invalid_claim_scope'),
-					created_at: normalizedEvent.created_at || now,
-				}, context, config);
-				return { decision: 'quarantine', reason: 'invalid_claim_scope', conflict, projection: false };
+				return insertClaimConflictResult(driver, normalizedEvent, null, 'invalid_claim_scope', context, config, now);
 			}
 			if (claimScope) {
 				requireDriverMethod(driver, 'loadActiveKernelClaim');
@@ -269,109 +365,16 @@ function createLocalBroker(options = {}) {
 					...evaluation.conflict,
 					created_at: evaluation.conflict.created_at || now,
 				}, context, config);
-				return {
-					...evaluation,
-					conflict,
-				};
+				return { ...evaluation, conflict };
 			}
 
 			if (evaluation.decision !== 'accept') {
 				return evaluation;
 			}
 
-			async function quarantineClaimConflict(currentClaim) {
-				const conflict = await driver.insertKernelConflict({
-					...buildClaimConflict(normalizedEvent, currentClaim),
-					created_at: normalizedEvent.created_at || now,
-				}, context, config);
-				return {
-					decision: 'quarantine',
-					reason: 'claim_conflict',
-					conflict,
-					projection: false,
-				};
-			}
-
-			// Re-read the idempotency key and, if a committed winner now exists,
-			// return a duplicate replay. Used wherever a same-key retry might
-			// otherwise be misread as a fresh conflict — the parallel guard reads
-			// are not a consistent snapshot, so the idempotency lookup can miss a
-			// winner that a later read (or an insert collision) then observes.
-			async function replayDuplicateIfIdempotent() {
-				if (!normalizedEvent.idempotency_key) return null;
-				const existingEvent = await driver.loadKernelEventByIdempotencyKey(
-					normalizedEvent.idempotency_key, context, config,
-				);
-				if (!existingEvent) return null;
-				return {
-					decision: 'duplicate',
-					event: normalizedEvent,
-					originalEvent: existingEvent,
-					projection: false,
-				};
-			}
-
-			let claimPlan = null;
-			if (claimScope) {
-				claimPlan = planClaimAcquisition({ event: normalizedEvent, activeClaim, now });
-				if (claimPlan.action === 'conflict') {
-					// Split-read guard: the idempotency lookup may have run before the
-					// winner committed while the active-claim lookup ran after, so a
-					// legitimate same-key retry can reach here. Re-check before quarantining.
-					return (await replayDuplicateIfIdempotent()) || quarantineClaimConflict(activeClaim);
-				}
-				if (claimPlan.action === 'reclaim') {
-					requireDriverMethod(driver, 'updateKernelClaimState');
-				}
-			}
-
-			await driver.exec('BEGIN IMMEDIATE;', config);
-			let acceptedEvent, outboxEntry;
-			try {
-				if (claimPlan) {
-					if (claimPlan.action === 'reclaim') {
-						await driver.updateKernelClaimState(
-							claimPlan.supersede.claimId, claimPlan.supersede.toState, context, config,
-						);
-					}
-					await driver.insertKernelClaim(claimPlan.claim, context, config);
-				}
-				acceptedEvent = await driver.insertKernelEvent({
-					...evaluation.event,
-					created_at: evaluation.event.created_at || now,
-				}, context, config);
-				outboxEntry = await driver.enqueueKernelProjection(
-					buildProjectionOutboxEntry(acceptedEvent, context.projectionTarget || 'beads', now),
-					context,
-					config,
-				);
-				await driver.exec('COMMIT;', config);
-			} catch (err) {
-				await driver.exec('ROLLBACK;', config);
-				// A same-idempotency-key claim retry can trip EITHER unique index
-				// first: the claim insert precedes the event insert, so the
-				// active-lease index may throw before the events idempotency index.
-				// Prefer an idempotency replay whenever a committed winner exists,
-				// regardless of which index tripped, so legitimate retries are
-				// replayed as duplicates rather than quarantined as conflicts.
-				const isUniqueConflict = isIdempotencyConflict(err)
-					|| (claimScope && isClaimLeaseConflict(err));
-				if (isUniqueConflict) {
-					const replay = await replayDuplicateIfIdempotent();
-					if (replay) return replay;
-				}
-				if (claimScope && isClaimLeaseConflict(err)) {
-					const winner = await driver.loadActiveKernelClaim(claimScope.issue_id, context, config);
-					return quarantineClaimConflict(winner);
-				}
-				throw err;
-			}
-
-			return {
-				...evaluation,
-				event: acceptedEvent,
-				outboxEntry,
-			};
+			return commitGuardedAccept({
+				driver, event: normalizedEvent, evaluation, claimScope, activeClaim, context, config, now,
+			});
 		},
 	};
 }

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -2,9 +2,9 @@
 
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');
-const { evaluateKernelEvent } = require('./evaluators');
+const { evaluateKernelEvent, normalizePayload } = require('./evaluators');
 const { buildKernelMigrationPlan } = require('./migrations');
-const { buildClaimConflict, planClaimAcquisition } = require('./lease-enforcer');
+const { buildClaimConflict, isValidExpiresAt, planClaimAcquisition } = require('./lease-enforcer');
 
 const LOCAL_BROKER_PRAGMAS = Object.freeze([
 	'PRAGMA journal_mode=WAL;',
@@ -137,11 +137,18 @@ function buildDependencyScope(event) {
 
 // A claim.create event targets entity_type='claim'/entity_id=<claim id>, so the
 // issue being claimed lives in the payload (exactly like dependency.add). Returns
-// null for non-claim events; getting this wrong silently disables enforcement.
+// null for non-claim events AND for malformed claim.create events (missing
+// issue_id or invalid expires_at) — the broker turns the latter into an
+// invalid_claim_scope quarantine rather than letting them through unscoped.
 function buildClaimScope(event) {
 	if (event.event_type !== 'claim.create') return null;
-	const payload = parseEventPayload(event);
-	if (!payload.issue_id) return null;
+	// Read from the SAME normalized payload the evaluator persists, so the lease
+	// can never describe a different issue than the accepted event/outbox.
+	const payload = normalizePayload(event);
+	if (!payload || !payload.issue_id) return null;
+	// Reject a malformed expires_at up front: a junk value would make
+	// isLeaseExpired meaningless (lock the issue forever or look instantly stale).
+	if (!isValidExpiresAt(payload.expires_at)) return null;
 	return {
 		issue_id: payload.issue_id,
 		entity_type: event.entity_type,

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -216,6 +216,18 @@ function createLocalBroker(options = {}) {
 				requireDriverMethod(driver, 'listKernelDependencies');
 			}
 			const claimScope = buildClaimScope(normalizedEvent);
+			// A claim.create with a missing/invalid payload.issue_id has no scope.
+			// Quarantine it instead of falling through as a non-claim event: the
+			// generic evaluator would otherwise accept and persist the event +
+			// outbox without ever creating a kernel_claims lease, so a later claim
+			// on the real issue would proceed as if nothing were claimed.
+			if (normalizedEvent.event_type === 'claim.create' && !claimScope) {
+				const conflict = await driver.insertKernelConflict({
+					...buildClaimConflict(normalizedEvent, null, 'invalid_claim_scope'),
+					created_at: normalizedEvent.created_at || now,
+				}, context, config);
+				return { decision: 'quarantine', reason: 'invalid_claim_scope', conflict, projection: false };
+			}
 			if (claimScope) {
 				requireDriverMethod(driver, 'loadActiveKernelClaim');
 				requireDriverMethod(driver, 'insertKernelClaim');

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -142,6 +142,11 @@ function buildDependencyScope(event) {
 // invalid_claim_scope quarantine rather than letting them through unscoped.
 function buildClaimScope(event) {
 	if (event.event_type !== 'claim.create') return null;
+	// A claim.create MUST be on the claim entity stream (entity_type='claim'). A
+	// claim.create carried on another entity (e.g. an 'issue' event) is malformed:
+	// it would otherwise insert a kernel_claims lease while the event/outbox are
+	// recorded on the wrong stream. Reject the scope so it quarantines.
+	if (event.entity_type !== 'claim') return null;
 	// Read from the SAME normalized payload the evaluator persists, so the lease
 	// can never describe a different issue than the accepted event/outbox.
 	const payload = normalizePayload(event);
@@ -326,13 +331,16 @@ function createLocalBroker(options = {}) {
 				requireDriverMethod(driver, 'listKernelDependencies');
 			}
 			const claimScope = buildClaimScope(normalizedEvent);
-			// A claim.create with a missing/invalid payload has no scope. Quarantine
-			// it instead of falling through as a non-claim event: the generic
-			// evaluator would otherwise accept and persist the event + outbox without
-			// ever creating a kernel_claims lease, so a later claim on the real issue
-			// would proceed as if nothing were claimed.
+			// A claim.create with a missing/invalid payload (or wrong entity) has no
+			// scope. Quarantine it instead of falling through as a non-claim event:
+			// the generic evaluator would otherwise accept and persist the event +
+			// outbox without ever creating a kernel_claims lease, so a later claim on
+			// the real issue would proceed as if nothing were claimed. BUT a retry of
+			// an already-accepted claim (same idempotency_key) must still replay as a
+			// duplicate even if this retry's payload is malformed, so check that first.
 			if (normalizedEvent.event_type === 'claim.create' && !claimScope) {
-				return insertClaimConflictResult(driver, normalizedEvent, null, 'invalid_claim_scope', context, config, now);
+				return (await replayDuplicateIfIdempotent(driver, normalizedEvent, context, config))
+					|| insertClaimConflictResult(driver, normalizedEvent, null, 'invalid_claim_scope', context, config, now);
 			}
 			if (claimScope) {
 				requireDriverMethod(driver, 'loadActiveKernelClaim');

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -282,11 +282,33 @@ function createLocalBroker(options = {}) {
 				};
 			}
 
+			// Re-read the idempotency key and, if a committed winner now exists,
+			// return a duplicate replay. Used wherever a same-key retry might
+			// otherwise be misread as a fresh conflict — the parallel guard reads
+			// are not a consistent snapshot, so the idempotency lookup can miss a
+			// winner that a later read (or an insert collision) then observes.
+			async function replayDuplicateIfIdempotent() {
+				if (!normalizedEvent.idempotency_key) return null;
+				const existingEvent = await driver.loadKernelEventByIdempotencyKey(
+					normalizedEvent.idempotency_key, context, config,
+				);
+				if (!existingEvent) return null;
+				return {
+					decision: 'duplicate',
+					event: normalizedEvent,
+					originalEvent: existingEvent,
+					projection: false,
+				};
+			}
+
 			let claimPlan = null;
 			if (claimScope) {
 				claimPlan = planClaimAcquisition({ event: normalizedEvent, activeClaim, now });
 				if (claimPlan.action === 'conflict') {
-					return quarantineClaimConflict(activeClaim);
+					// Split-read guard: the idempotency lookup may have run before the
+					// winner committed while the active-claim lookup ran after, so a
+					// legitimate same-key retry can reach here. Re-check before quarantining.
+					return (await replayDuplicateIfIdempotent()) || quarantineClaimConflict(activeClaim);
 				}
 				if (claimPlan.action === 'reclaim') {
 					requireDriverMethod(driver, 'updateKernelClaimState');
@@ -324,18 +346,9 @@ function createLocalBroker(options = {}) {
 				// replayed as duplicates rather than quarantined as conflicts.
 				const isUniqueConflict = isIdempotencyConflict(err)
 					|| (claimScope && isClaimLeaseConflict(err));
-				if (isUniqueConflict && normalizedEvent.idempotency_key) {
-					const existingEvent = await driver.loadKernelEventByIdempotencyKey(
-						normalizedEvent.idempotency_key, context, config,
-					);
-					if (existingEvent) {
-						return {
-							decision: 'duplicate',
-							event: normalizedEvent,
-							originalEvent: existingEvent,
-							projection: false,
-						};
-					}
+				if (isUniqueConflict) {
+					const replay = await replayDuplicateIfIdempotent();
+					if (replay) return replay;
 				}
 				if (claimScope && isClaimLeaseConflict(err)) {
 					const winner = await driver.loadActiveKernelClaim(claimScope.issue_id, context, config);

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -145,7 +145,10 @@ function buildClaimScope(event) {
 	// Read from the SAME normalized payload the evaluator persists, so the lease
 	// can never describe a different issue than the accepted event/outbox.
 	const payload = normalizePayload(event);
-	if (!payload || !payload.issue_id) return null;
+	// issue_id must be a non-empty STRING: a truthy non-string ({}, [], a number)
+	// would otherwise be coerced into a bogus lease key or surface as a raw FK
+	// error instead of the documented invalid_claim_scope quarantine.
+	if (!payload || typeof payload.issue_id !== 'string' || !payload.issue_id) return null;
 	// Reject a malformed expires_at up front: a junk value would make
 	// isLeaseExpired meaningless (lock the issue forever or look instantly stale).
 	if (!isValidExpiresAt(payload.expires_at)) return null;

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -189,5 +189,6 @@ function evaluateKernelEvent(input = {}) {
 module.exports = {
 	dependencyCreatesCycle,
 	evaluateKernelEvent,
+	normalizePayload,
 	stableStringify,
 };

--- a/lib/kernel/lease-enforcer.js
+++ b/lib/kernel/lease-enforcer.js
@@ -44,7 +44,7 @@ function isValidExpiresAt(value) {
 // with a trailing 'Z' (see isValidExpiresAt), so lexicographic comparison equals
 // chronological comparison.
 function isLeaseExpired(claim, now) {
-	if (!claim || !claim.expires_at) return false;
+	if (!claim?.expires_at) return false;
 	return claim.expires_at <= now;
 }
 

--- a/lib/kernel/lease-enforcer.js
+++ b/lib/kernel/lease-enforcer.js
@@ -30,8 +30,14 @@ const { normalizePayload } = require('./evaluators');
 function isValidExpiresAt(value) {
 	if (value === null || value === undefined) return true;
 	if (typeof value !== 'string') return false;
-	if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/.test(value)) return false;
-	return !Number.isNaN(Date.parse(value));
+	const timestamp = Date.parse(value);
+	if (Number.isNaN(timestamp)) return false;
+	// Require the EXACT canonical Date#toISOString form (YYYY-MM-DDTHH:MM:SS.mmmZ):
+	// isLeaseExpired compares lexicographically, so a non-canonical spelling like
+	// '...00Z' would sort after the equal instant '...00.000Z' (Z > .) and a reclaim
+	// at the expiry instant would wrongly look live. The round-trip also rejects
+	// rollover dates Date.parse silently normalises (e.g. 2026-02-31 -> 2026-03-03).
+	return new Date(timestamp).toISOString() === value;
 }
 
 // A lease with no expires_at never expires. Timestamps are validated UTC ISO-8601

--- a/lib/kernel/lease-enforcer.js
+++ b/lib/kernel/lease-enforcer.js
@@ -74,7 +74,7 @@ function planClaimAcquisition({ event, activeClaim, now }) {
 // NOT NULL expected_revision / actual_revision columns default to 0. The
 // human-meaningful detail (who owns the live lease, who attempted) lives in
 // payload_json.
-function buildClaimConflict(event, activeClaim) {
+function buildClaimConflict(event, activeClaim, reason = 'claim_conflict') {
 	const payload = normalizeClaimPayload(event);
 	return {
 		entity_type: event.entity_type,
@@ -82,10 +82,10 @@ function buildClaimConflict(event, activeClaim) {
 		expected_revision: 0,
 		actual_revision: 0,
 		status: 'quarantined',
-		reason: 'claim_conflict',
+		reason,
 		payload_json: JSON.stringify({
-			reason: 'claim_conflict',
-			issue_id: payload.issue_id,
+			reason,
+			issue_id: payload.issue_id ?? null,
 			attempted_by: event.actor,
 			current_owner: activeClaim ? activeClaim.actor : null,
 			current_claim_id: activeClaim ? activeClaim.id : null,

--- a/lib/kernel/lease-enforcer.js
+++ b/lib/kernel/lease-enforcer.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// Pure claim-lease enforcement helpers (task 9.5.10). No I/O — the broker
+// performs all reads/writes and the DB partial UNIQUE index
+// (idx_kernel_claims_active_lease) is the hard race-safe guarantee. These
+// functions are the optimization + clean error path layered on top, mirroring
+// the pure style of evaluators.js.
+//
+// Ownership model (Slice 1, deliberately conservative): a claim lease is a
+// kernel_claims row with state='active'. A lease is "live" iff it is active and
+// not expired. ANY claim.create against a live lease quarantines as
+// 'claim_conflict' — there is NO silent same-owner renewal, because `actor` is
+// not yet guaranteed distinct per concurrent agent and a renewal branch could
+// let one agent silently steal another's live lease. Legitimate same-key
+// retries never reach here: they are collapsed to duplicate replays by the
+// idempotency-key path before claim planning runs.
+
+function normalizeClaimPayload(event) {
+	if (event && event.payload && typeof event.payload === 'object') {
+		return event.payload;
+	}
+	if (event && typeof event.payload_json === 'string') {
+		try {
+			return JSON.parse(event.payload_json);
+		} catch {
+			return {};
+		}
+	}
+	return {};
+}
+
+// A lease with no expires_at never expires. Timestamps are UTC ISO-8601 with a
+// trailing 'Z', so lexicographic comparison equals chronological comparison.
+function isLeaseExpired(claim, now) {
+	if (!claim || !claim.expires_at) return false;
+	return claim.expires_at <= now;
+}
+
+function buildClaimRow(event, now) {
+	const payload = normalizeClaimPayload(event);
+	return {
+		id: event.entity_id,
+		issue_id: payload.issue_id,
+		actor: event.actor,
+		state: 'active',
+		session_id: event.session_id ?? null,
+		worktree_id: event.worktree_id ?? null,
+		claimed_at: now,
+		expires_at: payload.expires_at ?? null,
+	};
+}
+
+// Decide how a claim.create event should be applied against the issue's current
+// active claim (if any). Returns one of:
+//   { action: 'insert',  claim }                  — no active claim
+//   { action: 'reclaim', supersede, claim }       — active claim has expired
+//   { action: 'conflict' }                        — a live lease blocks the claim
+function planClaimAcquisition({ event, activeClaim, now }) {
+	if (!activeClaim) {
+		return { action: 'insert', claim: buildClaimRow(event, now) };
+	}
+	if (isLeaseExpired(activeClaim, now)) {
+		return {
+			action: 'reclaim',
+			supersede: { claimId: activeClaim.id, toState: 'reclaimable' },
+			claim: buildClaimRow(event, now),
+		};
+	}
+	return { action: 'conflict' };
+}
+
+// Build a conflicts-table row for a quarantined claim conflict. Matches the
+// shape produced by evaluators.buildConflict: claims are not revisioned, so the
+// NOT NULL expected_revision / actual_revision columns default to 0. The
+// human-meaningful detail (who owns the live lease, who attempted) lives in
+// payload_json.
+function buildClaimConflict(event, activeClaim) {
+	const payload = normalizeClaimPayload(event);
+	return {
+		entity_type: event.entity_type,
+		entity_id: event.entity_id,
+		expected_revision: 0,
+		actual_revision: 0,
+		status: 'quarantined',
+		reason: 'claim_conflict',
+		payload_json: JSON.stringify({
+			reason: 'claim_conflict',
+			issue_id: payload.issue_id,
+			attempted_by: event.actor,
+			current_owner: activeClaim ? activeClaim.actor : null,
+			current_claim_id: activeClaim ? activeClaim.id : null,
+		}),
+		created_at: event.created_at,
+	};
+}
+
+module.exports = {
+	buildClaimConflict,
+	buildClaimRow,
+	isLeaseExpired,
+	planClaimAcquisition,
+};

--- a/lib/kernel/lease-enforcer.js
+++ b/lib/kernel/lease-enforcer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { normalizePayload } = require('./evaluators');
+
 // Pure claim-lease enforcement helpers (task 9.5.10). No I/O — the broker
 // performs all reads/writes and the DB partial UNIQUE index
 // (idx_kernel_claims_active_lease) is the hard race-safe guarantee. These
@@ -14,30 +16,34 @@
 // let one agent silently steal another's live lease. Legitimate same-key
 // retries never reach here: they are collapsed to duplicate replays by the
 // idempotency-key path before claim planning runs.
+//
+// Claim scope/row/conflict all read from the SAME normalizePayload the evaluator
+// uses to persist the event, so the lease can never describe a different issue
+// than the accepted event/outbox.
 
-function normalizeClaimPayload(event) {
-	if (event && event.payload && typeof event.payload === 'object') {
-		return event.payload;
-	}
-	if (event && typeof event.payload_json === 'string') {
-		try {
-			return JSON.parse(event.payload_json);
-		} catch {
-			return {};
-		}
-	}
-	return {};
+// A claim lease's expires_at, if present, must be a UTC ISO-8601 timestamp with a
+// trailing 'Z' AND a real calendar date — otherwise lexicographic comparison in
+// isLeaseExpired is meaningless (e.g. 'zzz' sorts after any timestamp and would
+// never expire; other junk sorts before and would look already expired). A
+// null/absent value is valid and means "never expires". The broker quarantines
+// any claim.create whose expires_at fails this check.
+function isValidExpiresAt(value) {
+	if (value === null || value === undefined) return true;
+	if (typeof value !== 'string') return false;
+	if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/.test(value)) return false;
+	return !Number.isNaN(Date.parse(value));
 }
 
-// A lease with no expires_at never expires. Timestamps are UTC ISO-8601 with a
-// trailing 'Z', so lexicographic comparison equals chronological comparison.
+// A lease with no expires_at never expires. Timestamps are validated UTC ISO-8601
+// with a trailing 'Z' (see isValidExpiresAt), so lexicographic comparison equals
+// chronological comparison.
 function isLeaseExpired(claim, now) {
 	if (!claim || !claim.expires_at) return false;
 	return claim.expires_at <= now;
 }
 
 function buildClaimRow(event, now) {
-	const payload = normalizeClaimPayload(event);
+	const payload = normalizePayload(event);
 	return {
 		id: event.entity_id,
 		issue_id: payload.issue_id,
@@ -75,7 +81,7 @@ function planClaimAcquisition({ event, activeClaim, now }) {
 // human-meaningful detail (who owns the live lease, who attempted) lives in
 // payload_json.
 function buildClaimConflict(event, activeClaim, reason = 'claim_conflict') {
-	const payload = normalizeClaimPayload(event);
+	const payload = normalizePayload(event);
 	return {
 		entity_type: event.entity_type,
 		entity_id: event.entity_id,
@@ -98,5 +104,6 @@ module.exports = {
 	buildClaimConflict,
 	buildClaimRow,
 	isLeaseExpired,
+	isValidExpiresAt,
 	planClaimAcquisition,
 };

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -108,6 +108,23 @@ function buildEventExpectedRevisionMigration() {
 	};
 }
 
+function buildClaimActiveLeaseMigration() {
+	// DB-enforced claim-lease invariant (task 9.5.10): at most one active claim
+	// per issue. A partial UNIQUE index is the only guarantee that survives
+	// multi-process races — a pre-read check cannot, because two writers can both
+	// read zero active claims before either commits. renderCreateIndex() has no
+	// partial-WHERE support, so this is a hand-written apply string (like 002).
+	return {
+		id: '003_kernel_claims_active_lease',
+		apply: [
+			"CREATE UNIQUE INDEX IF NOT EXISTS idx_kernel_claims_active_lease ON kernel_claims (issue_id) WHERE state = 'active';",
+		],
+		rollback: [
+			'DROP INDEX IF EXISTS idx_kernel_claims_active_lease;',
+		],
+	};
+}
+
 function validateKernelMigrations(migrations) {
 	const ids = new Set();
 	for (const migration of migrations) {
@@ -129,7 +146,11 @@ function validateKernelMigrations(migrations) {
 	return true;
 }
 
-function buildKernelMigrationPlan(migrations = [buildSchemaMigration(), buildEventExpectedRevisionMigration()]) {
+function buildKernelMigrationPlan(migrations = [
+	buildSchemaMigration(),
+	buildEventExpectedRevisionMigration(),
+	buildClaimActiveLeaseMigration(),
+]) {
 	validateKernelMigrations(migrations);
 
 	return {
@@ -140,6 +161,7 @@ function buildKernelMigrationPlan(migrations = [buildSchemaMigration(), buildEve
 }
 
 module.exports = {
+	buildClaimActiveLeaseMigration,
 	buildEventExpectedRevisionMigration,
 	buildKernelMigrationPlan,
 	buildSchemaMigration,

--- a/test/beads-setup.test.js
+++ b/test/beads-setup.test.js
@@ -159,6 +159,49 @@ describe('writeBeadsGitignore', () => {
 // ---------------------------------------------------------------------------
 describe('ensureBeadsGitExclude', () => {
   let tmpDir;
+  let gitHome;
+  let savedGitEnv;
+
+  // These tests exercise the real `git` plumbing in `ensureBeadsGitExclude`, so
+  // each one spawns several git subprocesses (init/add here, plus the rev-parse,
+  // ls-files and rm --cached the function shells out to — each prefixed by a
+  // `where`/`which` lookup inside secureExecFileSync). On Windows under
+  // full-suite load that runs 5-8s per test, which intermittently blew bun's
+  // per-test timeout and produced nondeterministic timeout failures across the
+  // whole block (not just the two `git init` tests). The default per-test
+  // timeout is 5000ms: bunfig.toml's `timeout` is NOT honored, so any run that
+  // does not pass `--timeout` on the CLI (e.g. a plain `bun test`) uses 5000ms.
+  //
+  // Primary fix: an explicit, generous per-test timeout (GIT_TEST_TIMEOUT_MS,
+  // applied as the 3rd arg to each test) that overrides the suite default no
+  // matter how `bun test` is invoked.
+  const GIT_TEST_TIMEOUT_MS = 30000;
+
+  // Secondary measure: run every git invocation hermetically. The tests (and
+  // `ensureBeadsGitExclude`, which inherits process.env) otherwise read the
+  // developer's shared global/system git config and any inherited GIT_* repo
+  // pointers. Pointing HOME/global config at a per-test temp dir, skipping
+  // system config, and scrubbing GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE removes
+  // that shared-state dependency so timing and behavior stay consistent.
+  //
+  // Mutating process.env here is safe: this suite runs sequentially (no
+  // concurrentTestGlob match), and afterEach restores the prior values exactly.
+  const GIT_ENV_KEYS = [
+    'HOME',
+    'USERPROFILE',
+    'GIT_CONFIG_GLOBAL',
+    'GIT_CONFIG_SYSTEM',
+    'GIT_CONFIG_NOSYSTEM',
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_TERMINAL_PROMPT',
+    'GIT_AUTHOR_NAME',
+    'GIT_AUTHOR_EMAIL',
+    'GIT_COMMITTER_NAME',
+    'GIT_COMMITTER_EMAIL'
+  ];
+
   function gitInTmp(args, options = {}) {
     return execFileSync('git', [
       '-c',
@@ -175,9 +218,52 @@ describe('ensureBeadsGitExclude', () => {
   beforeEach(() => {
     tmpDir = makeTmpDir();
     fs.mkdirSync(path.join(tmpDir, '.git', 'info'), { recursive: true });
+
+    // Per-test isolated HOME with a minimal, deterministic global git config so
+    // no git subprocess reads or contends on the shared developer/system config.
+    gitHome = fs.mkdtempSync(path.join(os.tmpdir(), 'beads-setup-home-'));
+    const globalConfig = path.join(gitHome, '.gitconfig');
+    fs.writeFileSync(
+      globalConfig,
+      '[user]\n'
+        + '\tname = Forge Test\n'
+        + '\temail = forge-test@example.invalid\n'
+        + '[init]\n'
+        + '\tdefaultBranch = main\n',
+      'utf8'
+    );
+
+    savedGitEnv = {};
+    for (const key of GIT_ENV_KEYS) {
+      savedGitEnv[key] = process.env[key];
+    }
+
+    process.env.HOME = gitHome;
+    process.env.USERPROFILE = gitHome;
+    process.env.GIT_CONFIG_GLOBAL = globalConfig;
+    process.env.GIT_CONFIG_NOSYSTEM = '1';
+    delete process.env.GIT_CONFIG_SYSTEM;
+    delete process.env.GIT_DIR;
+    delete process.env.GIT_WORK_TREE;
+    delete process.env.GIT_INDEX_FILE;
+    process.env.GIT_TERMINAL_PROMPT = '0';
+    process.env.GIT_AUTHOR_NAME = 'Forge Test';
+    process.env.GIT_AUTHOR_EMAIL = 'forge-test@example.invalid';
+    process.env.GIT_COMMITTER_NAME = 'Forge Test';
+    process.env.GIT_COMMITTER_EMAIL = 'forge-test@example.invalid';
   });
   afterEach(() => {
+    for (const key of GIT_ENV_KEYS) {
+      if (savedGitEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedGitEnv[key];
+      }
+    }
     rmrf(tmpDir);
+    if (gitHome) {
+      rmrf(gitHome);
+    }
   });
 
   test('adds local exclude rules for Beads state without touching tracked ignore files', () => {
@@ -191,7 +277,7 @@ describe('ensureBeadsGitExclude', () => {
     expect(content).toContain('.dolt/');
     expect(content).toContain('.beads-credential-key');
     expect(fs.existsSync(path.join(tmpDir, '.gitignore'))).toBe(false);
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 
   test('is idempotent when local exclude rules already exist', () => {
     ensureBeadsGitExclude(tmpDir);
@@ -202,7 +288,7 @@ describe('ensureBeadsGitExclude', () => {
 
     expect(content.match(/# Forge local Beads state/g)).toHaveLength(1);
     expect(content.match(/\.beads\//g)).toHaveLength(1);
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 
   test('untracks previously committed Beads state without deleting local files', () => {
     gitInTmp(['init'], { stdio: 'pipe' });
@@ -218,7 +304,7 @@ describe('ensureBeadsGitExclude', () => {
     expect(fs.readFileSync(beadsFile, 'utf8')).toBe('{"id":"forge-test"}\n');
     expect(gitInTmp(['ls-files', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
     expect(gitInTmp(['status', '--short', '--', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 
   test('untracks staged Beads state even when the working file diverged', () => {
     gitInTmp(['init'], { stdio: 'pipe' });
@@ -233,7 +319,7 @@ describe('ensureBeadsGitExclude', () => {
     expect(fs.readFileSync(beadsFile, 'utf8')).toBe('{"id":"working"}\n');
     expect(gitInTmp(['ls-files', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
     expect(gitInTmp(['status', '--short', '--', '.beads'], { encoding: 'utf8' }).trim()).toBe('');
-  });
+  }, GIT_TEST_TIMEOUT_MS);
 });
 
 // ---------------------------------------------------------------------------

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -343,6 +343,22 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
     expect(ops).not.toContain('insertKernelClaim');
   });
 
+  test('quarantines a claim.create whose issue_id is a truthy non-string (e.g. {})', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({}, ops);
+
+    const result = await broker.runGuardedEvent(
+      claimEvent({ payload: { issue_id: {}, expires_at: null } }),
+      { now: CLAIM_NOW },
+    );
+
+    expect(result.decision).toBe('quarantine');
+    expect(result.reason).toBe('invalid_claim_scope');
+    expect(ops).toContain('insertKernelConflict');
+    expect(ops).not.toContain('loadActiveKernelClaim');
+    expect(ops).not.toContain('insertKernelClaim');
+  });
+
   test('scopes the lease from payload_json (the persisted payload) when payload disagrees', async () => {
     const ops = [];
     let loadedIssueId = null;

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -104,3 +104,138 @@ describe('local Kernel broker atomicity (9.5.6)', () => {
     expect(ops).not.toContain('exec:COMMIT;');
   });
 });
+
+const CLAIM_NOW = '2026-06-18T00:00:00.000Z';
+
+function claimEvent(overrides = {}) {
+  return {
+    entity_type: 'claim',
+    entity_id: 'claim-issue-1-A',
+    event_type: 'claim.create',
+    idempotency_key: 'claim:issue-1:A',
+    actor: 'agent-A',
+    payload: { issue_id: 'issue-1', expires_at: '2026-06-18T01:00:00.000Z' },
+    created_at: CLAIM_NOW,
+    ...overrides,
+  };
+}
+
+function activeClaimRow(overrides = {}) {
+  return {
+    id: 'claim-issue-1-B',
+    issue_id: 'issue-1',
+    actor: 'agent-B',
+    state: 'active',
+    claimed_at: '2026-06-17T00:00:00.000Z',
+    expires_at: '2026-06-18T01:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function claimBrokerWith(driverOverrides, ops) {
+  return createLocalBroker({
+    projectRoot: PROJECT_ROOT,
+    gitCommonDir: GIT_COMMON_DIR,
+    driver: {
+      async exec(statement) { ops.push(`exec:${statement}`); },
+      async loadKernelEntity() { return null; },
+      async listKernelEvents() { return []; },
+      async loadKernelEventByIdempotencyKey() { return null; },
+      async listKernelDependencies() { return []; },
+      async insertKernelConflict(conflict) { ops.push('insertKernelConflict'); return { ...conflict, id: 'conflict-1' }; },
+      async insertKernelEvent(event) { ops.push('insertKernelEvent'); return { ...event, id: 'event-1' }; },
+      async enqueueKernelProjection(entry) { ops.push('enqueueKernelProjection'); return { ...entry, id: 'outbox-1' }; },
+      async loadActiveKernelClaim() { ops.push('loadActiveKernelClaim'); return null; },
+      async insertKernelClaim(claim) { ops.push('insertKernelClaim'); return { ...claim, id: claim.id || 'claim-1' }; },
+      async updateKernelClaimState(claimId, state) { ops.push(`updateKernelClaimState:${state}`); return { id: claimId, state }; },
+      ...driverOverrides,
+    },
+  });
+}
+
+const TXN_OPS = [
+  'exec:BEGIN IMMEDIATE;',
+  'updateKernelClaimState:reclaimable',
+  'insertKernelClaim',
+  'insertKernelEvent',
+  'enqueueKernelProjection',
+  'exec:COMMIT;',
+];
+
+describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
+  test('inserts an active claim inside the transaction when the issue is unclaimed', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({}, ops);
+
+    const result = await broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW });
+
+    expect(result.decision).toBe('accept');
+    const txn = ops.filter(op => TXN_OPS.includes(op));
+    expect(txn).toEqual([
+      'exec:BEGIN IMMEDIATE;',
+      'insertKernelClaim',
+      'insertKernelEvent',
+      'enqueueKernelProjection',
+      'exec:COMMIT;',
+    ]);
+  });
+
+  test('quarantines a claim against a live lease held by another actor without opening a transaction', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({
+      async loadActiveKernelClaim() { ops.push('loadActiveKernelClaim'); return activeClaimRow(); },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW });
+
+    expect(result.decision).toBe('quarantine');
+    expect(result.reason).toBe('claim_conflict');
+    expect(result.projection).toBe(false);
+    expect(ops).toContain('insertKernelConflict');
+    expect(ops).not.toContain('exec:BEGIN IMMEDIATE;');
+    expect(ops).not.toContain('insertKernelClaim');
+  });
+
+  test('reclaims an expired lease by superseding it before inserting the new claim, atomically', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({
+      async loadActiveKernelClaim() {
+        ops.push('loadActiveKernelClaim');
+        return activeClaimRow({ id: 'claim-stale', expires_at: '2026-06-17T23:00:00.000Z' });
+      },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW });
+
+    expect(result.decision).toBe('accept');
+    const txn = ops.filter(op => TXN_OPS.includes(op));
+    expect(txn).toEqual(TXN_OPS);
+  });
+
+  test('recovers a concurrent active-lease index collision as a claim conflict (9.5.1-9.5.3 proof)', async () => {
+    const ops = [];
+    let claimLookups = 0;
+    const broker = claimBrokerWith({
+      async loadActiveKernelClaim() {
+        claimLookups += 1;
+        ops.push('loadActiveKernelClaim');
+        // Pre-read sees nothing; recovery read finds the race winner's lease.
+        return claimLookups > 1 ? activeClaimRow() : null;
+      },
+      async insertKernelClaim(_claim) {
+        ops.push('insertKernelClaim');
+        throw new Error('UNIQUE constraint failed: kernel_claims.issue_id');
+      },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW });
+
+    expect(result.decision).toBe('quarantine');
+    expect(result.reason).toBe('claim_conflict');
+    expect(result.projection).toBe(false);
+    expect(ops).toContain('exec:BEGIN IMMEDIATE;');
+    expect(ops).toContain('exec:ROLLBACK;');
+    expect(ops).not.toContain('exec:COMMIT;');
+    expect(ops).toContain('insertKernelConflict');
+  });
+});

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -327,6 +327,45 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
     expect(ops).not.toContain('insertKernelClaim');
   });
 
+  test('quarantines a claim.create with a malformed expires_at instead of storing junk', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({}, ops);
+
+    const result = await broker.runGuardedEvent(
+      claimEvent({ payload: { issue_id: 'issue-1', expires_at: 'not-a-date' } }),
+      { now: CLAIM_NOW },
+    );
+
+    expect(result.decision).toBe('quarantine');
+    expect(result.reason).toBe('invalid_claim_scope');
+    expect(ops).toContain('insertKernelConflict');
+    expect(ops).not.toContain('exec:BEGIN IMMEDIATE;');
+    expect(ops).not.toContain('insertKernelClaim');
+  });
+
+  test('scopes the lease from payload_json (the persisted payload) when payload disagrees', async () => {
+    const ops = [];
+    let loadedIssueId = null;
+    let insertedClaim = null;
+    const broker = claimBrokerWith({
+      async loadActiveKernelClaim(issueId) { loadedIssueId = issueId; ops.push('loadActiveKernelClaim'); return null; },
+      async insertKernelClaim(claim) { insertedClaim = claim; ops.push('insertKernelClaim'); return { ...claim, id: claim.id || 'claim-1' }; },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(
+      claimEvent({
+        payload: { issue_id: 'issue-A', expires_at: null },
+        payload_json: JSON.stringify({ issue_id: 'issue-B', expires_at: null }),
+      }),
+      { now: CLAIM_NOW },
+    );
+
+    expect(result.decision).toBe('accept');
+    // The lease must match what the evaluator persists (payload_json), not payload.
+    expect(loadedIssueId).toBe('issue-B');
+    expect(insertedClaim.issue_id).toBe('issue-B');
+  });
+
   test('passes broker config to the transaction exec calls', async () => {
     // A driver constructed without its own databasePath resolves the database
     // from the broker config on every exec, so BEGIN/COMMIT must receive it.

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -178,6 +178,7 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
       'enqueueKernelProjection',
       'exec:COMMIT;',
     ]);
+    expect(ops).not.toContain('exec:ROLLBACK;');
   });
 
   test('quarantines a claim against a live lease held by another actor without opening a transaction', async () => {
@@ -210,6 +211,7 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
     expect(result.decision).toBe('accept');
     const txn = ops.filter(op => TXN_OPS.includes(op));
     expect(txn).toEqual(TXN_OPS);
+    expect(ops).not.toContain('exec:ROLLBACK;');
   });
 
   test('recovers a concurrent active-lease index collision as a claim conflict (9.5.1-9.5.3 proof)', async () => {
@@ -237,5 +239,65 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
     expect(ops).toContain('exec:ROLLBACK;');
     expect(ops).not.toContain('exec:COMMIT;');
     expect(ops).toContain('insertKernelConflict');
+  });
+
+  test('replays a same-idempotency-key claim race as a duplicate, not a conflict', async () => {
+    // A retry of the SAME claim races the winner: its claim insert trips the
+    // active-lease index BEFORE the events idempotency index, so the broker must
+    // re-read the idempotency winner and replay as a duplicate.
+    const ops = [];
+    const existingEvent = { id: 'event-existing', idempotency_key: 'claim:issue-1:A' };
+    const broker = claimBrokerWith({
+      async loadKernelEventByIdempotencyKey() {
+        // Pre-read sees nothing; recovery read (inside catch) finds the winner.
+        return ops.includes('insertKernelClaim') ? existingEvent : null;
+      },
+      async insertKernelClaim(_claim) {
+        ops.push('insertKernelClaim');
+        throw new Error('UNIQUE constraint failed: kernel_claims.issue_id');
+      },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW });
+
+    expect(result.decision).toBe('duplicate');
+    expect(result.originalEvent).toEqual(existingEvent);
+    expect(result.projection).toBe(false);
+    expect(ops).toContain('exec:ROLLBACK;');
+    expect(ops).not.toContain('exec:COMMIT;');
+    expect(ops).not.toContain('insertKernelConflict');
+  });
+
+  test('rethrows a non-lease UNIQUE violation (e.g. duplicate claim id) instead of quarantining', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({
+      async insertKernelClaim(_claim) {
+        ops.push('insertKernelClaim');
+        throw new Error('UNIQUE constraint failed: kernel_claims.id');
+      },
+    }, ops);
+
+    await expect(broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW }))
+      .rejects.toThrow('UNIQUE constraint failed: kernel_claims.id');
+    expect(ops).toContain('exec:ROLLBACK;');
+    expect(ops).not.toContain('insertKernelConflict');
+  });
+
+  test('passes broker config to the transaction exec calls', async () => {
+    // A driver constructed without its own databasePath resolves the database
+    // from the broker config on every exec, so BEGIN/COMMIT must receive it.
+    const ops = [];
+    const execConfigs = [];
+    const broker = claimBrokerWith({
+      async exec(statement, config) { ops.push(`exec:${statement}`); execConfigs.push([statement, config]); },
+    }, ops);
+
+    await broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW });
+
+    for (const statement of ['BEGIN IMMEDIATE;', 'COMMIT;']) {
+      const call = execConfigs.find(([s]) => s === statement);
+      expect(call).toBeDefined();
+      expect(call[1]).toMatchObject({ mode: 'local' });
+    }
   });
 });

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -343,6 +343,40 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
     expect(ops).not.toContain('insertKernelClaim');
   });
 
+  test('replays a malformed claim.create retry as a duplicate when its idempotency key already won', async () => {
+    // A retry of an already-accepted claim (same idempotency_key) must replay as
+    // a duplicate even if THIS retry's payload is malformed — not quarantine.
+    const ops = [];
+    const existingEvent = { id: 'event-existing', idempotency_key: 'claim:issue-1:A' };
+    const broker = claimBrokerWith({
+      async loadKernelEventByIdempotencyKey() { return existingEvent; },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(
+      claimEvent({ payload: { expires_at: null } }), // no issue_id → no scope
+      { now: CLAIM_NOW },
+    );
+
+    expect(result.decision).toBe('duplicate');
+    expect(result.originalEvent).toEqual(existingEvent);
+    expect(ops).not.toContain('insertKernelConflict');
+  });
+
+  test('quarantines a claim.create carried on a non-claim entity (entity_type !== claim)', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({}, ops);
+
+    const result = await broker.runGuardedEvent(
+      claimEvent({ entity_type: 'issue', payload: { issue_id: 'issue-1', expires_at: null } }),
+      { now: CLAIM_NOW },
+    );
+
+    expect(result.decision).toBe('quarantine');
+    expect(result.reason).toBe('invalid_claim_scope');
+    expect(ops).toContain('insertKernelConflict');
+    expect(ops).not.toContain('insertKernelClaim');
+  });
+
   test('quarantines a claim.create whose issue_id is a truthy non-string (e.g. {})', async () => {
     const ops = [];
     const broker = claimBrokerWith({}, ops);

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -268,6 +268,31 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
     expect(ops).not.toContain('insertKernelConflict');
   });
 
+  test('replays a same-key retry as duplicate when the pre-write conflict path split-reads the winner', async () => {
+    // The parallel guard reads are not a consistent snapshot: the idempotency
+    // lookup can run pre-commit (null) while the active-claim lookup runs
+    // post-commit (sees the winner's live lease), driving planClaimAcquisition
+    // to 'conflict'. The pre-write path must re-check idempotency before quarantining.
+    const ops = [];
+    const existingEvent = { id: 'event-existing', idempotency_key: 'claim:issue-1:A' };
+    let idemLookups = 0;
+    const broker = claimBrokerWith({
+      async loadActiveKernelClaim() { ops.push('loadActiveKernelClaim'); return activeClaimRow(); },
+      async loadKernelEventByIdempotencyKey() {
+        idemLookups += 1;
+        return idemLookups > 1 ? existingEvent : null;
+      },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(claimEvent(), { now: CLAIM_NOW });
+
+    expect(result.decision).toBe('duplicate');
+    expect(result.originalEvent).toEqual(existingEvent);
+    expect(result.projection).toBe(false);
+    expect(ops).not.toContain('exec:BEGIN IMMEDIATE;');
+    expect(ops).not.toContain('insertKernelConflict');
+  });
+
   test('rethrows a non-lease UNIQUE violation (e.g. duplicate claim id) instead of quarantining', async () => {
     const ops = [];
     const broker = claimBrokerWith({

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -283,6 +283,25 @@ describe('local Kernel broker claim leases (9.5.10 / 9.5.3)', () => {
     expect(ops).not.toContain('insertKernelConflict');
   });
 
+  test('quarantines a malformed claim.create with no issue_id instead of persisting an unscoped event', async () => {
+    const ops = [];
+    const broker = claimBrokerWith({}, ops);
+
+    const result = await broker.runGuardedEvent(
+      claimEvent({ payload: { expires_at: '2026-06-18T01:00:00.000Z' } }),
+      { now: CLAIM_NOW },
+    );
+
+    expect(result.decision).toBe('quarantine');
+    expect(result.reason).toBe('invalid_claim_scope');
+    expect(result.projection).toBe(false);
+    expect(ops).toContain('insertKernelConflict');
+    // Nothing is persisted: no transaction, no event/outbox, no claim row.
+    expect(ops).not.toContain('exec:BEGIN IMMEDIATE;');
+    expect(ops).not.toContain('insertKernelEvent');
+    expect(ops).not.toContain('insertKernelClaim');
+  });
+
   test('passes broker config to the transaction exec calls', async () => {
     // A driver constructed without its own databasePath resolves the database
     // from the broker config on every exec, so BEGIN/COMMIT must receive it.

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -76,4 +76,31 @@ describe('local Kernel broker atomicity (9.5.6)', () => {
     expect(ops).not.toContain('exec:COMMIT;');
     expect(ops.indexOf('insertKernelEvent')).toBeLessThan(ops.indexOf('exec:ROLLBACK;'));
   });
+
+  test('recovers a concurrent idempotency collision as a duplicate replay (9.5.9)', async () => {
+    const ops = [];
+    const existingEvent = { id: 'event-existing', idempotency_key: 'issue-update:issue-1:rev-0' };
+    let idempotencyLookupCalls = 0;
+    const broker = brokerWith({
+      async loadKernelEventByIdempotencyKey() {
+        idempotencyLookupCalls += 1;
+        // Pre-read sees nothing; recovery read (inside catch) finds the winner's event.
+        return idempotencyLookupCalls > 1 ? existingEvent : null;
+      },
+      async insertKernelEvent() {
+        ops.push('insertKernelEvent');
+        throw new Error('UNIQUE constraint failed: kernel_events.idempotency_key');
+      },
+    }, ops);
+
+    const result = await broker.runGuardedEvent(acceptEvent(), {});
+
+    expect(result.decision).toBe('duplicate');
+    expect(result.originalEvent).toEqual(existingEvent);
+    expect(result.projection).toBe(false);
+    // Transaction attempted but rolled back — never committed.
+    expect(ops).toContain('exec:BEGIN IMMEDIATE;');
+    expect(ops).toContain('exec:ROLLBACK;');
+    expect(ops).not.toContain('exec:COMMIT;');
+  });
 });

--- a/test/kernel/broker-concurrency.test.js
+++ b/test/kernel/broker-concurrency.test.js
@@ -1,0 +1,79 @@
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+
+const PROJECT_ROOT = path.join(os.tmpdir(), 'forge-worktree');
+const GIT_COMMON_DIR = path.join(os.tmpdir(), 'forge-common-dir');
+
+// A guarded event that the evaluator accepts: expected_revision 0 against a
+// fresh (revision 0 / absent) entity, with no idempotency or dependency state.
+function acceptEvent() {
+  return {
+    entity_type: 'issue',
+    entity_id: 'issue-1',
+    event_type: 'issue.update',
+    idempotency_key: 'issue-update:issue-1:rev-0',
+    expected_revision: 0,
+    payload: { title: 'Renamed' },
+    created_at: '2026-06-17T00:00:00.000Z',
+  };
+}
+
+function brokerWith(driverOverrides, ops) {
+  return createLocalBroker({
+    projectRoot: PROJECT_ROOT,
+    gitCommonDir: GIT_COMMON_DIR,
+    driver: {
+      async exec(statement) { ops.push(`exec:${statement}`); },
+      async loadKernelEntity() { return null; },
+      async listKernelEvents() { return []; },
+      async loadKernelEventByIdempotencyKey() { return null; },
+      async listKernelDependencies() { return []; },
+      async insertKernelConflict(conflict) { ops.push('insertKernelConflict'); return conflict; },
+      async insertKernelEvent(event) { ops.push('insertKernelEvent'); return { ...event, id: 'event-1' }; },
+      async enqueueKernelProjection(entry) { ops.push('enqueueKernelProjection'); return { ...entry, id: 'outbox-1' }; },
+      ...driverOverrides,
+    },
+  });
+}
+
+describe('local Kernel broker atomicity (9.5.6)', () => {
+  test('wraps accept-path event insert + projection enqueue in a single BEGIN IMMEDIATE transaction', async () => {
+    const ops = [];
+    const broker = brokerWith({}, ops);
+
+    const result = await broker.runGuardedEvent(acceptEvent(), {});
+
+    expect(result.decision).toBe('accept');
+    expect(result.event.id).toBe('event-1');
+    expect(result.outboxEntry.id).toBe('outbox-1');
+    // The mutation is bracketed by an immediate-write transaction, with the
+    // event insert and outbox enqueue committed together (no interleaving).
+    expect(ops).toEqual([
+      'exec:BEGIN IMMEDIATE;',
+      'insertKernelEvent',
+      'enqueueKernelProjection',
+      'exec:COMMIT;',
+    ]);
+  });
+
+  test('rolls back the inserted event when projection enqueue fails', async () => {
+    const ops = [];
+    const broker = brokerWith({
+      async enqueueKernelProjection() {
+        ops.push('enqueueKernelProjection');
+        throw new Error('outbox write failed');
+      },
+    }, ops);
+
+    await expect(broker.runGuardedEvent(acceptEvent(), {})).rejects.toThrow('outbox write failed');
+
+    // The transaction is rolled back — never committed — so the event insert is undone.
+    expect(ops).toContain('exec:BEGIN IMMEDIATE;');
+    expect(ops).toContain('exec:ROLLBACK;');
+    expect(ops).not.toContain('exec:COMMIT;');
+    expect(ops.indexOf('insertKernelEvent')).toBeLessThan(ops.indexOf('exec:ROLLBACK;'));
+  });
+});

--- a/test/kernel/broker-guards.test.js
+++ b/test/kernel/broker-guards.test.js
@@ -10,6 +10,7 @@ describe('local Kernel broker guard ordering', () => {
 			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
 			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
 			driver: {
+				async exec() {},
 				async loadKernelEntity() {
 					return { entity_revision: 3 };
 				},
@@ -57,6 +58,7 @@ describe('local Kernel broker guard ordering', () => {
 			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
 			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
 			driver: {
+				async exec() {},
 				async loadKernelEntity() {
 					return { entity_revision: 2 };
 				},
@@ -115,6 +117,7 @@ describe('local Kernel broker guard ordering', () => {
 			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
 			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
 			driver: {
+				async exec() {},
 				async loadKernelEntity() {
 					return { entity_revision: 2 };
 				},
@@ -164,6 +167,7 @@ describe('local Kernel broker guard ordering', () => {
 			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
 			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
 			driver: {
+				async exec() {},
 				async loadKernelEntity() {
 					return { entity_revision: 0 };
 				},
@@ -226,6 +230,7 @@ describe('local Kernel broker guard ordering', () => {
 			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
 			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
 			driver: {
+				async exec() {},
 				async loadKernelEntity() {
 					return { entity_revision: 0 };
 				},

--- a/test/kernel/broker-multiprocess.test.js
+++ b/test/kernel/broker-multiprocess.test.js
@@ -1,0 +1,96 @@
+const { afterAll, beforeAll, describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+const { buildKernelMigrationPlan } = require('../../lib/kernel/migrations');
+
+// Real multi-process contention proof (tasks 9.5.1 / 9.5.3): spawn N independent
+// OS processes that all race to claim the SAME issue against ONE on-disk WAL
+// database, and assert the DB-enforced invariant holds — exactly one active
+// claim row survives and every other process observes a conflict. This is the
+// load-bearing guarantee for local multi-agent safety; the broker's recovery
+// logic on top of it is proven separately with unit-level mocks.
+
+const WORKER = path.join(__dirname, 'fixtures', 'claim-race-worker.js');
+const ISSUE_ID = 'issue-race-1';
+const WORKER_COUNT = 5;
+
+let tmpDir;
+let databasePath;
+
+async function applySetup() {
+	const driver = createBuiltinSQLiteDriver({ databasePath });
+	try {
+		await driver.exec('PRAGMA journal_mode=WAL;');
+		await driver.exec('PRAGMA foreign_keys=ON;');
+		for (const statement of buildKernelMigrationPlan().apply) {
+			await driver.exec(statement);
+		}
+		// The claim FK requires the parent issue to exist.
+		await driver.exec(
+			"INSERT INTO kernel_issues (id, title, created_at, updated_at) VALUES ("
+			+ `'${ISSUE_ID}', 'Race target', '2026-06-18T00:00:00.000Z', '2026-06-18T00:00:00.000Z'`
+			+ ');',
+		);
+	} finally {
+		// Close so the workers do not contend with the setup connection's lock.
+		driver.close();
+	}
+}
+
+async function countActiveClaims() {
+	const driver = createBuiltinSQLiteDriver({ databasePath });
+	try {
+		const rows = await driver.queryAll(
+			`SELECT COUNT(*) AS n FROM kernel_claims WHERE issue_id = '${ISSUE_ID}' AND state = 'active';`,
+		);
+		return Number(rows[0].n);
+	} finally {
+		driver.close();
+	}
+}
+
+beforeAll(async () => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-claim-race-'));
+	databasePath = path.join(tmpDir, 'kernel.sqlite');
+	await applySetup();
+});
+
+afterAll(() => {
+	if (tmpDir) {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	}
+});
+
+describe('local Kernel claim lease multi-process contention (9.5.1 / 9.5.3)', () => {
+	test('exactly one of N racing processes acquires the lease; the rest see a conflict', async () => {
+		const procs = Array.from({ length: WORKER_COUNT }, (_unused, i) => globalThis.Bun.spawn({
+			cmd: ['bun', WORKER, databasePath, ISSUE_ID, String(i)],
+			stdout: 'pipe',
+			stderr: 'pipe',
+		}));
+
+		const results = await Promise.all(procs.map(async (proc) => {
+			const stdout = (await new Response(proc.stdout).text()).trim();
+			const stderr = (await new Response(proc.stderr).text()).trim();
+			await proc.exited;
+			return { stdout, stderr, code: proc.exitCode };
+		}));
+
+		// No worker hit an unexpected (non-conflict) error.
+		for (const result of results) {
+			expect(result.stderr).toBe('');
+			expect(result.code).toBe(0);
+		}
+
+		const acquired = results.filter(r => r.stdout === 'acquired').length;
+		const conflicts = results.filter(r => r.stdout === 'conflict').length;
+
+		expect(acquired).toBe(1);
+		expect(conflicts).toBe(WORKER_COUNT - 1);
+		// The DB-level invariant: one issue can hold at most one active lease.
+		expect(await countActiveClaims()).toBe(1);
+	}, 30000);
+});

--- a/test/kernel/fixtures/claim-race-worker.js
+++ b/test/kernel/fixtures/claim-race-worker.js
@@ -39,8 +39,11 @@ async function main() {
 		} catch {
 			// The failed statement may already have aborted the transaction.
 		}
-		const message = String(err && err.message ? err.message : err);
-		if (/UNIQUE constraint failed/i.test(message)) {
+		const message = String(err?.message ?? err);
+		// Only the active-lease index (kernel_claims.issue_id) counts as a lease
+		// conflict — aligns with the broker's isClaimLeaseConflict classifier and
+		// avoids masking unrelated UNIQUE/schema regressions as false passes.
+		if (/UNIQUE constraint failed/i.test(message) && /kernel_claims\.issue_id/i.test(message)) {
 			process.stdout.write('conflict');
 		} else {
 			process.stderr.write(message);

--- a/test/kernel/fixtures/claim-race-worker.js
+++ b/test/kernel/fixtures/claim-race-worker.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// Multi-process claim-lease contention worker (task 9.5.1). Each worker is a
+// separate OS process that opens the SAME on-disk WAL SQLite database and races
+// to insert an active claim for the SAME issue_id inside BEGIN IMMEDIATE,
+// mirroring the broker's transaction. The partial UNIQUE index
+// (idx_kernel_claims_active_lease) is what guarantees exactly one winner — under
+// BEGIN IMMEDIATE alone every INSERT would succeed and leave N active rows.
+//
+// Prints exactly one token to stdout: 'acquired' (won the lease) or 'conflict'
+// (lost to the active-lease UNIQUE index). Any other failure exits non-zero.
+
+const { createBuiltinSQLiteDriver } = require('../../../lib/kernel/sqlite-driver');
+
+async function main() {
+	const [databasePath, issueId, workerId] = process.argv.slice(2);
+	const driver = createBuiltinSQLiteDriver({ databasePath });
+	// busy_timeout MUST be set first: opening a WAL database can trigger lock
+	// contention (including WAL recovery) on the very first statement, and
+	// without a busy timeout that surfaces as an immediate SQLITE_BUSY instead
+	// of waiting for the lock. WAL journal mode itself persists in the database
+	// header from setup, so it is not (and must not be) re-issued here.
+	await driver.exec('PRAGMA busy_timeout=5000;');
+	await driver.exec('PRAGMA foreign_keys=ON;');
+
+	const now = new Date().toISOString();
+	try {
+		await driver.exec('BEGIN IMMEDIATE;');
+		await driver.exec(
+			'INSERT INTO kernel_claims (id, issue_id, actor, state, claimed_at) VALUES ('
+			+ `'claim-${workerId}', '${issueId}', 'agent-${workerId}', 'active', '${now}'`
+			+ ');',
+		);
+		await driver.exec('COMMIT;');
+		process.stdout.write('acquired');
+	} catch (err) {
+		try {
+			await driver.exec('ROLLBACK;');
+		} catch {
+			// The failed statement may already have aborted the transaction.
+		}
+		const message = String(err && err.message ? err.message : err);
+		if (/UNIQUE constraint failed/i.test(message)) {
+			process.stdout.write('conflict');
+		} else {
+			process.stderr.write(message);
+			process.exitCode = 1;
+		}
+	} finally {
+		driver.close();
+	}
+}
+
+main();

--- a/test/kernel/lease-enforcer.test.js
+++ b/test/kernel/lease-enforcer.test.js
@@ -2,6 +2,7 @@ const { describe, expect, test } = require('bun:test');
 
 const {
 	isLeaseExpired,
+	isValidExpiresAt,
 	planClaimAcquisition,
 	buildClaimConflict,
 } = require('../../lib/kernel/lease-enforcer');
@@ -49,7 +50,36 @@ describe('lease-enforcer isLeaseExpired', () => {
 	});
 });
 
+describe('lease-enforcer isValidExpiresAt', () => {
+	test('accepts a null/absent expires_at (non-expiring lease)', () => {
+		expect(isValidExpiresAt(null)).toBe(true);
+		expect(isValidExpiresAt(undefined)).toBe(true);
+	});
+
+	test('accepts a UTC ISO-8601 timestamp with a trailing Z', () => {
+		expect(isValidExpiresAt('2026-06-18T01:00:00.000Z')).toBe(true);
+		expect(isValidExpiresAt('2026-06-18T01:00:00Z')).toBe(true);
+	});
+
+	test('rejects junk, non-Z, impossible-date, and non-string values', () => {
+		expect(isValidExpiresAt('zzz')).toBe(false);
+		expect(isValidExpiresAt('2026-06-18T01:00:00')).toBe(false);
+		expect(isValidExpiresAt('2026-99-99T00:00:00.000Z')).toBe(false);
+		expect(isValidExpiresAt(1750000000000)).toBe(false);
+	});
+});
+
 describe('lease-enforcer planClaimAcquisition', () => {
+	test('derives the claim from payload_json (the persisted payload) when both are present', () => {
+		const event = claimEvent({
+			payload: { issue_id: 'issue-A', expires_at: null },
+			payload_json: JSON.stringify({ issue_id: 'issue-B', expires_at: '2026-06-18T01:00:00.000Z' }),
+		});
+		const plan = planClaimAcquisition({ event, activeClaim: null, now: NOW });
+		expect(plan.claim.issue_id).toBe('issue-B');
+		expect(plan.claim.expires_at).toBe('2026-06-18T01:00:00.000Z');
+	});
+
 	test('reads issue_id/expires_at from payload_json when no payload object is present', () => {
 		const event = claimEvent({
 			payload: undefined,

--- a/test/kernel/lease-enforcer.test.js
+++ b/test/kernel/lease-enforcer.test.js
@@ -56,15 +56,22 @@ describe('lease-enforcer isValidExpiresAt', () => {
 		expect(isValidExpiresAt(undefined)).toBe(true);
 	});
 
-	test('accepts a UTC ISO-8601 timestamp with a trailing Z', () => {
+	test('accepts only the exact canonical Date#toISOString form', () => {
 		expect(isValidExpiresAt('2026-06-18T01:00:00.000Z')).toBe(true);
-		expect(isValidExpiresAt('2026-06-18T01:00:00Z')).toBe(true);
 	});
 
-	test('rejects junk, non-Z, impossible-date, and non-string values', () => {
-		expect(isValidExpiresAt('zzz')).toBe(false);
+	test('rejects non-canonical spellings so lexicographic ordering stays correct', () => {
+		// Same instant, different spelling: 'Z' sorts after '.', so this would
+		// mis-order against a '.000Z' clock — must be rejected.
+		expect(isValidExpiresAt('2026-06-18T01:00:00Z')).toBe(false);
 		expect(isValidExpiresAt('2026-06-18T01:00:00')).toBe(false);
+		expect(isValidExpiresAt('2026-06-18T01:00:00.00Z')).toBe(false);
+	});
+
+	test('rejects rollover dates, junk, and non-string values', () => {
+		expect(isValidExpiresAt('2026-02-31T00:00:00.000Z')).toBe(false);
 		expect(isValidExpiresAt('2026-99-99T00:00:00.000Z')).toBe(false);
+		expect(isValidExpiresAt('zzz')).toBe(false);
 		expect(isValidExpiresAt(1750000000000)).toBe(false);
 	});
 });

--- a/test/kernel/lease-enforcer.test.js
+++ b/test/kernel/lease-enforcer.test.js
@@ -50,6 +50,17 @@ describe('lease-enforcer isLeaseExpired', () => {
 });
 
 describe('lease-enforcer planClaimAcquisition', () => {
+	test('reads issue_id/expires_at from payload_json when no payload object is present', () => {
+		const event = claimEvent({
+			payload: undefined,
+			payload_json: JSON.stringify({ issue_id: 'issue-1', expires_at: '2026-06-18T01:00:00.000Z' }),
+		});
+		const plan = planClaimAcquisition({ event, activeClaim: null, now: NOW });
+		expect(plan.action).toBe('insert');
+		expect(plan.claim.issue_id).toBe('issue-1');
+		expect(plan.claim.expires_at).toBe('2026-06-18T01:00:00.000Z');
+	});
+
 	test('plans a plain insert when no active claim exists', () => {
 		const plan = planClaimAcquisition({ event: claimEvent(), activeClaim: null, now: NOW });
 		expect(plan.action).toBe('insert');
@@ -87,6 +98,14 @@ describe('lease-enforcer planClaimAcquisition', () => {
 });
 
 describe('lease-enforcer buildClaimConflict', () => {
+	test('falls back to an empty payload when payload_json is malformed (no throw)', () => {
+		const event = claimEvent({ payload: undefined, payload_json: '{bad-json' });
+		expect(() => buildClaimConflict(event, activeClaim())).not.toThrow();
+		const parsed = JSON.parse(buildClaimConflict(event, activeClaim()).payload_json);
+		expect(parsed.issue_id).toBeUndefined();
+		expect(parsed.reason).toBe('claim_conflict');
+	});
+
 	test('builds a quarantined conflict row carrying the current owner and attempting actor', () => {
 		const conflict = buildClaimConflict(claimEvent(), activeClaim());
 		expect(conflict).toMatchObject({

--- a/test/kernel/lease-enforcer.test.js
+++ b/test/kernel/lease-enforcer.test.js
@@ -102,8 +102,19 @@ describe('lease-enforcer buildClaimConflict', () => {
 		const event = claimEvent({ payload: undefined, payload_json: '{bad-json' });
 		expect(() => buildClaimConflict(event, activeClaim())).not.toThrow();
 		const parsed = JSON.parse(buildClaimConflict(event, activeClaim()).payload_json);
-		expect(parsed.issue_id).toBeUndefined();
+		expect(parsed.issue_id).toBeNull();
 		expect(parsed.reason).toBe('claim_conflict');
+	});
+
+	test('uses a custom reason and null owner fields for a scopeless/malformed claim', () => {
+		const event = claimEvent({ payload: {} });
+		const conflict = buildClaimConflict(event, null, 'invalid_claim_scope');
+		expect(conflict.reason).toBe('invalid_claim_scope');
+		const parsed = JSON.parse(conflict.payload_json);
+		expect(parsed.reason).toBe('invalid_claim_scope');
+		expect(parsed.issue_id).toBeNull();
+		expect(parsed.current_owner).toBeNull();
+		expect(parsed.current_claim_id).toBeNull();
 	});
 
 	test('builds a quarantined conflict row carrying the current owner and attempting actor', () => {

--- a/test/kernel/lease-enforcer.test.js
+++ b/test/kernel/lease-enforcer.test.js
@@ -1,0 +1,108 @@
+const { describe, expect, test } = require('bun:test');
+
+const {
+	isLeaseExpired,
+	planClaimAcquisition,
+	buildClaimConflict,
+} = require('../../lib/kernel/lease-enforcer');
+
+const NOW = '2026-06-18T00:00:00.000Z';
+
+function claimEvent(overrides = {}) {
+	return {
+		entity_type: 'claim',
+		entity_id: 'claim-issue-1-A',
+		event_type: 'claim.create',
+		idempotency_key: 'claim:issue-1:A',
+		actor: 'agent-A',
+		payload: { issue_id: 'issue-1', expires_at: '2026-06-18T01:00:00.000Z' },
+		created_at: NOW,
+		...overrides,
+	};
+}
+
+function activeClaim(overrides = {}) {
+	return {
+		id: 'claim-issue-1-B',
+		issue_id: 'issue-1',
+		actor: 'agent-B',
+		state: 'active',
+		claimed_at: '2026-06-17T00:00:00.000Z',
+		expires_at: '2026-06-18T01:00:00.000Z',
+		...overrides,
+	};
+}
+
+describe('lease-enforcer isLeaseExpired', () => {
+	test('returns true when expires_at is at or before now', () => {
+		expect(isLeaseExpired({ expires_at: '2026-06-17T23:59:59.000Z' }, NOW)).toBe(true);
+		expect(isLeaseExpired({ expires_at: NOW }, NOW)).toBe(true);
+	});
+
+	test('returns false when expires_at is after now', () => {
+		expect(isLeaseExpired({ expires_at: '2026-06-18T00:00:01.000Z' }, NOW)).toBe(false);
+	});
+
+	test('treats a null/absent expires_at as never expiring', () => {
+		expect(isLeaseExpired({ expires_at: null }, NOW)).toBe(false);
+		expect(isLeaseExpired({}, NOW)).toBe(false);
+	});
+});
+
+describe('lease-enforcer planClaimAcquisition', () => {
+	test('plans a plain insert when no active claim exists', () => {
+		const plan = planClaimAcquisition({ event: claimEvent(), activeClaim: null, now: NOW });
+		expect(plan.action).toBe('insert');
+		expect(plan.supersede).toBeUndefined();
+		expect(plan.claim).toMatchObject({
+			id: 'claim-issue-1-A',
+			issue_id: 'issue-1',
+			actor: 'agent-A',
+			state: 'active',
+			claimed_at: NOW,
+			expires_at: '2026-06-18T01:00:00.000Z',
+		});
+	});
+
+	test('quarantines as a conflict when a live lease is held by anyone (no silent renewal)', () => {
+		// Conservative model: a live lease blocks ALL new claims, even the same actor.
+		// Same-key retries are collapsed to duplicate replays upstream before this runs.
+		const live = activeClaim({ actor: 'agent-B', expires_at: '2026-06-18T00:00:01.000Z' });
+		expect(planClaimAcquisition({ event: claimEvent(), activeClaim: live, now: NOW }).action).toBe('conflict');
+
+		const sameActorLive = activeClaim({ actor: 'agent-A', expires_at: '2026-06-18T00:00:01.000Z' });
+		expect(planClaimAcquisition({ event: claimEvent(), activeClaim: sameActorLive, now: NOW }).action).toBe('conflict');
+
+		const nonExpiring = activeClaim({ expires_at: null });
+		expect(planClaimAcquisition({ event: claimEvent(), activeClaim: nonExpiring, now: NOW }).action).toBe('conflict');
+	});
+
+	test('plans a reclaim that supersedes the stale lease before inserting when the active claim has expired', () => {
+		const expired = activeClaim({ id: 'claim-stale', expires_at: '2026-06-17T23:00:00.000Z' });
+		const plan = planClaimAcquisition({ event: claimEvent(), activeClaim: expired, now: NOW });
+		expect(plan.action).toBe('reclaim');
+		expect(plan.supersede).toEqual({ claimId: 'claim-stale', toState: 'reclaimable' });
+		expect(plan.claim).toMatchObject({ id: 'claim-issue-1-A', issue_id: 'issue-1', state: 'active' });
+	});
+});
+
+describe('lease-enforcer buildClaimConflict', () => {
+	test('builds a quarantined conflict row carrying the current owner and attempting actor', () => {
+		const conflict = buildClaimConflict(claimEvent(), activeClaim());
+		expect(conflict).toMatchObject({
+			entity_type: 'claim',
+			entity_id: 'claim-issue-1-A',
+			expected_revision: 0,
+			actual_revision: 0,
+			status: 'quarantined',
+			reason: 'claim_conflict',
+			created_at: NOW,
+		});
+		const parsed = JSON.parse(conflict.payload_json);
+		expect(parsed.reason).toBe('claim_conflict');
+		expect(parsed.issue_id).toBe('issue-1');
+		expect(parsed.attempted_by).toBe('agent-A');
+		expect(parsed.current_owner).toBe('agent-B');
+		expect(parsed.current_claim_id).toBe('claim-issue-1-B');
+	});
+});

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -21,14 +21,36 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.apply).toContain('ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
-		expect(plan.rollback[0]).toBe('CREATE TABLE IF NOT EXISTS kernel_events_002_rollback (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
+		// Rollback runs migrations in reverse, so 003's index drop comes first.
+		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_claims_active_lease;');
+		expect(plan.rollback).toContain('CREATE TABLE IF NOT EXISTS kernel_events_002_rollback (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.rollback).toContain('INSERT INTO kernel_events_002_rollback (id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at) SELECT id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at FROM kernel_events;');
 		expect(plan.rollback).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_kernel_events_idempotency ON kernel_events (idempotency_key);');
 		expect(plan.rollback.at(-1)).toBe('DROP TABLE IF EXISTS kernel_issues;');
 		expect(plan.migrations.map(migration => migration.id)).toEqual([
 			'001_kernel_schema',
 			'002_kernel_events_expected_revision',
+			'003_kernel_claims_active_lease',
 		]);
+	});
+
+	test('enforces a single active claim lease per issue via a partial unique index (9.5.10)', () => {
+		const { buildClaimActiveLeaseMigration } = require('../../lib/kernel/migrations');
+		const migration = buildClaimActiveLeaseMigration();
+
+		expect(migration.id).toBe('003_kernel_claims_active_lease');
+		// The hard DB-level invariant: at most one row with state='active' per issue_id.
+		// renderCreateIndex has no partial-WHERE support, so this must be a raw apply string.
+		expect(migration.apply).toContain(
+			"CREATE UNIQUE INDEX IF NOT EXISTS idx_kernel_claims_active_lease ON kernel_claims (issue_id) WHERE state = 'active';",
+		);
+		expect(migration.rollback).toContain('DROP INDEX IF EXISTS idx_kernel_claims_active_lease;');
+
+		const plan = buildKernelMigrationPlan();
+		expect(plan.apply).toContain(
+			"CREATE UNIQUE INDEX IF NOT EXISTS idx_kernel_claims_active_lease ON kernel_claims (issue_id) WHERE state = 'active';",
+		);
+		expect(plan.rollback).toContain('DROP INDEX IF EXISTS idx_kernel_claims_active_lease;');
 	});
 
 	test('rejects duplicate migration IDs', () => {


### PR DESCRIPTION
## Summary

Proves the local Kernel broker enforces its concurrency invariants **atomically** and survives **real multi-process contention** on a single machine / git common-dir. This hardens the broker *primitive* (`runGuardedEvent`); wiring the user-facing `forge claim` surface to emit guarded events is an explicit follow-up (see **Wiring deferral**).

Design doc: [`docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md`](docs/work/2026-06-06-kernel-backlog-memory-roadmap/local-broker-lease-enforcement.md)

## What landed (Phase B — Local Broker Proof)

| Task | Guarantee | Where |
| --- | --- | --- |
| **9.5.6** | Event insert + projection-outbox enqueue commit atomically | `broker.js` `BEGIN IMMEDIATE…COMMIT`, ROLLBACK on failure |
| **9.5.9** | Concurrent idempotency-key collisions resolve to a duplicate replay, not a raw error | `broker.js` catch-block re-reads the winner's event |
| **9.5.10** | At most one **active** claim lease per issue | partial UNIQUE index + pure `lease-enforcer.js` + broker integration |
| **9.5.1 / 9.5.3** | The lease invariant holds under real concurrent OS processes | `test/kernel/broker-multiprocess.test.js` + worker fixture |

## Enforcement model (two layers)

1. **Hard invariant (load-bearing):** partial UNIQUE index `idx_kernel_claims_active_lease ON kernel_claims (issue_id) WHERE state='active'` (migration 003). The only guarantee that survives a multi-process race — a pre-read check cannot, since two writers can both read zero active claims before either commits. Mirrors `idx_kernel_events_idempotency`.
2. **Optimization + clean error path:** pure `lease-enforcer.js` + broker integration. A live lease is quarantined pre-write without opening a transaction; a race that slips past the pre-read is caught when the UNIQUE index throws, rolled back, and re-read into a `claim_conflict` quarantine — mirroring the idempotency-recovery architecture.

The pure evaluator (`evaluators.js`) is intentionally unchanged: claim conflict needs a fresh read of claim state, so it is decided in the broker transaction.

## Key decisions

- **Conservative ownership (no silent renewal):** a live lease blocks ALL new `claim.create` events, even one with a matching `actor`. `actor` is not yet distinct per concurrent agent (not populated on the command path today), and a renewal branch keyed on `actor` would let agents sharing a git identity silently steal each other's lease. Genuine same-claim retries carry the same `idempotency_key` and are collapsed to a duplicate replay (9.5.9) before claim planning runs.
- **Wiring deferral (conscious):** `runGuardedEvent` is a broker primitive exercised only by tests; the real `forge claim` path runs `runIssueOperation → driver.issueOperation('claim')`, and no production higher-level driver exists yet. This PR proves the primitive under contention (matching the "broker safety **proof**" scope). **Follow-up:** implement a real higher-level Kernel driver and make `issueOperation('claim'|'release')` emit guarded events through `runGuardedEvent`.

## Deferred to Slice 2

- `claim.release` semantics (owner → `released`; non-owner of a live lease → conflict).
- Broad non-owner write guard (extend claim-scope to `issue.update`/`issue.close`) — touches every existing broker fixture, so a separate change.

## Test evidence

- `bun test test/kernel/` → **67 pass / 0 fail**.
- Full suite → **3656 pass**, 58 skip. The only failures are 2 pre-existing **flaky** `beads-setup.test.js` `ensureBeadsGitExclude` tests (real-git tests sensitive to concurrent full-suite load; pass 32/0 in isolation, fail count varies 1↔2 between runs) — unrelated to this PR's `lib/kernel/` changes.
- ESLint clean on all touched files (`--max-warnings 0`).
- D20 bd-call-site kill-list verified current (no bd refs in changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Kernel broker now enforces exclusive claim leases, providing deterministic conflict/quarantine handling when concurrent claim attempts occur.
  * Added a database-level rule to guarantee only one active lease per claim issue.

* **Documentation**
  * New page explains the two-layer lease enforcement approach, lease semantics, and the planned rollout scope.

* **Tests**
  * Expanded concurrency, atomicity, lease expiration, and multi-process contention test coverage to validate recovery, idempotency, and quarantine behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->