### PR TITLE
feat(kernel): Wave 2 agent-parity — comments in show, label write, reparent + close --reason, suggest-next

### DIFF
--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -9,7 +9,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 | --- | ---: | ---: |
 | command | 120 | 11 |
 | runtime | 343 | 47 |
-| docs | 435 | 67 |
+| docs | 436 | 67 |
 | skills | 22 | 9 |
 | hooks | 0 | 0 |
 
@@ -185,8 +185,8 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 10 (bd), 80 (bd), 81 (bd, dolt), 85 (dolt), 109 (dolt)
 - [ ] docs/guides/SUPPORT.md (26)
   - lines: 18 (bd), 19 (bd, dolt), 23 (bd), 53 (dolt), 58 (dolt), 60 (.beads), 66 (bd), 67 (bd, dolt), 68 (bd, dolt), 69 (bd, dolt), 72 (.beads, dolt), 76 (.beads), 78 (bd), 79 (.beads), 80 (.beads), 81 (bd, dolt), 85 (dolt), 87 (.beads), 93 (bd), 94 (bd, dolt), 119 (dolt), 131 (.beads), 144 (.beads), 152 (.beads), 158 (.beads), 165 (.beads)
-- [ ] docs/PROJECT_DESIGN.md (19)
-  - lines: 20 (dolt), 29 (.beads), 47 (dolt), 59 (dolt), 61 (dolt), 64 (dolt), 65 (.beads, dolt), 72 (dolt), 78 (dolt), 309 (dolt), 312 (dolt), 337 (dolt), 338 (.beads), 339 (dolt), 404 (bd), 407 (bd), 408 (.beads), 414 (bd), 420 (bd, dolt)
+- [ ] docs/PROJECT_DESIGN.md (20)
+  - lines: 20 (dolt), 29 (.beads), 47 (dolt), 59 (dolt), 61 (dolt), 64 (dolt), 65 (.beads, dolt), 72 (dolt), 78 (dolt), 309 (dolt), 312 (dolt), 337 (dolt), 338 (.beads), 339 (dolt), 404 (bd), 407 (bd), 408 (.beads), 414 (bd), 420 (bd, dolt), 629 (dolt)
 - [ ] docs/reference/ADAPTERS.md (2)
   - lines: 16 (bd), 20 (bd)
 - [ ] docs/reference/agent-permissions.md (3)

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -588,6 +588,31 @@ function mutationIssueId(operation, event) {
 	return event.entity_id;
 }
 
+// Build the accept-decision mutation response data (id + revision plus the op-specific
+// id echoes). Extracted from mapMutationResult so that function's cognitive complexity
+// stays low as op-specific fields accrue (comment_id / dependency_id / claim_id /
+// KAP-8 newly_unblocked).
+function buildAcceptMutationData(operation, event, mutation) {
+	const data = {
+		id: mutation.id ?? event.entity_id,
+		revision: Number(mutation.revision ?? 0),
+	};
+	if (mutation.comment_id) data.comment_id = mutation.comment_id;
+	if (DEPENDENCY_OPERATIONS.has(operation)) {
+		data.dependency_id = mutation.dependency_id ?? event.entity_id;
+	}
+	if (CLAIM_OPERATIONS.has(operation)) {
+		data.claim_id = mutation.claim_id ?? event.entity_id;
+	}
+	// KAP-8: a close surfaces the ids that became ready now that this issue is done.
+	// Only the close path's driver mutation populates newly_unblocked; echo it when
+	// present (an empty array is meaningful — "nothing unblocked" — so include it).
+	if (operation === 'close' && Array.isArray(mutation.newly_unblocked)) {
+		data.newly_unblocked = mutation.newly_unblocked;
+	}
+	return data;
+}
+
 // Map a runGuardedEvent result to an issue-command-contract mutation response (or
 // error). A duplicate replay reports the existing single row; a quarantine becomes
 // a (sometimes retryable) conflict error; an accept returns
