### PR TITLE
feat(kernel): Wave 3 agent-parity — content fields, assignee, lint (KAP-10/11/12)

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -2526,7 +2526,7 @@ function parseFlags() {
 
   // Issue passthrough commands delegate all flags to bd.
   // Skip global parsing so flags like --type, -p, --help reach the handler intact.
-  const issuePassthroughCommands = ['create', 'update', 'claim', 'close', 'show', 'list', 'ready', 'blocked', 'stale', 'orphans', 'issue', 'issues'];
+  const issuePassthroughCommands = ['create', 'update', 'claim', 'close', 'show', 'list', 'ready', 'blocked', 'stale', 'orphans', 'lint', 'issue', 'issues'];
   if (issuePassthroughCommands.includes(args[0])) {
     return flags;
   }

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -18,7 +18,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] bin/forge.js (25)
   - lines: 2371 (bd), 2373 (bd), 2527 (bd), 2929 (bd), 2938 (bd), 2951 (bd), 2964 (.beads), 2984 (bd), 2986 (bd), 2988 (bd), 3023 (bd), 3047 (bd), 3133 (bd), 3177 (bd), 3201 (bd), 3207 (bd), 3211 (bd), 3216 (bd), 3222 (bd), 3232 (bd), 3364 (bd), 3369 (bd), 3380 (bd), 3447 (bd), 4655 (bd)
 - [ ] lib/commands/_issue.js (15)
-  - lines: 10 (bd), 16 (bd), 22 (bd), 27 (bd), 52 (bd), 58 (bd), 64 (bd), 70 (bd), 76 (bd), 82 (bd), 88 (bd), 92 (bd), 168 (bd), 324 (bd), 381 (bd)
+  - lines: 10 (bd), 16 (bd), 22 (bd), 27 (bd), 52 (bd), 58 (bd), 64 (bd), 70 (bd), 76 (bd), 82 (bd), 88 (bd), 92 (bd), 177 (bd), 333 (bd), 390 (bd)
 - [ ] lib/commands/clean.js (2)
   - lines: 10 (dolt), 175 (dolt)
 - [ ] lib/commands/dev.js (1)

