### PR TITLE
feat(kernel): SQLite driver issue layer — kernel serves all 13 issue ops (K-DRV)

### DIFF
--- a/docs/work/2026-06-19-kernel-driver-issue-layer/design.md
+++ b/docs/work/2026-06-19-kernel-driver-issue-layer/design.md
@@ -1,0 +1,67 @@
+# Design — Kernel Driver Issue Layer (K-DRV)
+
+**Slug:** kernel-driver-issue-layer · **Date:** 2026-06-19 · **Status:** planned (D34 external-planner artifact)
+**Branch:** feat/kernel-driver-issue-layer · **Worktree:** .worktrees/kernel-driver-issue-layer
+**Beads ceremony:** deferred — bd/Dolt unreachable (K0). Epic/issue filing happens after K0; this artifact satisfies the `/dev` entry contract per D34 (structured tasks + acceptance criteria).
+
+## Purpose
+
+The Forge Kernel cannot serve a single issue today. A smoke spike ran all 13 issue ops via `issueBackend=kernel` and every one threw `Kernel local broker driver must provide issueOperation()`. Root cause: `lib/kernel/sqlite-driver.js` implements only `exec`/`queryAll` + migration/backup/FTS5 self-tests; the high-level + guarded-event methods the broker requires are missing. The broker's domain logic (#220) was proven against **inline fake drivers** in tests — never the real SQLite driver. This feature implements the real driver method surface so the kernel becomes a working issue backend, unblocking dogfooding, the Beads→kernel migration (K8), and the default-flip (K11).
+
+## Success criteria (measurable)
+
+1. **Acceptance = the smoke spike:** `create, list, ready, show, update, comment, claim, release, dep.add, dep.remove, search, stats, close` all succeed via `runIssueOperation(op, args, root, { issueBackend: 'kernel', kernelDatabasePath })` against a fresh DB — `success !== false`, contract-shaped output (`{ ok, schema_version, command, data, next_commands }`).
+2. All `requireDriverMethod` / `requireGuardedDriverMethods` assertions in `broker.js` are satisfied by the real driver (no throws).
+3. Existing kernel tests stay green (broker, broker-concurrency, broker-multiprocess, lease-enforcer, evaluators, projection-jsonl-writer, taxonomy-validator, readiness-model).
+4. Idempotency, DB-enforced claim leases, stale-revision quarantine, and dependency handling behave per #220 against the **real** driver (not just fakes).
+
+## Out of scope
+
+- Beads removal / hot-path burn-down (K9). Kernel runs **alongside** Beads.
+- Beads→kernel issue migration of the 389 legacy issues (K8).
+- Persistent `issueBackend: kernel` config / default-flip (K11) — selection stays per-call (`deps.issueBackend`).
+- Agent skills, hooks, MCP.
+
+## Approach selected
+
+Implement the 16 missing methods on the existing `lib/kernel/sqlite-driver.js` (extend its returned driver object, reusing `exec`/`queryAll`) as parameterized SQL over the existing `kernel_*` schema.
+
+**Key decision — how mutations honor the guarded-event machinery.** The `KernelIssueAdapter` routes all 14 ops to `broker.runIssueOperation` → `driver.issueOperation`. But mutations must keep #220's event-sourcing guarantees (CAS, idempotency, leases, quarantine), which live in `broker.runGuardedEvent` (`evaluateKernelEvent` + `commitGuardedAccept`). A driver method cannot call back into the broker. Resolution:
+
+- **Reads** (`ready/list/show/search/stats`) → `driver.issueOperation` does direct parameterized `SELECT`s (no events).
+- **Mutations** (`create/update/close/comment/dep.add/dep.remove/claim/release`) → routed through the **guarded path**: `broker.runIssueOperation` detects mutation ops and builds the kernel event, calling `runGuardedEvent`, which uses the driver's low-level primitives (`insertKernelEvent`, `loadKernelEntity`, `insertKernelClaim`, …). The driver implements the **primitives**; the broker keeps orchestration. This requires a small, surgical change to `broker.runIssueOperation` routing (Task 10) and maximizes reuse of the proven guarded path.
+- *Rejected alternative:* `driver.issueOperation` does all writes directly — simpler but bypasses event-sourcing/idempotency/quarantine, throwing away #220's value.
+
+## Constraints
+
+- Honor `issue-command-contract.js` output schemas + error shape (`{code, message, exit_code, retryable}`) and `next_commands` hints.
+- Honor taxonomy (4 types `epic/task/bug/decision`; 5 stored statuses; `ready`/`blocked` derived via `readiness-model.js`, not stored).
+- Parameterized SQL only (no string interpolation of values) — SQL-injection safe.
+- WAL + transactions; idempotency keys; DB-enforced single active claim per issue.
+- Zero new Beads/Dolt coupling; works on `node:sqlite` (≥22.13) and `bun:sqlite`.
+
+## Edge cases (Q&A decisions)
+
+- **Empty DB:** `ready`/`list`/`stats` return empty/zero shapes, not errors. Schema auto-applied via broker `initialize()` before first op.
+- **Stale revision** on update/close → `evaluateKernelEvent` quarantines (`insertKernelConflict`); op returns retryable error.
+- **Duplicate idempotency key** → replay as duplicate (no double-write).
+- **Claim on already-claimed issue** → conflict (`invalid_claim_scope`/active-claim), not silent overwrite.
+- **dep.add creating a cycle** → quarantine (`dependency_cycle`).
+- **close with open dependents** → allowed but surfaced (dependents recomputed as ready/blocked by the read model).
+
+## Ambiguity policy
+
+7-dimension rubric per `/dev` decision gate. ≥80% confidence: proceed + document. <80%: stop and ask. The reads-vs-guarded routing (Task 10) is the most likely gate — if the broker change proves larger than surgical, stop and confirm.
+
+## Technical research
+
+**Driver contract the broker requires (17 methods; `exec` exists, 16 to build):**
+`issueOperation` · `insertKernelEvent` · `loadKernelEntity` · `listKernelEvents` · `loadKernelEventByIdempotencyKey` · `listKernelDependencies` · `loadActiveKernelClaim` · `insertKernelClaim` · `updateKernelClaimState` · `insertKernelConflict` · `enqueueKernelProjection` · `listProjectionOutbox` · `loadProjectionModel` · `markProjectionDelivered` · `recordProjectionFailure` · `deadLetterProjection`.
+
+**Schema (already defined, `lib/kernel/schema.js`):** `kernel_issues` (id/title/body/type/status/priority_rank/created_at/updated_at/entity_revision/parent_id/sprint_id/release_id/stage_state/labels/acceptance_criteria/estimate), `kernel_dependencies`, `kernel_comments`, `kernel_priority_events`, `kernel_claims`, plus events/conflicts/projection-outbox/dead-letters tables. Build SQL against these — do not alter the schema.
+
+**Reference spec:** the inline fake drivers in `test/kernel/broker.test.js` (e.g. `async issueOperation(operation, args, context, brokerConfig)`) define exact method signatures `(…, context, config)`. Mirror them.
+
+**OWASP:** A03 Injection — parameterized SQL only (primary risk). A01/A08 — local-file DB, filesystem doctor (separate); low remote surface.
+
+**TDD scenarios (min):** (1) read on empty DB returns empty shapes; (2) create→show round-trips contract-shaped data + revision; (3) double-claim → conflict (lease enforced) on the real driver; (4) idempotent create replay = single row; (5) dep.add then `ready` reflects the blocked dependent.