@@ -596,25 +621,7 @@ async function mapMutationResult(driver, operation, event, result, context, conf
 	const commandId = ISSUE_MUTATION_COMMAND_IDS[operation];
 
 	if (result.decision === 'accept') {
-		const mutation = result.mutation || {};
-		const data = {
-			id: mutation.id ?? event.entity_id,
-			revision: Number(mutation.revision ?? 0),
-		};
-		if (mutation.comment_id) data.comment_id = mutation.comment_id;
-		if (DEPENDENCY_OPERATIONS.has(operation)) {
-			data.dependency_id = mutation.dependency_id ?? event.entity_id;
-		}
-		if (CLAIM_OPERATIONS.has(operation)) {
-			data.claim_id = mutation.claim_id ?? event.entity_id;
-		}
-		// KAP-8: a close surfaces the ids that became ready now that this issue is done.
-		// Only the close path's driver mutation populates newly_unblocked; echo it when
-		// present (an empty array is meaningful — "nothing unblocked" — so include it).
-		if (operation === 'close' && Array.isArray(mutation.newly_unblocked)) {
-			data.newly_unblocked = mutation.newly_unblocked;
-		}
-		return okMutationResponse(commandId, data);
+		return okMutationResponse(commandId, buildAcceptMutationData(operation, event, result.mutation || {}));
 	}
 
 	if (result.decision === 'duplicate' || result.decision === 'dedupe' || result.decision === 'projection_echo') {

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -386,6 +386,16 @@ function parseFlagPairs(args = []) {
 	return flags;
 }
 
+// KAP-4: parseFlagPairs is last-value-wins, so repeated --label flags do NOT
+// accumulate. The CLI surface is a single COMMA-SEPARATED flag (--label "a,b");
+// split on ',', trim each, and drop empties into a string[]. A non-string flag
+// (bare --label with no value) yields []. The driver persists this as JSON-array
+// TEXT; the read side (parseLabels/rowToIssueSummary) already surfaces labels[].
+function parseLabelFlag(value) {
+	if (typeof value !== 'string') return [];
+	return value.split(',').map(label => label.trim()).filter(Boolean);
+}
+
 // Build the create payload from flags. --id is optional (minted when absent); the
 // minted/declared id becomes the event entity_id and the new issue's primary key.
 function buildCreatePayload(flags) {
@@ -398,6 +408,7 @@ function buildCreatePayload(flags) {
 	if (typeof flags.priority === 'string') payload.priority = flags.priority;
 	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
 	if (typeof flags.parent === 'string') payload.parent_id = flags.parent;
+	if (typeof flags.label === 'string') payload.labels = parseLabelFlag(flags.label);
 	return payload;
 }
 
@@ -409,6 +420,13 @@ function buildUpdatePayload(flags) {
 	if (typeof flags.body === 'string') payload.body = flags.body;
 	if (typeof flags.priority === 'string') payload.priority = flags.priority;
 	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
+	// KAP-4: --label reparents the full label set (last-value-wins, comma-split).
+	if (typeof flags.label === 'string') payload.labels = parseLabelFlag(flags.label);
+	// KAP-5: --parent reparents on update (create already maps --parent → parent_id).
+	if (typeof flags.parent === 'string') payload.parent_id = flags.parent;
+	// KAP-5: --reason is captured in the close EVENT payload (no column/migration);
+	// kernel_events already persists payload_json. The close op uses buildUpdatePayload.
+	if (typeof flags.reason === 'string') payload.reason = flags.reason;
 	return payload;
 }
 
@@ -589,6 +607,12 @@ async function mapMutationResult(driver, operation, event, result, context, conf
 		}
 		if (CLAIM_OPERATIONS.has(operation)) {
 			data.claim_id = mutation.claim_id ?? event.entity_id;
+		}
+		// KAP-8: a close surfaces the ids that became ready now that this issue is done.
+		// Only the close path's driver mutation populates newly_unblocked; echo it when
+		// present (an empty array is meaningful — "nothing unblocked" — so include it).
+		if (operation === 'close' && Array.isArray(mutation.newly_unblocked)) {
+			data.newly_unblocked = mutation.newly_unblocked;
 		}
 		return okMutationResponse(commandId, data);
 	}

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -55,6 +55,7 @@ const ISSUE_SUMMARY_SCHEMA = {
 			type: 'array',
 			items: {
 				type: 'object',
+				required: ['id', 'body', 'actor', 'created_at'],
 				properties: {
 					id: { type: 'string' },
 					body: { type: ['string', 'null'] },

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -48,6 +48,21 @@ const ISSUE_SUMMARY_SCHEMA = {
 		dependencies: { type: 'array', items: { type: 'string' } },
 		created_at: { type: 'string' },
 		updated_at: { type: 'string' },
+		// KAP-3: `show` attaches the issue's comments; other reads (list/ready/search/
+		// stats) omit the key. Optional (NOT in required) so comment-less summaries still
+		// validate. Each item carries id/body/actor/created_at (body may be null).
+		comments: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					id: { type: 'string' },
+					body: { type: ['string', 'null'] },
+					actor: { type: 'string' },
+					created_at: { type: 'string' },
+				},
+			},
+		},
 	},
 };
 

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -153,6 +153,9 @@ const ISSUE_COMMAND_RESPONSE_SCHEMAS = deepFreeze({
 					comment_id: { type: 'string' },
 					dependency_id: { type: 'string' },
 					claim_id: { type: 'string' },
+					// KAP-8: close only — ids that became ready now the issue is done.
+					// OPTIONAL (not in `required`) so every other mutation still validates.
+					newly_unblocked: { type: 'array', items: { type: 'string' } },
 					projection: {
 						type: 'object',
 						properties: {

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -843,10 +843,32 @@ function resolveMutationStatus(eventType, payload) {
 	return null;
 }
 
+// KAP-8: after a close COMMITS the issue to a terminal status, compute the issues
+// that become newly READY because this issue is now done. This is a LOCALIZED
+// post-write read on the SAME connection/transaction — the issue row is already
+// `done`, so loadBoardReadiness sees the post-close state. We restrict the result
+// to DIRECT dependents of the closed issue (kernel_dependencies rows where
+// blocks_issue_id === closedId) whose readiness now flips to ready (the closed
+// blocker is terminal and dropped, and they carry no OTHER live blocker). Sorted
+// for a deterministic response.
+function computeNewlyUnblocked(runtime, db, closedIssueId, context = {}) {
+	const dependents = safeAll(
+		runtime,
+		db,
+		'SELECT DISTINCT issue_id FROM kernel_dependencies WHERE blocks_issue_id = ?',
+		[closedIssueId],
+	).map(row => row.issue_id).filter(Boolean);
+	if (dependents.length === 0) return [];
+	const { index } = loadBoardReadiness(runtime, db, context);
+	return dependents
+		.filter(id => Boolean(index.readinessById[id]?.ready))
+		.sort((a, b) => String(a).localeCompare(String(b)));
+}
+
 // Upsert the issue row for an accepted issue event and bump entity_revision. The
 // evaluator already enforced CAS (expected_revision === stored), so the new
 // revision is monotonic: stored + 1 for an update, 0 for a fresh create.
-function applyAcceptedIssueEvent(runtime, db, event) {
+function applyAcceptedIssueEvent(runtime, db, event, context = {}) {
 	const payload = event.payload || (event.payload_json ? JSON.parse(event.payload_json) : {});
 	const issueId = event.entity_id;
 	const now = event.created_at;
@@ -880,7 +902,10 @@ function applyAcceptedIssueEvent(runtime, db, event) {
 		const value = column === 'status' ? status : payload[column];
 		if (value === undefined || value === null) continue;
 		assignments.push(`${column} = ?`);
-		values.push(value);
+		// KAP-4: labels arrive as a string[] (broker parseLabelFlag). SQLite cannot
+		// bind an array param, so persist as JSON-array TEXT — the canonical form
+		// parseLabels reads back on the read side. Every other column binds as-is.
+		values.push(column === 'labels' ? JSON.stringify(value) : value);
 	}
 	assignments.push('updated_at = ?');
 	values.push(now);
@@ -916,7 +941,7 @@ function applyAcceptedIssueEvent(runtime, db, event) {
 			error.actualRevision = expectedRevision;
 			throw error;
 		}
-		return { id: issueId, revision: nextRevision };
+		return finalizeIssueMutation(runtime, db, event, issueId, nextRevision, context);
 	}
 	runParams(
 		runtime,
@@ -924,7 +949,18 @@ function applyAcceptedIssueEvent(runtime, db, event) {
 		`UPDATE kernel_issues SET ${assignments.join(', ')} WHERE id = ?`,
 		[...values, issueId],
 	);
-	return { id: issueId, revision: nextRevision };
+	return finalizeIssueMutation(runtime, db, event, issueId, nextRevision, context);
+}
+
+// Build the issue-mutation summary, attaching KAP-8 newly_unblocked for a close.
+// The issue row is already at its terminal status here (the UPDATE above committed
+// on this connection), so computeNewlyUnblocked sees the post-close readiness.
+function finalizeIssueMutation(runtime, db, event, issueId, revision, context) {
+	const summary = { id: issueId, revision };
+	if (event.event_type === 'issue.close') {
+		summary.newly_unblocked = computeNewlyUnblocked(runtime, db, issueId, context);
+	}
+	return summary;
 }
 
 // Append a comment row for an accepted issue.comment event.
@@ -1012,7 +1048,7 @@ function applyAcceptedClaimReleaseEvent(runtime, db, event) {
 // insertKernelClaim inside the transaction). The entity_type guard is critical:
 // dependency/claim events must NEVER fall into the issue-upsert branch, which
 // would corrupt kernel_issues with a bogus row keyed by the dep/claim id.
-function applyAcceptedMutation(runtime, db, event) {
+function applyAcceptedMutation(runtime, db, event, context = {}) {
 	if (event.entity_type === 'dependency') {
 		if (event.event_type === 'dependency.remove') {
 			return applyAcceptedDependencyRemoveEvent(runtime, db, event);
@@ -1031,7 +1067,9 @@ function applyAcceptedMutation(runtime, db, event) {
 		return applyAcceptedCommentEvent(runtime, db, event);
 	}
 	if (event.entity_type === 'issue') {
-		return applyAcceptedIssueEvent(runtime, db, event);
+		// context carries now/actor so KAP-8's post-close readiness recompute uses the
+		// same clock/actor the rest of the guarded path did.
+		return applyAcceptedIssueEvent(runtime, db, event, context);
 	}
 	return null;
 }
@@ -1158,8 +1196,8 @@ function createDriver(runtime, configuredDatabasePath) {
 		// transaction to apply an accepted issue event to the authority tables. The
 		// returned summary ({id, revision, comment_id?}) flows back through
 		// runGuardedEvent's result so runIssueOperation can shape the mutation response.
-		async applyAcceptedIssueMutation(event, _context = {}, config = {}) {
-			return applyAcceptedMutation(runtime, getDatabase(config), event);
+		async applyAcceptedIssueMutation(event, context = {}, config = {}) {
+			return applyAcceptedMutation(runtime, getDatabase(config), event, context);
 		},
 		close() {
 			closeDatabase(db);

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -371,7 +371,24 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 			});
 		}
 		const { index, claimedById, dependenciesById } = loadBoardReadiness(runtime, db, context);
-		return okIssueResponse('issue.show', rowToIssueSummary(rows[0], index.readinessById[id], claimedById[id], dependenciesById[id]));
+		// KAP-3: `show` (and only `show`) attaches the issue's comments, ordered oldest
+		// first. Map to the contract's { id, body, actor, created_at } shape — never the
+		// raw row — so the projection stays stable.
+		const commentRows = allParams(
+			runtime, db,
+			'SELECT * FROM kernel_comments WHERE issue_id = ? ORDER BY created_at ASC, id ASC',
+			[id],
+		);
+		const comments = commentRows.map(comment => ({
+			id: comment.id,
+			body: comment.body ?? null,
+			actor: comment.actor,
+			created_at: comment.created_at,
+		}));
+		return okIssueResponse('issue.show', {
+			...rowToIssueSummary(rows[0], index.readinessById[id], claimedById[id], dependenciesById[id]),
+			comments,
+		});
 	}
 	if (operation === 'search') {
 		const term = `%${firstPositional(args) || ''}%`;

--- a/test/kernel/issue-command-contract.test.js
+++ b/test/kernel/issue-command-contract.test.js
@@ -70,6 +70,27 @@ describe('Kernel issue command contract', () => {
 			.toBe(ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList.properties.data.properties.issues.items);
 	});
 
+	test('KAP-3: issue summary schema declares an optional comments array', () => {
+		const { ISSUE_COMMAND_RESPONSE_SCHEMAS } = require('../../lib/kernel/issue-command-contract');
+		// The show response's data is the issue summary schema; comments live there.
+		const summarySchema = ISSUE_COMMAND_RESPONSE_SCHEMAS.issue.properties.data;
+		const comments = summarySchema.properties.comments;
+
+		// Existence first (clean RED — never a TypeError on undefined.type).
+		expect(comments).toBeDefined();
+		expect(comments.type).toBe('array');
+		// Each item exposes id/body/actor/created_at; body may be null.
+		expect(comments.items.type).toBe('object');
+		expect(comments.items.properties.id).toBeDefined();
+		expect(comments.items.properties.body).toBeDefined();
+		expect(comments.items.properties.actor).toBeDefined();
+		expect(comments.items.properties.created_at).toBeDefined();
+
+		// Optional: comments must NOT be in required, so list/ready summaries (no
+		// comments) still validate against the same summary schema.
+		expect(summarySchema.required).not.toContain('comments');
+	});
+
 	test('defines a stable error envelope and meaningful exit codes', () => {
 		const {
 			ISSUE_COMMAND_ERROR_SCHEMA,

--- a/test/kernel/issue-command-contract.test.js
+++ b/test/kernel/issue-command-contract.test.js
@@ -62,6 +62,13 @@ describe('Kernel issue command contract', () => {
 		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.mutation.properties.data.required)
 			.toContain('revision');
 
+		// KAP-8: close adds an OPTIONAL newly_unblocked string[]; it must be declared in
+		// properties but NOT required, so non-close mutation responses still validate.
+		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.mutation.properties.data.properties.newly_unblocked)
+			.toEqual({ type: 'array', items: { type: 'string' } });
+		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.mutation.properties.data.required)
+			.not.toContain('newly_unblocked');
+
 		// KAP-7: blocked/orphans reuse the issueList shape; stale adds threshold_days.
 		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.staleList.required).toContain('next_commands');
 		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.staleList.properties.data.properties.threshold_days)

--- a/test/kernel/sqlite-driver-deps-claims.test.js
+++ b/test/kernel/sqlite-driver-deps-claims.test.js
@@ -133,6 +133,50 @@ describe('Kernel SQLite driver — dependencies + claims via guarded path (Wave 
 		expect(readyIds).toContain('rem-a');
 	});
 
+	// KAP-8: closing a blocker surfaces the dependents that become ready.
+	test('close surfaces newly_unblocked dependents whose only blocker is now done', async () => {
+		// B depends on A (issue_id=B, blocks_issue_id=A) → B is blocked while A is open.
+		await createIssue('unb-a', 'Blocker');
+		await createIssue('unb-b', 'Dependent');
+		await broker.runIssueOperation(
+			'dep.add', ['--issue', 'unb-b', '--blocks', 'unb-a'], { now, actor: 'tester' },
+		);
+
+		// B is blocked before the close.
+		const before = await driver.issueOperation('ready', [], { now }, config);
+		expect(before.data.issues.map(i => i.id)).not.toContain('unb-b');
+
+		const closed = await broker.runIssueOperation(
+			'close', ['unb-a'], { now: '2026-06-20T00:02:00.000Z', actor: 'tester' },
+		);
+
+		expect(closed.ok).toBe(true);
+		expect(closed.command).toBe('issue.close');
+		// A is done → B's only blocker is terminal → B flips to ready.
+		expect(closed.data.newly_unblocked).toEqual(['unb-b']);
+	});
+
+	test('close newly_unblocked omits dependents that still have another open blocker', async () => {
+		// C depends on BOTH A and another open issue D — closing A alone must NOT unblock C.
+		await createIssue('two-a', 'BlockerA');
+		await createIssue('two-d', 'BlockerD');
+		await createIssue('two-c', 'Dependent');
+		await broker.runIssueOperation(
+			'dep.add', ['--issue', 'two-c', '--blocks', 'two-a'], { now, actor: 'tester' },
+		);
+		await broker.runIssueOperation(
+			'dep.add', ['--issue', 'two-c', '--blocks', 'two-d'], { now: '2026-06-20T00:01:00.000Z', actor: 'tester' },
+		);
+
+		const closed = await broker.runIssueOperation(
+			'close', ['two-a'], { now: '2026-06-20T00:02:00.000Z', actor: 'tester' },
+		);
+
+		expect(closed.ok).toBe(true);
+		// D is still open, so C stays blocked → not newly unblocked.
+		expect(closed.data.newly_unblocked).toEqual([]);
+	});
+
 	test('dep.add closing a cycle quarantines as dependency_cycle and writes no edge', async () => {
 		await createIssue('cyc-a');
 		await createIssue('cyc-b');

--- a/test/kernel/sqlite-driver-issue.test.js
+++ b/test/kernel/sqlite-driver-issue.test.js
@@ -190,6 +190,69 @@ describe('Kernel SQLite driver — enriched issue projection (KAP-2)', () => {
 	});
 });
 
+// KAP-3: `show` surfaces the issue's comments (the list/ready/search/stats reads do
+// NOT). Comments are loaded from kernel_comments ordered created_at ASC, id ASC and
+// mapped to { id, body, actor, created_at }. The contract field is optional, so list
+// summaries (which never carry comments) still validate.
+describe('Kernel SQLite driver — comments in show (KAP-3)', () => {
+	let tmpDir;
+	let driver;
+	let config;
+	const now = '2026-06-20T00:00:00.000Z';
+
+	beforeAll(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-kap3-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		const broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+
+		// Insert the issue first (kernel_comments.issue_id references it), then two
+		// comments with distinct created_at so the ASC sort is actually exercised.
+		await driver.exec(
+			`INSERT INTO kernel_issues (id,title,type,status,priority_rank,created_at,updated_at,entity_revision) VALUES
+				('k1','Has comments','task','open',0,'${now}','${now}',0);`,
+			config,
+		);
+		await driver.exec(
+			`INSERT INTO kernel_comments (id,issue_id,body,actor,visibility,created_at) VALUES
+				('cm2','k1','second note','bob','public','2026-06-20T00:00:02.000Z'),
+				('cm1','k1','first note','alice','public','2026-06-20T00:00:01.000Z');`,
+			config,
+		);
+	});
+
+	afterAll(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('show returns the issue comments in created_at order with body and actor', async () => {
+		const res = await driver.issueOperation('show', ['k1'], {}, config);
+		expect(res.ok).toBe(true);
+		expect(Array.isArray(res.data.comments)).toBe(true);
+		expect(res.data.comments).toHaveLength(2);
+		// Inserted out of order; created_at ASC must put the earlier note first.
+		expect(res.data.comments[0]).toMatchObject({ id: 'cm1', body: 'first note', actor: 'alice' });
+		expect(res.data.comments[1]).toMatchObject({ id: 'cm2', body: 'second note', actor: 'bob' });
+		expect(res.data.comments[0].created_at).toBe('2026-06-20T00:00:01.000Z');
+		expect(res.data.comments[1].created_at).toBe('2026-06-20T00:00:02.000Z');
+	});
+
+	test('list summaries do NOT carry a comments key', async () => {
+		const res = await driver.issueOperation('list', [], {}, config);
+		const k1 = res.data.issues.find(issue => issue.id === 'k1');
+		expect(k1).toBeDefined();
+		expect(k1.comments).toBeUndefined();
+	});
+});
+
 // KAP-6: server-side `list` filters. The list op accepts --status / --type / --label
 // (both `--flag value` and `--flag=value` forms). status/type are exact-match; --label
 // keeps issues whose labels[] INCLUDES the value. Multiple filters AND together; an

--- a/test/kernel/sqlite-driver-mutations.test.js
+++ b/test/kernel/sqlite-driver-mutations.test.js
@@ -151,6 +151,84 @@ describe('Kernel SQLite driver — issue mutations via guarded path (Wave 3)', (
 		expect(rows.map(row => row.body)).toEqual(['First note', 'Second note']);
 	});
 
+	// KAP-4: --label is a single comma-separated flag (last-value-wins under
+	// parseFlagPairs), parsed into a string[] and persisted as JSON-array TEXT.
+	test('create --label persists a comma-separated label set as labels[]', async () => {
+		await broker.runIssueOperation(
+			'create',
+			['--id', 'lbl-1', '--title', 'Labeled', '--type', 'task', '--label', 'backend, api ,'],
+			{ now, actor: 'tester' },
+		);
+
+		const shown = await driver.issueOperation('show', ['lbl-1'], {}, config);
+		// Whitespace trimmed, empty segments dropped, order preserved.
+		expect(shown.data.labels).toEqual(['backend', 'api']);
+
+		// Persisted as JSON-array TEXT in the column (the canonical KAP-4 form).
+		const rows = await driver.queryAll('SELECT labels FROM kernel_issues WHERE id = \'lbl-1\'', config);
+		expect(rows[0].labels).toBe('["backend","api"]');
+	});
+
+	test('update --label replaces the full label set', async () => {
+		await broker.runIssueOperation(
+			'create',
+			['--id', 'lbl-2', '--title', 'Relabel', '--type', 'task', '--label', 'a,b'],
+			{ now, actor: 'tester' },
+		);
+		expect((await driver.issueOperation('show', ['lbl-2'], {}, config)).data.labels).toEqual(['a', 'b']);
+
+		await broker.runIssueOperation(
+			'update',
+			['lbl-2', '--label', 'c'],
+			{ now: '2026-06-19T00:08:00.000Z', actor: 'tester' },
+		);
+
+		const shown = await driver.issueOperation('show', ['lbl-2'], {}, config);
+		expect(shown.data.labels).toEqual(['c']);
+	});
+
+	// KAP-5: --parent reparents an existing issue on update (create already maps it).
+	test('update --parent reparents the issue (parent_id persisted)', async () => {
+		// parent_id carries an FK to kernel_issues(id), so the parent must exist.
+		await broker.runIssueOperation(
+			'create', ['--id', 'epic-x', '--title', 'Epic', '--type', 'epic'], { now, actor: 'tester' },
+		);
+		await broker.runIssueOperation(
+			'create', ['--id', 'par-1', '--title', 'Child', '--type', 'task'], { now, actor: 'tester' },
+		);
+
+		await broker.runIssueOperation(
+			'update', ['par-1', '--parent', 'epic-x'],
+			{ now: '2026-06-19T00:09:00.000Z', actor: 'tester' },
+		);
+
+		const shown = await driver.issueOperation('show', ['par-1'], {}, config);
+		expect(shown.data.parent_id).toBe('epic-x');
+	});
+
+	// KAP-5: close --reason is captured in the close EVENT payload (no column/migration).
+	test('close --reason succeeds and records the reason in the close event payload', async () => {
+		await broker.runIssueOperation(
+			'create', ['--id', 'rsn-1', '--title', 'Closeme', '--type', 'task'], { now, actor: 'tester' },
+		);
+
+		const closed = await broker.runIssueOperation(
+			'close', ['rsn-1', '--reason', 'done deal'],
+			{ now: '2026-06-19T00:10:00.000Z', actor: 'tester' },
+		);
+		expect(closed.ok).toBe(true);
+		expect(closed.command).toBe('issue.close');
+
+		// The reason lives in the persisted close event payload (kernel_events), NOT a
+		// new kernel_issues column.
+		const events = await driver.queryAll(
+			'SELECT payload_json FROM kernel_events WHERE entity_id = \'rsn-1\' AND event_type = \'issue.close\'',
+			config,
+		);
+		expect(events).toHaveLength(1);
+		expect(JSON.parse(events[0].payload_json).reason).toBe('done deal');
+	});
+
 	test('create twice through runIssueOperation replays as a single row (duplicate mapping)', async () => {
 		const createArgs = ['--id', 'forge-dup', '--title', 'Dup', '--type', 'task'];
 


### PR DESCRIPTION
## Problem

After Wave 1 (#226), the kernel could surface issue data but several everyday agent/CLI affordances were still missing: `show` didn't return an issue's comments, there was no way to write `labels` or reparent an issue, `close` couldn't capture a reason, and closing a blocker gave no hint about what it unblocked.

## Root Cause

These are the Wave 2 slice of the Kernel Agent-Parity (KAP) backlog — capabilities Beads has that the kernel hadn't implemented yet. The read projection (KAP-2) and write paths existed but didn't cover comments, label/parent writes, close metadata, or post-close readiness hints.

## Fix

Four features, implemented via two parallel TDD lanes (file-disjoint) then integrated:

- **KAP-3** — `show` now returns the issue's `comments[]` (from `kernel_comments`), as an optional field on the issue summary schema.
- **KAP-4** — `--label "a,b,c"` write path on `create`/`update`; the comma-list is parsed in the broker and persisted as JSON-array TEXT in `kernel_issues.labels` (read side already surfaced `labels[]`).
- **KAP-5** — `--parent` reparent on `update` (create already supported it) + `close --reason` captured in the close **event payload** (no schema/migration).
- **KAP-8** — `close --suggest-next`: the close response now carries `newly_unblocked[]`, computed by re-deriving readiness post-commit and restricting to direct dependents of the closed issue that are now ready.

## Value

Agents get the full issue picture from one `show` (comments included), can manage labels/hierarchy/close-reasons through the CLI, and learn what a close unblocked — closing real parity gaps vs Beads without cloning it.

## Beads

N/A — bd/Dolt unreachable (K0). The backlog is dogfooded in the kernel itself (`FORGE_ISSUE_BACKEND=kernel`); `kap-3/4/5/8` are marked `review` and close on merge.

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Full affected suite **915 tests / 0 fail** (kernel + commands + adapters + forge-issues + issue-backend + release-readiness).
- New TDD coverage per feature: comments-in-show, label create/update round-trip, reparent + close-reason, newly-unblocked-on-close; plus contract-schema assertions.

### Security Review
- N/A risk surface — no new external inputs beyond CLI flags already routed through the parameterized driver (all writes use bound `?` params; labels JSON-serialized, not interpolated).

### Design Doc
See: [docs/work/2026-06-20-kernel-agent-parity/design.md](docs/work/2026-06-20-kernel-agent-parity/design.md) (KAP backlog, Wave 2 = KAP-3/4/5/8).

### Key Decisions
- **`--label` is comma-separated**, not repeated — `parseFlagPairs` is last-value-wins, so a repeated flag wouldn't accumulate.
- **`close --reason` rides the event payload** — `kernel_events` already persists payloads, so no new column or migration.
- **`newly_unblocked` uses an in-transaction `loadBoardReadiness` recompute** (post-commit), restricted to direct dependents — not a separate response-architecture change.

### Documentation Updated
- Regenerated the D20 bd call-site kill-list artifact (line-number drift from the lib edits).

### Validation
- [x] Lint passing (`eslint --max-warnings 0`, 0 warnings)
- [x] All tests passing (915 / 0)
- [x] D20 release-readiness gate green
- [x] Real-CLI e2e per feature (labels, comments, reparent, close-reason, newly_unblocked)

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code
- [x] ESLint passes with zero warnings
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (additive — new flags/fields; default Beads path untouched)
- [x] TDD compliance: all new source paths have corresponding tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for comma-separated `--label` values in issue operations (trims whitespace, ignores empty entries) and persists labels as a canonical set.
  * `issue.show` now returns issue `comments` (ordered by creation time) while issue summaries remain unchanged.
  * `issue.close` responses now report `newly_unblocked` dependent issues (including empty results when none are unblocked).
* **Tests**
  * Expanded coverage for label parsing/persistence, comment ordering, close dependency/unblocked behavior, and mutation response shapes.
* **Documentation**
  * Updated call-site documentation and checklist reference counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->