--- a/lib/adapters/kernel-issue-adapter.js
+++ b/lib/adapters/kernel-issue-adapter.js
@@ -14,6 +14,7 @@ const KERNEL_ISSUE_OPERATIONS = Object.freeze({
 	blocked: 'blocked',
 	stale: 'stale',
 	orphans: 'orphans',
+	lint: 'lint',
 	read: 'show',
 	show: 'show',
 	create: 'create',

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -105,6 +105,15 @@ const SUBCOMMANDS = {
     helpCommand: 'orphans',
     buildBdArgs: (args) => ['orphans', ...args],
   },
+  // KAP-12: read-only content lint — issues missing required content
+  // (task/bug with no acceptance_criteria). A READ, so NOT in WRITE_SUBCOMMANDS;
+  // routes through runIssueOperation('lint', ...) on the Kernel path.
+  lint: {
+    description: 'Show issues missing required content via Forge',
+    usage: 'forge issue lint',
+    helpCommand: 'lint',
+    buildBdArgs: (args) => ['lint', ...args],
+  },
   dep: {
     description: 'Manage issue dependencies via Forge',
     usage: 'forge issue dep <add|remove> <issue-id> <blocks-issue-id>',

--- a/lib/commands/lint.js
+++ b/lib/commands/lint.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { makeAliasCommand } = require('./_issue');
+
+module.exports = makeAliasCommand('lint');

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -803,7 +803,7 @@ function createLocalBroker(options = {}) {
 			// whole plan on every init, and no blanket duplicate-error swallow.
 			await driver.exec(MIGRATION_LEDGER_CREATE, config);
 			const appliedRows = await driver.queryAll(`SELECT id FROM ${MIGRATION_LEDGER_TABLE};`, config);
-			const applied = new Set((appliedRows || []).map(row => row && row.id));
+			const applied = new Set((appliedRows || []).map(row => row?.id));
 			const newlyApplied = [];
 			for (const migration of config.migrationPlan.migrations) {
 				if (applied.has(migration.id)) continue;

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -76,8 +76,14 @@ function requireDriverMethod(driver, methodName) {
 	}
 }
 
-function isExpectedRevisionAddColumn(statement) {
-	return statement === 'ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;';
+// A migration ADD COLUMN is idempotent against a DB whose schema already declares
+// the column: the broker re-runs migrationPlan.apply on every init (there is no
+// ledger), and a fresh DB's CREATE TABLE seeds the same columns that later ALTER
+// migrations add (002 expected_revision; 004 design/notes/assignee). Match any
+// ADD COLUMN so a duplicate-column error on re-run/fresh-init is swallowed once,
+// not just the original 002 statement.
+function isAddColumnStatement(statement) {
+	return /\bALTER\s+TABLE\b.*\bADD\s+COLUMN\b/i.test(String(statement || ''));
 }
 
 function isDuplicateColumnError(error) {
@@ -110,7 +116,7 @@ async function execMigrationStatement(driver, statement, config) {
 	try {
 		await driver.exec(statement, config);
 	} catch (error) {
-		if (isExpectedRevisionAddColumn(statement) && isDuplicateColumnError(error)) {
+		if (isAddColumnStatement(statement) && isDuplicateColumnError(error)) {
 			return { skipped: true, reason: 'column-already-exists' };
 		}
 		throw error;
@@ -409,6 +415,12 @@ function buildCreatePayload(flags) {
 	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
 	if (typeof flags.parent === 'string') payload.parent_id = flags.parent;
 	if (typeof flags.label === 'string') payload.labels = parseLabelFlag(flags.label);
+	// KAP-10 (acceptance/design/notes) + KAP-11 (assignee): authored content fields
+	// and a persistent assignee. The driver persists each to its own column.
+	if (typeof flags.acceptance === 'string') payload.acceptance_criteria = flags.acceptance;
+	if (typeof flags.design === 'string') payload.design = flags.design;
+	if (typeof flags.notes === 'string') payload.notes = flags.notes;
+	if (typeof flags.assignee === 'string') payload.assignee = flags.assignee;
 	return payload;
 }
 
@@ -427,6 +439,12 @@ function buildUpdatePayload(flags) {
 	// KAP-5: --reason is captured in the close EVENT payload (no column/migration);
 	// kernel_events already persists payload_json. The close op uses buildUpdatePayload.
 	if (typeof flags.reason === 'string') payload.reason = flags.reason;
+	// KAP-10 (acceptance/design/notes) + KAP-11 (assignee): update overwrites each
+	// content field / reassigns the assignee when its flag is supplied.
+	if (typeof flags.acceptance === 'string') payload.acceptance_criteria = flags.acceptance;
+	if (typeof flags.design === 'string') payload.design = flags.design;
+	if (typeof flags.notes === 'string') payload.notes = flags.notes;
+	if (typeof flags.assignee === 'string') payload.assignee = flags.assignee;
 	return payload;
 }
 

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -76,18 +76,36 @@ function requireDriverMethod(driver, methodName) {
 	}
 }
 
-// A migration ADD COLUMN is idempotent against a DB whose schema already declares
-// the column: the broker re-runs migrationPlan.apply on every init (there is no
-// ledger), and a fresh DB's CREATE TABLE seeds the same columns that later ALTER
-// migrations add (002 expected_revision; 004 design/notes/assignee). Match any
-// ADD COLUMN so a duplicate-column error on re-run/fresh-init is swallowed once,
-// not just the original 002 statement.
-function isAddColumnStatement(statement) {
-	return /\bALTER\s+TABLE\b.*\bADD\s+COLUMN\b/i.test(String(statement || ''));
+// The migration ledger records which migration ids have been applied so initialize()
+// applies each migration AT MOST ONCE — no full re-run, no blanket duplicate-error
+// swallow. The ledger table is broker-managed bookkeeping (created before the plan is
+// consulted), so it is intentionally NOT part of the migration schema/plan.
+const MIGRATION_LEDGER_TABLE = 'kernel_migrations';
+const MIGRATION_LEDGER_CREATE = `CREATE TABLE IF NOT EXISTS ${MIGRATION_LEDGER_TABLE} (\n  id TEXT NOT NULL PRIMARY KEY,\n  applied_at TEXT NOT NULL\n);`;
+
+// Guarded ADD COLUMN: a PRECONDITION check (PRAGMA table_info), NOT a catch. SQLite has
+// no `ADD COLUMN IF NOT EXISTS`, and the target column can already exist on a fresh DB
+// (001 never seeds migration-added columns, but a pre-ledger DB the old re-run model
+// already migrated will have it). Skip the ADD when the column is present; ANY real SQL
+// error from the run still propagates — the discarded blanket swallow could not.
+function parseAddColumnTarget(statement) {
+	const match = /^\s*ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)\b/i.exec(String(statement || ''));
+	return match ? { table: match[1], column: match[2] } : null;
 }
 
-function isDuplicateColumnError(error) {
-	return /duplicate column name/i.test(String(error && error.message ? error.message : error));
+async function columnExists(driver, table, column, config) {
+	const rows = await driver.queryAll(`PRAGMA table_info(${table});`, config);
+	return Array.isArray(rows) && rows.some(row => row && row.name === column);
+}
+
+// Record a migration as applied. The id is a controlled internal constant, validated to
+// a ledger-safe charset before interpolation (the broker driver exposes only param-less
+// exec). INSERT OR IGNORE makes a concurrent double-init a harmless no-op.
+function recordMigrationSql(id) {
+	if (typeof id !== 'string' || !/^[0-9a-z_]+$/i.test(id)) {
+		throw new Error(`Kernel migration id is not ledger-safe: ${id}`);
+	}
+	return `INSERT OR IGNORE INTO ${MIGRATION_LEDGER_TABLE} (id, applied_at) VALUES ('${id}', '${new Date().toISOString()}');`;
 }
 
 function isIdempotencyConflict(error) {
@@ -113,14 +131,11 @@ function isRevisionConflict(error) {
 }
 
 async function execMigrationStatement(driver, statement, config) {
-	try {
-		await driver.exec(statement, config);
-	} catch (error) {
-		if (isAddColumnStatement(statement) && isDuplicateColumnError(error)) {
-			return { skipped: true, reason: 'column-already-exists' };
-		}
-		throw error;
+	const addColumn = parseAddColumnTarget(statement);
+	if (addColumn && await columnExists(driver, addColumn.table, addColumn.column, config)) {
+		return { skipped: true, reason: 'column-already-exists' };
 	}
+	await driver.exec(statement, config);
 	return { skipped: false };
 }
 
@@ -779,12 +794,24 @@ function createLocalBroker(options = {}) {
 
 		async initialize() {
 			requireDriverMethod(driver, 'exec');
+			requireDriverMethod(driver, 'queryAll');
 			const config = getConfig();
 			for (const statement of config.pragmas) {
 				await driver.exec(statement, config);
 			}
-			for (const statement of config.migrationPlan.apply) {
-				await execMigrationStatement(driver, statement, config);
+			// Apply only un-applied migrations, tracked in the ledger — no re-run of the
+			// whole plan on every init, and no blanket duplicate-error swallow.
+			await driver.exec(MIGRATION_LEDGER_CREATE, config);
+			const appliedRows = await driver.queryAll(`SELECT id FROM ${MIGRATION_LEDGER_TABLE};`, config);
+			const applied = new Set((appliedRows || []).map(row => row && row.id));
+			const newlyApplied = [];
+			for (const migration of config.migrationPlan.migrations) {
+				if (applied.has(migration.id)) continue;
+				for (const statement of migration.apply || []) {
+					await execMigrationStatement(driver, statement, config);
+				}
+				await driver.exec(recordMigrationSql(migration.id), config);
+				newlyApplied.push(migration.id);
 			}
 
 			return {
@@ -796,6 +823,7 @@ function createLocalBroker(options = {}) {
 				synchronous: config.synchronous,
 				foreignKeys: config.foreignKeys,
 				migrationsApplied: config.migrationPlan.migrations.map(migration => migration.id),
+				migrationsNewlyApplied: newlyApplied,
 			};
 		},
 

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -83,11 +83,14 @@ function requireDriverMethod(driver, methodName) {
 const MIGRATION_LEDGER_TABLE = 'kernel_migrations';
 const MIGRATION_LEDGER_CREATE = `CREATE TABLE IF NOT EXISTS ${MIGRATION_LEDGER_TABLE} (\n  id TEXT NOT NULL PRIMARY KEY,\n  applied_at TEXT NOT NULL\n);`;
 
-// Guarded ADD COLUMN: a PRECONDITION check (PRAGMA table_info), NOT a catch. SQLite has
-// no `ADD COLUMN IF NOT EXISTS`, and the target column can already exist on a fresh DB
-// (001 never seeds migration-added columns, but a pre-ledger DB the old re-run model
-// already migrated will have it). Skip the ADD when the column is present; ANY real SQL
-// error from the run still propagates — the discarded blanket swallow could not.
+// Guarded ADD COLUMN: a PRECONDITION check (PRAGMA table_info) plus a TOCTOU catch
+// fallback. SQLite has no `ADD COLUMN IF NOT EXISTS`, and the target column can already
+// exist on a fresh DB (001 never seeds migration-added columns, but a pre-ledger DB the
+// old re-run model already migrated will have it). Skip the ADD when the column is
+// already present; if a concurrent initialize() adds it between the check and the run,
+// the catch re-verifies the post-state and skips too. ANY other SQL error still
+// propagates — the discarded blanket swallow could not, because it trusted the error
+// string instead of confirming the actual column state.
 function parseAddColumnTarget(statement) {
 	const match = /^\s*ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)\b/i.exec(String(statement || ''));
 	return match ? { table: match[1], column: match[2] } : null;
@@ -135,7 +138,27 @@ async function execMigrationStatement(driver, statement, config) {
 	if (addColumn && await columnExists(driver, addColumn.table, addColumn.column, config)) {
 		return { skipped: true, reason: 'column-already-exists' };
 	}
-	await driver.exec(statement, config);
+	try {
+		await driver.exec(statement, config);
+	} catch (error) {
+		// TOCTOU: a concurrent initialize() can add this column between our pre-check
+		// and this exec — both readers saw it missing; the other writer won. Re-verify
+		// the actual post-state via PRAGMA: if the column is now present the migration's
+		// intent is satisfied, so skip. This is post-condition verification, NOT the
+		// discarded error-string swallow. Any other failure — and any failure where the
+		// column still isn't there — propagates. If the re-check itself throws, surface
+		// the ORIGINAL exec error, not the re-check's.
+		if (addColumn) {
+			try {
+				if (await columnExists(driver, addColumn.table, addColumn.column, config)) {
+					return { skipped: true, reason: 'column-added-concurrently' };
+				}
+			} catch {
+				throw error; // re-check failed — surface the ORIGINAL exec error
+			}
+		}
+		throw error;
+	}
 	return { skipped: false };
 }
 
@@ -807,6 +830,11 @@ function createLocalBroker(options = {}) {
 			const newlyApplied = [];
 			for (const migration of config.migrationPlan.migrations) {
 				if (applied.has(migration.id)) continue;
+				// Concurrency scope: execMigrationStatement only makes ADD COLUMN
+				// race-safe (pre-check + TOCTOU catch). This apply loop is NOT
+				// serialized, so a future non-idempotent, non-ADD-COLUMN migration
+				// (data backfill, non-`IF NOT EXISTS` DDL) would reintroduce a race —
+				// it would need `BEGIN IMMEDIATE` + an in-lock ledger re-read.
 				for (const statement of migration.apply || []) {
 					await execMigrationStatement(driver, statement, config);
 				}
@@ -880,5 +908,6 @@ module.exports = {
 	LOCAL_BROKER_PRAGMAS,
 	buildLocalBrokerConfig,
 	createLocalBroker,
+	execMigrationStatement,
 	resolveGitCommonDir,
 };

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -48,6 +48,13 @@ const ISSUE_SUMMARY_SCHEMA = {
 		dependencies: { type: 'array', items: { type: 'string' } },
 		created_at: { type: 'string' },
 		updated_at: { type: 'string' },
+		// KAP-10 (acceptance_criteria/design/notes) + KAP-11 (assignee): nullable
+		// content fields and a persistent assignee. Optional (NOT required) so summaries
+		// that omit them still validate.
+		acceptance_criteria: { type: ['string', 'null'] },
+		design: { type: ['string', 'null'] },
+		notes: { type: ['string', 'null'] },
+		assignee: { type: ['string', 'null'] },
 		// KAP-3: `show` attaches the issue's comments; other reads (list/ready/search/
 		// stats) omit the key. Optional (NOT in required) so comment-less summaries still
 		// validate. Each item carries id/body/actor/created_at (body may be null).

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -64,6 +64,17 @@ const ISSUE_SUMMARY_SCHEMA = {
 				},
 			},
 		},
+		// KAP-12: `lint` attaches a content-validation result to each FAILING issue;
+		// other reads (list/ready/search/...) omit the key. Optional (NOT in required)
+		// so validation-less summaries still validate. rules_failed names the broken
+		// content rules (e.g. 'missing_acceptance_criteria').
+		validation: {
+			type: 'object',
+			required: ['rules_failed'],
+			properties: {
+				rules_failed: { type: 'array', items: { type: 'string' } },
+			},
+		},
 	},
 };
 
@@ -254,6 +265,10 @@ const COMMANDS = [
 	command('issue.orphans', 'forge orphans --json', 'orphans', 'read', ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList, [
 		'forge issue show <id> --json',
 		'forge issue dep add <issue-id> <blocks-issue-id>',
+	]),
+	command('issue.lint', 'forge lint --json', 'lint', 'read', ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList, [
+		'forge issue show <id> --json',
+		'forge issue update <id> --acceptance "<criteria>"',
 	]),
 	command('issue.create', 'forge issue create', 'create', 'mutation', ISSUE_COMMAND_RESPONSE_SCHEMAS.mutation, [
 		'forge issue show <id> --json',

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -60,6 +60,8 @@ function getInitialKernelSchema() {
 	// migration runs (else "duplicate column name"). schema.js stays the full current
 	// schema; this map mirrors which columns each later migration backfills.
 	//   events.expected_revision → 002 ; issues.design/notes/assignee → 004
+	// KEEP IN SYNC: every new `ALTER TABLE … ADD COLUMN` migration MUST add its
+	// column(s) here, or a fresh DB will hit "duplicate column name" on setup.
 	const MIGRATION_ADDED_COLUMNS = {
 		events: ['expected_revision'],
 		issues: ['design', 'notes', 'assignee'],

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -140,8 +140,9 @@ function buildClaimActiveLeaseMigration() {
 // KAP-10 (acceptance/design/notes) + KAP-11 (assignee): three additive content
 // columns on kernel_issues. acceptance_criteria/estimate already exist; these add
 // the remaining authored fields plus a persistent assignee (distinct from the
-// transient kernel_claims lease). Plain ADD COLUMNs — the broker's duplicate-column
-// guard makes them idempotent against a fresh DB whose schema already declared them.
+// transient kernel_claims lease). Plain ADD COLUMNs — the 001 initial schema omits
+// these columns (getInitialKernelSchema/MIGRATION_ADDED_COLUMNS) and the broker's
+// per-migration ledger + guarded ADD COLUMN apply them exactly once.
 function buildIssueContentFieldsMigration() {
 	return {
 		id: '004_kernel_issues_content_fields',

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -125,6 +125,27 @@ function buildClaimActiveLeaseMigration() {
 	};
 }
 
+// KAP-10 (acceptance/design/notes) + KAP-11 (assignee): three additive content
+// columns on kernel_issues. acceptance_criteria/estimate already exist; these add
+// the remaining authored fields plus a persistent assignee (distinct from the
+// transient kernel_claims lease). Plain ADD COLUMNs — the broker's duplicate-column
+// guard makes them idempotent against a fresh DB whose schema already declared them.
+function buildIssueContentFieldsMigration() {
+	return {
+		id: '004_kernel_issues_content_fields',
+		apply: [
+			'ALTER TABLE kernel_issues ADD COLUMN design TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN notes TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN assignee TEXT;',
+		],
+		rollback: [
+			'ALTER TABLE kernel_issues DROP COLUMN assignee;',
+			'ALTER TABLE kernel_issues DROP COLUMN notes;',
+			'ALTER TABLE kernel_issues DROP COLUMN design;',
+		],
+	};
+}
+
 function validateKernelMigrations(migrations) {
 	const ids = new Set();
 	for (const migration of migrations) {
@@ -150,6 +171,7 @@ function buildKernelMigrationPlan(migrations = [
 	buildSchemaMigration(),
 	buildEventExpectedRevisionMigration(),
 	buildClaimActiveLeaseMigration(),
+	buildIssueContentFieldsMigration(),
 ]) {
 	validateKernelMigrations(migrations);
 
@@ -163,6 +185,7 @@ function buildKernelMigrationPlan(migrations = [
 module.exports = {
 	buildClaimActiveLeaseMigration,
 	buildEventExpectedRevisionMigration,
+	buildIssueContentFieldsMigration,
 	buildKernelMigrationPlan,
 	buildSchemaMigration,
 	validateKernelMigrations,

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -55,13 +55,23 @@ function renderDropTable(table) {
 
 function getInitialKernelSchema() {
 	const schema = getKernelSchema();
+	// Columns added by a later migration MUST be excluded from the initial (001)
+	// CREATE TABLE, so a fresh DB doesn't create them before the ALTER … ADD COLUMN
+	// migration runs (else "duplicate column name"). schema.js stays the full current
+	// schema; this map mirrors which columns each later migration backfills.
+	//   events.expected_revision → 002 ; issues.design/notes/assignee → 004
+	const MIGRATION_ADDED_COLUMNS = {
+		events: ['expected_revision'],
+		issues: ['design', 'notes', 'assignee'],
+	};
 	return {
 		...schema,
 		tables: schema.tables.map(table => {
-			if (table.name !== 'events') return table;
+			const excluded = MIGRATION_ADDED_COLUMNS[table.name];
+			if (!excluded) return table;
 			return {
 				...table,
-				fields: table.fields.filter(field => field.name !== 'expected_revision'),
+				fields: table.fields.filter(field => !excluded.includes(field.name)),
 			};
 		}),
 	};

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -80,6 +80,11 @@ const TABLE_LIST = deepFreeze([
 		field('labels', 'TEXT'),
 		field('acceptance_criteria', 'TEXT'),
 		field('estimate', 'TEXT'),
+		// KAP-10 (design/notes) + KAP-11 (assignee): authored content fields and a
+		// persistent assignee. Migration 004 backfills existing DBs; fresh DBs get them here.
+		field('design', 'TEXT'),
+		field('notes', 'TEXT'),
+		field('assignee', 'TEXT'),
 	], [
 		index('idx_kernel_issues_status_priority', ['status', 'priority_rank']),
 		index('idx_kernel_issues_updated_at', ['updated_at']),

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -199,6 +199,13 @@ function rowToIssueSummary(row, readinessEntry, claimedBy = null, dependencyIds 
 		dependencies: Array.isArray(dependencyIds) ? dependencyIds : [],
 		created_at: row.created_at,
 		updated_at: row.updated_at,
+		// KAP-10 (acceptance_criteria/design/notes) + KAP-11 (assignee): authored
+		// content fields and the persistent assignee, each null when unset. assignee is
+		// distinct from claimed_by (the transient lease holder) — both coexist.
+		acceptance_criteria: row.acceptance_criteria ?? null,
+		design: row.design ?? null,
+		notes: row.notes ?? null,
+		assignee: row.assignee ?? null,
 	};
 }
 
@@ -850,6 +857,12 @@ const ISSUE_MUTABLE_COLUMNS = Object.freeze([
 	'labels',
 	'acceptance_criteria',
 	'estimate',
+	// KAP-10 (design/notes) + KAP-11 (assignee): persisted on create AND update via
+	// the same assignment loop. assignee is the persistent owner, distinct from the
+	// transient kernel_claims lease.
+	'design',
+	'notes',
+	'assignee',
 ]);
 
 // close drives the issue to a terminal status; an explicit payload.status (rework

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -476,6 +476,26 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 		);
 		return okIssueResponse('issue.orphans', { issues: summaries, count: summaries.length });
 	}
+	// KAP-12: read-only content lint — issues that FAIL required-content validation.
+	// An issue FAILS iff its type is task|bug AND acceptance_criteria is null or
+	// empty/whitespace-only. epic/decision are EXEMPT (no acceptance_criteria
+	// requirement). Each failing issue carries its standard summary PLUS a
+	// `validation: { rules_failed: ['missing_acceptance_criteria'] }`. The predicate
+	// references ONLY base-existing columns (type/acceptance_criteria); both arrive on
+	// the loadBoardReadiness rows via `SELECT *`. Results sort like list (rank asc).
+	if (operation === 'lint') {
+		const { issues, index, claimedById, dependenciesById } = loadBoardReadiness(runtime, db, context);
+		const LINTED_TYPES = new Set(['task', 'bug']);
+		const summaries = sortIssueSummaries(
+			issues
+				.filter(row => LINTED_TYPES.has(row.type) && String(row.acceptance_criteria ?? '').trim() === '')
+				.map(row => ({
+					...rowToIssueSummary(row, index.readinessById[row.id], claimedById[row.id], dependenciesById[row.id]),
+					validation: { rules_failed: ['missing_acceptance_criteria'] },
+				})),
+		);
+		return okIssueResponse('issue.lint', { issues: summaries, count: summaries.length });
+	}
 	return null;
 }
 
@@ -1144,7 +1164,7 @@ function createDriver(runtime, configuredDatabasePath) {
 		},
 		async issueOperation(operation, args = [], context = {}, config = {}) {
 			const database = getDatabase(config);
-			const READ_OPERATIONS = new Set(['ready', 'list', 'show', 'search', 'stats', 'blocked', 'stale', 'orphans']);
+			const READ_OPERATIONS = new Set(['ready', 'list', 'show', 'search', 'stats', 'blocked', 'stale', 'orphans', 'lint']);
 			if (READ_OPERATIONS.has(operation)) {
 				return runIssueReadOperation(runtime, database, operation, args, context);
 			}

--- a/test/commands/_issue.test.js
+++ b/test/commands/_issue.test.js
@@ -88,10 +88,28 @@ describe('forge issue helpers', () => {
     ]);
   });
 
+  test('KAP-12 lint alias routes to the kernel lint operation', async () => {
+    const calls = [];
+    const opts = {
+      useKernelBroker: true,
+      runIssueOperation: async (operation, args, projectRoot, deps) => {
+        calls.push({ operation, args, projectRoot, deps });
+        return { ok: true, command: operation, data: { issues: [] } };
+      },
+    };
+
+    await makeAliasCommand('lint').handler(['--json'], {}, '/repo', opts);
+
+    expect(calls.map(call => ({ operation: call.operation, args: call.args }))).toEqual([
+      { operation: 'lint', args: ['--json'] },
+    ]);
+  });
+
   test('KAP-7 read aliases map to Beads-compatible passthroughs', () => {
     expect(buildBdArgs('blocked', ['--json'])).toEqual(['blocked', '--json']);
     expect(buildBdArgs('stale', ['--days', '7'])).toEqual(['stale', '--days', '7']);
     expect(buildBdArgs('orphans', [])).toEqual(['orphans']);
+    expect(buildBdArgs('lint', ['--json'])).toEqual(['lint', '--json']);
   });
 
   test('buildBdArgs maps comment to bd comments add passthrough', () => {

--- a/test/commands/lint.test.js
+++ b/test/commands/lint.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const lint = require('../../lib/commands/lint');
+
+describe('forge lint command', () => {
+  test('exports the lint alias command', () => {
+    expect(lint.name).toBe('lint');
+    expect(typeof lint.description).toBe('string');
+    expect(typeof lint.handler).toBe('function');
+  });
+});

--- a/test/kernel/broker-migration-ledger.test.js
+++ b/test/kernel/broker-migration-ledger.test.js
@@ -5,7 +5,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createLocalBroker, execMigrationStatement } = require('../../lib/kernel/broker');
 const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
 const { buildKernelMigrationPlan } = require('../../lib/kernel/migrations');
 
@@ -100,5 +100,98 @@ describe('Kernel broker — migration ledger', () => {
 
 		const reapplied = await makeBroker(extendedPlan).initialize();
 		expect(reapplied.migrationsNewlyApplied).toEqual([]);
+	});
+
+	test('two brokers initializing the same DB concurrently both succeed with one ledger row per migration', async () => {
+		// Integration realism for the concurrent-init path. NOTE: this is SCHEDULING-
+		// DEPENDENT — whether the second init lands in the pre-check or the TOCTOU catch
+		// is microtask-ordering luck, so it can pass even on unfixed code when scheduling
+		// happens to serialize. It asserts only the end state; the DETERMINISTIC guard
+		// for the catch path lives in the execMigrationStatement suite below.
+		const driver2 = createBuiltinSQLiteDriver({});
+		try {
+			const a = makeBroker();
+			const b = createLocalBroker({
+				projectRoot: tmpDir,
+				execFileSync: () => path.join(tmpDir, '.git'),
+				databasePath: config.databasePath,
+				driver: driver2,
+			});
+
+			const [resultA, resultB] = await Promise.all([a.initialize(), b.initialize()]);
+
+			expect(resultA.success).toBe(true);
+			expect(resultB.success).toBe(true);
+			const planIds = buildKernelMigrationPlan().migrations.map(migration => migration.id);
+			expect(await ledgerIds()).toEqual([...planIds].sort());
+		} finally {
+			driver2.close();
+		}
+	});
+});
+
+// Deterministic guards for the ADD COLUMN TOCTOU catch path. These drive
+// execMigrationStatement with a fake driver so the exact "another writer added the
+// column between our pre-check and our exec" interleaving is forced every run (no
+// reliance on scheduling). The first FAILS on the pre-fix code (which had no catch).
+describe('Kernel broker — execMigrationStatement ADD COLUMN race (TOCTOU)', () => {
+	const ADD_COLUMN = 'ALTER TABLE kernel_issues ADD COLUMN design TEXT;';
+
+	test('skips (does not throw) when a concurrent writer adds the column between pre-check and exec', async () => {
+		// Pre-check sees the column MISSING; exec then loses the race and throws
+		// duplicate-column; the catch re-verifies and now sees it PRESENT → skip.
+		let pragmaCalls = 0;
+		const driver = {
+			async queryAll(statement) {
+				if (/PRAGMA table_info/i.test(statement)) {
+					pragmaCalls += 1;
+					return pragmaCalls === 1 ? [] : [{ name: 'design' }];
+				}
+				return [];
+			},
+			async exec() {
+				throw new Error('SQLITE_ERROR: duplicate column name: design');
+			},
+		};
+
+		const result = await execMigrationStatement(driver, ADD_COLUMN, {});
+
+		expect(result).toEqual({ skipped: true, reason: 'column-added-concurrently' });
+		expect(pragmaCalls).toBe(2); // pre-check + post-failure re-verify
+	});
+
+	test('rethrows when exec fails and the column is still absent (no blanket swallow)', async () => {
+		// A non-duplicate failure with the column never appearing must propagate.
+		const driver = {
+			async queryAll() {
+				return []; // column never present
+			},
+			async exec() {
+				throw new Error('SQLITE_ERROR: disk I/O error');
+			},
+		};
+
+		await expect(execMigrationStatement(driver, ADD_COLUMN, {}))
+			.rejects.toThrow(/disk I\/O error/);
+	});
+
+	test('surfaces the original exec error when the post-failure re-check itself throws', async () => {
+		let pragmaCalls = 0;
+		const driver = {
+			async queryAll(statement) {
+				if (/PRAGMA table_info/i.test(statement)) {
+					pragmaCalls += 1;
+					if (pragmaCalls === 1) return []; // pre-check: missing
+					throw new Error('re-check boom'); // post-failure re-verify blows up
+				}
+				return [];
+			},
+			async exec() {
+				throw new Error('original exec failure');
+			},
+		};
+
+		await expect(execMigrationStatement(driver, ADD_COLUMN, {}))
+			.rejects.toThrow(/original exec failure/);
 	});
 });

--- a/test/kernel/broker-migration-ledger.test.js
+++ b/test/kernel/broker-migration-ledger.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+const { buildKernelMigrationPlan } = require('../../lib/kernel/migrations');
+
+// The kernel_migrations ledger records applied migration ids so initialize() applies
+// each migration AT MOST ONCE — replacing the old "re-run the whole plan every init +
+// swallow any duplicate-column error" model. ADD COLUMNs are guarded by a PRAGMA
+// precondition (skip if the column already exists), so a pre-ledger DB that already has
+// the columns backfills the ledger cleanly without a swallow, and a genuine SQL error
+// still propagates.
+describe('Kernel broker — migration ledger', () => {
+	let tmpDir;
+	let driver;
+	let config;
+
+	function makeBroker(migrationPlan) {
+		return createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: config.databasePath,
+			driver,
+			...(migrationPlan ? { migrationPlan } : {}),
+		});
+	}
+
+	async function ledgerIds() {
+		const rows = await driver.queryAll('SELECT id FROM kernel_migrations ORDER BY id ASC;', config);
+		return rows.map(row => row.id);
+	}
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-ledger-'));
+		config = { databasePath: path.join(tmpDir, 'kernel.sqlite') };
+		driver = createBuiltinSQLiteDriver({});
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('a fresh DB records every plan migration id exactly once', async () => {
+		const plan = buildKernelMigrationPlan();
+		const result = await makeBroker(plan).initialize();
+
+		const expectedIds = plan.migrations.map(migration => migration.id);
+		expect(result.migrationsNewlyApplied).toEqual(expectedIds);
+		expect(await ledgerIds()).toEqual([...expectedIds].sort());
+		const count = await driver.queryAll('SELECT COUNT(*) AS n FROM kernel_migrations;', config);
+		expect(Number(count[0].n)).toBe(expectedIds.length);
+	});
+
+	test('a second initialize applies nothing (the ledger short-circuits)', async () => {
+		await makeBroker().initialize();
+		const before = await ledgerIds();
+
+		const second = await makeBroker().initialize();
+
+		expect(second.migrationsNewlyApplied).toEqual([]);
+		expect(await ledgerIds()).toEqual(before);
+	});
+
+	test('an existing DB whose ledger was lost backfills without a duplicate-column throw', async () => {
+		await makeBroker().initialize();
+		// Simulate a pre-ledger DB: the columns exist, but the ledger does not.
+		await driver.exec('DROP TABLE kernel_migrations;', config);
+
+		const result = await makeBroker().initialize();
+
+		expect(result.success).toBe(true);
+		// Guarded ADD COLUMN skipped the already-present columns; the ledger is backfilled.
+		const planIds = buildKernelMigrationPlan().migrations.map(migration => migration.id);
+		expect(await ledgerIds()).toEqual([...planIds].sort());
+	});
+
+	test('a newly added ADD COLUMN migration applies once on an up-to-date DB', async () => {
+		await makeBroker().initialize();
+
+		const newMigration = {
+			id: '900_ledger_test_new_column',
+			apply: ['ALTER TABLE kernel_issues ADD COLUMN ledger_test_col TEXT;'],
+			rollback: ['ALTER TABLE kernel_issues DROP COLUMN ledger_test_col;'],
+		};
+		const extendedPlan = buildKernelMigrationPlan([
+			...buildKernelMigrationPlan().migrations,
+			newMigration,
+		]);
+
+		const applied = await makeBroker(extendedPlan).initialize();
+		expect(applied.migrationsNewlyApplied).toEqual([newMigration.id]);
+		const cols = await driver.queryAll('PRAGMA table_info(kernel_issues);', config);
+		expect(cols.some(col => col.name === 'ledger_test_col')).toBe(true);
+
+		const reapplied = await makeBroker(extendedPlan).initialize();
+		expect(reapplied.migrationsNewlyApplied).toEqual([]);
+	});
+});

--- a/test/kernel/broker.test.js
+++ b/test/kernel/broker.test.js
@@ -42,6 +42,10 @@ describe('local Kernel broker contract', () => {
 				async exec(statement) {
 					statements.push(statement);
 				},
+				// Empty ledger + no pre-existing columns → every migration applies.
+				async queryAll() {
+					return [];
+				},
 			},
 		});
 
@@ -60,33 +64,6 @@ describe('local Kernel broker contract', () => {
 			'PRAGMA busy_timeout=5000;',
 		]);
 		expect(statements).toContain('CREATE TABLE IF NOT EXISTS kernel_issues (\n  id TEXT NOT NULL PRIMARY KEY,\n  title TEXT NOT NULL,\n  body TEXT,\n  type TEXT NOT NULL DEFAULT \'task\',\n  status TEXT NOT NULL DEFAULT \'open\',\n  priority TEXT NOT NULL DEFAULT \'P2\',\n  priority_rank INTEGER NOT NULL DEFAULT 0,\n  created_at TEXT NOT NULL,\n  updated_at TEXT NOT NULL,\n  entity_revision INTEGER NOT NULL DEFAULT 0,\n  parent_id TEXT REFERENCES kernel_issues(id),\n  sprint_id TEXT,\n  release_id TEXT,\n  stage_state TEXT,\n  labels TEXT,\n  acceptance_criteria TEXT,\n  estimate TEXT\n);');
-	});
-
-	test('does not fail when the expected revision column migration is replayed', async () => {
-		const { createLocalBroker } = require('../../lib/kernel/broker');
-		const addColumn = 'ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;';
-		let addColumnAttempts = 0;
-		const broker = createLocalBroker({
-			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
-			gitCommonDir: path.join(os.tmpdir(), 'forge-common-dir'),
-			migrationPlan: {
-				migrations: [{ id: '002_kernel_events_expected_revision' }],
-				apply: [addColumn],
-			},
-			driver: {
-				async exec(statement) {
-					if (statement !== addColumn) return;
-					addColumnAttempts += 1;
-					if (addColumnAttempts > 1) {
-						throw new Error('duplicate column name: expected_revision');
-					}
-				},
-			},
-		});
-
-		await expect(broker.initialize()).resolves.toMatchObject({ success: true });
-		await expect(broker.initialize()).resolves.toMatchObject({ success: true });
-		expect(addColumnAttempts).toBe(2);
 	});
 
 	test('exposes a testable issue-operation boundary without requiring a bundled sqlite dependency', async () => {

--- a/test/kernel/issue-command-contract.test.js
+++ b/test/kernel/issue-command-contract.test.js
@@ -98,6 +98,17 @@ describe('Kernel issue command contract', () => {
 		expect(summarySchema.required).not.toContain('comments');
 	});
 
+	test('KAP-10/11: issue summary schema declares acceptance_criteria/design/notes/assignee', () => {
+		const { ISSUE_COMMAND_RESPONSE_SCHEMAS } = require('../../lib/kernel/issue-command-contract');
+		const summarySchema = ISSUE_COMMAND_RESPONSE_SCHEMAS.issue.properties.data;
+
+		// Each content field is a nullable string and OPTIONAL (issues without it still validate).
+		for (const fieldName of ['acceptance_criteria', 'design', 'notes', 'assignee']) {
+			expect(summarySchema.properties[fieldName]).toEqual({ type: ['string', 'null'] });
+			expect(summarySchema.required).not.toContain(fieldName);
+		}
+	});
+
 	test('defines a stable error envelope and meaningful exit codes', () => {
 		const {
 			ISSUE_COMMAND_ERROR_SCHEMA,

--- a/test/kernel/issue-command-contract.test.js
+++ b/test/kernel/issue-command-contract.test.js
@@ -20,6 +20,7 @@ describe('Kernel issue command contract', () => {
 			'issue.blocked',
 			'issue.stale',
 			'issue.orphans',
+			'issue.lint',
 			'issue.create',
 			'issue.update',
 			'issue.close',
@@ -75,6 +76,20 @@ describe('Kernel issue command contract', () => {
 			.toEqual({ type: 'integer' });
 		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.staleList.properties.data.properties.issues.items)
 			.toBe(ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList.properties.data.properties.issues.items);
+
+		// KAP-12: `lint` reuses the issueList shape (array of ISSUE_SUMMARY_SCHEMA +
+		// count). The summary schema declares an OPTIONAL `validation` object so lint
+		// items can carry rules_failed without breaking comment-less/validation-less
+		// summaries, and it stays OUT of `required`.
+		expect(getIssueCommandContract('issue.lint')).toMatchObject({
+			id: 'issue.lint',
+			operation: 'lint',
+			mode: 'read',
+			outputSchema: ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList,
+		});
+		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList.properties.data.properties.issues.items
+			.properties.validation).toBeDefined();
+		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList.required).not.toContain('validation');
 	});
 
 	test('KAP-3: issue summary schema declares an optional comments array', () => {

--- a/test/kernel/issue-command-contract.test.js
+++ b/test/kernel/issue-command-contract.test.js
@@ -89,7 +89,8 @@ describe('Kernel issue command contract', () => {
 		});
 		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList.properties.data.properties.issues.items
 			.properties.validation).toBeDefined();
-		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList.required).not.toContain('validation');
+		expect(ISSUE_COMMAND_RESPONSE_SCHEMAS.issueList.properties.data.properties.issues.items
+			.required).not.toContain('validation');
 	});
 
 	test('KAP-3: issue summary schema declares an optional comments array', () => {

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -21,8 +21,9 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.apply).toContain('ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
-		// Rollback runs migrations in reverse, so 003's index drop comes first.
-		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_claims_active_lease;');
+		// Rollback runs migrations in reverse, so 004's last column drop comes first.
+		expect(plan.rollback[0]).toBe('ALTER TABLE kernel_issues DROP COLUMN assignee;');
+		expect(plan.rollback).toContain('DROP INDEX IF EXISTS idx_kernel_claims_active_lease;');
 		expect(plan.rollback).toContain('CREATE TABLE IF NOT EXISTS kernel_events_002_rollback (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.rollback).toContain('INSERT INTO kernel_events_002_rollback (id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at) SELECT id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at FROM kernel_events;');
 		expect(plan.rollback).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_kernel_events_idempotency ON kernel_events (idempotency_key);');
@@ -31,7 +32,34 @@ describe('kernel migration plans', () => {
 			'001_kernel_schema',
 			'002_kernel_events_expected_revision',
 			'003_kernel_claims_active_lease',
+			'004_kernel_issues_content_fields',
 		]);
+	});
+
+	test('KAP-10/11: migration 004 adds design/notes/assignee content fields and drops them on rollback', () => {
+		const { buildIssueContentFieldsMigration } = require('../../lib/kernel/migrations');
+		const migration = buildIssueContentFieldsMigration();
+
+		expect(migration.id).toBe('004_kernel_issues_content_fields');
+		// The three additive content columns (KAP-10: design/notes; KAP-11: assignee).
+		expect(migration.apply).toEqual([
+			'ALTER TABLE kernel_issues ADD COLUMN design TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN notes TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN assignee TEXT;',
+		]);
+		// Rollback drops them in reverse so dependent ordering is symmetric.
+		expect(migration.rollback).toEqual([
+			'ALTER TABLE kernel_issues DROP COLUMN assignee;',
+			'ALTER TABLE kernel_issues DROP COLUMN notes;',
+			'ALTER TABLE kernel_issues DROP COLUMN design;',
+		]);
+
+		// Registered in the default plan so fresh and existing DBs both migrate.
+		const plan = buildKernelMigrationPlan();
+		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN design TEXT;');
+		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN notes TEXT;');
+		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN assignee TEXT;');
+		expect(plan.rollback).toContain('ALTER TABLE kernel_issues DROP COLUMN assignee;');
 	});
 
 	test('enforces a single active claim lease per issue via a partial unique index (9.5.10)', () => {

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -47,6 +47,13 @@ describe('kernel schema registry', () => {
 		expect(KERNEL_TABLES.projections.indexes.map(index => index.name)).toContain('idx_kernel_projections_target_status');
 		expect(KERNEL_TABLES.conflicts.indexes.map(index => index.name)).toContain('idx_kernel_conflicts_status');
 		expect(KERNEL_TABLES.events.fields.map(field => field.name)).toContain('expected_revision');
+
+		// KAP-10/11: fresh DBs get the content/assignee columns directly from the schema
+		// (migration 004 backfills existing DBs). estimate/acceptance_criteria predate this.
+		const issueFieldNames = KERNEL_TABLES.issues.fields.map(field => field.name);
+		expect(issueFieldNames).toContain('design');
+		expect(issueFieldNames).toContain('notes');
+		expect(issueFieldNames).toContain('assignee');
 	});
 
 	test('classifies every table and field with valid storage and authority metadata', () => {

--- a/test/kernel/sqlite-driver-issue.test.js
+++ b/test/kernel/sqlite-driver-issue.test.js
@@ -169,6 +169,32 @@ describe('Kernel SQLite driver — enriched issue projection (KAP-2)', () => {
 		});
 	});
 
+	// KAP-10 (acceptance_criteria/design/notes) + KAP-11 (assignee): rowToIssueSummary
+	// surfaces the four content fields, each defaulting to null when the column is empty.
+	test('show surfaces acceptance_criteria/design/notes/assignee, null when unset', async () => {
+		await driver.exec(
+			`INSERT INTO kernel_issues (id,title,type,status,priority,priority_rank,acceptance_criteria,design,notes,assignee,created_at,updated_at,entity_revision) VALUES
+				('cf-show','Has content','task','open','P2',9,'AC body','Design body','Notes body','alice','${now}','${now}',0);`,
+			config,
+		);
+
+		const res = await driver.issueOperation('show', ['cf-show'], {}, config);
+		expect(res.data).toMatchObject({
+			id: 'cf-show',
+			acceptance_criteria: 'AC body',
+			design: 'Design body',
+			notes: 'Notes body',
+			assignee: 'alice',
+		});
+
+		// p1 was seeded without the content columns → each surfaces as null.
+		const bare = await driver.issueOperation('show', ['p1'], {}, config);
+		expect(bare.data.acceptance_criteria).toBeNull();
+		expect(bare.data.design).toBeNull();
+		expect(bare.data.notes).toBeNull();
+		expect(bare.data.assignee).toBeNull();
+	});
+
 	test('list carries the enriched fields for every issue', async () => {
 		const res = await driver.issueOperation('list', [], {}, config);
 		const c1 = res.data.issues.find(issue => issue.id === 'c1');

--- a/test/kernel/sqlite-driver-issue.test.js
+++ b/test/kernel/sqlite-driver-issue.test.js
@@ -536,3 +536,63 @@ describe('Kernel SQLite driver — orphans query (KAP-7)', () => {
 		expect(res.data.count).toBe(2);
 	});
 });
+
+// KAP-12: read-only `lint` — flags issues missing required content. An issue FAILS
+// content lint iff its type is task|bug AND acceptance_criteria is null or
+// empty/whitespace-only. epic/decision are exempt. Each failing issue carries a
+// `validation: { rules_failed: ['missing_acceptance_criteria'] }`. Results sort like
+// list (rank asc). The rule references ONLY base-existing columns.
+describe('Kernel SQLite driver — lint query (KAP-12)', () => {
+	let tmpDir;
+	let driver;
+	let config;
+	const now = '2026-06-20T00:00:00.000Z';
+
+	beforeAll(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-kap12-lint-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		const broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+
+		// l1: task, no acceptance_criteria (NULL)        → FAILS.
+		// l2: task, has acceptance_criteria               → passes.
+		// l3: bug, whitespace-only acceptance_criteria    → FAILS.
+		// l4: epic, no acceptance_criteria                → EXEMPT (passes).
+		// l5: task, empty-string acceptance_criteria      → FAILS.
+		await driver.exec(
+			`INSERT INTO kernel_issues (id,title,type,status,priority_rank,acceptance_criteria,created_at,updated_at,entity_revision) VALUES
+				('l1','Task missing AC','task','open',1,NULL,'${now}','${now}',0),
+				('l2','Task with AC','task','open',2,'Given X, then Y','${now}','${now}',0),
+				('l3','Bug whitespace AC','bug','open',3,'   ','${now}','${now}',0),
+				('l4','Epic missing AC','epic','open',4,NULL,'${now}','${now}',0),
+				('l5','Task empty AC','task','open',5,'','${now}','${now}',0);`,
+			config,
+		);
+	});
+
+	afterAll(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('lint returns exactly the task/bug issues missing acceptance_criteria, each with rules_failed', async () => {
+		const res = await driver.issueOperation('lint', [], {}, config);
+		expect(res.ok).toBe(true);
+		expect(res.schema_version).toBe('forge.issue.v1');
+		expect(res.command).toBe('issue.lint');
+		// l1 (NULL), l3 (whitespace), l5 (empty) fail. l2 has AC; l4 is an epic (exempt).
+		// Sorted like list (rank asc).
+		expect(res.data.issues.map(issue => issue.id)).toEqual(['l1', 'l3', 'l5']);
+		expect(res.data.count).toBe(3);
+		for (const issue of res.data.issues) {
+			expect(issue.validation).toEqual({ rules_failed: ['missing_acceptance_criteria'] });
+		}
+	});
+});

--- a/test/kernel/sqlite-driver-mutations.test.js
+++ b/test/kernel/sqlite-driver-mutations.test.js
@@ -206,6 +206,67 @@ describe('Kernel SQLite driver — issue mutations via guarded path (Wave 3)', (
 		expect(shown.data.parent_id).toBe('epic-x');
 	});
 
+	// KAP-10 (acceptance/design/notes) + KAP-11 (assignee): the four content fields
+	// persist on create via the issue-upsert write allow-list, and surface on show.
+	test('create persists acceptance_criteria/design/notes/assignee', async () => {
+		await broker.runIssueOperation(
+			'create',
+			[
+				'--id', 'cf-1', '--title', 'Content fields', '--type', 'task',
+				'--acceptance', 'AC text', '--design', 'Design text',
+				'--notes', 'Notes text', '--assignee', 'alice',
+			],
+			{ now, actor: 'tester' },
+		);
+
+		const shown = await driver.issueOperation('show', ['cf-1'], {}, config);
+		expect(shown.data.acceptance_criteria).toBe('AC text');
+		expect(shown.data.design).toBe('Design text');
+		expect(shown.data.notes).toBe('Notes text');
+		expect(shown.data.assignee).toBe('alice');
+
+		// Persisted directly to their columns (not just the event payload).
+		const rows = await driver.queryAll(
+			'SELECT acceptance_criteria, design, notes, assignee FROM kernel_issues WHERE id = \'cf-1\'',
+			config,
+		);
+		expect(rows[0]).toEqual({
+			acceptance_criteria: 'AC text',
+			design: 'Design text',
+			notes: 'Notes text',
+			assignee: 'alice',
+		});
+	});
+
+	// KAP-11: assignee is a persistent reassignment on update (distinct from the
+	// transient claim lease). The other three content fields update the same way.
+	test('update reassigns assignee and overwrites design/notes/acceptance', async () => {
+		await broker.runIssueOperation(
+			'create',
+			[
+				'--id', 'cf-2', '--title', 'Reassign', '--type', 'task',
+				'--acceptance', 'old AC', '--design', 'old D',
+				'--notes', 'old N', '--assignee', 'alice',
+			],
+			{ now, actor: 'tester' },
+		);
+
+		await broker.runIssueOperation(
+			'update',
+			[
+				'cf-2', '--acceptance', 'new AC', '--design', 'new D',
+				'--notes', 'new N', '--assignee', 'bob',
+			],
+			{ now: '2026-06-19T00:10:00.000Z', actor: 'tester' },
+		);
+
+		const shown = await driver.issueOperation('show', ['cf-2'], {}, config);
+		expect(shown.data.acceptance_criteria).toBe('new AC');
+		expect(shown.data.design).toBe('new D');
+		expect(shown.data.notes).toBe('new N');
+		expect(shown.data.assignee).toBe('bob');
+	});
+
 	// KAP-5: close --reason is captured in the close EVENT payload (no column/migration).
 	test('close --reason succeeds and records the reason in the close event payload', async () => {
 		await broker.runIssueOperation(


### PR DESCRIPTION
## Problem

The kernel still lacked the "model-depth" affordances from the KAP backlog: no way to write authored content fields (acceptance/design/notes), no persistent assignee, and no way to lint issues for missing required content.

## Root Cause

These are Wave 3 (Track 3) of the Kernel Agent-Parity backlog — the slice that needs schema growth (`design`/`notes`/`assignee` columns) on top of the existing `acceptance_criteria`/`estimate` precedent.

## Fix

Three features via two parallel TDD lanes, then integrated:

- **KAP-10** — `--acceptance`/`--design`/`--notes` write flags (acceptance maps to the existing `acceptance_criteria` column; design/notes are new), surfaced in the issue projection.
- **KAP-11** — `--assignee` persistent assignment (a *durable* field, distinct from the transient claim lease in `claimed_by`).
- **KAP-12** — `forge lint`: a read-only content-validation op flagging issues that fail required-section rules; full CLI stack (driver op + contract + subcommand + adapter + alias + passthrough).

KAP-10/11 ship one schema migration (`004`) adding `design`/`notes`/`assignee`. The integration also fixed `getInitialKernelSchema()` to exclude migration-added columns from the `001` CREATE TABLE (so a fresh DB doesn't create them before the ALTER…ADD COLUMN runs — the established `expected_revision`/`002` pattern, now generalized to a per-table map).

## Value

Agents can capture acceptance criteria / design notes / ownership through the CLI and lint a board for issues missing required content — closing the remaining model-depth parity gaps with Beads.

## Beads

N/A — bd/Dolt unreachable (K0). Dogfooded in the kernel (`FORGE_ISSUE_BACKEND=kernel`); `kap-10/11/12` marked `review`, close on merge.

<details>
<summary>Implementation Details</summary>

### Test Coverage
- Full affected suite **892 tests / 0 fail**. New TDD per feature: migration 004 apply/rollback, content-field write round-trips, assignee persistence, lint rule (task/bug missing acceptance → flagged; epic exempt; issues WITH acceptance excluded).
- Integration caught + fixed a cross-file break (`broker-multiprocess` direct-plan-apply hit a duplicate-column because the `001` schema filter wasn't extended) — the architecturally-correct fix, not a swallow workaround.

### Security Review
- N/A new risk — CLI flags routed through the parameterized write path (bound `?` params); new columns are nullable TEXT.

### Design Doc
See: [docs/work/2026-06-20-kernel-agent-parity/design.md](docs/work/2026-06-20-kernel-agent-parity/design.md) (KAP Track 3).

### Key Decisions
- **`design`/`notes`/`assignee` get real columns** (migration 004), extending the existing `acceptance_criteria`/`estimate` precedent. NOTE: this is schema commitment that the "track C / Model A storage" work was meant to design first — the track-C design should inherit this decision.
- **Migration-added columns are excluded from the `001` initial schema** via a per-table map in `getInitialKernelSchema()` (mirrors `events.expected_revision`); schema.js remains the full current schema.
- **`assignee` is distinct from the claim lease** — durable ownership vs transient active-claim holder.
- **Lint rule (base fields only):** `type ∈ {task,bug}` ⇒ non-empty `acceptance_criteria`.

### Documentation Updated
- Regenerated the D20 bd call-site kill-list (line drift from lib edits).

### Validation
- [x] Lint passing (`eslint --max-warnings 0`)
- [x] All tests passing (892 / 0)
- [x] D20 release-readiness gate green
- [x] Real-CLI e2e per feature (content fields, assignee, lint excluding issues with acceptance)

</details>

---

### Self-Review Checklist

- [x] I reviewed the full diff on GitHub
- [x] No debug code
- [x] ESLint passes with zero warnings
- [x] All tests pass locally (`bun test`)
- [x] No hardcoded secrets or API keys
- [x] No breaking changes (additive — new flags/columns/op; default Beads path untouched)
- [x] TDD compliance: all new source paths have corresponding tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `forge lint` to list task/bug issues missing required acceptance criteria, including per-issue validation details (`rules_failed`).
  * Extended issue data to persist and return `acceptance_criteria`, `design`, `notes`, and `assignee`.
* **Bug Fixes**
  * Improved CLI handling so `forge lint` no longer interferes with other top-level setup flags.
  * Enhanced kernel database initialization/migrations with safer migration tracking and more robust handling of already-present columns.
* **Tests**
  * Added/updated coverage for `forge lint`, the new issue fields, and improved kernel query, schema, migration, and concurrency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->