--- a/docs/work/2026-06-19-kernel-driver-issue-layer/design.md
+++ b/docs/work/2026-06-19-kernel-driver-issue-layer/design.md
@@ -65,3 +65,19 @@ Implement the 16 missing methods on the existing `lib/kernel/sqlite-driver.js` (
 **OWASP:** A03 Injection — parameterized SQL only (primary risk). A01/A08 — local-file DB, filesystem doctor (separate); low remote surface.
 
 **TDD scenarios (min):** (1) read on empty DB returns empty shapes; (2) create→show round-trips contract-shaped data + revision; (3) double-claim → conflict (lease enforced) on the real driver; (4) idempotent create replay = single row; (5) dep.add then `ready` reflects the blocked dependent.
+
+## Artifacts
+
+**This design phase:** `docs/work/2026-06-19-kernel-driver-issue-layer/design.md`, `tasks.md`.
+
+**Produced during `/dev` (now complete):**
+- Implementation: `lib/kernel/sqlite-driver.js` (16 driver methods), `lib/kernel/broker.js` (mutation routing + revision-conflict recovery), `lib/kernel/evaluators.js` (`buildConflict` export).
+- Tests: `test/kernel/sqlite-driver-issue.test.js`, `sqlite-driver-events.test.js`, `sqlite-driver-mutations.test.js`, `sqlite-driver-deps-claims.test.js`, `driver-smoke.test.js` (13-op acceptance).
+
+## Next
+
+**Stage gate outcome:** the Task 10 ambiguity gate (broker mutation routing) resolved as **surgical** — `runGuardedEvent` body extracted to `runGuardedEventImpl` + an additive mutation branch in `runIssueOperation`; `runGuardedEvent`'s behavior/return shape unchanged, all existing broker tests green (commit `962b54c`). No escalation was needed.
+
+**Status:** implemented, validated (`bun run check` green; smoke 13/13; kernel suite green), shipped as PR #224. The kernel runs **alongside** Beads — no default change.
+
+**Follow-ups (post-merge):** K0 (bd/Dolt repair → file these issues into the kernel), K8 (Beads→kernel migration of legacy issues), K11 (default-flip to the kernel backend). Multi-process issue-CAS is now DB-backed (revision compare-and-swap at the row write).

--- a/docs/work/2026-06-19-kernel-driver-issue-layer/tasks.md
+++ b/docs/work/2026-06-19-kernel-driver-issue-layer/tasks.md
@@ -76,3 +76,21 @@ OWNS: `lib/kernel/broker.js`, `test/kernel/broker.test.js`
 - No Beads removal; selection stays per-call (`deps.issueBackend='kernel'`).
 - Run `bun test test/kernel/` after each task; full `bun run check` before ship.
 - Beads epic/issue filing deferred to K0 (bd unreachable); record this PR's issues there once bd is repaired.
+
+## Artifacts (delivered)
+
+| Wave / Task | Test file | Implementation |
+|---|---|---|
+| 1 (reads) | `sqlite-driver-issue.test.js` | `sqlite-driver.js` — `issueOperation` read branch |
+| 2 (events) | `sqlite-driver-events.test.js` | `sqlite-driver.js` — event-store primitives |
+| 3 (mutations) | `sqlite-driver-mutations.test.js` | `sqlite-driver.js` + `broker.js` (guarded-event routing) |
+| 4 (deps/claims) | `sqlite-driver-deps-claims.test.js` | `sqlite-driver.js` — dependency + claim primitives (DB-enforced lease) |
+| 5 (projection/smoke) | `driver-smoke.test.js` (acceptance) | `sqlite-driver.js` — projection-outbox primitives |
+| CAS hardening | (in mutations test) | `sqlite-driver.js` row-write CAS + `broker.js`/`evaluators.js` recovery |
+
+## Next (post-implementation)
+
+- **Task 5 / Task 10 gate — RESOLVED.** The broker mutation routing was implemented in Wave 3 (Task 5) and the Task 10 change was **surgical** (extract `runGuardedEventImpl` + additive `runIssueOperation` mutation branch; `runGuardedEvent` unchanged, all broker tests green — commit `962b54c`). No deferral/escalation; the conditional Task 10 was satisfied in-place.
+- **Validation:** `bun run check` green; `driver-smoke.test.js` 13/13; full kernel suite green; lint clean. SQL all parameterized; no Beads coupling; DB-enforced single-active-claim lease; row-write revision CAS; projection-outbox atomic within the guarded commit.
+- **Ship:** PR #224 (kernel alongside Beads; no default change).
+- **Post-merge epics:** K0 (bd/Dolt repair), K8 (Beads→kernel migration), K11 (default-flip).

--- a/docs/work/2026-06-19-kernel-driver-issue-layer/tasks.md
+++ b/docs/work/2026-06-19-kernel-driver-issue-layer/tasks.md
@@ -1,0 +1,78 @@
+# Tasks — Kernel Driver Issue Layer (K-DRV)
+
+TDD. Each task: write failing test → confirm red → implement → green → commit. Target driver: `lib/kernel/sqlite-driver.js` (extend the returned driver object; reuse `exec`/`queryAll`). Signatures mirror the broker's fake drivers: `(operation, args, context, config)` for `issueOperation`; `(…, context, config)` for primitives. All SQL parameterized.
+
+**Acceptance for the whole feature:** Task 9 smoke test — all 13 ops green via `runIssueOperation(op, args, root, {issueBackend:'kernel', kernelDatabasePath})`.
+
+## Wave 1 — Foundation (reads, no events)
+
+### Task 1 — Schema applied on a fresh DB
+OWNS: `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-issue.test.js`
+- Test: `createLocalBroker({driver: realSqliteDriver(), databasePath: tmp}).initialize()` creates `kernel_issues` (assert via `queryAll` on `sqlite_master`). Red first.
+- Implement: ensure `initialize()`’s migration statements run through the real driver `exec`; add `queryAll` use if needed.
+- Commit: `test:`/`feat: kernel sqlite driver applies schema on init`
+
+### Task 2 — `issueOperation` read branch: list / show / stats
+OWNS: `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-issue.test.js`
+- Test: seed rows via direct SQL, then `issueOperation('list'|'show'|'stats', args, ctx, config)` returns contract-shaped `{ok, schema_version, command, data, next_commands}` (`data.issues`, `data.issue`, `data.counts`).
+- Implement: parameterized SELECTs over `kernel_issues` (+ `kernel_comments` for show); map to contract output via `issue-command-contract` schemas.
+- Commit: `feat: kernel driver read ops (list/show/stats)`
+
+### Task 3 — Read ops: ready / search (derived readiness)
+OWNS: `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-issue.test.js`
+- Test: with deps + claims seeded, `ready` excludes blocked/claimed/closed and ranks by `priority_rank`; `search` matches title/body.
+- Implement: compute ready/blocked via `readiness-model.js` over `kernel_issues`+`kernel_dependencies`+`kernel_claims` (derived, never stored). `search` = LIKE/FTS over title/body.
+- Commit: `feat: kernel driver ready/search read ops`
+
+## Wave 2 — Guarded-event primitives (event store)
+
+### Task 4 — Event-store primitives
+OWNS: `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-events.test.js`
+- Test each: `insertKernelEvent`, `loadKernelEntity`, `listKernelEvents`, `loadKernelEventByIdempotencyKey` round-trip against the events/issues tables.
+- Implement: parameterized INSERT/SELECT; entity-revision read for CAS.
+- Commit: `feat: kernel driver event-store primitives`
+
+### Task 5 — Mutation ops via guarded path: create / update / close / comment
+OWNS: `lib/kernel/broker.js` (routing), `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-mutations.test.js`
+- Test: `create` then `show` round-trips; `update --status` bumps `entity_revision`; stale revision → quarantine + retryable error; duplicate idempotency key → single row (replay); `comment` appends to `kernel_comments`.
+- Implement: broker `runIssueOperation` routes mutation ops → builds event → `runGuardedEvent` (Task 10 covers the routing change if it grows). Driver supplies `commitGuardedAccept`'s writes (issue upsert, comment insert) + `insertKernelConflict`.
+- Commit: `feat: kernel driver create/update/close/comment via guarded path`
+
+## Wave 3 — Dependencies & claims
+
+### Task 6 — Dependency primitives + dep.add / dep.remove
+OWNS: `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-deps.test.js`
+- Test: `dep.add` inserts; `ready` reflects the now-blocked dependent; cycle → quarantine (`dependency_cycle`); `dep.remove` deletes.
+- Implement: `listKernelDependencies` + dep INSERT/DELETE over `kernel_dependencies`.
+- Commit: `feat: kernel driver dependency ops`
+
+### Task 7 — Claim primitives + claim / release (lease enforced)
+OWNS: `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-claims.test.js`
+- Test: `claim` creates a lease; second `claim` by another actor → conflict (`invalid_claim_scope`/active-claim); `release` clears it; lease invariant enforced at DB level (unique active claim per issue).
+- Implement: `loadActiveKernelClaim`, `insertKernelClaim`, `updateKernelClaimState` over `kernel_claims` with the DB uniqueness invariant.
+- Commit: `feat: kernel driver claim/release with DB-enforced lease`
+
+## Wave 4 — Conflicts, projection outbox, integration
+
+### Task 8 — Conflict + projection-outbox primitives
+OWNS: `lib/kernel/sqlite-driver.js`, `test/kernel/sqlite-driver-projection.test.js`
+- Test: `insertKernelConflict` persists; `enqueueKernelProjection`/`listProjectionOutbox`/`loadProjectionModel`/`markProjectionDelivered`/`recordProjectionFailure`/`deadLetterProjection` round-trip.
+- Implement: parameterized SQL over the conflicts + projection-outbox + dead-letter tables.
+- Commit: `feat: kernel driver conflict + projection-outbox primitives`
+
+### Task 9 — Integration: formalize the smoke spike (ACCEPTANCE)
+OWNS: `test/kernel/driver-smoke.test.js`
+- Test: run all 13 ops in sequence via `runIssueOperation(op, args, REPO, {issueBackend:'kernel', kernelDatabasePath: tmp})`; assert each `success !== false` and contract-shaped output. This is the feature's acceptance gate.
+- Commit: `test: kernel driver end-to-end smoke (all 13 ops green)`
+
+## Wave 5 — Uncertain (last, deferrable)
+
+### Task 10 — Broker mutation-routing change (only if Wave-2 needs it)
+OWNS: `lib/kernel/broker.js`, `test/kernel/broker.test.js`
+- If routing mutations through `runGuardedEvent` from `runIssueOperation` is more than surgical, STOP and confirm with the user (ambiguity gate). Test the read-vs-mutation routing explicitly; keep existing broker tests green.
+- Commit: `refactor: route kernel mutation ops through guarded-event path`
+
+## Notes
+- No Beads removal; selection stays per-call (`deps.issueBackend='kernel'`).
+- Run `bun test test/kernel/` after each task; full `bun run check` before ship.
+- Beads epic/issue filing deferred to K0 (bd unreachable); record this PR's issues there once bd is repaired.

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -3,7 +3,7 @@
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');
 const { randomUUID } = require('node:crypto');
-const { evaluateKernelEvent, normalizePayload } = require('./evaluators');
+const { buildConflict, evaluateKernelEvent, normalizePayload } = require('./evaluators');
 const { buildKernelMigrationPlan } = require('./migrations');
 const { buildClaimConflict, isValidExpiresAt, planClaimAcquisition } = require('./lease-enforcer');
 const {
@@ -95,6 +95,15 @@ function isIdempotencyConflict(error) {
 function isClaimLeaseConflict(error) {
 	const msg = String(error?.message ?? error);
 	return /UNIQUE constraint failed/i.test(msg) && /kernel_claims\.issue_id/i.test(msg);
+}
+
+// The real driver's applyAcceptedIssueMutation tags a lost-update collision (its
+// row-level CAS UPDATE matched 0 rows because the issue's revision moved between
+// the evaluator's out-of-transaction pre-read and the serialized commit). It is the
+// issue-revision analogue of the claim-lease partial-UNIQUE backstop: a structural
+// guarantee the evaluator's pre-read alone cannot provide under concurrency.
+function isRevisionConflict(error) {
+	return Boolean(error && error.kernelRevisionConflict);
 }
 
 async function execMigrationStatement(driver, statement, config) {
@@ -242,6 +251,20 @@ async function recoverGuardedFailure({ driver, err, event, claimScope, context, 
 	if (claimScope && isClaimLeaseConflict(err)) {
 		const winner = await driver.loadActiveKernelClaim(claimScope.issue_id, context, config);
 		return insertClaimConflictResult(driver, event, winner, 'claim_conflict', context, config, now);
+	}
+	// Issue-revision lost-update detected by the driver's row-level CAS: a same-key
+	// retry of an already-committed winner still replays as a duplicate; otherwise
+	// quarantine as stale_revision (byte-identical to an evaluator-produced conflict)
+	// so mapMutationResult surfaces it as a RETRYABLE conflict — the caller re-reads
+	// the bumped revision and retries.
+	if (isRevisionConflict(err)) {
+		const replay = await replayDuplicateIfIdempotent(driver, event, context, config);
+		if (replay) return replay;
+		const conflict = await driver.insertKernelConflict({
+			...buildConflict(event, 'stale_revision', err.actualRevision),
+			created_at: event.created_at || now,
+		}, context, config);
+		return { decision: 'quarantine', reason: 'stale_revision', conflict, projection: false };
 	}
 	throw err;
 }

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -103,7 +103,7 @@ function isClaimLeaseConflict(error) {
 // issue-revision analogue of the claim-lease partial-UNIQUE backstop: a structural
 // guarantee the evaluator's pre-read alone cannot provide under concurrency.
 function isRevisionConflict(error) {
-	return Boolean(error && error.kernelRevisionConflict);
+	return Boolean(error?.kernelRevisionConflict);
 }
 
 async function execMigrationStatement(driver, statement, config) {

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -301,7 +301,15 @@ async function commitGuardedAccept({ driver, event, evaluation, claimScope, acti
 // Ops that must go through runGuardedEvent. Reads stay on driver.issueOperation.
 const ISSUE_MUTATION_OPERATIONS = Object.freeze(new Set([
 	'create', 'update', 'close', 'comment',
+	'dep.add', 'dep.remove', 'claim', 'release',
 ]));
+
+// Ops whose kernel event targets a non-issue entity stream (a dependency edge or a
+// claim lease). These carry entity_type 'dependency'/'claim' and an entity_id that
+// is the dep/claim row id — NOT the issue id — so they must never fall into the
+// issue-upsert apply branch in the driver.
+const DEPENDENCY_OPERATIONS = Object.freeze(new Set(['dep.add', 'dep.remove']));
+const CLAIM_OPERATIONS = Object.freeze(new Set(['claim', 'release']));
 
 // Map an issue mutation op to its event_type and the contract command id used for
 // response/error shaping.
@@ -310,12 +318,20 @@ const ISSUE_MUTATION_EVENT_TYPES = Object.freeze({
 	update: 'issue.update',
 	close: 'issue.close',
 	comment: 'issue.comment',
+	'dep.add': 'dependency.add',
+	'dep.remove': 'dependency.remove',
+	claim: 'claim.create',
+	release: 'claim.release',
 });
 const ISSUE_MUTATION_COMMAND_IDS = Object.freeze({
 	create: 'issue.create',
 	update: 'issue.update',
 	close: 'issue.close',
 	comment: 'issue.comment',
+	'dep.add': 'issue.dep.add',
+	'dep.remove': 'issue.dep.remove',
+	claim: 'claim',
+	release: 'release',
 });
 
 function nextCommandsFor(commandId) {
@@ -380,6 +396,69 @@ function buildCommentPayload(issueId, args) {
 	return { issue_id: issueId, body, comment_id: randomUUID() };
 }
 
+// Resolve the (issue_id, blocks_issue_id) endpoints a dependency op names. Accepts
+// the --issue/--blocks flag pair; both MUST be present so buildDependencyScope can
+// scope the event (else the cycle guard is skipped and the edge insert is malformed).
+function resolveDependencyEndpoints(flags) {
+	return {
+		issue_id: typeof flags.issue === 'string' ? flags.issue : undefined,
+		blocks_issue_id: typeof flags.blocks === 'string' ? flags.blocks : undefined,
+		dependency_type: typeof flags['dep-type'] === 'string' ? flags['dep-type'] : 'blocks',
+	};
+}
+
+// Build the kernel event for a dependency.add / dependency.remove op. The event is
+// scoped on the 'dependency' entity stream: a freshly minted entity_id becomes the
+// dependency row id (add) and the cycle-guard / edge-write key. The idempotency key
+// is derived from the edge endpoints so a retry of the same edge replays rather
+// than minting a second row.
+function buildDependencyMutationEvent(operation, flags, actor, origin, context) {
+	const endpoints = resolveDependencyEndpoints(flags);
+	const dependencyId = context.dependencyId || randomUUID();
+	const eventType = ISSUE_MUTATION_EVENT_TYPES[operation];
+	const idempotencyKey = context.idempotencyKey
+		|| `${eventType}:${endpoints.issue_id}:${endpoints.blocks_issue_id}`;
+	return {
+		entity_type: 'dependency',
+		entity_id: dependencyId,
+		event_type: eventType,
+		idempotency_key: idempotencyKey,
+		expected_revision: 0,
+		actor,
+		origin,
+		payload: {
+			issue_id: endpoints.issue_id,
+			blocks_issue_id: endpoints.blocks_issue_id,
+			dependency_type: endpoints.dependency_type,
+		},
+	};
+}
+
+// Build the kernel event for a claim / release op. The event is scoped on the
+// 'claim' entity stream (entity_id = claim lease id). The default idempotency key
+// is keyed on issue_id + actor so a same-actor retry replays as a duplicate while a
+// different actor produces a distinct key that reaches the lease-conflict path.
+function buildClaimMutationEvent(operation, flags, actor, origin, context) {
+	const issueId = typeof flags.issue === 'string' ? flags.issue : undefined;
+	const claimId = context.claimId || randomUUID();
+	const eventType = ISSUE_MUTATION_EVENT_TYPES[operation];
+	const idempotencyKey = context.idempotencyKey || `${eventType}:${issueId}:${actor}`;
+	const payload = { issue_id: issueId };
+	if (typeof flags.expires === 'string') payload.expires_at = flags.expires;
+	return {
+		entity_type: 'claim',
+		entity_id: claimId,
+		event_type: eventType,
+		idempotency_key: idempotencyKey,
+		expected_revision: 0,
+		actor,
+		origin,
+		session_id: context.sessionId ?? null,
+		worktree_id: context.worktreeId ?? null,
+		payload,
+	};
+}
+
 // Construct the kernel event for a mutation op. For update/close/comment, the
 // expected_revision is the FRESHLY READ stored revision (so runIssueOperation can
 // never manufacture a stale CAS — a behind revision only arrives via a raw
@@ -401,6 +480,15 @@ async function buildIssueMutationEvent(driver, operation, args, context, config)
 			origin,
 			payload,
 		};
+	}
+
+	// Dependency / claim ops target their own entity stream (no issue-row CAS): the
+	// event entity_type is 'dependency'/'claim' and entity_id is a fresh dep/claim id.
+	if (DEPENDENCY_OPERATIONS.has(operation)) {
+		return buildDependencyMutationEvent(operation, flags, actor, origin, context);
+	}
+	if (CLAIM_OPERATIONS.has(operation)) {
+		return buildClaimMutationEvent(operation, flags, actor, origin, context);
 	}
 
 	const issueId = firstPositionalArg(args);
@@ -441,9 +529,21 @@ function okMutationResponse(commandId, data) {
 	};
 }
 
+// The issue id a mutation event touches: for issue ops it IS the entity_id; for
+// dependency/claim ops the entity_id is the dep/claim row id, so the issue lives in
+// the payload. Used to report a stable issue revision on a duplicate replay.
+function mutationIssueId(operation, event) {
+	if (DEPENDENCY_OPERATIONS.has(operation) || CLAIM_OPERATIONS.has(operation)) {
+		const payload = parseEventPayload(event);
+		return payload.issue_id;
+	}
+	return event.entity_id;
+}
+
 // Map a runGuardedEvent result to an issue-command-contract mutation response (or
 // error). A duplicate replay reports the existing single row; a quarantine becomes
-// a retryable conflict error; an accept returns {id, revision, comment_id?}.
+// a (sometimes retryable) conflict error; an accept returns
+// {id, revision, comment_id?/dependency_id?/claim_id?}.
 async function mapMutationResult(driver, operation, event, result, context, config) {
 	const commandId = ISSUE_MUTATION_COMMAND_IDS[operation];
 
@@ -454,17 +554,28 @@ async function mapMutationResult(driver, operation, event, result, context, conf
 			revision: Number(mutation.revision ?? 0),
 		};
 		if (mutation.comment_id) data.comment_id = mutation.comment_id;
+		if (DEPENDENCY_OPERATIONS.has(operation)) {
+			data.dependency_id = mutation.dependency_id ?? event.entity_id;
+		}
+		if (CLAIM_OPERATIONS.has(operation)) {
+			data.claim_id = mutation.claim_id ?? event.entity_id;
+		}
 		return okMutationResponse(commandId, data);
 	}
 
 	if (result.decision === 'duplicate' || result.decision === 'dedupe' || result.decision === 'projection_echo') {
-		// Idempotent replay / equivalent write: no double-write. Report the issue's
-		// current persisted revision so the caller sees a stable, single-row result.
-		const entity = await driver.loadKernelEntity('issue', event.entity_id, context, config);
-		return okMutationResponse(commandId, {
+		// Idempotent replay / equivalent write: no double-write. Report the host
+		// issue's current persisted revision so the caller sees a stable result. For
+		// dep/claim ops the issue id comes from the payload, not the entity_id.
+		const issueId = mutationIssueId(operation, event);
+		const entity = await driver.loadKernelEntity('issue', issueId, context, config);
+		const data = {
 			id: event.entity_id,
 			revision: Number(entity?.entity_revision || 0),
-		});
+		};
+		if (DEPENDENCY_OPERATIONS.has(operation)) data.dependency_id = event.entity_id;
+		if (CLAIM_OPERATIONS.has(operation)) data.claim_id = event.entity_id;
+		return okMutationResponse(commandId, data);
 	}
 
 	if (result.decision === 'quarantine') {

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -2,9 +2,16 @@
 
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');
+const { randomUUID } = require('node:crypto');
 const { evaluateKernelEvent, normalizePayload } = require('./evaluators');
 const { buildKernelMigrationPlan } = require('./migrations');
 const { buildClaimConflict, isValidExpiresAt, planClaimAcquisition } = require('./lease-enforcer');
+const {
+	ISSUE_COMMAND_EXIT_CODES,
+	ISSUE_COMMAND_SCHEMA_VERSION,
+	formatIssueCommandError,
+	getIssueCommandContract,
+} = require('./issue-command-contract');
 
 const LOCAL_BROKER_PRAGMAS = Object.freeze([
 	'PRAGMA journal_mode=WAL;',
@@ -261,17 +268,227 @@ async function commitGuardedAccept({ driver, event, evaluation, claimScope, acti
 			...evaluation.event,
 			created_at: evaluation.event.created_at || now,
 		}, context, config);
+		// Apply the accepted event's authority-table effect (issue upsert / revision
+		// bump / comment insert) on the SAME connection, inside this transaction, so
+		// the event and its issue-row effect commit or roll back atomically. The hook
+		// is OPTIONAL: drivers that only supply event-store primitives (and every
+		// inline broker test fake) omit it, leaving the append/CAS path unchanged.
+		let mutation;
+		if (typeof driver.applyAcceptedIssueMutation === 'function') {
+			mutation = await driver.applyAcceptedIssueMutation(acceptedEvent, context, config);
+		}
 		const outboxEntry = await driver.enqueueKernelProjection(
 			buildProjectionOutboxEntry(acceptedEvent, context.projectionTarget || 'beads', now),
 			context,
 			config,
 		);
 		await driver.exec('COMMIT;', config);
-		return { ...evaluation, event: acceptedEvent, outboxEntry };
+		return { ...evaluation, event: acceptedEvent, outboxEntry, mutation };
 	} catch (err) {
 		await driver.exec('ROLLBACK;', config);
 		return recoverGuardedFailure({ driver, err, event, claimScope, context, config, now });
 	}
+}
+
+// --- Issue-mutation routing (K-DRV Wave 3) ------------------------------------
+// The KernelIssueAdapter routes every op to runIssueOperation. Reads delegate
+// straight to driver.issueOperation; mutations must instead flow through the
+// guarded-event path so CAS/idempotency/quarantine (proven in #220) apply. This
+// surface builds a kernel event from the CLI args, runs runGuardedEvent, and maps
+// the decision back to an issue-command-contract response — without changing
+// runGuardedEvent itself.
+
+// Ops that must go through runGuardedEvent. Reads stay on driver.issueOperation.
+const ISSUE_MUTATION_OPERATIONS = Object.freeze(new Set([
+	'create', 'update', 'close', 'comment',
+]));
+
+// Map an issue mutation op to its event_type and the contract command id used for
+// response/error shaping.
+const ISSUE_MUTATION_EVENT_TYPES = Object.freeze({
+	create: 'issue.create',
+	update: 'issue.update',
+	close: 'issue.close',
+	comment: 'issue.comment',
+});
+const ISSUE_MUTATION_COMMAND_IDS = Object.freeze({
+	create: 'issue.create',
+	update: 'issue.update',
+	close: 'issue.close',
+	comment: 'issue.comment',
+});
+
+function nextCommandsFor(commandId) {
+	const contract = getIssueCommandContract(commandId);
+	return contract ? [...contract.nextCommands] : [];
+}
+
+// First non-flag token (the issue id for update/close/comment).
+function firstPositionalArg(args = []) {
+	return (args || []).find(value => typeof value === 'string' && !value.startsWith('-'));
+}
+
+// Parse the long-flag pairs CLI mutations carry (e.g. --title "x" --type task).
+// Only --key value pairs are captured; bare positionals are ignored here.
+function parseFlagPairs(args = []) {
+	const flags = {};
+	for (let index = 0; index < args.length; index += 1) {
+		const token = args[index];
+		if (typeof token !== 'string' || !token.startsWith('--')) continue;
+		const key = token.slice(2);
+		const next = args[index + 1];
+		if (typeof next === 'string' && !next.startsWith('--')) {
+			flags[key] = next;
+			index += 1;
+		} else {
+			flags[key] = true;
+		}
+	}
+	return flags;
+}
+
+// Build the create payload from flags. --id is optional (minted when absent); the
+// minted/declared id becomes the event entity_id and the new issue's primary key.
+function buildCreatePayload(flags) {
+	const id = typeof flags.id === 'string' ? flags.id : randomUUID();
+	const payload = { id };
+	if (typeof flags.title === 'string') payload.title = flags.title;
+	if (typeof flags.body === 'string') payload.body = flags.body;
+	payload.type = typeof flags.type === 'string' ? flags.type : 'task';
+	payload.status = typeof flags.status === 'string' ? flags.status : 'open';
+	if (typeof flags.priority === 'string') payload.priority = flags.priority;
+	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
+	if (typeof flags.parent === 'string') payload.parent_id = flags.parent;
+	return payload;
+}
+
+// Build the update/close payload from flags (status/title/etc. when present).
+function buildUpdatePayload(flags) {
+	const payload = {};
+	if (typeof flags.status === 'string') payload.status = flags.status;
+	if (typeof flags.title === 'string') payload.title = flags.title;
+	if (typeof flags.body === 'string') payload.body = flags.body;
+	if (typeof flags.priority === 'string') payload.priority = flags.priority;
+	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
+	return payload;
+}
+
+// The comment body is the first non-id positional (forge comment <id> <body...>).
+function buildCommentPayload(issueId, args) {
+	const positionals = (args || []).filter(value => typeof value === 'string' && !value.startsWith('-'));
+	const body = positionals.slice(1).join(' ');
+	return { issue_id: issueId, body, comment_id: randomUUID() };
+}
+
+// Construct the kernel event for a mutation op. For update/close/comment, the
+// expected_revision is the FRESHLY READ stored revision (so runIssueOperation can
+// never manufacture a stale CAS — a behind revision only arrives via a raw
+// runGuardedEvent call). entity_id is the issue id; payload carries the change.
+async function buildIssueMutationEvent(driver, operation, args, context, config) {
+	const flags = parseFlagPairs(args);
+	const actor = context.actor || 'forge';
+	const origin = context.origin || 'cli';
+
+	if (operation === 'create') {
+		const payload = buildCreatePayload(flags);
+		return {
+			entity_type: 'issue',
+			entity_id: payload.id,
+			event_type: ISSUE_MUTATION_EVENT_TYPES.create,
+			idempotency_key: context.idempotencyKey || `issue.create:${payload.id}`,
+			expected_revision: 0,
+			actor,
+			origin,
+			payload,
+		};
+	}
+
+	const issueId = firstPositionalArg(args);
+	const entity = await driver.loadKernelEntity('issue', issueId, context, config);
+	const expectedRevision = Number(entity?.entity_revision || 0);
+	// For close, the driver maps event_type='issue.close' to a terminal status; an
+	// explicit --status flag (rework move) still wins via the update payload.
+	const payload = operation === 'comment'
+		? buildCommentPayload(issueId, args)
+		: buildUpdatePayload(flags);
+	// Comments never bump entity_revision, so a revision-based key would collide for
+	// every comment on the same issue (second → false duplicate → silently dropped).
+	// Key on the minted comment_id instead. For update/close the synthesized key uses
+	// the current revision: a CLI retry re-reads the bumped revision and re-applies
+	// (not truly idempotent) — callers needing retry-safety pass context.idempotencyKey.
+	const idempotencyKey = context.idempotencyKey || (operation === 'comment'
+		? `${ISSUE_MUTATION_EVENT_TYPES.comment}:${issueId}:${payload.comment_id}`
+		: `${ISSUE_MUTATION_EVENT_TYPES[operation]}:${issueId}:rev-${expectedRevision}`);
+	return {
+		entity_type: 'issue',
+		entity_id: issueId,
+		event_type: ISSUE_MUTATION_EVENT_TYPES[operation],
+		idempotency_key: idempotencyKey,
+		expected_revision: expectedRevision,
+		actor,
+		origin,
+		payload,
+	};
+}
+
+function okMutationResponse(commandId, data) {
+	return {
+		ok: true,
+		schema_version: ISSUE_COMMAND_SCHEMA_VERSION,
+		command: commandId,
+		data,
+		next_commands: nextCommandsFor(commandId),
+	};
+}
+
+// Map a runGuardedEvent result to an issue-command-contract mutation response (or
+// error). A duplicate replay reports the existing single row; a quarantine becomes
+// a retryable conflict error; an accept returns {id, revision, comment_id?}.
+async function mapMutationResult(driver, operation, event, result, context, config) {
+	const commandId = ISSUE_MUTATION_COMMAND_IDS[operation];
+
+	if (result.decision === 'accept') {
+		const mutation = result.mutation || {};
+		const data = {
+			id: mutation.id ?? event.entity_id,
+			revision: Number(mutation.revision ?? 0),
+		};
+		if (mutation.comment_id) data.comment_id = mutation.comment_id;
+		return okMutationResponse(commandId, data);
+	}
+
+	if (result.decision === 'duplicate' || result.decision === 'dedupe' || result.decision === 'projection_echo') {
+		// Idempotent replay / equivalent write: no double-write. Report the issue's
+		// current persisted revision so the caller sees a stable, single-row result.
+		const entity = await driver.loadKernelEntity('issue', event.entity_id, context, config);
+		return okMutationResponse(commandId, {
+			id: event.entity_id,
+			revision: Number(entity?.entity_revision || 0),
+		});
+	}
+
+	if (result.decision === 'quarantine') {
+		const retryable = result.reason === 'stale_revision';
+		return formatIssueCommandError({
+			command: commandId,
+			code: `FORGE_ISSUE_${String(result.reason || 'CONFLICT').toUpperCase()}`,
+			message: `Issue mutation ${operation} on ${event.entity_id} was quarantined: ${result.reason}`,
+			exitCode: ISSUE_COMMAND_EXIT_CODES.conflict,
+			retryable,
+			details: { reason: result.reason, entity_id: event.entity_id },
+			nextCommands: nextCommandsFor(commandId),
+		});
+	}
+
+	// Any other decision (should not occur for issue mutations) is an internal error.
+	return formatIssueCommandError({
+		command: commandId,
+		code: 'FORGE_ISSUE_INTERNAL',
+		message: `Issue mutation ${operation} returned an unexpected decision: ${result.decision}`,
+		exitCode: ISSUE_COMMAND_EXIT_CODES.internal,
+		retryable: false,
+		nextCommands: nextCommandsFor(commandId),
+	});
 }
 
 function createLocalBroker(options = {}) {
@@ -283,6 +500,86 @@ function createLocalBroker(options = {}) {
 			cachedConfig = buildLocalBrokerConfig(options);
 		}
 		return cachedConfig;
+	}
+
+	// The guarded-event pipeline (CAS/idempotency/lease/quarantine + atomic commit).
+	// Extracted to a local function so runIssueOperation can route issue mutations
+	// through it without re-implementing the path or going through `this`.
+	async function runGuardedEventImpl(event, context = {}) {
+		requireGuardedDriverMethods(driver);
+
+		const config = getConfig();
+		const now = context.now || new Date().toISOString();
+		const normalizedEvent = {
+			...event,
+			created_at: event.created_at || now,
+		};
+		const dependencyScope = buildDependencyScope(normalizedEvent);
+		if (dependencyScope) {
+			requireDriverMethod(driver, 'listKernelDependencies');
+		}
+		const claimScope = buildClaimScope(normalizedEvent);
+		// A claim.create with a missing/invalid payload (or wrong entity) has no
+		// scope. Quarantine it instead of falling through as a non-claim event:
+		// the generic evaluator would otherwise accept and persist the event +
+		// outbox without ever creating a kernel_claims lease, so a later claim on
+		// the real issue would proceed as if nothing were claimed. BUT a retry of
+		// an already-accepted claim (same idempotency_key) must still replay as a
+		// duplicate even if this retry's payload is malformed, so check that first.
+		if (normalizedEvent.event_type === 'claim.create' && !claimScope) {
+			return (await replayDuplicateIfIdempotent(driver, normalizedEvent, context, config))
+				|| insertClaimConflictResult(driver, normalizedEvent, null, 'invalid_claim_scope', context, config, now);
+		}
+		if (claimScope) {
+			requireDriverMethod(driver, 'loadActiveKernelClaim');
+			requireDriverMethod(driver, 'insertKernelClaim');
+		}
+
+		const [entity, entityEvents, idempotencyEvent, dependencies, activeClaim] = await Promise.all([
+			driver.loadKernelEntity(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
+			driver.listKernelEvents(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
+			driver.loadKernelEventByIdempotencyKey(normalizedEvent.idempotency_key, context, config),
+			dependencyScope
+				? driver.listKernelDependencies(dependencyScope, context, config)
+				: Promise.resolve([]),
+			claimScope
+				? driver.loadActiveKernelClaim(claimScope.issue_id, context, config)
+				: Promise.resolve(null),
+		]);
+		const priorEvents = idempotencyEvent
+			? [idempotencyEvent, ...entityEvents.filter(candidate => candidate.id !== idempotencyEvent.id)]
+			: entityEvents;
+		const evaluation = evaluateKernelEvent({
+			event: normalizedEvent,
+			entity,
+			priorEvents,
+			dependencies,
+		});
+
+		if (evaluation.decision === 'quarantine') {
+			const conflict = await driver.insertKernelConflict({
+				...evaluation.conflict,
+				created_at: evaluation.conflict.created_at || now,
+			}, context, config);
+			return { ...evaluation, conflict };
+		}
+
+		if (evaluation.decision !== 'accept') {
+			return evaluation;
+		}
+
+		return commitGuardedAccept({
+			driver, event: normalizedEvent, evaluation, claimScope, activeClaim, context, config, now,
+		});
+	}
+
+	// Route an issue mutation op through the guarded-event path: build the event,
+	// run it, and shape the issue-command-contract response/error.
+	async function runIssueMutation(operation, args, context) {
+		const config = getConfig();
+		const event = await buildIssueMutationEvent(driver, operation, args, context, config);
+		const result = await runGuardedEventImpl(event, context);
+		return mapMutationResult(driver, operation, event, result, context, config);
 	}
 
 	return {
@@ -313,76 +610,20 @@ function createLocalBroker(options = {}) {
 		},
 
 		async runIssueOperation(operation, args = [], context = {}) {
+			// Mutations (create/update/close/comment) flow through the guarded-event
+			// path to preserve CAS/idempotency/quarantine; reads delegate directly to
+			// the driver's parameterized SELECT branch.
+			if (ISSUE_MUTATION_OPERATIONS.has(operation)) {
+				requireGuardedDriverMethods(driver);
+				requireDriverMethod(driver, 'applyAcceptedIssueMutation');
+				return runIssueMutation(operation, args, context);
+			}
 			requireDriverMethod(driver, 'issueOperation');
 			return driver.issueOperation(operation, args, context, getConfig());
 		},
 
 		async runGuardedEvent(event, context = {}) {
-			requireGuardedDriverMethods(driver);
-
-			const config = getConfig();
-			const now = context.now || new Date().toISOString();
-			const normalizedEvent = {
-				...event,
-				created_at: event.created_at || now,
-			};
-			const dependencyScope = buildDependencyScope(normalizedEvent);
-			if (dependencyScope) {
-				requireDriverMethod(driver, 'listKernelDependencies');
-			}
-			const claimScope = buildClaimScope(normalizedEvent);
-			// A claim.create with a missing/invalid payload (or wrong entity) has no
-			// scope. Quarantine it instead of falling through as a non-claim event:
-			// the generic evaluator would otherwise accept and persist the event +
-			// outbox without ever creating a kernel_claims lease, so a later claim on
-			// the real issue would proceed as if nothing were claimed. BUT a retry of
-			// an already-accepted claim (same idempotency_key) must still replay as a
-			// duplicate even if this retry's payload is malformed, so check that first.
-			if (normalizedEvent.event_type === 'claim.create' && !claimScope) {
-				return (await replayDuplicateIfIdempotent(driver, normalizedEvent, context, config))
-					|| insertClaimConflictResult(driver, normalizedEvent, null, 'invalid_claim_scope', context, config, now);
-			}
-			if (claimScope) {
-				requireDriverMethod(driver, 'loadActiveKernelClaim');
-				requireDriverMethod(driver, 'insertKernelClaim');
-			}
-
-			const [entity, entityEvents, idempotencyEvent, dependencies, activeClaim] = await Promise.all([
-				driver.loadKernelEntity(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
-				driver.listKernelEvents(normalizedEvent.entity_type, normalizedEvent.entity_id, context, config),
-				driver.loadKernelEventByIdempotencyKey(normalizedEvent.idempotency_key, context, config),
-				dependencyScope
-					? driver.listKernelDependencies(dependencyScope, context, config)
-					: Promise.resolve([]),
-				claimScope
-					? driver.loadActiveKernelClaim(claimScope.issue_id, context, config)
-					: Promise.resolve(null),
-			]);
-			const priorEvents = idempotencyEvent
-				? [idempotencyEvent, ...entityEvents.filter(candidate => candidate.id !== idempotencyEvent.id)]
-				: entityEvents;
-			const evaluation = evaluateKernelEvent({
-				event: normalizedEvent,
-				entity,
-				priorEvents,
-				dependencies,
-			});
-
-			if (evaluation.decision === 'quarantine') {
-				const conflict = await driver.insertKernelConflict({
-					...evaluation.conflict,
-					created_at: evaluation.conflict.created_at || now,
-				}, context, config);
-				return { ...evaluation, conflict };
-			}
-
-			if (evaluation.decision !== 'accept') {
-				return evaluation;
-			}
-
-			return commitGuardedAccept({
-				driver, event: normalizedEvent, evaluation, claimScope, activeClaim, context, config, now,
-			});
+			return runGuardedEventImpl(event, context);
 		},
 
 		// --- Projection-outbox read/update surface (D16) -----------------------

--- a/lib/kernel/evaluators.js
+++ b/lib/kernel/evaluators.js
@@ -187,6 +187,7 @@ function evaluateKernelEvent(input = {}) {
 }
 
 module.exports = {
+	buildConflict,
 	dependencyCreatesCycle,
 	evaluateKernelEvent,
 	normalizePayload,

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -149,7 +149,7 @@ function safeAll(runtime, db, sql, params = []) {
 	}
 }
 
-function rowToIssueSummary(row, readinessEntry) {
+function rowToIssueSummary(row, readinessEntry, claimedBy = null) {
 	return {
 		id: row.id,
 		title: row.title,
@@ -159,7 +159,10 @@ function rowToIssueSummary(row, readinessEntry) {
 		rank: Number(row.priority_rank) || 0,
 		revision: Number(row.entity_revision) || 0,
 		blocked: readinessEntry ? Boolean(readinessEntry.blocked) : false,
-		claimed_by: row.claimed_by ?? null,
+		// kernel_issues has no claimed_by column; the active lease in kernel_claims is
+		// the authority. Derive the holder from the issue's active claim (the
+		// partial-UNIQUE index guarantees at most one), defaulting to null when free.
+		claimed_by: claimedBy ?? row.claimed_by ?? null,
 		updated_at: row.updated_at,
 	};
 }
@@ -188,7 +191,16 @@ function loadBoardReadiness(runtime, db, context = {}) {
 		now: context.now,
 		actor: context.actor,
 	});
-	return { issues, index };
+	// Surface the active lease holder per issue for issue summaries. Filter on state
+	// only (matches loadActiveKernelClaimRow); the partial-UNIQUE active-lease index
+	// guarantees at most one active row per issue, so the map is unambiguous.
+	const claimedById = {};
+	for (const claim of claims) {
+		if ((claim.state || 'active') === 'active' && claim.issue_id) {
+			claimedById[claim.issue_id] = claim.actor ?? null;
+		}
+	}
+	return { issues, index, claimedById };
 }
 
 function firstPositional(args = []) {
@@ -200,16 +212,16 @@ function firstPositional(args = []) {
 // through the broker's guarded-event path (later wave).
 function runIssueReadOperation(runtime, db, operation, args, context) {
 	if (operation === 'list') {
-		const { issues, index } = loadBoardReadiness(runtime, db, context);
+		const { issues, index, claimedById } = loadBoardReadiness(runtime, db, context);
 		const summaries = issues
-			.map(row => rowToIssueSummary(row, index.readinessById[row.id]))
+			.map(row => rowToIssueSummary(row, index.readinessById[row.id], claimedById[row.id]))
 			.sort((a, b) => (a.rank - b.rank) || String(a.id).localeCompare(String(b.id)));
 		return okIssueResponse('issue.list', { issues: summaries, count: summaries.length });
 	}
 	if (operation === 'ready') {
-		const { issues, index } = loadBoardReadiness(runtime, db, context);
+		const { issues, index, claimedById } = loadBoardReadiness(runtime, db, context);
 		const byId = new Map(issues.map(row => [row.id, row]));
-		const summaries = index.readyQueue.map(id => rowToIssueSummary(byId.get(id), index.readinessById[id]));
+		const summaries = index.readyQueue.map(id => rowToIssueSummary(byId.get(id), index.readinessById[id], claimedById[id]));
 		return okIssueResponse('issue.ready', { issues: summaries, count: summaries.length });
 	}
 	if (operation === 'show') {
@@ -223,8 +235,8 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 				exitCode: ISSUE_COMMAND_EXIT_CODES.notFound,
 			});
 		}
-		const { index } = loadBoardReadiness(runtime, db, context);
-		return okIssueResponse('issue.show', rowToIssueSummary(rows[0], index.readinessById[id]));
+		const { index, claimedById } = loadBoardReadiness(runtime, db, context);
+		return okIssueResponse('issue.show', rowToIssueSummary(rows[0], index.readinessById[id], claimedById[id]));
 	}
 	if (operation === 'search') {
 		const term = `%${firstPositional(args) || ''}%`;
@@ -233,8 +245,8 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 			'SELECT * FROM kernel_issues WHERE title LIKE ? OR body LIKE ? ORDER BY priority_rank ASC, id ASC',
 			[term, term],
 		);
-		const { index } = loadBoardReadiness(runtime, db, context);
-		const summaries = rows.map(row => rowToIssueSummary(row, index.readinessById[row.id]));
+		const { index, claimedById } = loadBoardReadiness(runtime, db, context);
+		const summaries = rows.map(row => rowToIssueSummary(row, index.readinessById[row.id], claimedById[row.id]));
 		return okIssueResponse('issue.search', { issues: summaries, count: summaries.length });
 	}
 	if (operation === 'stats') {
@@ -681,15 +693,43 @@ function applyAcceptedIssueEvent(runtime, db, event) {
 	values.push(now);
 	// Monotonic CAS bump: increment the stored revision on every accepted write
 	// (a create stays at 0 because the INSERT seeded 0 and this UPDATE runs once).
-	const nextRevision = existing ? Number(existing.entity_revision || 0) + 1 : 0;
+	const expectedRevision = Number(existing ? existing.entity_revision || 0 : 0);
+	const nextRevision = existing ? expectedRevision + 1 : 0;
 	assignments.push('entity_revision = ?');
 	values.push(nextRevision);
-	values.push(issueId);
+	if (existing) {
+		// Optimistic CAS at the row write for revision-bumping mutations (update/close).
+		// The evaluator pre-reads the entity OUTSIDE this transaction, so two writers
+		// that both pre-read rev=N both pass the evaluator; BEGIN IMMEDIATE then
+		// serializes them and the second would otherwise apply on top of N+1 — a silent
+		// lost update. Gate the WHERE on the event's expected_revision: if the row's
+		// actual revision has moved (0 rows changed), throw a tagged conflict the broker
+		// converts into a stale_revision quarantine. A create INSERTs a fresh row (the PK
+		// guards it) so it takes the un-gated path below.
+		const result = runParams(
+			runtime,
+			db,
+			`UPDATE kernel_issues SET ${assignments.join(', ')} WHERE id = ? AND entity_revision = ?`,
+			[...values, issueId, Number(event.expected_revision || 0)],
+		);
+		// Both runtimes' run() return a changed-row count (bun:sqlite .changes;
+		// node:sqlite StatementSync.run() → { changes, lastInsertRowid }). 0 changes
+		// means the CAS predicate (entity_revision = expected) matched no row.
+		if (Number(result?.changes || 0) === 0) {
+			const error = new Error('kernel issue revision conflict');
+			error.kernelRevisionConflict = true;
+			error.entityId = issueId;
+			error.expectedRevision = Number(event.expected_revision || 0);
+			error.actualRevision = expectedRevision;
+			throw error;
+		}
+		return { id: issueId, revision: nextRevision };
+	}
 	runParams(
 		runtime,
 		db,
 		`UPDATE kernel_issues SET ${assignments.join(', ')} WHERE id = ?`,
-		values,
+		[...values, issueId],
 	);
 	return { id: issueId, revision: nextRevision };
 }

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -423,6 +423,71 @@ function listKernelDependencyRows(runtime, db, _scope = {}) {
 	return safeAll(runtime, db, 'SELECT * FROM kernel_dependencies');
 }
 
+// Read the single live-lease candidate for an issue: the row in state='active'.
+// Filter on STATE ONLY, never on expiry — planClaimAcquisition needs the
+// expired-but-active row to fire its reclaim/supersede branch. Dropping it here
+// would null the active row and the next insert would collide on the partial
+// UNIQUE index (idx_kernel_claims_active_lease). The partial index guarantees at
+// most one such row, so the first match is authoritative.
+function loadActiveKernelClaimRow(runtime, db, issueId) {
+	const rows = allParams(
+		runtime,
+		db,
+		"SELECT * FROM kernel_claims WHERE issue_id = ? AND state = 'active' ORDER BY claimed_at ASC LIMIT 1",
+		[issueId],
+	);
+	return rows[0] || null;
+}
+
+// The 8 columns buildClaimRow (lease-enforcer) produces. The native
+// partial-UNIQUE(issue_id WHERE state='active') error is intentionally NOT caught
+// here — the broker's recoverGuardedFailure parses it to convert a cross-owner
+// lease collision into a claim_conflict quarantine.
+const KERNEL_CLAIM_COLUMNS = Object.freeze([
+	'id',
+	'issue_id',
+	'actor',
+	'state',
+	'session_id',
+	'worktree_id',
+	'claimed_at',
+	'expires_at',
+]);
+
+function insertKernelClaimRow(runtime, db, claim) {
+	const row = {
+		id: claim.id || randomUUID(),
+		issue_id: claim.issue_id,
+		actor: claim.actor,
+		state: claim.state || 'active',
+		session_id: claim.session_id ?? null,
+		worktree_id: claim.worktree_id ?? null,
+		claimed_at: claim.claimed_at,
+		expires_at: claim.expires_at ?? null,
+	};
+	const placeholders = KERNEL_CLAIM_COLUMNS.map(() => '?').join(', ');
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_claims (${KERNEL_CLAIM_COLUMNS.join(', ')}) VALUES (${placeholders})`,
+		KERNEL_CLAIM_COLUMNS.map(column => row[column]),
+	);
+	return { ...claim, id: row.id };
+}
+
+// Transition a claim row's state (e.g. active → reclaimable when superseding an
+// expired lease). Moving a row out of 'active' frees the partial-UNIQUE slot so a
+// fresh active lease can be inserted in the same transaction.
+function updateKernelClaimStateRow(runtime, db, claimId, state) {
+	runParams(
+		runtime,
+		db,
+		'UPDATE kernel_claims SET state = ? WHERE id = ?',
+		[state, claimId],
+	);
+	return { id: claimId, state };
+}
+
 // Columns the issue upsert may set from an accepted event payload. id/title are
 // required for a create; the rest are optional and only overwritten when present.
 const ISSUE_MUTABLE_COLUMNS = Object.freeze([
@@ -528,10 +593,83 @@ function applyAcceptedCommentEvent(runtime, db, event) {
 	return { id: payload.issue_id ?? event.entity_id, revision: Number(issue?.entity_revision || 0), comment_id: commentId };
 }
 
+// Insert the dependency edge for an accepted dependency.add event. The event's
+// entity_id IS the dependency row id (the broker scopes the event on the
+// 'dependency' entity stream), so the row is uniquely keyed without minting a new
+// id. This is the ONLY place dependency rows are written — the cycle guard already
+// fired in the evaluator before this accepted event reached the commit.
+function applyAcceptedDependencyAddEvent(runtime, db, event) {
+	const payload = event.payload || (event.payload_json ? JSON.parse(event.payload_json) : {});
+	const dependencyId = event.entity_id;
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_dependencies (id, issue_id, blocks_issue_id, dependency_type, created_at)
+			VALUES (?, ?, ?, ?, ?)`,
+		[
+			dependencyId,
+			payload.issue_id,
+			payload.blocks_issue_id,
+			payload.dependency_type || 'blocks',
+			event.created_at,
+		],
+	);
+	return { id: dependencyId, revision: 0, dependency_id: dependencyId };
+}
+
+// Delete the dependency edge for an accepted dependency.remove event, keyed by the
+// (issue_id, blocks_issue_id) pair the payload names — the dependent's id is not
+// the dependency row id, so delete by the edge endpoints, not entity_id.
+function applyAcceptedDependencyRemoveEvent(runtime, db, event) {
+	const payload = event.payload || (event.payload_json ? JSON.parse(event.payload_json) : {});
+	runParams(
+		runtime,
+		db,
+		'DELETE FROM kernel_dependencies WHERE issue_id = ? AND blocks_issue_id = ?',
+		[payload.issue_id, payload.blocks_issue_id],
+	);
+	return { id: event.entity_id, revision: 0, dependency_id: event.entity_id };
+}
+
+// Clear the active lease for an accepted claim.release event. Conservatively
+// releases the issue's active lease (the required ownership model is same-actor
+// "release clears it"; cross-owner authorization is deliberately out of scope).
+// claim.create is NOT handled here — its lease row is inserted by the broker's
+// insertKernelClaim inside commitGuardedAccept; re-inserting it here would be a
+// double-INSERT that trips the partial-UNIQUE index.
+function applyAcceptedClaimReleaseEvent(runtime, db, event) {
+	const payload = event.payload || (event.payload_json ? JSON.parse(event.payload_json) : {});
+	runParams(
+		runtime,
+		db,
+		"UPDATE kernel_claims SET state = 'released' WHERE issue_id = ? AND state = 'active'",
+		[payload.issue_id],
+	);
+	return { id: event.entity_id, revision: 0, claim_id: event.entity_id };
+}
+
 // Apply an accepted event's authority-table effect. Returns the mutation summary
-// ({id, revision, comment_id?}) the broker threads back into the issue-command
-// response, or null for events with no issue-table side effect (claims, deps).
+// ({id, revision, comment_id?/dependency_id?/claim_id?}) the broker threads back
+// into the issue-command response, or null for events with no synchronous
+// side effect here (claim.create's lease is written by the broker's
+// insertKernelClaim inside the transaction). The entity_type guard is critical:
+// dependency/claim events must NEVER fall into the issue-upsert branch, which
+// would corrupt kernel_issues with a bogus row keyed by the dep/claim id.
 function applyAcceptedMutation(runtime, db, event) {
+	if (event.entity_type === 'dependency') {
+		if (event.event_type === 'dependency.remove') {
+			return applyAcceptedDependencyRemoveEvent(runtime, db, event);
+		}
+		return applyAcceptedDependencyAddEvent(runtime, db, event);
+	}
+	if (event.entity_type === 'claim') {
+		if (event.event_type === 'claim.release') {
+			return applyAcceptedClaimReleaseEvent(runtime, db, event);
+		}
+		// claim.create: the lease row is written by the broker's insertKernelClaim
+		// inside commitGuardedAccept; no authority-table effect to apply here.
+		return null;
+	}
 	if (event.entity_type === 'issue' && event.event_type === 'issue.comment') {
 		return applyAcceptedCommentEvent(runtime, db, event);
 	}
@@ -625,6 +763,20 @@ function createDriver(runtime, configuredDatabasePath) {
 		},
 		async listKernelDependencies(scope, _context = {}, config = {}) {
 			return listKernelDependencyRows(runtime, getDatabase(config), scope);
+		},
+		// Claim-lease primitives (Wave 4) — composed by commitGuardedAccept /
+		// resolveClaimAcquisition. loadActiveKernelClaim feeds planClaimAcquisition;
+		// insertKernelClaim / updateKernelClaimState are the lease writes. The DB
+		// partial-UNIQUE index (idx_kernel_claims_active_lease) enforces the
+		// single-active-claim-per-issue invariant under concurrent writers.
+		async loadActiveKernelClaim(issueId, _context = {}, config = {}) {
+			return loadActiveKernelClaimRow(runtime, getDatabase(config), issueId);
+		},
+		async insertKernelClaim(claim, _context = {}, config = {}) {
+			return insertKernelClaimRow(runtime, getDatabase(config), claim);
+		},
+		async updateKernelClaimState(claimId, state, _context = {}, config = {}) {
+			return updateKernelClaimStateRow(runtime, getDatabase(config), claimId, state);
 		},
 		// commitGuardedAccept invokes this (typeof-guarded) INSIDE its BEGIN IMMEDIATE
 		// transaction to apply an accepted issue event to the authority tables. The

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -415,6 +415,130 @@ function enqueueKernelProjectionRow(runtime, db, entry) {
 	return { ...entry, id: row.id };
 }
 
+// --- Projection-outbox read/update primitives (Wave 5) ------------------------
+// The outbox consumer (projection-jsonl-writer.runJsonlProjectionConsumer) is the
+// PRECISE spec for these shapes. They are additive read/update writes over
+// kernel_outbox + kernel_dead_letters — they NEVER touch the append/CAS path
+// (insertKernelEvent / enqueueKernelProjection) and never mutate Kernel authority
+// tables. A projection failure is recorded out-of-band so the event log stays
+// the single source of truth.
+
+// List the drainable outbox rows for one target. `now` gates backoff: a row that
+// failed and was scheduled forward (next_attempt_at in the future) MUST NOT be
+// re-listed until its backoff elapses, else recordProjectionFailure's exponential
+// backoff is dead and a poison row re-drains every tick. A NULL next_attempt_at
+// (never-retried) is always eligible. Ordered by created_at so the snapshot the
+// consumer takes reflects insertion order deterministically.
+function listProjectionOutboxRows(runtime, db, filter = {}) {
+	const clauses = [];
+	const params = [];
+	if (filter.target !== undefined) {
+		clauses.push('target = ?');
+		params.push(filter.target);
+	}
+	if (filter.status !== undefined) {
+		clauses.push('status = ?');
+		params.push(filter.status);
+	}
+	if (filter.now !== undefined) {
+		clauses.push('(next_attempt_at IS NULL OR next_attempt_at <= ?)');
+		params.push(filter.now);
+	}
+	const where = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
+	return allParams(
+		runtime,
+		db,
+		`SELECT * FROM kernel_outbox${where} ORDER BY created_at ASC, id ASC`,
+		params,
+	);
+}
+
+// The full projection read-model: every authority issue/comment/dependency row.
+// The consumer renders ONE full snapshot per drain, so this returns the whole
+// board (not a delta). Tables may be empty on a fresh DB; safeAll degrades a
+// partially-migrated table to [].
+function loadProjectionModelRows(runtime, db) {
+	return {
+		issues: safeAll(runtime, db, 'SELECT * FROM kernel_issues ORDER BY id ASC'),
+		comments: safeAll(runtime, db, 'SELECT * FROM kernel_comments ORDER BY issue_id ASC, created_at ASC, id ASC'),
+		dependencies: safeAll(runtime, db, 'SELECT * FROM kernel_dependencies ORDER BY issue_id ASC, blocks_issue_id ASC, id ASC'),
+	};
+}
+
+// Mark the drained outbox rows delivered. Builds one `?` placeholder per id (never
+// interpolate ids) and guards an empty list so we don't emit `IN ()` (a syntax
+// error on both runtimes). Returns {updated:n} — the count the consumer reports.
+function markProjectionDeliveredRows(runtime, db, ids = [], _meta = {}) {
+	const list = Array.isArray(ids) ? ids.filter(id => id !== undefined && id !== null) : [];
+	if (list.length === 0) return { updated: 0 };
+	const placeholders = list.map(() => '?').join(', ');
+	runParams(
+		runtime,
+		db,
+		`UPDATE kernel_outbox SET status = 'delivered' WHERE id IN (${placeholders})`,
+		list,
+	);
+	return { updated: list.length };
+}
+
+// Record a transient projection failure: bump attempts + schedule the next retry
+// while keeping the row pending. kernel_outbox has NO error column, so the
+// record.error has nowhere to land here (it is surfaced only when the row is
+// finally dead-lettered) — that is intentional, not a dropped field.
+function recordProjectionFailureRows(runtime, db, record = {}) {
+	runParams(
+		runtime,
+		db,
+		"UPDATE kernel_outbox SET status = 'pending', attempts = ?, next_attempt_at = ? WHERE id = ?",
+		[Number(record.attempts || 0), record.next_attempt_at ?? null, record.id],
+	);
+	return { id: record.id, attempts: Number(record.attempts || 0) };
+}
+
+const KERNEL_DEAD_LETTER_COLUMNS = Object.freeze([
+	'id',
+	'outbox_id',
+	'target',
+	'status',
+	'error',
+	'payload_json',
+	'created_at',
+]);
+
+// Terminal projection failure: insert a dead_letters row AND transition the source
+// outbox row out of 'pending' (→ 'dead') so it is never re-drained. Both writes run
+// on the same connection; the consumer calls this from its catch path, not inside a
+// guarded transaction, so the two writes are best-effort sequential (a projection
+// failure must not block authority). Returns {id} (the new dead-letter id).
+function deadLetterProjectionRows(runtime, db, record = {}) {
+	const id = record.id || randomUUID();
+	const row = {
+		id,
+		outbox_id: record.outbox_id ?? null,
+		target: record.target,
+		status: record.status || 'open',
+		error: record.error ?? '',
+		payload_json: record.payload_json ?? JSON.stringify(record.payload ?? {}),
+		created_at: record.created_at ?? record.now,
+	};
+	const placeholders = KERNEL_DEAD_LETTER_COLUMNS.map(() => '?').join(', ');
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_dead_letters (${KERNEL_DEAD_LETTER_COLUMNS.join(', ')}) VALUES (${placeholders})`,
+		KERNEL_DEAD_LETTER_COLUMNS.map(column => row[column]),
+	);
+	if (record.outbox_id) {
+		runParams(
+			runtime,
+			db,
+			"UPDATE kernel_outbox SET status = 'dead' WHERE id = ?",
+			[record.outbox_id],
+		);
+	}
+	return { id };
+}
+
 // All blocking edges, so the evaluator can detect a cycle the new dependency.add
 // edge would close. The broker only calls this for dependency.add events with a
 // complete scope; an empty/absent table degrades to []. The cycle check needs the
@@ -760,6 +884,25 @@ function createDriver(runtime, configuredDatabasePath) {
 		},
 		async enqueueKernelProjection(entry, _context = {}, config = {}) {
 			return enqueueKernelProjectionRow(runtime, getDatabase(config), entry);
+		},
+		// --- Projection-outbox read/update surface (Wave 5) — composed by the
+		// broker's projection-outbox methods, consumed by runJsonlProjectionConsumer.
+		// These never touch the append/CAS path; `context` is part of the broker
+		// contract but unused by these direct reads/writes (prefixed `_`).
+		async listProjectionOutbox(filter = {}, _context = {}, config = {}) {
+			return listProjectionOutboxRows(runtime, getDatabase(config), filter);
+		},
+		async loadProjectionModel(_context = {}, config = {}) {
+			return loadProjectionModelRows(runtime, getDatabase(config));
+		},
+		async markProjectionDelivered(ids = [], meta = {}, _context = {}, config = {}) {
+			return markProjectionDeliveredRows(runtime, getDatabase(config), ids, meta);
+		},
+		async recordProjectionFailure(record, _context = {}, config = {}) {
+			return recordProjectionFailureRows(runtime, getDatabase(config), record);
+		},
+		async deadLetterProjection(record, _context = {}, config = {}) {
+			return deadLetterProjectionRows(runtime, getDatabase(config), record);
 		},
 		async listKernelDependencies(scope, _context = {}, config = {}) {
 			return listKernelDependencyRows(runtime, getDatabase(config), scope);

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -141,11 +141,16 @@ function runParams(runtime, db, sql, params = []) {
 }
 
 // A table may not exist on a partially-migrated DB; readiness inputs degrade to empty.
+// ONLY a missing-table error is tolerated — a locked/corrupt DB or a real SQL
+// regression must surface, not silently produce wrong readiness/stats/projection.
 function safeAll(runtime, db, sql, params = []) {
 	try {
 		return allParams(runtime, db, sql, params);
-	} catch {
-		return [];
+	} catch (error) {
+		if (/no such table/i.test(String(error?.message || ''))) {
+			return [];
+		}
+		throw error;
 	}
 }
 
@@ -194,7 +199,9 @@ function loadBoardReadiness(runtime, db, context = {}) {
 	// Surface the active lease holder per issue for issue summaries. Filter on state
 	// only (matches loadActiveKernelClaimRow); the partial-UNIQUE active-lease index
 	// guarantees at most one active row per issue, so the map is unambiguous.
-	const claimedById = {};
+	// Null-prototype map: issue ids are unconstrained external strings, so a literal `{}`
+	// keyed by them would be a prototype-pollution vector (matches buildReadinessIndex).
+	const claimedById = Object.create(null);
 	for (const claim of claims) {
 		if ((claim.state || 'active') === 'active' && claim.issue_id) {
 			claimedById[claim.issue_id] = claim.actor ?? null;

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -342,6 +342,205 @@ function loadKernelEventByIdempotencyKeyRow(runtime, db, idempotencyKey) {
 	return rows[0] || null;
 }
 
+// --- Guarded-event commit writes (Wave 3) -------------------------------------
+// commitGuardedAccept (broker) opens BEGIN IMMEDIATE, inserts the event + outbox,
+// and — via the typeof-guarded applyAcceptedIssueMutation hook — calls back into
+// the driver to apply the accepted issue mutation to the authority tables. These
+// writes run on the SAME connection inside the broker's transaction, so an event
+// insert and its issue-row effect commit (or roll back) atomically.
+
+// kernel_conflicts has no `reason`/`payload` columns; persist only the stored
+// schema columns (the evaluator's reason is encoded inside payload_json).
+const KERNEL_CONFLICT_COLUMNS = Object.freeze([
+	'id',
+	'entity_type',
+	'entity_id',
+	'expected_revision',
+	'actual_revision',
+	'status',
+	'payload_json',
+	'created_at',
+]);
+
+function insertKernelConflictRow(runtime, db, conflict) {
+	const row = {
+		id: conflict.id || randomUUID(),
+		entity_type: conflict.entity_type,
+		entity_id: conflict.entity_id,
+		expected_revision: Number(conflict.expected_revision || 0),
+		actual_revision: Number(conflict.actual_revision || 0),
+		status: conflict.status || 'quarantined',
+		payload_json: conflict.payload_json ?? JSON.stringify(conflict.payload ?? {}),
+		created_at: conflict.created_at,
+	};
+	const placeholders = KERNEL_CONFLICT_COLUMNS.map(() => '?').join(', ');
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_conflicts (${KERNEL_CONFLICT_COLUMNS.join(', ')}) VALUES (${placeholders})`,
+		KERNEL_CONFLICT_COLUMNS.map(column => row[column]),
+	);
+	return { ...conflict, id: row.id };
+}
+
+// kernel_outbox status/attempts default in the schema, but we write them explicitly
+// so a freshly-enqueued entry is fully specified regardless of runtime defaults.
+const KERNEL_OUTBOX_COLUMNS = Object.freeze([
+	'id',
+	'event_id',
+	'target',
+	'status',
+	'attempts',
+	'next_attempt_at',
+	'created_at',
+]);
+
+function enqueueKernelProjectionRow(runtime, db, entry) {
+	const row = {
+		id: entry.id || randomUUID(),
+		event_id: entry.event_id,
+		target: entry.target,
+		status: entry.status || 'pending',
+		attempts: Number(entry.attempts || 0),
+		next_attempt_at: entry.next_attempt_at ?? null,
+		created_at: entry.created_at,
+	};
+	const placeholders = KERNEL_OUTBOX_COLUMNS.map(() => '?').join(', ');
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_outbox (${KERNEL_OUTBOX_COLUMNS.join(', ')}) VALUES (${placeholders})`,
+		KERNEL_OUTBOX_COLUMNS.map(column => row[column]),
+	);
+	return { ...entry, id: row.id };
+}
+
+// All blocking edges, so the evaluator can detect a cycle the new dependency.add
+// edge would close. The broker only calls this for dependency.add events with a
+// complete scope; an empty/absent table degrades to []. The cycle check needs the
+// whole graph (not just the scoped edge), so `scope` is currently informational.
+function listKernelDependencyRows(runtime, db, _scope = {}) {
+	return safeAll(runtime, db, 'SELECT * FROM kernel_dependencies');
+}
+
+// Columns the issue upsert may set from an accepted event payload. id/title are
+// required for a create; the rest are optional and only overwritten when present.
+const ISSUE_MUTABLE_COLUMNS = Object.freeze([
+	'title',
+	'body',
+	'type',
+	'status',
+	'priority',
+	'priority_rank',
+	'parent_id',
+	'sprint_id',
+	'release_id',
+	'stage_state',
+	'labels',
+	'acceptance_criteria',
+	'estimate',
+]);
+
+// close drives the issue to a terminal status; an explicit payload.status (rework
+// transitions) still wins so the broker can model any accepted lifecycle move.
+function resolveMutationStatus(eventType, payload) {
+	if (typeof payload.status === 'string' && payload.status) return payload.status;
+	if (eventType === 'issue.close') return 'done';
+	return null;
+}
+
+// Upsert the issue row for an accepted issue event and bump entity_revision. The
+// evaluator already enforced CAS (expected_revision === stored), so the new
+// revision is monotonic: stored + 1 for an update, 0 for a fresh create.
+function applyAcceptedIssueEvent(runtime, db, event) {
+	const payload = event.payload || (event.payload_json ? JSON.parse(event.payload_json) : {});
+	const issueId = event.entity_id;
+	const now = event.created_at;
+	const existing = loadKernelEntityRow(runtime, db, 'issue', issueId);
+	const status = resolveMutationStatus(event.event_type, payload);
+
+	if (!existing) {
+		// Fresh create: seed required NOT NULL columns, then overwrite with any
+		// supplied payload values via the shared column map below.
+		runParams(
+			runtime,
+			db,
+			`INSERT INTO kernel_issues (id, title, type, status, priority, priority_rank, created_at, updated_at, entity_revision)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+			[
+				issueId,
+				payload.title ?? issueId,
+				payload.type ?? 'task',
+				status ?? payload.status ?? 'open',
+				payload.priority ?? 'P2',
+				Number(payload.priority_rank ?? 0),
+				now,
+				now,
+			],
+		);
+	}
+
+	const assignments = [];
+	const values = [];
+	for (const column of ISSUE_MUTABLE_COLUMNS) {
+		const value = column === 'status' ? status : payload[column];
+		if (value === undefined || value === null) continue;
+		assignments.push(`${column} = ?`);
+		values.push(value);
+	}
+	assignments.push('updated_at = ?');
+	values.push(now);
+	// Monotonic CAS bump: increment the stored revision on every accepted write
+	// (a create stays at 0 because the INSERT seeded 0 and this UPDATE runs once).
+	const nextRevision = existing ? Number(existing.entity_revision || 0) + 1 : 0;
+	assignments.push('entity_revision = ?');
+	values.push(nextRevision);
+	values.push(issueId);
+	runParams(
+		runtime,
+		db,
+		`UPDATE kernel_issues SET ${assignments.join(', ')} WHERE id = ?`,
+		values,
+	);
+	return { id: issueId, revision: nextRevision };
+}
+
+// Append a comment row for an accepted issue.comment event.
+function applyAcceptedCommentEvent(runtime, db, event) {
+	const payload = event.payload || (event.payload_json ? JSON.parse(event.payload_json) : {});
+	const commentId = payload.comment_id || randomUUID();
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_comments (id, issue_id, body, actor, visibility, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+		[
+			commentId,
+			payload.issue_id ?? event.entity_id,
+			payload.body ?? '',
+			event.actor ?? payload.actor ?? 'forge',
+			payload.visibility ?? 'local',
+			event.created_at,
+		],
+	);
+	// A comment never bumps the issue revision; report the host issue's current one.
+	const issue = loadKernelEntityRow(runtime, db, 'issue', payload.issue_id ?? event.entity_id);
+	return { id: payload.issue_id ?? event.entity_id, revision: Number(issue?.entity_revision || 0), comment_id: commentId };
+}
+
+// Apply an accepted event's authority-table effect. Returns the mutation summary
+// ({id, revision, comment_id?}) the broker threads back into the issue-command
+// response, or null for events with no issue-table side effect (claims, deps).
+function applyAcceptedMutation(runtime, db, event) {
+	if (event.entity_type === 'issue' && event.event_type === 'issue.comment') {
+		return applyAcceptedCommentEvent(runtime, db, event);
+	}
+	if (event.entity_type === 'issue') {
+		return applyAcceptedIssueEvent(runtime, db, event);
+	}
+	return null;
+}
+
 function closeDatabase(db) {
 	if (db && typeof db.close === 'function') {
 		db.close();
@@ -417,6 +616,22 @@ function createDriver(runtime, configuredDatabasePath) {
 		},
 		async loadKernelEventByIdempotencyKey(idempotencyKey, _context = {}, config = {}) {
 			return loadKernelEventByIdempotencyKeyRow(runtime, getDatabase(config), idempotencyKey);
+		},
+		async insertKernelConflict(conflict, _context = {}, config = {}) {
+			return insertKernelConflictRow(runtime, getDatabase(config), conflict);
+		},
+		async enqueueKernelProjection(entry, _context = {}, config = {}) {
+			return enqueueKernelProjectionRow(runtime, getDatabase(config), entry);
+		},
+		async listKernelDependencies(scope, _context = {}, config = {}) {
+			return listKernelDependencyRows(runtime, getDatabase(config), scope);
+		},
+		// commitGuardedAccept invokes this (typeof-guarded) INSIDE its BEGIN IMMEDIATE
+		// transaction to apply an accepted issue event to the authority tables. The
+		// returned summary ({id, revision, comment_id?}) flows back through
+		// runGuardedEvent's result so runIssueOperation can shape the mutation response.
+		async applyAcceptedIssueMutation(event, _context = {}, config = {}) {
+			return applyAcceptedMutation(runtime, getDatabase(config), event);
 		},
 		close() {
 			closeDatabase(db);

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -4,6 +4,13 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const {
+	ISSUE_COMMAND_SCHEMA_VERSION,
+	ISSUE_COMMAND_EXIT_CODES,
+	formatIssueCommandError,
+} = require('./issue-command-contract');
+const { buildReadinessIndex } = require('./readiness-model');
+
 const BUILTIN_SQLITE_RUNTIME_ORDER = Object.freeze(['bun:sqlite', 'node:sqlite']);
 let probeCounter = 0;
 
@@ -109,6 +116,133 @@ function queryOne(runtime, db, sql) {
 	return queryAll(runtime, db, sql)[0] || {};
 }
 
+// Parameterized statement helpers — bun:sqlite and node:sqlite both bind positional
+// `?` params, but expose them through different APIs. All issue-layer SQL MUST use these
+// (never string interpolation of values) to stay injection-safe.
+function allParams(runtime, db, sql, params = []) {
+	if (runtime.id === 'bun:sqlite') {
+		return db.query(sql).all(...params);
+	}
+	return db.prepare(sql).all(...params);
+}
+
+// A table may not exist on a partially-migrated DB; readiness inputs degrade to empty.
+function safeAll(runtime, db, sql, params = []) {
+	try {
+		return allParams(runtime, db, sql, params);
+	} catch {
+		return [];
+	}
+}
+
+function rowToIssueSummary(row, readinessEntry) {
+	return {
+		id: row.id,
+		title: row.title,
+		body: row.body ?? null,
+		type: row.type,
+		status: row.status,
+		rank: Number(row.priority_rank) || 0,
+		revision: Number(row.entity_revision) || 0,
+		blocked: readinessEntry ? Boolean(readinessEntry.blocked) : false,
+		claimed_by: row.claimed_by ?? null,
+		updated_at: row.updated_at,
+	};
+}
+
+function okIssueResponse(command, data, nextCommands = []) {
+	return {
+		ok: true,
+		schema_version: ISSUE_COMMAND_SCHEMA_VERSION,
+		command,
+		data,
+		next_commands: nextCommands,
+	};
+}
+
+// Derive the whole-board readiness read model (D18) from the authority tables.
+function loadBoardReadiness(runtime, db, context = {}) {
+	const issues = allParams(runtime, db, 'SELECT * FROM kernel_issues');
+	const dependencies = safeAll(runtime, db, 'SELECT * FROM kernel_dependencies');
+	const conflicts = safeAll(runtime, db, 'SELECT * FROM kernel_conflicts');
+	const claims = safeAll(runtime, db, 'SELECT * FROM kernel_claims');
+	const index = buildReadinessIndex({
+		issues,
+		dependencies,
+		conflicts,
+		claims,
+		now: context.now,
+		actor: context.actor,
+	});
+	return { issues, index };
+}
+
+function firstPositional(args = []) {
+	return (args || []).find(value => typeof value === 'string' && !value.startsWith('-'));
+}
+
+// Read-side of driver.issueOperation: ready/list/show/search/stats as parameterized
+// SELECTs returning issue-command-contract shapes. Mutations are handled separately
+// through the broker's guarded-event path (later wave).
+function runIssueReadOperation(runtime, db, operation, args, context) {
+	if (operation === 'list') {
+		const { issues, index } = loadBoardReadiness(runtime, db, context);
+		const summaries = issues
+			.map(row => rowToIssueSummary(row, index.readinessById[row.id]))
+			.sort((a, b) => (a.rank - b.rank) || String(a.id).localeCompare(String(b.id)));
+		return okIssueResponse('issue.list', { issues: summaries, count: summaries.length });
+	}
+	if (operation === 'ready') {
+		const { issues, index } = loadBoardReadiness(runtime, db, context);
+		const byId = new Map(issues.map(row => [row.id, row]));
+		const summaries = index.readyQueue.map(id => rowToIssueSummary(byId.get(id), index.readinessById[id]));
+		return okIssueResponse('issue.ready', { issues: summaries, count: summaries.length });
+	}
+	if (operation === 'show') {
+		const id = firstPositional(args);
+		const rows = allParams(runtime, db, 'SELECT * FROM kernel_issues WHERE id = ?', [id]);
+		if (!rows[0]) {
+			return formatIssueCommandError({
+				command: 'issue.show',
+				code: 'FORGE_ISSUE_NOT_FOUND',
+				message: `Issue ${id ?? '<missing id>'} not found`,
+				exitCode: ISSUE_COMMAND_EXIT_CODES.notFound,
+			});
+		}
+		const { index } = loadBoardReadiness(runtime, db, context);
+		return okIssueResponse('issue.show', rowToIssueSummary(rows[0], index.readinessById[id]));
+	}
+	if (operation === 'search') {
+		const term = `%${firstPositional(args) || ''}%`;
+		const rows = allParams(
+			runtime, db,
+			'SELECT * FROM kernel_issues WHERE title LIKE ? OR body LIKE ? ORDER BY priority_rank ASC, id ASC',
+			[term, term],
+		);
+		const { index } = loadBoardReadiness(runtime, db, context);
+		const summaries = rows.map(row => rowToIssueSummary(row, index.readinessById[row.id]));
+		return okIssueResponse('issue.search', { issues: summaries, count: summaries.length });
+	}
+	if (operation === 'stats') {
+		const { index } = loadBoardReadiness(runtime, db, context);
+		const statusRows = allParams(runtime, db, 'SELECT status, COUNT(*) AS n FROM kernel_issues GROUP BY status');
+		const counts = {};
+		for (const row of statusRows) {
+			counts[row.status] = Number(row.n);
+		}
+		const activeClaims = Number(
+			safeAll(runtime, db, "SELECT COUNT(*) AS n FROM kernel_claims WHERE state = 'active'")[0]?.n || 0,
+		);
+		return okIssueResponse('issue.stats', {
+			counts,
+			ready_count: index.readyQueue.length,
+			blocked_count: index.blocked.length,
+			active_claims: activeClaims,
+		});
+	}
+	return null;
+}
+
 function closeDatabase(db) {
 	if (db && typeof db.close === 'function') {
 		db.close();
@@ -159,6 +293,16 @@ function createDriver(runtime, configuredDatabasePath) {
 		},
 		async queryAll(statement, config) {
 			return queryAll(runtime, getDatabase(config), statement);
+		},
+		async issueOperation(operation, args = [], context = {}, config = {}) {
+			const database = getDatabase(config);
+			const READ_OPERATIONS = new Set(['ready', 'list', 'show', 'search', 'stats']);
+			if (READ_OPERATIONS.has(operation)) {
+				return runIssueReadOperation(runtime, database, operation, args, context);
+			}
+			// Mutations (create/update/close/comment/dep.add/dep.remove/claim/release) are
+			// implemented through the broker's guarded-event path in a later wave.
+			throw new Error(`Kernel SQLite driver issueOperation: mutation operation '${operation}' is not implemented yet (reads only)`);
 		},
 		close() {
 			closeDatabase(db);

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { randomUUID } = require('node:crypto');
 
 const {
 	ISSUE_COMMAND_SCHEMA_VERSION,
@@ -126,6 +127,19 @@ function allParams(runtime, db, sql, params = []) {
 	return db.prepare(sql).all(...params);
 }
 
+// Parameterized write helper (INSERT/UPDATE/DELETE). Like allParams, both runtimes
+// bind positional `?` params but expose .run() through different statement APIs. All
+// mutating issue-layer SQL MUST use this (never interpolate values) to stay
+// injection-safe. Native UNIQUE-constraint errors are intentionally allowed to
+// propagate unmodified — the broker parses their raw message to convert an
+// idempotency/lease collision into a duplicate replay.
+function runParams(runtime, db, sql, params = []) {
+	if (runtime.id === 'bun:sqlite') {
+		return db.query(sql).run(...params);
+	}
+	return db.prepare(sql).run(...params);
+}
+
 // A table may not exist on a partially-migrated DB; readiness inputs degrade to empty.
 function safeAll(runtime, db, sql, params = []) {
 	try {
@@ -243,6 +257,91 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 	return null;
 }
 
+// --- Event-store primitives (Wave 2) -------------------------------------------
+// Low-level reads/writes over kernel_events + kernel_issues that the broker's
+// guarded-event path composes. Signatures mirror the inline fake drivers in
+// broker-*.test.js exactly. CAS/idempotency/lease orchestration lives in the
+// broker; these stay deliberately mechanical.
+
+const KERNEL_EVENT_COLUMNS = Object.freeze([
+	'id',
+	'entity_type',
+	'entity_id',
+	'event_type',
+	'idempotency_key',
+	'expected_revision',
+	'actor',
+	'origin',
+	'payload_json',
+	'created_at',
+]);
+
+// Persist one event. The id is supplied by the caller or minted here (event ids are
+// TEXT, not autoincrement). The event's payload is stored as payload_json: a
+// pre-serialized payload_json wins, else the payload object is JSON-stringified. The
+// native UNIQUE(idempotency_key) error is intentionally NOT caught here.
+function insertKernelEventRow(runtime, db, event) {
+	const id = event.id || randomUUID();
+	const payloadJson = event.payload_json ?? JSON.stringify(event.payload ?? {});
+	const row = {
+		id,
+		entity_type: event.entity_type,
+		entity_id: event.entity_id,
+		event_type: event.event_type,
+		idempotency_key: event.idempotency_key,
+		expected_revision: event.expected_revision,
+		actor: event.actor,
+		origin: event.origin,
+		payload_json: payloadJson,
+		created_at: event.created_at,
+	};
+	const placeholders = KERNEL_EVENT_COLUMNS.map(() => '?').join(', ');
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_events (${KERNEL_EVENT_COLUMNS.join(', ')}) VALUES (${placeholders})`,
+		KERNEL_EVENT_COLUMNS.map(column => row[column]),
+	);
+	// Return what we wrote (minted id included) so callers can build the projection
+	// outbox entry — don't depend on .run()'s return shape across runtimes.
+	return { ...event, ...row };
+}
+
+// Read the entity-revision row for an issue (the CAS authority). Only issues store
+// entity_revision; any other entity type has no stored revision, so return null and
+// let the evaluator treat it as a brand-new (revision-0) entity.
+function loadKernelEntityRow(runtime, db, entityType, entityId) {
+	if (entityType !== 'issue') return null;
+	const rows = allParams(runtime, db, 'SELECT * FROM kernel_issues WHERE id = ?', [entityId]);
+	return rows[0] || null;
+}
+
+// Read the full event stream for one entity, oldest first (matches
+// idx_kernel_events_entity_created; there is no seq column, so created_at is the
+// ordering key).
+function listKernelEventRows(runtime, db, entityType, entityId) {
+	return allParams(
+		runtime,
+		db,
+		'SELECT * FROM kernel_events WHERE entity_type = ? AND entity_id = ? ORDER BY created_at ASC',
+		[entityType, entityId],
+	);
+}
+
+// Look up the committed event for an idempotency key (the duplicate-replay probe).
+// The broker calls this unconditionally inside a Promise.all even for keyless
+// events, so guard a falsy key up front rather than binding undefined.
+function loadKernelEventByIdempotencyKeyRow(runtime, db, idempotencyKey) {
+	if (!idempotencyKey) return null;
+	const rows = allParams(
+		runtime,
+		db,
+		'SELECT * FROM kernel_events WHERE idempotency_key = ?',
+		[idempotencyKey],
+	);
+	return rows[0] || null;
+}
+
 function closeDatabase(db) {
 	if (db && typeof db.close === 'function') {
 		db.close();
@@ -303,6 +402,21 @@ function createDriver(runtime, configuredDatabasePath) {
 			// Mutations (create/update/close/comment/dep.add/dep.remove/claim/release) are
 			// implemented through the broker's guarded-event path in a later wave.
 			throw new Error(`Kernel SQLite driver issueOperation: mutation operation '${operation}' is not implemented yet (reads only)`);
+		},
+		// --- Event-store primitives (Wave 2) — composed by broker.runGuardedEvent.
+		// `context` is part of the broker contract but unused by these direct SQL
+		// reads/writes (prefixed `_` for eslint no-unused-vars).
+		async insertKernelEvent(event, _context = {}, config = {}) {
+			return insertKernelEventRow(runtime, getDatabase(config), event);
+		},
+		async loadKernelEntity(entityType, entityId, _context = {}, config = {}) {
+			return loadKernelEntityRow(runtime, getDatabase(config), entityType, entityId);
+		},
+		async listKernelEvents(entityType, entityId, _context = {}, config = {}) {
+			return listKernelEventRows(runtime, getDatabase(config), entityType, entityId);
+		},
+		async loadKernelEventByIdempotencyKey(idempotencyKey, _context = {}, config = {}) {
+			return loadKernelEventByIdempotencyKeyRow(runtime, getDatabase(config), idempotencyKey);
 		},
 		close() {
 			closeDatabase(db);

--- a/test/kernel/driver-smoke.test.js
+++ b/test/kernel/driver-smoke.test.js
@@ -1,0 +1,281 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { runIssueOperation } = require('../../lib/forge-issues');
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+const { runJsonlProjectionConsumer } = require('../../lib/kernel/projection-jsonl-writer');
+
+// Windows releases the SQLite WAL/SHM mmap sidecars asynchronously after close, so
+// a teardown rmSync can race the unmap and throw EBUSY/EPERM (worse for the heavy
+// 13-op test). Retry with a REAL timer yield (a sync spin would block the very
+// thread that finalizes the unmap), then tolerate a final lock error only — the OS
+// reclaims temp dirs, so a Windows file race must not fail an otherwise-green test.
+// A non-lock error is a genuine bug and still rethrows. POSIX removes first try.
+async function removeDirWithRetry(dir, attempts = 10) {
+	for (let attempt = 0; attempt < attempts; attempt += 1) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+			return;
+		} catch (error) {
+			const locked = ['EBUSY', 'EPERM', 'ENOTEMPTY'].includes(error.code);
+			if (!locked || attempt === attempts - 1) {
+				if (locked) return;
+				throw error;
+			}
+			await new Promise(resolve => setTimeout(resolve, 100));
+		}
+	}
+}
+
+// Wave 5 (K-DRV): acceptance smoke. Drives ALL 13 issue ops through the PUBLIC
+// entry point — forge-issues.runIssueOperation(op, args, projectRoot, deps) with
+// deps.issueBackend='kernel' + kernelDatabasePath — against the REAL SQLite driver,
+// proving the full read + guarded-mutation surface answers contract-shaped results
+// end-to-end. A second focused test exercises the projection-outbox primitives the
+// 13 ops never reach (the consumer drains pending rows → marks delivered).
+//
+// Note (recorded finding): forge-issues.runIssueOperation does NOT call
+// broker.initialize() — production callers must migrate the kernel DB at setup.
+// The smoke test migrates once through a setup broker that SHARES the driver
+// instance (the driver caches its connection), so the per-op brokers built from
+// kernelDatabasePath see the already-migrated tables.
+describe('Kernel SQLite driver — acceptance smoke through the public entry point (Wave 5)', () => {
+	let tmpDir;
+	let dbPath;
+	let projectRoot;
+	let driver;
+	let deps;
+	const now = '2026-06-20T00:00:00.000Z';
+
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-smoke-'));
+		dbPath = path.join(tmpDir, 'kernel.sqlite');
+		projectRoot = tmpDir;
+		// Share ONE driver: createBuiltinSQLiteDriver({}) has no configured path, so it
+		// adopts config.databasePath and caches the open connection for the run.
+		driver = createBuiltinSQLiteDriver({});
+		const execFileSync = () => path.join(tmpDir, '.git');
+
+		// Migrate once: the public entry point never initializes the broker.
+		const setup = createLocalBroker({
+			projectRoot,
+			execFileSync,
+			databasePath: dbPath,
+			driver,
+		});
+		await setup.initialize();
+
+		// The deps the task names — issueBackend + kernelDatabasePath select the kernel
+		// backend; kernelDriver/execFileSync are the mechanically-required plumbing
+		// (no default driver; resolveGitCommonDir runs against projectRoot otherwise).
+		deps = {
+			issueBackend: 'kernel',
+			kernelDatabasePath: dbPath,
+			kernelDriver: driver,
+			execFileSync,
+		};
+	});
+
+	afterEach(async () => {
+		if (driver) driver.close();
+		// Windows can briefly hold a lock on the WAL/SHM sidecar files after close;
+		// retry the temp-dir removal (async yield) rather than failing on EBUSY.
+		if (tmpDir) await removeDirWithRetry(tmpDir);
+	});
+
+	function op(operation, args, ctx = {}) {
+		return runIssueOperation(operation, args, projectRoot, { ...deps, ...ctx });
+	}
+
+	test('all 13 issue ops answer ok-shaped results in sequence', async () => {
+		// 1. create — the issue under test.
+		const created = await op('create', ['--id', 'smoke-1', '--title', 'Primary', '--type', 'task'], { now, actor: 'tester' });
+		expect(created.ok).toBe(true);
+		expect(created.command).toBe('issue.create');
+		expect(created.data.id).toBe('smoke-1');
+		expect(created.data.revision).toBe(0);
+
+		// A second issue so dep.add/dep.remove have a valid FK-constrained blocker
+		// (a self-edge would trip the cycle guard → quarantine → not ok).
+		const blocker = await op('create', ['--id', 'smoke-2', '--title', 'Blocker', '--type', 'task'], { now, actor: 'tester' });
+		expect(blocker.ok).toBe(true);
+
+		// 2. list — both issues present.
+		const listed = await op('list', [], { now });
+		expect(listed.ok).toBe(true);
+		expect(listed.command).toBe('issue.list');
+		expect(listed.data.issues.map(issue => issue.id).sort()).toEqual(['smoke-1', 'smoke-2']);
+
+		// 3. ready — unblocked issues are ready.
+		const ready = await op('ready', [], { now });
+		expect(ready.ok).toBe(true);
+		expect(ready.command).toBe('issue.ready');
+		expect(ready.data.issues.map(issue => issue.id)).toContain('smoke-1');
+
+		// 4. show — single contract-shaped issue.
+		const shown = await op('show', ['smoke-1'], { now });
+		expect(shown.ok).toBe(true);
+		expect(shown.command).toBe('issue.show');
+		expect(shown.data).toMatchObject({ id: 'smoke-1', title: 'Primary', status: 'open', revision: 0 });
+
+		// 5. update — bumps the revision.
+		const updated = await op('update', ['smoke-1', '--status', 'in_progress'], { now: '2026-06-20T00:01:00.000Z', actor: 'tester' });
+		expect(updated.ok).toBe(true);
+		expect(updated.command).toBe('issue.update');
+		expect(updated.data.revision).toBe(1);
+
+		// 6. comment — appends a comment, returns comment_id.
+		const commented = await op('comment', ['smoke-1', 'A handoff note'], { now: '2026-06-20T00:02:00.000Z', actor: 'tester' });
+		expect(commented.ok).toBe(true);
+		expect(commented.command).toBe('issue.comment');
+		expect(typeof commented.data.comment_id).toBe('string');
+		expect(commented.data.comment_id.length).toBeGreaterThan(0);
+
+		// 7. claim — acquires an active lease, returns claim_id.
+		const claimed = await op('claim', ['--issue', 'smoke-1'], { now: '2026-06-20T00:03:00.000Z', actor: 'alice' });
+		expect(claimed.ok).toBe(true);
+		expect(claimed.command).toBe('claim');
+		expect(typeof claimed.data.claim_id).toBe('string');
+		expect(claimed.data.claim_id.length).toBeGreaterThan(0);
+
+		// 8. release — clears the lease (must follow claim).
+		const released = await op('release', ['--issue', 'smoke-1'], { now: '2026-06-20T00:04:00.000Z', actor: 'alice' });
+		expect(released.ok).toBe(true);
+		expect(released.command).toBe('release');
+		expect(typeof released.data.claim_id).toBe('string');
+
+		// 9. dep.add — smoke-1 blocked by smoke-2, returns dependency_id.
+		const depAdded = await op('dep.add', ['--issue', 'smoke-1', '--blocks', 'smoke-2'], { now: '2026-06-20T00:05:00.000Z', actor: 'tester' });
+		expect(depAdded.ok).toBe(true);
+		expect(depAdded.command).toBe('issue.dep.add');
+		expect(typeof depAdded.data.dependency_id).toBe('string');
+		expect(depAdded.data.dependency_id.length).toBeGreaterThan(0);
+
+		// 10. dep.remove — restores the edge (must follow dep.add).
+		const depRemoved = await op('dep.remove', ['--issue', 'smoke-1', '--blocks', 'smoke-2'], { now: '2026-06-20T00:06:00.000Z', actor: 'tester' });
+		expect(depRemoved.ok).toBe(true);
+		expect(depRemoved.command).toBe('issue.dep.remove');
+		expect(typeof depRemoved.data.dependency_id).toBe('string');
+
+		// 11. search — title/body LIKE match.
+		const searched = await op('search', ['Primary'], { now });
+		expect(searched.ok).toBe(true);
+		expect(searched.command).toBe('issue.search');
+		expect(searched.data.issues.map(issue => issue.id)).toContain('smoke-1');
+
+		// 12. stats — aggregate counts.
+		const stats = await op('stats', [], { now });
+		expect(stats.ok).toBe(true);
+		expect(stats.command).toBe('issue.stats');
+		expect(typeof stats.data.counts).toBe('object');
+
+		// 13. close — terminal status, bumps the revision again.
+		const closed = await op('close', ['smoke-1'], { now: '2026-06-20T00:07:00.000Z', actor: 'tester' });
+		expect(closed.ok).toBe(true);
+		expect(closed.command).toBe('issue.close');
+		expect(closed.data.revision).toBe(2);
+	});
+
+	test('projection-outbox primitives drain pending rows through the real driver', async () => {
+		// Each accepted mutation enqueues a pending kernel_outbox row. Run the JSONL
+		// consumer against a broker built from the SAME shared driver: it lists pending
+		// rows (target/status/now filtered), loads the projection model, writes a
+		// snapshot, and marks the drained rows delivered — exercising 3 of the 5 new
+		// primitives end-to-end against the real SQLite driver.
+		await op('create', ['--id', 'proj-1', '--title', 'Projected', '--type', 'task'], { now, actor: 'tester' });
+		await op('comment', ['proj-1', 'note'], { now: '2026-06-20T00:01:00.000Z', actor: 'tester' });
+
+		const consumerBroker = createLocalBroker({
+			projectRoot,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+
+		const projectionDir = path.join(tmpDir, 'projection');
+		const result = await runJsonlProjectionConsumer({
+			broker: consumerBroker,
+			projectionDir,
+			projectRoot,
+			now: '2026-06-20T00:10:00.000Z',
+			target: 'beads', // commitGuardedAccept defaults the outbox target to 'beads'
+		});
+
+		expect(result.written).toBe(true);
+		expect(result.drained).toBeGreaterThanOrEqual(2);
+		expect(result.delivered.length).toBe(result.drained);
+		expect(result.dead).toEqual([]);
+		expect(result.retried).toEqual([]);
+
+		// Drained rows are now delivered, so a second drain finds nothing pending.
+		const second = await runJsonlProjectionConsumer({
+			broker: consumerBroker,
+			projectionDir,
+			projectRoot,
+			now: '2026-06-20T00:11:00.000Z',
+			target: 'beads',
+		});
+		expect(second.drained).toBe(0);
+		expect(second.written).toBe(false);
+	});
+
+	test('recordProjectionFailure keeps a row pending under backoff and deadLetterProjection retires it', async () => {
+		// Drive the failure + dead-letter primitives directly against the real driver
+		// (the consumer only reaches them on a write error). Enqueue one pending row,
+		// then prove: (a) a failure with a FUTURE next_attempt_at hides the row from a
+		// now-gated list, and (b) dead-lettering inserts a dead_letters row and flips
+		// the outbox row out of pending so it is never re-drained.
+		await op('create', ['--id', 'fail-1', '--title', 'Fails', '--type', 'task'], { now, actor: 'tester' });
+
+		const consumerBroker = createLocalBroker({
+			projectRoot,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+
+		const pending = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T00:10:00.000Z' });
+		expect(pending.length).toBe(1);
+		const row = pending[0];
+
+		await consumerBroker.recordProjectionFailure({
+			id: row.id,
+			attempts: 1,
+			next_attempt_at: '2026-06-20T01:00:00.000Z',
+			error: 'boom',
+			now: '2026-06-20T00:10:00.000Z',
+		});
+
+		// The row is still pending but in backoff — a now-gated list before the
+		// backoff elapses must NOT return it.
+		const beforeBackoff = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T00:30:00.000Z' });
+		expect(beforeBackoff.map(entry => entry.id)).not.toContain(row.id);
+		// After the backoff elapses, the row is eligible again.
+		const afterBackoff = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T02:00:00.000Z' });
+		expect(afterBackoff.map(entry => entry.id)).toContain(row.id);
+
+		// Dead-letter it: a dead_letters row is inserted and the outbox row leaves
+		// 'pending' so it is never re-drained.
+		const dead = await consumerBroker.deadLetterProjection({
+			outbox_id: row.id,
+			target: 'beads',
+			error: 'boom',
+			payload_json: JSON.stringify({ event_id: row.event_id, attempts: 5 }),
+			now: '2026-06-20T02:00:00.000Z',
+		});
+		expect(typeof dead.id).toBe('string');
+		expect(dead.id.length).toBeGreaterThan(0);
+
+		const deadLetters = await driver.queryAll('SELECT * FROM kernel_dead_letters', { databasePath: dbPath });
+		expect(deadLetters).toHaveLength(1);
+		expect(deadLetters[0].outbox_id).toBe(row.id);
+
+		const stillPending = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T03:00:00.000Z' });
+		expect(stillPending.map(entry => entry.id)).not.toContain(row.id);
+	});
+});

--- a/test/kernel/sqlite-driver-deps-claims.test.js
+++ b/test/kernel/sqlite-driver-deps-claims.test.js
@@ -1,0 +1,298 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Wave 4 (K-DRV): dependencies + claims through the broker's guarded-event path.
+// dep.add/dep.remove and claim/release are issue mutations that build a kernel
+// event (entity_type 'dependency'/'claim') and run through runGuardedEvent. The
+// real SQLite driver supplies the low-level claim primitives (loadActiveKernelClaim
+// / insertKernelClaim / updateKernelClaimState) plus the dependency/claim authority
+// writes (applyAcceptedIssueMutation). The single-active-claim-per-issue lease is a
+// DB-enforced partial UNIQUE index, exercised end-to-end here.
+describe('Kernel SQLite driver — dependencies + claims via guarded path (Wave 4)', () => {
+	let tmpDir;
+	let driver;
+	let broker;
+	let config;
+	const now = '2026-06-20T00:00:00.000Z';
+
+	async function createIssue(id, title = id) {
+		return broker.runIssueOperation(
+			'create',
+			['--id', id, '--title', title, '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+	}
+
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-deps-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// --- Dependencies -----------------------------------------------------------
+
+	test('dep.add inserts a dependency row and makes the dependent blocked (out of ready)', async () => {
+		await createIssue('dep-a', 'Dependent');
+		await createIssue('dep-b', 'Blocker');
+
+		// dep-a is blocked BY dep-b: issue_id=dep-a, blocks_issue_id=dep-b.
+		const added = await broker.runIssueOperation(
+			'dep.add',
+			['--issue', 'dep-a', '--blocks', 'dep-b'],
+			{ now, actor: 'tester' },
+		);
+
+		expect(added.ok).toBe(true);
+		expect(added.command).toBe('issue.dep.add');
+		expect(typeof added.data.dependency_id).toBe('string');
+		expect(added.data.dependency_id.length).toBeGreaterThan(0);
+
+		const rows = await driver.queryAll('SELECT * FROM kernel_dependencies', config);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].issue_id).toBe('dep-a');
+		expect(rows[0].blocks_issue_id).toBe('dep-b');
+
+		// dep-a is now blocked → absent from the ready queue; dep-b is ready.
+		const ready = await driver.issueOperation('ready', [], { now }, config);
+		const readyIds = ready.data.issues.map(issue => issue.id);
+		expect(readyIds).toContain('dep-b');
+		expect(readyIds).not.toContain('dep-a');
+
+		const shown = await driver.issueOperation('show', ['dep-a'], { now }, config);
+		expect(shown.data.blocked).toBe(true);
+	});
+
+	test('dep.remove deletes the dependency row and restores the dependent to ready', async () => {
+		await createIssue('rem-a', 'Dependent');
+		await createIssue('rem-b', 'Blocker');
+		await broker.runIssueOperation(
+			'dep.add',
+			['--issue', 'rem-a', '--blocks', 'rem-b'],
+			{ now, actor: 'tester' },
+		);
+
+		const removed = await broker.runIssueOperation(
+			'dep.remove',
+			['--issue', 'rem-a', '--blocks', 'rem-b'],
+			{ now: '2026-06-20T00:01:00.000Z', actor: 'tester' },
+		);
+
+		expect(removed.ok).toBe(true);
+		expect(removed.command).toBe('issue.dep.remove');
+
+		const rows = await driver.queryAll('SELECT * FROM kernel_dependencies', config);
+		expect(rows).toHaveLength(0);
+
+		const ready = await driver.issueOperation('ready', [], { now }, config);
+		const readyIds = ready.data.issues.map(issue => issue.id);
+		expect(readyIds).toContain('rem-a');
+	});
+
+	test('dep.add closing a cycle quarantines as dependency_cycle and writes no edge', async () => {
+		await createIssue('cyc-a');
+		await createIssue('cyc-b');
+		// a blocked by b.
+		await broker.runIssueOperation(
+			'dep.add',
+			['--issue', 'cyc-a', '--blocks', 'cyc-b'],
+			{ now, actor: 'tester' },
+		);
+
+		// b blocked by a → closes a cycle, must quarantine.
+		const cycle = await broker.runIssueOperation(
+			'dep.add',
+			['--issue', 'cyc-b', '--blocks', 'cyc-a'],
+			{ now: '2026-06-20T00:01:00.000Z', actor: 'tester' },
+		);
+
+		expect(cycle.ok).toBe(false);
+		expect(cycle.command).toBe('issue.dep.add');
+		expect(cycle.error.code).toContain('DEPENDENCY_CYCLE');
+		expect(cycle.error.exit_code).toBe(4);
+
+		// Only the first (valid) edge persists; the cycle edge was never written.
+		const rows = await driver.queryAll('SELECT * FROM kernel_dependencies', config);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].issue_id).toBe('cyc-a');
+
+		const conflicts = await driver.queryAll('SELECT * FROM kernel_conflicts', config);
+		expect(conflicts).toHaveLength(1);
+	});
+
+	// --- Claims -----------------------------------------------------------------
+
+	test('claim creates an active lease row and returns a claim_id', async () => {
+		await createIssue('clm-1', 'Claimable');
+
+		const claimed = await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-1'],
+			{ now, actor: 'alice' },
+		);
+
+		expect(claimed.ok).toBe(true);
+		expect(claimed.command).toBe('claim');
+		expect(typeof claimed.data.claim_id).toBe('string');
+		expect(claimed.data.claim_id.length).toBeGreaterThan(0);
+
+		const rows = await driver.queryAll('SELECT * FROM kernel_claims', config);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].issue_id).toBe('clm-1');
+		expect(rows[0].actor).toBe('alice');
+		expect(rows[0].state).toBe('active');
+	});
+
+	test('a second claim on the same issue by another actor is a non-retryable conflict (lease held)', async () => {
+		await createIssue('clm-2', 'Contended');
+
+		const first = await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-2'],
+			{ now, actor: 'alice' },
+		);
+		expect(first.ok).toBe(true);
+
+		const second = await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-2'],
+			{ now: '2026-06-20T00:01:00.000Z', actor: 'bob' },
+		);
+
+		expect(second.ok).toBe(false);
+		expect(second.command).toBe('claim');
+		expect(second.error.code).toContain('CLAIM_CONFLICT');
+		expect(second.error.exit_code).toBe(4);
+		expect(second.error.retryable).toBe(false);
+
+		// Exactly one active lease survives; it still belongs to alice.
+		const active = await driver.queryAll(
+			'SELECT * FROM kernel_claims WHERE issue_id = \'clm-2\' AND state = \'active\'',
+			config,
+		);
+		expect(active).toHaveLength(1);
+		expect(active[0].actor).toBe('alice');
+	});
+
+	test('release clears the active lease so the issue can be claimed again', async () => {
+		await createIssue('clm-3', 'Releasable');
+		await broker.runIssueOperation('claim', ['--issue', 'clm-3'], { now, actor: 'alice' });
+
+		const released = await broker.runIssueOperation(
+			'release',
+			['--issue', 'clm-3'],
+			{ now: '2026-06-20T00:01:00.000Z', actor: 'alice' },
+		);
+		expect(released.ok).toBe(true);
+		expect(released.command).toBe('release');
+
+		const active = await driver.queryAll(
+			'SELECT * FROM kernel_claims WHERE issue_id = \'clm-3\' AND state = \'active\'',
+			config,
+		);
+		expect(active).toHaveLength(0);
+
+		// A fresh actor may now acquire the issue.
+		const reclaimed = await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-3'],
+			{ now: '2026-06-20T00:02:00.000Z', actor: 'bob' },
+		);
+		expect(reclaimed.ok).toBe(true);
+
+		const nowActive = await driver.queryAll(
+			'SELECT * FROM kernel_claims WHERE issue_id = \'clm-3\' AND state = \'active\'',
+			config,
+		);
+		expect(nowActive).toHaveLength(1);
+		expect(nowActive[0].actor).toBe('bob');
+	});
+
+	test('loadActiveKernelClaim returns an expired-but-active row so the broker can reclaim it', async () => {
+		await createIssue('clm-4', 'Expiring');
+		await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-4', '--expires', '2026-06-20T00:00:30.000Z'],
+			{ now, actor: 'alice' },
+		);
+
+		// A new claim by bob AFTER the lease expired must succeed by superseding the
+		// stale lease (planClaimAcquisition reclaim path needs the still-active row).
+		const reclaimed = await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-4'],
+			{ now: '2026-06-20T01:00:00.000Z', actor: 'bob' },
+		);
+		expect(reclaimed.ok).toBe(true);
+
+		const active = await driver.queryAll(
+			'SELECT * FROM kernel_claims WHERE issue_id = \'clm-4\' AND state = \'active\'',
+			config,
+		);
+		expect(active).toHaveLength(1);
+		expect(active[0].actor).toBe('bob');
+	});
+
+	test('the DB partial-unique index rejects a second active lease for the same issue', async () => {
+		// The user-facing claim conflict tests above all short-circuit on the broker's
+		// in-memory pre-read (planClaimAcquisition sees the active row before any
+		// transaction). This drives the DB-level invariant DIRECTLY — two raw active
+		// inserts for one issue — proving (a) the partial UNIQUE index actually rejects
+		// the second lease, and (b) the real bun:sqlite error message matches the exact
+		// predicate broker.isClaimLeaseConflict relies on to recover a multi-process race.
+		await createIssue('lease-x', 'Index guard');
+		const base = { issue_id: 'lease-x', state: 'active', claimed_at: now, expires_at: null };
+		await driver.insertKernelClaim({ ...base, id: 'claim-a', actor: 'alice' }, {}, config);
+
+		let err;
+		try {
+			await driver.insertKernelClaim({ ...base, id: 'claim-b', actor: 'bob' }, {}, config);
+		} catch (caught) {
+			err = caught;
+		}
+
+		expect(err).toBeDefined();
+		expect(String(err.message)).toMatch(/UNIQUE constraint failed/i);
+		expect(String(err.message)).toMatch(/kernel_claims\.issue_id/i);
+
+		const active = await driver.queryAll(
+			'SELECT * FROM kernel_claims WHERE issue_id = \'lease-x\' AND state = \'active\'',
+			config,
+		);
+		expect(active).toHaveLength(1);
+	});
+
+	test('a same-actor claim retry replays as a single lease (idempotent, no conflict)', async () => {
+		await createIssue('clm-5', 'Retryable');
+		const args = ['--issue', 'clm-5'];
+		const ctx = { now, actor: 'alice', idempotencyKey: 'claim:clm-5:alice' };
+
+		const first = await broker.runIssueOperation('claim', args, ctx);
+		expect(first.ok).toBe(true);
+
+		const retry = await broker.runIssueOperation('claim', args, { ...ctx, now: '2026-06-20T00:01:00.000Z' });
+		expect(retry.ok).toBe(true);
+
+		const rows = await driver.queryAll('SELECT * FROM kernel_claims WHERE issue_id = \'clm-5\'', config);
+		expect(rows).toHaveLength(1);
+	});
+});

--- a/test/kernel/sqlite-driver-events.test.js
+++ b/test/kernel/sqlite-driver-events.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const { describe, test, expect, beforeAll, afterAll } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Wave 2 (K-DRV): event-store primitives on the SQLite driver. These are the
+// low-level reads/writes the broker's guarded-event path composes — signatures
+// MUST mirror the inline fake drivers in broker-*.test.js exactly:
+//   insertKernelEvent(event, context, config)            -> { ...event, id }
+//   loadKernelEntity(entityType, entityId, context, config) -> row | null
+//   listKernelEvents(entityType, entityId, context, config) -> row[]  (created_at ASC)
+//   loadKernelEventByIdempotencyKey(key, context, config)   -> row | null
+describe('Kernel SQLite driver — event-store primitives (Wave 2)', () => {
+	let tmpDir;
+	let driver;
+	let config;
+	const now = '2026-06-19T00:00:00.000Z';
+
+	beforeAll(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-events-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		const broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+
+		// Seed one issue so loadKernelEntity has an entity-revision row to read.
+		await driver.exec(
+			`INSERT INTO kernel_issues (id,title,type,status,priority_rank,created_at,updated_at,entity_revision) VALUES
+				('forge-1','Alpha task','task','open',1,'${now}','${now}',5);`,
+			config,
+		);
+	});
+
+	afterAll(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('insertKernelEvent persists an event and returns it with a minted id', async () => {
+		const inserted = await driver.insertKernelEvent({
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.create',
+			idempotency_key: 'create:forge-1',
+			expected_revision: 0,
+			actor: 'tester',
+			origin: 'cli',
+			payload: { title: 'Alpha task' },
+			created_at: '2026-06-19T00:00:01.000Z',
+		}, {}, config);
+
+		expect(typeof inserted.id).toBe('string');
+		expect(inserted.id.length).toBeGreaterThan(0);
+		expect(inserted.entity_id).toBe('forge-1');
+		expect(inserted.event_type).toBe('issue.create');
+
+		// Round-trip: it is retrievable by its idempotency key.
+		const fetched = await driver.loadKernelEventByIdempotencyKey('create:forge-1', {}, config);
+		expect(fetched).not.toBeNull();
+		expect(fetched.id).toBe(inserted.id);
+		expect(fetched.event_type).toBe('issue.create');
+		expect(fetched.payload_json).toBe(JSON.stringify({ title: 'Alpha task' }));
+	});
+
+	test('insertKernelEvent honors an explicit event id and a pre-serialized payload_json', async () => {
+		const inserted = await driver.insertKernelEvent({
+			id: 'event-explicit',
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.update',
+			idempotency_key: 'update:forge-1:rev-5',
+			expected_revision: 5,
+			actor: 'tester',
+			origin: 'cli',
+			payload_json: '{"title":"Renamed"}',
+			created_at: '2026-06-19T00:00:02.000Z',
+		}, {}, config);
+
+		expect(inserted.id).toBe('event-explicit');
+		const fetched = await driver.loadKernelEventByIdempotencyKey('update:forge-1:rev-5', {}, config);
+		expect(fetched.id).toBe('event-explicit');
+		expect(fetched.payload_json).toBe('{"title":"Renamed"}');
+	});
+
+	test('duplicate idempotency_key surfaces the raw UNIQUE constraint error (broker recovery relies on the message)', async () => {
+		await expect(driver.insertKernelEvent({
+			entity_type: 'issue',
+			entity_id: 'forge-1',
+			event_type: 'issue.update',
+			idempotency_key: 'create:forge-1',
+			expected_revision: 0,
+			actor: 'tester',
+			origin: 'cli',
+			payload: {},
+			created_at: '2026-06-19T00:00:03.000Z',
+		}, {}, config)).rejects.toThrow(/UNIQUE constraint failed/i);
+	});
+
+	test('listKernelEvents returns an entity stream ordered by created_at ASC', async () => {
+		const rows = await driver.listKernelEvents('issue', 'forge-1', {}, config);
+		expect(rows.map(row => row.idempotency_key)).toEqual([
+			'create:forge-1',
+			'update:forge-1:rev-5',
+		]);
+	});
+
+	test('listKernelEvents returns [] for an entity with no events', async () => {
+		const rows = await driver.listKernelEvents('issue', 'forge-unknown', {}, config);
+		expect(rows).toEqual([]);
+	});
+
+	test('loadKernelEventByIdempotencyKey returns null for a missing key and for a falsy key', async () => {
+		expect(await driver.loadKernelEventByIdempotencyKey('does-not-exist', {}, config)).toBeNull();
+		expect(await driver.loadKernelEventByIdempotencyKey(undefined, {}, config)).toBeNull();
+	});
+
+	test('loadKernelEntity reads the entity-revision row for an issue', async () => {
+		const entity = await driver.loadKernelEntity('issue', 'forge-1', {}, config);
+		expect(entity).not.toBeNull();
+		expect(entity.id).toBe('forge-1');
+		expect(Number(entity.entity_revision)).toBe(5);
+	});
+
+	test('loadKernelEntity returns null for a missing issue', async () => {
+		expect(await driver.loadKernelEntity('issue', 'forge-unknown', {}, config)).toBeNull();
+	});
+
+	test('loadKernelEntity returns null for a non-issue entity type (no stored revision)', async () => {
+		expect(await driver.loadKernelEntity('claim', 'claim-1', {}, config)).toBeNull();
+	});
+});

--- a/test/kernel/sqlite-driver-issue.test.js
+++ b/test/kernel/sqlite-driver-issue.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const { describe, test, expect, beforeAll, afterAll } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Wave 1 (K-DRV): the SQLite driver's issueOperation read branch. Mutations are a
+// later wave and must still throw. Acceptance for reads = contract-shaped responses
+// (forge.issue.v1) with derived ready/blocked from the readiness model.
+describe('Kernel SQLite driver — issueOperation reads (Wave 1)', () => {
+	let tmpDir;
+	let driver;
+	let config;
+	const now = '2026-06-19T00:00:00.000Z';
+
+	beforeAll(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-issue-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		const broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+
+		await driver.exec(
+			`INSERT INTO kernel_issues (id,title,type,status,priority_rank,created_at,updated_at,entity_revision) VALUES
+				('k1','Alpha task','task','open',1,'${now}','${now}',0),
+				('k2','Beta bug','bug','open',2,'${now}','${now}',0),
+				('k3','Closed thing','task','done',3,'${now}','${now}',0);`,
+			config,
+		);
+		// k1 depends on k2 (k2 blocks k1) — so k1 is blocked while k2 stays open.
+		await driver.exec(
+			`INSERT INTO kernel_dependencies (id,issue_id,blocks_issue_id,dependency_type,created_at) VALUES
+				('d1','k1','k2','blocks','${now}');`,
+			config,
+		);
+	});
+
+	afterAll(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('list returns a contract-shaped issueList ranked by priority_rank', async () => {
+		const res = await driver.issueOperation('list', [], {}, config);
+		expect(res.ok).toBe(true);
+		expect(res.schema_version).toBe('forge.issue.v1');
+		expect(res.command).toBe('issue.list');
+		expect(res.data.issues.map(issue => issue.id)).toEqual(['k1', 'k2', 'k3']);
+		expect(res.data.count).toBe(3);
+		expect(res.data.issues.find(issue => issue.id === 'k1')).toMatchObject({
+			title: 'Alpha task', type: 'task', status: 'open', revision: 0,
+		});
+		expect(Array.isArray(res.next_commands)).toBe(true);
+	});
+
+	test('ready excludes blocked (k1) and closed (k3) — k2 is the only ready issue', async () => {
+		const res = await driver.issueOperation('ready', [], {}, config);
+		expect(res.ok).toBe(true);
+		expect(res.data.issues.map(issue => issue.id)).toEqual(['k2']);
+	});
+
+	test('show returns one issue with the derived blocked flag', async () => {
+		const res = await driver.issueOperation('show', ['k1'], {}, config);
+		expect(res.ok).toBe(true);
+		expect(res.data).toMatchObject({ id: 'k1', blocked: true, status: 'open' });
+	});
+
+	test('show on a missing id returns the notFound error shape', async () => {
+		const res = await driver.issueOperation('show', ['nope'], {}, config);
+		expect(res.ok).toBe(false);
+		expect(res.error.code).toBe('FORGE_ISSUE_NOT_FOUND');
+		expect(res.error.exit_code).toBe(3);
+		expect(res.error.retryable).toBe(false);
+	});
+
+	test('search matches a title substring', async () => {
+		const res = await driver.issueOperation('search', ['Beta'], {}, config);
+		expect(res.data.issues.map(issue => issue.id)).toEqual(['k2']);
+	});
+
+	test('stats reports status counts plus derived ready/blocked/active_claims', async () => {
+		const res = await driver.issueOperation('stats', [], {}, config);
+		expect(res.ok).toBe(true);
+		expect(res.data.counts).toMatchObject({ open: 2, done: 1 });
+		expect(res.data.ready_count).toBe(1);
+		expect(res.data.blocked_count).toBe(1);
+		expect(res.data.active_claims).toBe(0);
+	});
+
+	test('a mutation op still throws (deferred to a later wave)', async () => {
+		await expect(driver.issueOperation('create', ['x'], {}, config)).rejects.toThrow(/not implemented yet/);
+	});
+});

--- a/test/kernel/sqlite-driver-mutations.test.js
+++ b/test/kernel/sqlite-driver-mutations.test.js
@@ -1,0 +1,278 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Wave 3 (K-DRV): issue MUTATIONS through the broker's guarded-event path. The
+// broker's runIssueOperation detects mutation ops, builds a kernel event from the
+// CLI args, and routes through runGuardedEvent (CAS/idempotency/quarantine intact).
+// The real SQLite driver supplies the commit writes commitGuardedAccept needs
+// (issue upsert, entity_revision bump, comment insert) via applyAcceptedIssueMutation.
+describe('Kernel SQLite driver — issue mutations via guarded path (Wave 3)', () => {
+	let tmpDir;
+	let driver;
+	let broker;
+	let config;
+	const now = '2026-06-19T00:00:00.000Z';
+
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-mut-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('create then show round-trips a contract-shaped issue at revision 0', async () => {
+		const created = await broker.runIssueOperation(
+			'create',
+			['--id', 'forge-1', '--title', 'Alpha task', '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+
+		expect(created.ok).toBe(true);
+		expect(created.schema_version).toBe('forge.issue.v1');
+		expect(created.command).toBe('issue.create');
+		expect(created.data.id).toBe('forge-1');
+		expect(created.data.revision).toBe(0);
+
+		const shown = await driver.issueOperation('show', ['forge-1'], {}, config);
+		expect(shown.ok).toBe(true);
+		expect(shown.data).toMatchObject({
+			id: 'forge-1',
+			title: 'Alpha task',
+			type: 'task',
+			status: 'open',
+			revision: 0,
+		});
+	});
+
+	test('update --status bumps the entity_revision', async () => {
+		await broker.runIssueOperation(
+			'create',
+			['--id', 'forge-2', '--title', 'Beta', '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+
+		const updated = await broker.runIssueOperation(
+			'update',
+			['forge-2', '--status', 'in_progress'],
+			{ now: '2026-06-19T00:01:00.000Z', actor: 'tester' },
+		);
+
+		expect(updated.ok).toBe(true);
+		expect(updated.command).toBe('issue.update');
+		expect(updated.data.id).toBe('forge-2');
+		expect(updated.data.revision).toBe(1);
+
+		const shown = await driver.issueOperation('show', ['forge-2'], {}, config);
+		expect(shown.data.status).toBe('in_progress');
+		expect(shown.data.revision).toBe(1);
+	});
+
+	test('close drives the issue to a terminal status and bumps the revision', async () => {
+		await broker.runIssueOperation(
+			'create',
+			['--id', 'forge-3', '--title', 'Gamma', '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+
+		const closed = await broker.runIssueOperation(
+			'close',
+			['forge-3'],
+			{ now: '2026-06-19T00:02:00.000Z', actor: 'tester' },
+		);
+
+		expect(closed.ok).toBe(true);
+		expect(closed.command).toBe('issue.close');
+		expect(closed.data.revision).toBe(1);
+
+		const shown = await driver.issueOperation('show', ['forge-3'], {}, config);
+		expect(shown.data.status).toBe('done');
+	});
+
+	test('comment appends a row to kernel_comments and returns a comment_id', async () => {
+		await broker.runIssueOperation(
+			'create',
+			['--id', 'forge-4', '--title', 'Delta', '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+
+		const commented = await broker.runIssueOperation(
+			'comment',
+			['forge-4', 'A handoff note'],
+			{ now: '2026-06-19T00:03:00.000Z', actor: 'tester' },
+		);
+
+		expect(commented.ok).toBe(true);
+		expect(commented.command).toBe('issue.comment');
+		expect(typeof commented.data.comment_id).toBe('string');
+		expect(commented.data.comment_id.length).toBeGreaterThan(0);
+
+		const rows = await driver.queryAll('SELECT * FROM kernel_comments WHERE issue_id = \'forge-4\'', config);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].body).toBe('A handoff note');
+		expect(rows[0].actor).toBe('tester');
+	});
+
+	test('a second comment on the same issue appends a distinct row (no idempotency collision)', async () => {
+		await broker.runIssueOperation(
+			'create',
+			['--id', 'forge-4b', '--title', 'Delta', '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+
+		const first = await broker.runIssueOperation(
+			'comment', ['forge-4b', 'First note'], { now: '2026-06-19T00:03:00.000Z', actor: 'tester' },
+		);
+		const second = await broker.runIssueOperation(
+			'comment', ['forge-4b', 'Second note'], { now: '2026-06-19T00:03:30.000Z', actor: 'tester' },
+		);
+
+		expect(first.data.comment_id).not.toBe(second.data.comment_id);
+		const rows = await driver.queryAll('SELECT * FROM kernel_comments WHERE issue_id = \'forge-4b\' ORDER BY created_at ASC', config);
+		expect(rows).toHaveLength(2);
+		expect(rows.map(row => row.body)).toEqual(['First note', 'Second note']);
+	});
+
+	test('create twice through runIssueOperation replays as a single row (duplicate mapping)', async () => {
+		const createArgs = ['--id', 'forge-dup', '--title', 'Dup', '--type', 'task'];
+
+		const first = await broker.runIssueOperation('create', createArgs, { now, actor: 'tester' });
+		expect(first.ok).toBe(true);
+		expect(first.data.revision).toBe(0);
+
+		// Same --id → same synthesized idempotency key → duplicate replay, NOT a
+		// second row. The mapped response stays ok and reports the single row.
+		const second = await broker.runIssueOperation('create', createArgs, { now: '2026-06-19T00:07:00.000Z', actor: 'tester' });
+		expect(second.ok).toBe(true);
+		expect(second.command).toBe('issue.create');
+		expect(second.data.id).toBe('forge-dup');
+		expect(second.data.revision).toBe(0);
+
+		const rows = await driver.queryAll('SELECT * FROM kernel_issues WHERE id = \'forge-dup\'', config);
+		expect(rows).toHaveLength(1);
+	});
+
+	test('a stale expected_revision quarantines against the real driver and leaves the issue untouched', async () => {
+		await broker.runIssueOperation(
+			'create',
+			['--id', 'forge-5', '--title', 'Epsilon', '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+		// Drive the CAS forward once so the live revision is 1.
+		await broker.runIssueOperation(
+			'update',
+			['forge-5', '--status', 'in_progress'],
+			{ now: '2026-06-19T00:04:00.000Z', actor: 'tester' },
+		);
+
+		// A guarded event with a behind expected_revision (0 against live 1) must
+		// quarantine — this is the CAS proof against the REAL driver.
+		const stale = await broker.runGuardedEvent({
+			entity_type: 'issue',
+			entity_id: 'forge-5',
+			event_type: 'issue.update',
+			idempotency_key: 'issue-update:forge-5:stale',
+			expected_revision: 0,
+			actor: 'tester',
+			origin: 'cli',
+			payload: { status: 'review' },
+		}, { now: '2026-06-19T00:05:00.000Z' });
+
+		expect(stale.decision).toBe('quarantine');
+		expect(stale.reason).toBe('stale_revision');
+
+		const conflicts = await driver.queryAll('SELECT * FROM kernel_conflicts', config);
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0].entity_id).toBe('forge-5');
+
+		// The issue row is untouched by the quarantined write.
+		const shown = await driver.issueOperation('show', ['forge-5'], {}, config);
+		expect(shown.data.revision).toBe(1);
+		expect(shown.data.status).toBe('in_progress');
+	});
+
+	test('a duplicate idempotency key replays as a single row (no double-write)', async () => {
+		const event = () => ({
+			entity_type: 'issue',
+			entity_id: 'forge-6',
+			event_type: 'issue.create',
+			idempotency_key: 'issue-create:forge-6',
+			expected_revision: 0,
+			actor: 'tester',
+			origin: 'cli',
+			payload: { id: 'forge-6', title: 'Zeta', type: 'task', status: 'open' },
+		});
+
+		const first = await broker.runGuardedEvent(event(), { now });
+		expect(first.decision).toBe('accept');
+
+		const replay = await broker.runGuardedEvent(event(), { now: '2026-06-19T00:06:00.000Z' });
+		expect(replay.decision).toBe('duplicate');
+
+		const rows = await driver.queryAll('SELECT * FROM kernel_issues WHERE id = \'forge-6\'', config);
+		expect(rows).toHaveLength(1);
+		const events = await driver.queryAll('SELECT * FROM kernel_events WHERE idempotency_key = \'issue-create:forge-6\'', config);
+		expect(events).toHaveLength(1);
+	});
+
+	test('runIssueOperation maps a quarantine decision to a retryable conflict error', async () => {
+		// Drive the user-facing path (runIssueOperation → mapMutationResult) into the
+		// quarantine branch with a fake whose stored revision is ahead of what
+		// buildIssueMutationEvent reads — proving the error shape the adapter returns.
+		const fake = {
+			async exec() {},
+			async issueOperation() { throw new Error('reads only'); },
+			loadKernelEntityCalls: 0,
+			async loadKernelEntity() {
+				// First read (event build) sees revision 0; the guarded re-read sees 5,
+				// so the evaluator quarantines as stale_revision.
+				this.loadKernelEntityCalls += 1;
+				return this.loadKernelEntityCalls === 1 ? { entity_revision: 0 } : { entity_revision: 5 };
+			},
+			async listKernelEvents() { return []; },
+			async loadKernelEventByIdempotencyKey() { return null; },
+			async insertKernelConflict(conflict) { return { ...conflict, id: 'conflict-1' }; },
+			async insertKernelEvent(event) { return { ...event, id: 'event-1' }; },
+			async enqueueKernelProjection(entry) { return { ...entry, id: 'outbox-1' }; },
+			async applyAcceptedIssueMutation() { return { id: 'x', revision: 0 }; },
+		};
+		const fakeBroker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: path.join(tmpDir, 'kernel-fake.sqlite'),
+			driver: fake,
+		});
+
+		const res = await fakeBroker.runIssueOperation('update', ['forge-x', '--status', 'review'], { now });
+
+		expect(res.ok).toBe(false);
+		expect(res.command).toBe('issue.update');
+		expect(res.error.exit_code).toBe(4);
+		expect(res.error.retryable).toBe(true);
+		expect(res.error.code).toContain('STALE_REVISION');
+	});
+
+	test('mutation ops do not reach driver.issueOperation (which still throws for writes)', async () => {
+		// Sanity: the broker intercepts mutations; the driver-level mutation branch
+		// remains unimplemented (Wave 1 contract preserved).
+		await expect(driver.issueOperation('create', ['x'], {}, config)).rejects.toThrow(/not implemented yet/);
+	});
+});

--- a/test/kernel/sqlite-driver-mutations.test.js
+++ b/test/kernel/sqlite-driver-mutations.test.js
@@ -275,4 +275,168 @@ describe('Kernel SQLite driver — issue mutations via guarded path (Wave 3)', (
 		// remains unimplemented (Wave 1 contract preserved).
 		await expect(driver.issueOperation('create', ['x'], {}, config)).rejects.toThrow(/not implemented yet/);
 	});
+
+	test('row-level CAS rejects a concurrent lost update: two accepted writes both at expected_revision=0', async () => {
+		// THE RACE PROOF. The evaluator pre-reads the entity OUTSIDE the transaction
+		// (broker Promise.all), so under TRUE concurrency two writers can both pre-read
+		// rev=N, both pass the evaluator, and the second would silently apply on top of
+		// N+1 — a lost update returned as decision:accept. A sequential test can't
+		// reproduce that (writer 2's pre-read would see N+1 and the evaluator would
+		// quarantine first), so we drive the driver's applyAcceptedIssueMutation hook
+		// DIRECTLY with two accepted events that BOTH carry expected_revision=0,
+		// simulating the post-evaluator commit of two writers that both saw rev 0.
+		await broker.runIssueOperation(
+			'create', ['--id', 'race-1', '--title', 'Race', '--type', 'task'], { now, actor: 'tester' },
+		);
+
+		const updateEvent = key => ({
+			entity_type: 'issue',
+			entity_id: 'race-1',
+			event_type: 'issue.update',
+			idempotency_key: key,
+			expected_revision: 0, // both writers observed rev 0 before either committed
+			actor: 'tester',
+			origin: 'cli',
+			payload: { status: 'in_progress' },
+			created_at: '2026-06-19T00:10:00.000Z',
+		});
+
+		// First accepted write applies cleanly: rev 0 → 1.
+		const firstApply = await driver.applyAcceptedIssueMutation(updateEvent('race:a'), {}, config);
+		expect(firstApply.revision).toBe(1);
+
+		// Second accepted write ALSO carries expected_revision=0 but the row is now at
+		// rev 1. Old code computed nextRevision = 1 + 1 and silently bumped to 2 (lost
+		// update). The CAS gates the UPDATE on entity_revision=0, matches 0 rows, and
+		// throws the tagged conflict the broker maps to stale_revision.
+		let caught;
+		try {
+			await driver.applyAcceptedIssueMutation(updateEvent('race:b'), {}, config);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeDefined();
+		expect(caught.kernelRevisionConflict).toBe(true);
+		expect(caught.entityId).toBe('race-1');
+
+		// The lost update was prevented: the row is still at rev 1, NOT 2.
+		const shown = await driver.issueOperation('show', ['race-1'], {}, config);
+		expect(shown.data.revision).toBe(1);
+		expect(shown.data.status).toBe('in_progress');
+	});
+
+	test('broker maps a driver revision-conflict into a stale_revision quarantine (recovery path)', async () => {
+		// The driver CAS throws INSIDE commitGuardedAccept; recoverGuardedFailure must
+		// catch the tagged error, ROLLBACK, and quarantine as stale_revision (not
+		// rethrow). Wrap the real driver so applyAcceptedIssueMutation throws the tag,
+		// proving the broker recovery branch end-to-end against the real event store.
+		await broker.runIssueOperation(
+			'create', ['--id', 'race-2', '--title', 'Race2', '--type', 'task'], { now, actor: 'tester' },
+		);
+
+		const guarded = {
+			...driver,
+			async applyAcceptedIssueMutation() {
+				const error = new Error('kernel issue revision conflict');
+				error.kernelRevisionConflict = true;
+				error.entityId = 'race-2';
+				error.expectedRevision = 0;
+				error.actualRevision = 3;
+				throw error;
+			},
+		};
+		const guardedBroker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: path.join(tmpDir, 'kernel.sqlite'),
+			driver: guarded,
+		});
+
+		const result = await guardedBroker.runGuardedEvent({
+			entity_type: 'issue',
+			entity_id: 'race-2',
+			event_type: 'issue.update',
+			idempotency_key: 'issue-update:race-2:cas',
+			expected_revision: 0,
+			actor: 'tester',
+			origin: 'cli',
+			payload: { status: 'review' },
+		}, { now: '2026-06-19T00:11:00.000Z' });
+
+		expect(result.decision).toBe('quarantine');
+		expect(result.reason).toBe('stale_revision');
+		expect(result.projection).toBe(false);
+
+		// A stale_revision conflict row was persisted (byte-identical evaluator shape).
+		const conflicts = await driver.queryAll('SELECT * FROM kernel_conflicts WHERE entity_id = \'race-2\'', config);
+		expect(conflicts).toHaveLength(1);
+
+		// The event was rolled back — no event/outbox row leaked from the failed accept.
+		const events = await driver.queryAll('SELECT * FROM kernel_events WHERE idempotency_key = \'issue-update:race-2:cas\'', config);
+		expect(events).toHaveLength(0);
+	});
+
+	test('runIssueOperation surfaces a driver revision-conflict as a retryable conflict error', async () => {
+		// The user-facing mapping: a driver-detected CAS conflict (not just the
+		// evaluator's pre-read quarantine) must reach mapMutationResult as a RETRYABLE
+		// stale_revision error so the adapter can re-read and retry.
+		await broker.runIssueOperation(
+			'create', ['--id', 'race-3', '--title', 'Race3', '--type', 'task'], { now, actor: 'tester' },
+		);
+
+		const guarded = {
+			...driver,
+			async applyAcceptedIssueMutation() {
+				const error = new Error('kernel issue revision conflict');
+				error.kernelRevisionConflict = true;
+				error.entityId = 'race-3';
+				error.actualRevision = 2;
+				throw error;
+			},
+		};
+		const guardedBroker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: path.join(tmpDir, 'kernel.sqlite'),
+			driver: guarded,
+		});
+
+		const res = await guardedBroker.runIssueOperation('update', ['race-3', '--status', 'review'], { now: '2026-06-19T00:12:00.000Z', actor: 'tester' });
+
+		expect(res.ok).toBe(false);
+		expect(res.command).toBe('issue.update');
+		expect(res.error.retryable).toBe(true);
+		expect(res.error.code).toContain('STALE_REVISION');
+	});
+
+	test('claimed_by is derived from the active lease and cleared on release', async () => {
+		// rowToIssueSummary has no claimed_by column to read; the active kernel_claims
+		// lease is the authority. Claiming an issue must surface claimed_by=<actor> in
+		// show AND list; releasing must clear it back to null.
+		await broker.runIssueOperation(
+			'create', ['--id', 'claimable-1', '--title', 'Claim me', '--type', 'task'], { now, actor: 'tester' },
+		);
+
+		// Before any claim, claimed_by is null.
+		const beforeShow = await driver.issueOperation('show', ['claimable-1'], {}, config);
+		expect(beforeShow.data.claimed_by).toBeNull();
+
+		await broker.runIssueOperation(
+			'claim', ['--issue', 'claimable-1'], { now: '2026-06-19T00:20:00.000Z', actor: 'alice' },
+		);
+
+		const claimedShow = await driver.issueOperation('show', ['claimable-1'], {}, config);
+		expect(claimedShow.data.claimed_by).toBe('alice');
+
+		const listed = await driver.issueOperation('list', [], {}, config);
+		const listedIssue = listed.data.issues.find(issue => issue.id === 'claimable-1');
+		expect(listedIssue.claimed_by).toBe('alice');
+
+		await broker.runIssueOperation(
+			'release', ['--issue', 'claimable-1'], { now: '2026-06-19T00:21:00.000Z', actor: 'alice' },
+		);
+
+		const releasedShow = await driver.issueOperation('show', ['claimable-1'], {}, config);
+		expect(releasedShow.data.claimed_by).toBeNull();
+	});
 });


### PR DESCRIPTION
## Problem

The Forge Kernel could not serve a single issue. A smoke spike ran all 13 issue ops via `issueBackend=kernel` and **every one threw** `Kernel local broker driver must provide issueOperation()`. The kernel scaffolding — driver runtime (#207), broker domain logic + leases (#220), schema/contract (#212/#219), JSONL projection (#218) — existed but was proven only against **mock/test drivers**. The real SQLite persistence driver implemented only `exec`/`queryAll`, so the kernel was effectively dormant: `lib/forge-issues.js` routes to Beads unless `issueBackend=kernel`, and selecting the kernel threw on every op.

## Root Cause

The 16 driver methods the broker requires — `issueOperation` (the 13 ops) + 9 guarded-event primitives + 6 projection-outbox methods — were never implemented on `lib/kernel/sqlite-driver.js`. #220's broker logic was tested with inline fake drivers, masking that the production driver had no issue/event implementation.

## Fix

Implements the full driver issue layer as parameterized SQL over the existing kernel schema, TDD, across 5 waves + a CAS-hardening fix:

- **Wave 1 — reads** (`ready/list/show/search/stats`) as direct SELECTs → `forge.issue.v1` contract shapes, with derived `ready`/`blocked` from the readiness model.
- **Wave 2 — event-store primitives** (`insertKernelEvent`/`loadKernelEntity`/`listKernelEvents`/`loadKernelEventByIdempotencyKey`).
- **Wave 3 — mutations** (`create/update/close/comment`) routed through the broker's proven guarded-event path (surgical `runIssueOperation` change; `runGuardedEvent` unchanged) so CAS/idempotency/quarantine are preserved.
- **Wave 4 — dependencies + claims** with the DB-enforced single-active-claim lease (validated the real `bun:sqlite` UNIQUE error against the recovery predicate — #220 had only tested fakes).
- **Wave 5 — projection-outbox primitives** + the 13-op acceptance smoke test.
- **CAS hardening** — issue-revision CAS made atomic at the row write (`UPDATE … WHERE entity_revision = expected_revision`; 0 rows → `stale_revision` quarantine), closing a lost-update race under concurrency that the adversarial review found. `claimed_by` now derived from the active lease.

## Value

The kernel can serve issues for the first time (`issueBackend=kernel`), unblocking dogfooding, the Beads→kernel migration (K8), and the eventual default-flip (K11). **The kernel runs alongside Beads — no Beads removal, no default change in this PR.**

## Beads
<!-- Deferred — bd/Dolt unreachable (K0). Issues filed into the kernel after K0. -->

<details><summary>Implementation Details</summary>

### Test Coverage
- Full kernel suite **260 pass / 0 fail**; 13-op smoke (`driver-smoke.test.js`) green; blast-radius (adapters/forge-issues/_issue/release-readiness) **93 pass**; `bun run check` green.
- The CAS race test was confirmed to **fail against the pre-fix code** (old code silently bumped the revision) — it genuinely guards the race.

### Security Review
- **A03 Injection — PASS** (adversarial review): every value-bearing statement is parameterized via `allParams`/`runParams`; column lists come from frozen allowlists, never payload keys. The escape-hatch `exec`/`queryAll` are only reached with migration DDL / fixed transaction-control statements.
- **Guarded-event correctness:** mutations provably route through `runGuardedEvent` — no direct-write back door (authority-write functions are module-private, invoked only inside `commitGuardedAccept`'s `BEGIN IMMEDIATE`).

### Out of scope (by design — for reviewers)
- Taxonomy enum validation on the mutation path is deferred to a separate validation layer (`design.md`), so out-of-enum `type`/`status` can currently round-trip; the response envelope stays contract-shaped.
- No runtime JSON-schema validator (tests use field assertions) — a test-design note, not a code defect.
- `node:sqlite` `.changes` is documented but exercised via `bun:sqlite` (the active runtime) — noted in a code comment.

### Design Doc
- `docs/work/2026-06-19-kernel-driver-issue-layer/{design.md,tasks.md}` (D34 external-planner artifact; bd ceremony deferred to K0).

### Validation
- [x] Lint passing (0 errors, 0 warnings)
- [x] All tests passing (`bun run check`)
- [x] Security review completed (SQL-injection PASS; guarded-event routing clean)
</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled real SQLite-backed issue reads (list/ready/show/search/stats) and derived readiness behavior.
  * Added guarded mutation routing for create/update/close/comment with idempotency and revision conflict quarantine.
  * Implemented full dependency edge handling (including cycle quarantine) plus claim/lease enforcement (claim, release, reclamation).
  * Added projection outbox delivery and dead-lettering for projection failures.
* **Documentation**
  * Added Kernel Driver Issue Layer design doc and a TDD task plan.
* **Tests**
  * Expanded driver and end-to-end coverage for reads, guarded writes, events, projections, dependencies, and claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->