### PR TITLE
feat(kernel): D19 default-on filesystem safety gate + forge doctor

### DIFF
--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -116,6 +116,7 @@ These commands exist as current CLI surfaces, but many are specialized and shoul
 forge audit
 forge explain
 forge docs
+forge doctor
 forge test
 forge push
 forge upgrade
@@ -125,6 +126,25 @@ forge add
 ```
 
 `forge migrate` is dry-run oriented in the current public docs. Do not present it as a migration executor.
+
+## Kernel Filesystem Safety
+
+The Forge Kernel stores its SQLite database under `.git/forge/kernel.sqlite`. SQLite WAL mode corrupts when a cloud-sync client (OneDrive, Dropbox, Google Drive, iCloud) or a network filesystem (UNC / SMB / NFS / mapped drive) rewrites the database mid-write. A default-on gate in `broker.initialize()` therefore **refuses** to initialize the kernel on those filesystems — the throw happens *before* any database file is created, so nothing is written to the unsafe location.
+
+```bash
+forge doctor          # human summary, exits non-zero on a refuse-class path
+forge doctor --json   # machine-readable report (schemaVersion 1)
+```
+
+`forge doctor` resolves the exact kernel database path the gate guards and reports its filesystem class **without creating any file**:
+
+| Class | Risk tier | Behavior |
+|-------|-----------|----------|
+| `local-ok` | safe | proceed silently |
+| `wsl-cross`, `unknown` | warn | proceed with a warning (fail-open) |
+| `onedrive`, `dropbox`, `gdrive`, `icloud`, `network-unc`, `mapped-network-drive` | refuse | block kernel init |
+
+**Escape hatch:** set `FORGE_KERNEL_ALLOW_UNSAFE_FS=1` to downgrade every `refuse` to a warning and proceed at your own risk (intended for reliable network homes, CI sandboxes, and incident recovery). It does not affect `safe`/`warn` classes. On Windows, mapped-drive detection **fails safe**: any probe failure is treated as `unknown` (warn), never silently allowed.
 
 ## Agent Workflow Stages
 

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/D19-filesystem-doctor-design.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/D19-filesystem-doctor-design.md
@@ -198,6 +198,7 @@ Wave 3 (optional, after both): D19-T4 docs/AGENTS surface note — non-code, syn
 ```
 
 ### File ownership (no collisions)
+
 | Task | OWNS (writes) | READS only |
 |------|---------------|------------|
 | D19-T1 | `lib/kernel/fs-class.js`, `test/kernel/fs-class.test.js` | — |

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/D19-filesystem-doctor-design.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/D19-filesystem-doctor-design.md
@@ -1,0 +1,261 @@
+# D19 — Filesystem Doctor (default-on gate): Design + TDD Task List
+
+**Status:** Design (no code). Hand-off artifact for parallel implementer agents.
+**Authority:** `decisions.md` §D19. **Scope discipline:** doctor *reports the filesystem class only*; broad health stays in `runtime-health.js` (do not balloon doctor).
+
+---
+
+## 0. Verified facts (load-bearing, read from source)
+
+| # | Claim | Evidence |
+|---|-------|----------|
+| F1 | **SQLite file creation is LAZY.** The injected driver opens/creates the DB on the **first `exec`/query**, not at construction. `lib/kernel/sqlite-driver.js`: `getDatabase(config)` (~L879) calls `createDatabase` → `new Database(databasePath,{create:true})` (~L97) only on first use. `createDriver` itself opens nothing. | sqlite-driver.js L84-100, L879-884 |
+| F2 | **The first disk touch is `broker.initialize()`.** It runs `await driver.exec(<pragma>)` in a loop, then migrations. The gate at the **top of `initialize()`, before the pragma loop**, fires *before* `kernel.sqlite` exists. | broker.js `initialize()` |
+| F3 | **`doctor.js` requires ZERO `bin/forge.js` edit.** `bin/forge.js` L4165 `loadCommands(lib/commands)` auto-discovers every non-`_` `.js` file; L4187 `if (registry.commands.has(command)) { … return; }` short-circuits **before** the `command==='setup'` else-if chain. Help (L2780) is registry-driven. Dropping `lib/commands/doctor.js` registers + routes + helps it automatically. **This dissolves the D20 collision warned about in the task.** | _registry.js `loadCommands`; bin/forge.js L4165-4187 |
+| F4 | Command module contract: `{ name:string, description:string, usage?:string, handler(args, flags, projectRoot) }` returning `{ success, output?, error? }`. `bin/forge.js` writes `result.output` to stdout, `result.error` to stderr + exit 1. | _registry.js `validateCommand`/`executeCommand`; orient.js, recap.js |
+| F5 | Real broker wiring is `lib/forge-issues.js` L285 `createKernelBroker = … createLocalBroker({…})` — the only production call site; broker tests inject fakes. The gate lives **inside** `initialize()` so it covers both paths without touching forge-issues.js. | forge-issues.js L10, L285 |
+| F6 | Test convention: `bun:test` (`describe/expect/test`), tests mirror lib path under `test/` (e.g. `test/kernel/broker.test.js`, `test/commands/orient.test.js`), deps injected via `options`. | broker.test.js header |
+
+---
+
+## 1. Design
+
+### 1.1 Filesystem-class detector (foundational, pure + thin I/O shell)
+
+**Module:** `lib/kernel/fs-class.js`. Two layers — the split is the testability crux.
+
+#### Layer A — pure classifier (100% synthetic-tested, zero I/O)
+```
+classifyFromSignals(signals) -> Classification
+```
+`signals` (plain object, fully injected):
+```
+{
+  platform:   'win32' | 'darwin' | 'linux',
+  absPath:    string,              // normalized absolute DB path
+  env:        { OneDrive, OneDriveConsumer, OneDriveCommercial, ICLOUD?, ... },
+  homedir:    string,
+  isUNC:      boolean,             // path starts with \\ or //
+  driveType:  'fixed'|'network'|'removable'|'unknown'|null,  // Windows, from probe
+  mountFsType:string|null,         // Linux, fs type at the mount covering absPath (drvfs/9p/cifs/nfs/fuse.*)
+  isWslInterop: boolean           // running under WSL (probe of /proc/version)
+}
+```
+`Classification` (the canonical return shape, reused by doctor + gate):
+```
+{
+  class:        'local-ok'|'onedrive'|'dropbox'|'gdrive'|'icloud'
+                |'network-unc'|'mapped-network-drive'|'wsl-cross'|'unknown',
+  riskTier:     'safe'|'warn'|'refuse',
+  signal:       string,            // the matched signal, e.g. 'env.OneDriveCommercial prefix'
+  remediationKey: string           // stable key → message table (1.4)
+}
+```
+
+**Detection signals per OS** (dependency-free; precedence = most-corrupting first):
+
+- **Windows (`win32`)**
+  - `network-unc` (refuse): `isUNC` true (`\\server\share`).
+  - `mapped-network-drive` (refuse): `driveType==='network'` for the path's drive letter.
+  - `onedrive` (refuse): `absPath` (case-insensitive) starts with any of `env.OneDrive`, `env.OneDriveConsumer`, `env.OneDriveCommercial`, **or** a path segment matching `/OneDrive([ -][^\\/]+)?/i` (covers "OneDrive - Contoso"). *This repo under `…\Downloads` is only OneDrive if Downloads is redirected into the OneDrive root — the env-prefix check catches exactly that.*
+  - `dropbox` (refuse): segment `\Dropbox\` or `env`-declared Dropbox root.
+  - `gdrive` (refuse): segment matching `/Google ?Drive|GoogleDrive|DriveFS/i` or a `My Drive` segment.
+  - else `local-ok` (safe).
+- **macOS (`darwin`)**
+  - `icloud` (refuse): under `${homedir}/Library/Mobile Documents` (incl. `com~apple~CloudDocs`).
+  - `dropbox` (refuse): `${homedir}/Dropbox` or `~/Library/CloudStorage/Dropbox*`.
+  - `gdrive` (refuse): `~/Google Drive`, `~/Library/CloudStorage/GoogleDrive*`.
+  - `onedrive` (refuse): `~/Library/CloudStorage/OneDrive*`.
+  - else `local-ok`.
+- **Linux / WSL**
+  - `wsl-cross` (warn): `isWslInterop` true **and** `absPath` starts with `/mnt/<letter>/` (DB on the Windows volume across the 9p/drvfs boundary).
+  - `network-unc` (refuse): `mountFsType ∈ {cifs, smb3, nfs, nfs4, fuse.sshfs}`.
+  - cloud (refuse): `mountFsType` startsWith `fuse.` for known sync daemons (`fuse.dropbox`, `fuse.rclone`, `fuse.google-drive-ocamlfuse`) → map to `dropbox`/`gdrive`; segment `/Dropbox/`, `/Google ?Drive/`, `/OneDrive/` as a secondary signal.
+  - else `local-ok`.
+- **Anything unmatched / probe failure** → `unknown` (warn, **fail-open** — never block on uncertainty).
+
+#### Layer B — thin signal gatherer (does the I/O, all probes injectable)
+```
+gatherSignals(absPath, deps = {}) -> signals
+```
+`deps` (each defaults to a real impl; tests pass fakes):
+- `platform = process.platform`, `env = process.env`, `homedir = os.homedir`
+- `probeDriveType(driveLetter)` — Windows. **No native deps:** shell out via `execFileSync('cmd', ['/c','wmic','logicaldrive',…])` is deprecated on Win11; prefer `execFileSync('net', ['use'])` parse for mapped letters + `execFileSync('powershell','-NoProfile','-Command','(Get-PSDrive …).DisplayRoot')` fallback. **Spec gap flagged below (G1).** Probe is wrapped in try/catch → `'unknown'` on failure.
+- `probeMounts()` — Linux. Read `/proc/mounts`, find the longest mountpoint that is a prefix of `absPath`, return its fs type.
+- `readWslInterop()` — Linux. `true` if `/proc/version` contains `microsoft` (case-insensitive) or `env.WSL_DISTRO_NAME` set.
+- `isUNC(absPath)` — pure string test.
+
+**Public entry:** `classifyFilesystem(absPath, deps={}) = classifyFromSignals(gatherSignals(absPath, deps))`. Detector takes **no real-FS dependency in tests** because every probe is injected.
+
+### 1.2 Policy: refuse vs warn (+ escape hatch)
+
+| Class | Tier | Justification |
+|-------|------|---------------|
+| local-ok | safe | proceed silently |
+| onedrive, dropbox, gdrive, icloud | **refuse** | active cloud-sync = highest WAL-corruption risk (sync daemon rewrites `-wal`/`-shm` mid-transaction) |
+| network-unc, mapped-network-drive | **refuse** | SQLite locking unreliable over SMB/NFS; documented corruption |
+| wsl-cross | warn | works but slow + lock edge cases; not silently corrupting |
+| unknown | warn | fail-open: never block a user we can't classify |
+
+**Refuse fires only when the DB path is *inside* the risky root** (the gather already scopes to `absPath`), never on the mere presence of OneDrive elsewhere on the machine.
+
+**Escape hatch:** `FORGE_KERNEL_ALLOW_UNSAFE_FS=1` downgrades every `refuse` → `warn` (proceeds, prints the warning + "override active"). Justification: power users on reliable network homes, CI sandboxes, and incident recovery must not be hard-blocked; an explicit env var is auditable and intentional. (Override does not affect `safe`/`warn`/`unknown`.)
+
+### 1.3 `forge doctor` output contract (JSON-first, mirrors orient/recap)
+
+`forge doctor [--json]`. Handler returns `{ success, output }`.
+- `--json` → `output = JSON.stringify(report,null,2)+'\n'`.
+- default → one human line per check + a summary line.
+
+Report shape:
+```json
+{
+  "command": "doctor",
+  "schemaVersion": 1,
+  "ok": true,
+  "checks": [
+    {
+      "id": "filesystem-class",
+      "ok": true,
+      "databasePath": "<resolved kernel.sqlite path>",
+      "class": "local-ok",
+      "riskTier": "safe",
+      "signal": "no cloud/network/wsl signal matched",
+      "remediation": null,
+      "overrideActive": false
+    }
+  ]
+}
+```
+- `ok` (top + per-check) = `riskTier !== 'refuse'` OR override active.
+- Human line: `✓ filesystem: local-ok (safe) — <path>` / `✗ filesystem: onedrive (REFUSE) — <remediation>`.
+- doctor resolves the path via `buildLocalBrokerConfig({projectRoot}).databasePath` (config build does **no** I/O — F1) so it reports the *exact* path the gate will guard, without creating anything.
+- **doctor never throws on a refuse**: it reports `ok:false` and exits non-zero (`result.error` set) so agents/CI can gate on it, but it is a *reporter*, not the enforcer.
+
+### 1.4 Where the default-on gate hooks (exact site) + remediation text
+
+**Hook:** top of `broker.initialize()` in `lib/kernel/broker.js`, **before** the pragma `for` loop (the first `await driver.exec`). Pseudocode:
+```js
+async initialize() {
+  const config = getConfig();                       // no I/O (F1)
+  assertFilesystemSafeForKernel(config.databasePath, {
+    env: process.env,                               // injectable in tests
+  });                                               // throws on refuse unless override
+  requireDriverMethod(driver, 'exec');
+  for (const statement of config.pragmas) { await driver.exec(statement, config); }
+  // … migrations …
+}
+```
+`assertFilesystemSafeForKernel(dbPath, deps)` lives in `lib/kernel/fs-class.js`:
+- classify; if `safe`/`warn`/`unknown` → return (warn classes `console.warn` the message).
+- if `refuse` and override unset → `throw new Error(REFUSE_MESSAGE)`.
+- if `refuse` and `FORGE_KERNEL_ALLOW_UNSAFE_FS` set → `console.warn` + return.
+
+Because it is at `initialize()` top, the throw happens **before** any `driver.exec`, so `kernel.sqlite` is never created on a refuse-class FS (F1/F2). Covers the real wiring (F5) without editing forge-issues.js.
+
+**Remediation message table** (`remediationKey` → text). Example (onedrive, the worked repo case):
+```
+Forge kernel cannot place its SQLite database on a cloud-synced folder
+(OneDrive). SQLite WAL mode corrupts when a sync client rewrites the
+database mid-write.
+
+  Detected: OneDrive sync root covers
+            <databasePath>
+  Class:    onedrive
+
+Fix: move this repository outside the OneDrive folder, e.g.
+     C:\dev\<repo>  (a non-synced local path), then re-run.
+
+Override (NOT recommended): set FORGE_KERNEL_ALLOW_UNSAFE_FS=1 to proceed
+at your own risk.
+```
+Network/mapped-drive and icloud/dropbox/gdrive variants follow the same template with class-specific "Fix" lines (move to a local fixed disk; use `\\?\` local path; etc.).
+
+---
+
+## 2. TDD task list (explicit parallel waves)
+
+### Dependency graph
+```
+        ┌──────────────────────────────┐
+Wave 1: │ D19-T1  fs-class detector     │   (foundational, ALONE — everyone depends on it)
+        │  lib/kernel/fs-class.js       │
+        └───────────────┬──────────────┘
+                        │ exports: classifyFilesystem, classifyFromSignals,
+                        │ gatherSignals, assertFilesystemSafeForKernel,
+                        │ REMEDIATION (table)
+            ┌───────────┴───────────┐
+Wave 2:     ▼                       ▼          (parallel — disjoint files)
+  ┌───────────────────┐   ┌────────────────────────────┐
+  │ D19-T2 doctor cmd │   │ D19-T3 broker default-on    │
+  │ lib/commands/     │   │ gate                         │
+  │   doctor.js       │   │ lib/kernel/broker.js         │
+  │ (+ helper reuse   │   │ (initialize() hook only)     │
+  │  of T1 + broker   │   └────────────────────────────┘
+  │  config builder)  │
+  └───────────────────┘
+Wave 3 (optional, after both): D19-T4 docs/AGENTS surface note — non-code, sync-commands if needed.
+```
+
+### File ownership (no collisions)
+| Task | OWNS (writes) | READS only |
+|------|---------------|------------|
+| D19-T1 | `lib/kernel/fs-class.js`, `test/kernel/fs-class.test.js` | — |
+| D19-T2 | `lib/commands/doctor.js`, `test/commands/doctor.test.js` | fs-class.js, broker.js (`buildLocalBrokerConfig`) |
+| D19-T3 | edit `lib/kernel/broker.js` `initialize()`, `test/kernel/broker-fs-gate.test.js` (new file) | fs-class.js |
+| D19-T4 | docs only (AGENTS.md/doctor reference) | — |
+
+**Critical:** T3 edits `broker.js`; no other D19 task edits it. **No task edits `bin/forge.js`** (F3) — so D19 and the parallel D20 `bin/forge.js` track do not collide at all.
+
+### Conventions every task honors (state in each task)
+- RED → GREEN → REFACTOR; one assertion-focused failing test first.
+- `bun:test`; **explicit per-test timeout as 3rd arg** (bunfig `[test]` timeout is NOT honored) — e.g. `test('…', () => {…}, 3000)`.
+- ESLint `--max-warnings 0`; prefix intentionally-unused params with `_`.
+- Run via `forge test` / `forge push` (not raw `bun`/`git`).
+- JSON-first output; Windows/Git-Bash shell model.
+- **All env/probes injected** — no test reads the real machine FS, drives, or `/proc`.
+
+---
+
+### D19-T1 — Filesystem-class detector (Wave 1, alone)
+**RED** — `test/kernel/fs-class.test.js`, all synthetic signals (zero real I/O), table-driven:
+- win32: UNC path → `network-unc`/refuse; mapped (`driveType:'network'`) → `mapped-network-drive`/refuse; `env.OneDriveCommercial` prefix → `onedrive`/refuse; `OneDrive - Contoso` segment → onedrive; `\Dropbox\` → dropbox; `Google Drive` segment → gdrive; plain `C:\dev\repo` → `local-ok`/safe; **`C:\Users\x\Downloads\forge` with NO OneDrive env → `local-ok`** (guards against false-positive on Downloads); same path **with** `env.OneDrive=C:\Users\x\OneDrive` and DB under it → onedrive.
+- darwin: `~/Library/Mobile Documents/...` → icloud; `~/Dropbox` → dropbox; `~/Google Drive` → gdrive; else local-ok.
+- linux/WSL: `isWslInterop && /mnt/c/...` → `wsl-cross`/warn; `mountFsType:'cifs'` → network-unc/refuse; `fuse.rclone` → gdrive/refuse; native ext4 → local-ok.
+- unknown/probe-throw → `unknown`/warn (fail-open).
+- `assertFilesystemSafeForKernel`: refuse class **throws**; same with `FORGE_KERNEL_ALLOW_UNSAFE_FS=1` (injected env) **does not throw** (warns); warn class never throws.
+- Each `Classification` carries `remediationKey` resolving to non-empty `REMEDIATION[key]`.
+
+**GREEN** — implement `classifyFromSignals` (pure), `gatherSignals` (injected probes, try/catch→unknown), `classifyFilesystem`, `assertFilesystemSafeForKernel`, `REMEDIATION` table. No native modules.
+**REFACTOR** — extract per-platform signal arrays into a precedence-ordered table; dedupe path-prefix helper (case-insensitive on win32). Export all four fns + table.
+
+### D19-T2 — `forge doctor` command (Wave 2, parallel to T3)
+**RED** — `test/commands/doctor.test.js`:
+- handler returns `{success:true, output}` with valid JSON when `--json`; report has `command/schemaVersion/ok/checks[0]`.
+- inject a stub classifier (or temp projectRoot + injected env) so `class:'onedrive'` → `ok:false`, human line contains `REFUSE` + remediation; `local-ok` → `ok:true`, `✓`.
+- module shape: exports `{name:'doctor', description, usage, handler}` (F4) — assert it passes `_registry.validateCommand`.
+- `databasePath` in report equals `buildLocalBrokerConfig({projectRoot}).databasePath`; calling doctor creates **no** file (assert path does not exist after).
+
+**GREEN** — implement `doctor.js`: resolve path via `buildLocalBrokerConfig`, call `classifyFilesystem`, build report, format text vs `--json` like recap.js. **No `bin/forge.js` edit** (auto-discovery, F3).
+**REFACTOR** — extract `buildDoctorReport(projectRoot, deps)` (pure-ish, injectable classifier) from the handler for testability; keep handler thin.
+
+### D19-T3 — Broker default-on gate (Wave 2, parallel to T2)
+**RED** — `test/kernel/broker-fs-gate.test.js` (mirrors broker.test.js fake-driver style, F6):
+- broker built with `databasePath` on a refuse-class path (injected classifier/env) → `await broker.initialize()` **rejects**, and the fake driver records **zero** `exec` calls (proves no file/pragma before throw).
+- same path with `FORGE_KERNEL_ALLOW_UNSAFE_FS=1` (injected) → `initialize()` resolves and pragmas run.
+- `local-ok` path → `initialize()` resolves normally (regression guard).
+- per-test timeout 3rd arg (3000).
+
+**GREEN** — add `assertFilesystemSafeForKernel(config.databasePath, {env})` call as the **first statement** of `initialize()` (before `requireDriverMethod`/pragma loop). Allow `options.env`/`options.classifyFilesystem` injection through the broker for deterministic tests.
+**REFACTOR** — ensure existing broker tests still green; confirm gate is a no-op for `:memory:`/`file:` paths (those classify `local-ok`).
+
+### D19-T4 — Surface note (Wave 3, optional, non-code)
+Document `forge doctor` + `FORGE_KERNEL_ALLOW_UNSAFE_FS` in AGENTS.md/doctor reference; run `node scripts/sync-commands.js` if any `.claude/commands` file is added. No source edits.
+
+---
+
+## 3. Ambiguity policy — flagged spec gaps (7-dim rubric)
+
+- **G1 — Windows mapped-drive probe mechanism (confidence ~72%, <80 → FLAG).** Detecting "is drive Z: a network mapping" dependency-free on Win11 is the one fragile probe. `wmic` is deprecated/absent on newer Win11; `net use` parsing covers mapped letters but not all SMB cases; `Get-PSDrive .DisplayRoot` needs PowerShell. **Recommendation pending user:** (a) ship `net use` parse + PowerShell fallback, probe wrapped try/catch→`unknown` (warn) so a probe miss fails open, OR (b) treat all non-`C:` fixed-looking letters as `unknown`/warn and rely on UNC + cloud-env detection (which catch the highest-risk cases) for v1. UNC and cloud-sync detection — the dominant corruption sources — are unaffected either way. **Please confirm (a) or (b).**
+- **G2 — `unknown` tier = warn, not refuse (confidence ~85%, proceed + documented).** Fail-open chosen so unclassifiable-but-fine setups aren't hard-blocked; refuse is reserved for positively-identified cloud/network. Assumption documented here.
+- **G3 — doctor scope = single `filesystem-class` check for D19 (confidence ~90%, proceed).** `checks[]` array is future-proof but D19 ships exactly one check; broader health stays in `runtime-health.js` per scope discipline. Documented.

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -73,12 +73,10 @@ function formatReportText(report) {
 	const lines = report.checks.map(formatCheckLine);
 	for (const check of report.checks) {
 		if (check.remediation) {
-			lines.push('');
-			lines.push(check.remediation);
+			lines.push('', check.remediation);
 		}
 	}
-	lines.push('');
-	lines.push(report.ok ? 'doctor: OK' : 'doctor: FAILED');
+	lines.push('', report.ok ? 'doctor: OK' : 'doctor: FAILED');
 	return `${lines.join('\n')}\n`;
 }
 

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// D19 — `forge doctor`: reports the filesystem class of the kernel DB path.
+//
+// Auto-discovered + routed by lib/commands/_registry.js (no bin/forge.js edit).
+// JSON-first, mirrors orient/recap. It is a REPORTER, not the enforcer — the
+// default-on gate lives in broker.initialize(). doctor resolves the exact path
+// the gate guards (via buildLocalBrokerConfig, which does no I/O) and reports
+// whether that path is safe, WITHOUT creating any file.
+
+const { buildLocalBrokerConfig } = require('../kernel/broker');
+const { classifyFilesystem, isUnsafeFsOverrideActive, REMEDIATION } = require('../kernel/fs-class');
+
+const SCHEMA_VERSION = 1;
+
+/**
+ * Build the doctor report. Pure-ish: all I/O-bearing deps are injectable.
+ * @param {string} projectRoot
+ * @param {object} deps - { classifyFilesystem?, env?, gitCommonDir?, execFileSync? }
+ */
+function buildDoctorReport(projectRoot, deps = {}) {
+	const env = deps.env || process.env;
+	const classify = deps.classifyFilesystem || classifyFilesystem;
+
+	// Config build does NO I/O (F1): it never opens/creates the DB.
+	const config = buildLocalBrokerConfig({
+		projectRoot,
+		gitCommonDir: deps.gitCommonDir,
+		execFileSync: deps.execFileSync,
+	});
+	const databasePath = config.databasePath;
+
+	const classification = classify(databasePath, deps);
+	const overrideActive = isUnsafeFsOverrideActive(env);
+	const isRefuse = classification.riskTier === 'refuse';
+	const checkOk = !isRefuse || overrideActive;
+	const remediation = isRefuse
+		? (REMEDIATION[classification.remediationKey] || REMEDIATION.unknown)
+		: null;
+
+	const check = {
+		id: 'filesystem-class',
+		ok: checkOk,
+		databasePath,
+		class: classification.class,
+		riskTier: classification.riskTier,
+		signal: classification.signal,
+		remediation,
+		overrideActive,
+	};
+
+	return {
+		command: 'doctor',
+		schemaVersion: SCHEMA_VERSION,
+		ok: check.ok,
+		checks: [check],
+	};
+}
+
+function formatCheckLine(check) {
+	if (check.riskTier === 'safe') {
+		return `✓ filesystem: ${check.class} (safe) — ${check.databasePath}`;
+	}
+	if (check.riskTier === 'warn') {
+		return `! filesystem: ${check.class} (warn) — ${check.databasePath}`;
+	}
+	// refuse
+	const tag = check.overrideActive ? 'REFUSE, override active' : 'REFUSE';
+	return `✗ filesystem: ${check.class} (${tag}) — ${check.databasePath}`;
+}
+
+function formatReportText(report) {
+	const lines = report.checks.map(formatCheckLine);
+	for (const check of report.checks) {
+		if (check.remediation) {
+			lines.push('');
+			lines.push(check.remediation);
+		}
+	}
+	lines.push('');
+	lines.push(report.ok ? 'doctor: OK' : 'doctor: FAILED');
+	return `${lines.join('\n')}\n`;
+}
+
+async function handler(args, _flags, projectRoot, deps = {}) {
+	const report = buildDoctorReport(projectRoot, deps);
+	const output = (args || []).includes('--json')
+		? `${JSON.stringify(report, null, 2)}\n`
+		: formatReportText(report);
+
+	const result = { success: report.ok, output };
+	if (!report.ok) {
+		result.error = `forge doctor found a refuse-class filesystem for the kernel database (${report.checks[0].class}).`;
+	}
+	return result;
+}
+
+module.exports = {
+	name: 'doctor',
+	description: 'Report the filesystem class of the kernel database path (cloud/network/local)',
+	usage: 'Usage: forge doctor [--json]',
+	handler,
+	buildDoctorReport,
+};

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -305,6 +305,10 @@ function createDefaultKernelBroker(brokerContext, deps) {
     databasePath: deps.kernelDatabasePath,
     driver,
     execFileSync: deps.execFileSync,
+    // Pass-through for the D19 default-on filesystem gate (fires in the broker's
+    // getConfig chokepoint). Forwarding it lets callers/tests inject a deterministic
+    // classifier instead of paying the real Windows drive probe per per-op broker.
+    classifyFilesystem: deps.classifyFilesystem,
   });
 }
 

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -12,6 +12,7 @@ const {
 	formatIssueCommandError,
 	getIssueCommandContract,
 } = require('./issue-command-contract');
+const { assertFilesystemSafeForKernel } = require('./fs-class');
 
 const LOCAL_BROKER_PRAGMAS = Object.freeze([
 	'PRAGMA journal_mode=WAL;',
@@ -723,9 +724,29 @@ function createLocalBroker(options = {}) {
 	const driver = options.driver;
 	let cachedConfig;
 
+	// Memoized config build AND the structural home of the D19 default-on
+	// filesystem gate. getConfig() is the single chokepoint every DB-creating
+	// broker path funnels through (initialize, runIssueOperation, runGuardedEvent,
+	// the projection-outbox surface, and the public `config` getter), so asserting
+	// here guards them ALL — not just initialize(). This closes the D19-B2 bypass
+	// where runIssueOperation / listProjectionOutbox reached driver.exec → getDatabase
+	// → createDatabase on a refuse-class FS without ever calling initialize().
+	//
+	// FAIL-CLOSED ordering: build a LOCAL config, assert, and ONLY THEN populate the
+	// memo. If we cached before asserting, the first call would throw but a second
+	// call would see a populated memo, skip the (re-)assert, and proceed to create
+	// the DB — reintroducing the bypass. env/classifier/warn are injectable via
+	// createLocalBroker options for deterministic tests. Throws on refuse unless
+	// FORGE_KERNEL_ALLOW_UNSAFE_FS is set; warns (never throws) on warn classes.
 	function getConfig() {
 		if (!cachedConfig) {
-			cachedConfig = buildLocalBrokerConfig(options);
+			const config = buildLocalBrokerConfig(options);
+			assertFilesystemSafeForKernel(config.databasePath, {
+				env: options.env,
+				warn: options.warn,
+				classifyFilesystem: options.classifyFilesystem,
+			});
+			cachedConfig = config;
 		}
 		return cachedConfig;
 	}
@@ -816,9 +837,14 @@ function createLocalBroker(options = {}) {
 		},
 
 		async initialize() {
+			// D19 default-on filesystem gate now lives in getConfig() (the structural
+			// chokepoint shared by every DB-creating path), so the first getConfig()
+			// call here asserts the FS is safe BEFORE any driver.exec — the SQLite file
+			// is never created on a refuse-class (cloud/network) FS. Throws on refuse
+			// unless FORGE_KERNEL_ALLOW_UNSAFE_FS; injectable via createLocalBroker opts.
+			const config = getConfig();
 			requireDriverMethod(driver, 'exec');
 			requireDriverMethod(driver, 'queryAll');
-			const config = getConfig();
 			for (const statement of config.pragmas) {
 				await driver.exec(statement, config);
 			}

--- a/lib/kernel/fs-class.js
+++ b/lib/kernel/fs-class.js
@@ -144,7 +144,7 @@ function classifyWin32(signals) {
 	const { absPath, env = {} } = signals;
 
 	if (signals.isUNC) {
-		return makeClassification('network-unc', 'UNC path (\\\\server\\share)');
+		return makeClassification('network-unc', String.raw`UNC path (\\server\share)`);
 	}
 	if (signals.driveType === 'network') {
 		return makeClassification('mapped-network-drive', 'driveType=network');
@@ -301,7 +301,7 @@ const WIN_PROBE_EXEC_OPTIONS = Object.freeze({
 function parseNetUseDriveType(stdout, driveLetter) {
 	const letter = String(driveLetter || '').replace(':', '');
 	if (!letter) return null;
-	const letterRe = new RegExp(`(^|\\s)${letter}:\\s`, 'i');
+	const letterRe = new RegExp(String.raw`(^|\s)${letter}:\s`, 'i');
 	for (const line of String(stdout || '').split(/\r?\n/)) {
 		if (letterRe.test(line)) {
 			return 'network';

--- a/lib/kernel/fs-class.js
+++ b/lib/kernel/fs-class.js
@@ -1,0 +1,495 @@
+'use strict';
+
+// D19 — Filesystem-class detector + default-on gate helper.
+//
+// Two layers (the split is the testability crux):
+//   Layer A — classifyFromSignals(signals): PURE, zero I/O. 100% synthetic-tested.
+//   Layer B — gatherSignals(absPath, deps): thin I/O shell, ALL probes injectable.
+// Public entry: classifyFilesystem(absPath, deps) = classifyFromSignals(gatherSignals(...)).
+//
+// Scope discipline: this module reports the filesystem CLASS only. Broad health
+// stays in runtime-health.js. See docs/work/2026-06-06-kernel-backlog-memory-roadmap/
+// D19-filesystem-doctor-design.md.
+
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+// --- Remediation message table (remediationKey -> human text) ----------------
+
+const OVERRIDE_LINE =
+	'Override (NOT recommended): set FORGE_KERNEL_ALLOW_UNSAFE_FS=1 to proceed\n' +
+	'at your own risk.';
+
+const REMEDIATION = Object.freeze({
+	'local-ok': 'No action needed — the kernel database is on a local fixed disk.',
+	onedrive:
+		'Forge kernel cannot place its SQLite database on a cloud-synced folder\n' +
+		'(OneDrive). SQLite WAL mode corrupts when a sync client rewrites the\n' +
+		'database mid-write.\n\n' +
+		'Fix: move this repository outside the OneDrive folder, e.g. a non-synced\n' +
+		'local path such as C:\\dev\\<repo>, then re-run.\n\n' +
+		OVERRIDE_LINE,
+	dropbox:
+		'Forge kernel cannot place its SQLite database on a Dropbox-synced folder.\n' +
+		'A sync client rewriting the DB mid-write corrupts SQLite WAL mode.\n\n' +
+		'Fix: move this repository outside the Dropbox folder to a non-synced\n' +
+		'local path, then re-run.\n\n' +
+		OVERRIDE_LINE,
+	gdrive:
+		'Forge kernel cannot place its SQLite database on a Google Drive folder.\n' +
+		'A sync/streaming client rewriting the DB mid-write corrupts SQLite WAL mode.\n\n' +
+		'Fix: move this repository outside the Google Drive folder to a non-synced\n' +
+		'local path, then re-run.\n\n' +
+		OVERRIDE_LINE,
+	icloud:
+		'Forge kernel cannot place its SQLite database under iCloud Drive\n' +
+		'(Library/Mobile Documents). iCloud may evict/rewrite the file and corrupt\n' +
+		'SQLite WAL mode.\n\n' +
+		'Fix: move this repository outside iCloud Drive to a non-synced local path,\n' +
+		'then re-run.\n\n' +
+		OVERRIDE_LINE,
+	'network-unc':
+		'Forge kernel cannot place its SQLite database on a network share\n' +
+		'(UNC / SMB / NFS). SQLite file locking is unreliable over network\n' +
+		'filesystems and can corrupt the database.\n\n' +
+		'Fix: move this repository to a local fixed disk, then re-run.\n\n' +
+		OVERRIDE_LINE,
+	'mapped-network-drive':
+		'Forge kernel cannot place its SQLite database on a mapped network drive.\n' +
+		'SQLite file locking is unreliable over SMB/NFS and can corrupt the database.\n\n' +
+		'Fix: move this repository to a local fixed disk, then re-run.\n\n' +
+		OVERRIDE_LINE,
+	'wsl-cross':
+		'Warning: the kernel database lives on the Windows volume across the WSL\n' +
+		'filesystem boundary (/mnt/<letter>). This works but is slow and has lock\n' +
+		'edge cases. For best results, keep the repository on the Linux-native\n' +
+		'filesystem (e.g. under your home directory).',
+	unknown:
+		'Warning: Forge could not classify the filesystem holding the kernel\n' +
+		'database. Proceeding (fail-open). If you hit database corruption, ensure\n' +
+		'the repository is on a local fixed disk (not cloud-synced or networked).',
+});
+
+// --- Risk-tier mapping (class -> tier) ---------------------------------------
+
+const REFUSE_CLASSES = new Set([
+	'onedrive',
+	'dropbox',
+	'gdrive',
+	'icloud',
+	'network-unc',
+	'mapped-network-drive',
+]);
+const WARN_CLASSES = new Set(['wsl-cross', 'unknown']);
+
+function riskTierFor(klass) {
+	if (REFUSE_CLASSES.has(klass)) return 'refuse';
+	if (WARN_CLASSES.has(klass)) return 'warn';
+	return 'safe';
+}
+
+function makeClassification(klass, signal) {
+	return {
+		class: klass,
+		riskTier: riskTierFor(klass),
+		signal,
+		remediationKey: klass,
+	};
+}
+
+// --- Path helpers (pure) -----------------------------------------------------
+
+// SQLite "paths" that never touch a real directory: in-memory and file: URIs.
+function isNonFsPath(absPath) {
+	if (!absPath) return true;
+	if (absPath === ':memory:') return true;
+	if (/^file:/i.test(absPath)) return true;
+	return false;
+}
+
+// Split a path into lowercase segments on both separators (for segment matching).
+function pathSegments(absPath) {
+	return String(absPath)
+		.split(/[\\/]+/)
+		.filter(Boolean)
+		.map(seg => seg.toLowerCase());
+}
+
+// Boundary-aware, case/separator-normalized prefix test. Returns true only when
+// `root` covers `absPath` at a path boundary (avoids OneDrive vs OneDriveBackup).
+function pathStartsWith(absPath, root, { caseInsensitive }) {
+	if (!root) return false;
+	const norm = value => {
+		let v = String(value).replace(/[\\/]+/g, '/').replace(/\/+$/, '');
+		if (caseInsensitive) v = v.toLowerCase();
+		return v;
+	};
+	const a = norm(absPath);
+	const r = norm(root);
+	if (a === r) return true;
+	return a.startsWith(`${r}/`);
+}
+
+function hasSegmentMatching(absPath, regex) {
+	return pathSegments(absPath).some(seg => regex.test(seg));
+}
+
+function hasExactSegment(absPath, lowerName) {
+	return pathSegments(absPath).includes(lowerName);
+}
+
+// --- Layer A: pure classifier ------------------------------------------------
+
+function classifyWin32(signals) {
+	const { absPath, env = {} } = signals;
+
+	if (signals.isUNC) {
+		return makeClassification('network-unc', 'UNC path (\\\\server\\share)');
+	}
+	if (signals.driveType === 'network') {
+		return makeClassification('mapped-network-drive', 'driveType=network');
+	}
+
+	// Cloud-sync detection is path/env-based and INDEPENDENT of the drive probe.
+	// It must run BEFORE the driveType==='unknown' fail-open below, so a positively
+	// identified OneDrive/Dropbox/gdrive path still REFUSES even when the mapped-
+	// drive probe failed (G1 fallback). Otherwise the highest-risk class would be
+	// silently downgraded to warn and the kernel would init on a synced folder.
+
+	// OneDrive: env-declared sync roots (boundary-aware) OR a path segment.
+	const oneDriveRoots = [env.OneDrive, env.OneDriveConsumer, env.OneDriveCommercial]
+		.filter(Boolean);
+	for (const root of oneDriveRoots) {
+		if (pathStartsWith(absPath, root, { caseInsensitive: true })) {
+			return makeClassification('onedrive', 'env OneDrive root prefix');
+		}
+	}
+	if (hasSegmentMatching(absPath, /^onedrive([ -].+)?$/i)) {
+		return makeClassification('onedrive', 'OneDrive path segment');
+	}
+
+	if (env.Dropbox && pathStartsWith(absPath, env.Dropbox, { caseInsensitive: true })) {
+		return makeClassification('dropbox', 'env Dropbox root prefix');
+	}
+	if (hasExactSegment(absPath, 'dropbox')) {
+		return makeClassification('dropbox', 'Dropbox path segment');
+	}
+
+	if (hasSegmentMatching(absPath, /^(google ?drive|googledrive|drivefs)$/i)) {
+		return makeClassification('gdrive', 'Google Drive path segment');
+	}
+
+	// Drive probe miss with no cloud signal: fail-open per G1 (warn, never block).
+	if (signals.driveType === 'unknown') {
+		return makeClassification('unknown', 'driveType probe returned unknown');
+	}
+
+	return makeClassification('local-ok', 'no cloud/network signal matched');
+}
+
+function classifyDarwin(signals) {
+	const { absPath, homedir } = signals;
+	const home = homedir || '';
+
+	if (pathStartsWith(absPath, `${home}/Library/Mobile Documents`, { caseInsensitive: false })) {
+		return makeClassification('icloud', 'iCloud Mobile Documents');
+	}
+	if (
+		pathStartsWith(absPath, `${home}/Dropbox`, { caseInsensitive: false }) ||
+		hasSegmentMatching(absPath, /^dropbox.*$/i) && absPath.includes('/Library/CloudStorage/')
+	) {
+		return makeClassification('dropbox', 'Dropbox folder');
+	}
+	if (
+		pathStartsWith(absPath, `${home}/Google Drive`, { caseInsensitive: false }) ||
+		hasSegmentMatching(absPath, /^googledrive.*$/i) && absPath.includes('/Library/CloudStorage/')
+	) {
+		return makeClassification('gdrive', 'Google Drive folder');
+	}
+	if (hasSegmentMatching(absPath, /^onedrive.*$/i) && absPath.includes('/Library/CloudStorage/')) {
+		return makeClassification('onedrive', 'OneDrive CloudStorage folder');
+	}
+
+	return makeClassification('local-ok', 'no cloud signal matched');
+}
+
+const NETWORK_FS_TYPES = new Set(['cifs', 'smb3', 'smb', 'nfs', 'nfs4', 'fuse.sshfs']);
+const FUSE_CLOUD_MAP = new Map([
+	['fuse.dropbox', 'dropbox'],
+	['fuse.rclone', 'gdrive'],
+	['fuse.google-drive-ocamlfuse', 'gdrive'],
+]);
+
+function classifyLinux(signals) {
+	const { absPath, mountFsType, isWslInterop } = signals;
+
+	if (isWslInterop && /^\/mnt\/[a-z]\//i.test(absPath)) {
+		return makeClassification('wsl-cross', 'WSL interop + /mnt/<letter>');
+	}
+	if (mountFsType && NETWORK_FS_TYPES.has(mountFsType)) {
+		return makeClassification('network-unc', `network mount fs=${mountFsType}`);
+	}
+	if (mountFsType && FUSE_CLOUD_MAP.has(mountFsType)) {
+		return makeClassification(FUSE_CLOUD_MAP.get(mountFsType), `fuse mount fs=${mountFsType}`);
+	}
+	// Secondary segment signal for cloud sync folders on native mounts. These are
+	// PATH-based and remain valid even when the mount probe threw, so they run
+	// BEFORE the unknown-on-throw fallback below.
+	if (hasSegmentMatching(absPath, /^onedrive.*$/i)) {
+		return makeClassification('onedrive', 'OneDrive path segment');
+	}
+	if (hasExactSegment(absPath, 'dropbox')) {
+		return makeClassification('dropbox', 'Dropbox path segment');
+	}
+	if (hasSegmentMatching(absPath, /^(google ?drive)$/i)) {
+		return makeClassification('gdrive', 'Google Drive path segment');
+	}
+
+	// M3: the mount probe THREW (could not read /proc/mounts) and no path/wsl signal
+	// matched. Treat as unknown/warn — symmetric with win32's G1 fail-safe — instead
+	// of silently returning local-ok, which would suppress the warning entirely.
+	if (signals.mountProbeThrew) {
+		return makeClassification('unknown', 'mount probe failed (could not classify)');
+	}
+
+	return makeClassification('local-ok', 'no cloud/network/wsl signal matched');
+}
+
+function classifyFromSignals(signals = {}) {
+	if (isNonFsPath(signals.absPath)) {
+		return makeClassification('local-ok', 'non-filesystem path (memory/uri)');
+	}
+	switch (signals.platform) {
+		case 'win32':
+			return classifyWin32(signals);
+		case 'darwin':
+			return classifyDarwin(signals);
+		case 'linux':
+			return classifyLinux(signals);
+		default:
+			return makeClassification('unknown', `unrecognized platform ${signals.platform}`);
+	}
+}
+
+// --- Layer B: thin signal gatherer (all probes injectable) -------------------
+
+function isUNC(absPath) {
+	return /^[\\/]{2}[^\\/]/.test(String(absPath || ''));
+}
+
+function driveLetterOf(absPath) {
+	const match = /^([a-z]):[\\/]/i.exec(String(absPath || ''));
+	return match ? `${match[1].toUpperCase()}:` : null;
+}
+
+// Bounded exec options for the Windows drive probes. The timeout is the BLOCKER-1
+// fix: execFileSync's try/catch only catches throws, never hangs, so an
+// unresponsive `net use` / PowerShell (e.g. a wedged network redirector) would
+// hang the whole process indefinitely. With a timeout, a hang becomes a throw
+// that the gatherSignals catch turns into driveType='unknown' → warn (never
+// refuse), symmetric with the G1 fail-safe. killSignal forces the child dead.
+const WIN_PROBE_EXEC_OPTIONS = Object.freeze({
+	encoding: 'utf8',
+	timeout: 1500,
+	killSignal: 'SIGKILL',
+});
+
+// PURE (M5): does `net use` stdout list this drive letter as a mapped (network)
+// connection? Returns 'network' on a boundary-matched letter, else null. The
+// regex is anchored to a line-leading "<letter>:" preceded by start/whitespace
+// so a stray mention of the letter elsewhere cannot false-positive.
+function parseNetUseDriveType(stdout, driveLetter) {
+	const letter = String(driveLetter || '').replace(':', '');
+	if (!letter) return null;
+	const letterRe = new RegExp(`(^|\\s)${letter}:\\s`, 'i');
+	for (const line of String(stdout || '').split(/\r?\n/)) {
+		if (letterRe.test(line)) {
+			return 'network';
+		}
+	}
+	return null;
+}
+
+// PURE (M5): a non-empty PowerShell DisplayRoot means the PSDrive is backed by a
+// network/remote root. Returns 'network' when non-blank, else null.
+function parseDisplayRoot(stdout) {
+	return String(stdout || '').trim() ? 'network' : null;
+}
+
+// Windows: detect whether a drive letter is a mapped network drive.
+// FAIL-SAFE FALLBACK (locked decision G1, option a): try `net use`, then a
+// PowerShell DisplayRoot fallback; on ANY probe failure (including a timeout-
+// induced throw, per BLOCKER 1) the caller treats the result as 'unknown'.
+// Probes use arg ARRAYS (no shell) so they remain injection-free.
+function defaultProbeDriveType(driveLetter, deps = {}) {
+	const exec = deps.execFileSync || execFileSync;
+
+	// Primary: `net use` lists mapped drive letters (and their remote paths).
+	const netOut = exec('net', ['use'], WIN_PROBE_EXEC_OPTIONS);
+	if (parseNetUseDriveType(netOut, driveLetter) === 'network') {
+		return 'network';
+	}
+
+	// Secondary: PowerShell DisplayRoot — non-empty for network-backed PSDrives.
+	const psLetter = String(driveLetter).replace(':', '');
+	const psCmd =
+		`(Get-PSDrive -Name '${psLetter}' -ErrorAction SilentlyContinue).DisplayRoot`;
+	const psOut = exec('powershell', ['-NoProfile', '-Command', psCmd], WIN_PROBE_EXEC_OPTIONS);
+	if (parseDisplayRoot(psOut) === 'network') {
+		return 'network';
+	}
+
+	// Letter exists, no network backing detected → fixed.
+	return 'fixed';
+}
+
+// Linux: read /proc/mounts, return fs type of the longest mountpoint prefixing absPath.
+function defaultProbeMounts(absPath, deps = {}) {
+	const readFileSync = deps.readFileSync || require('node:fs').readFileSync;
+	const raw = String(readFileSync('/proc/mounts', 'utf8') || '');
+	let best = null;
+	let bestLen = -1;
+	for (const line of raw.split('\n')) {
+		const parts = line.split(/\s+/);
+		if (parts.length < 3) continue;
+		const mountPoint = parts[1];
+		const fsType = parts[2];
+		if (
+			(absPath === mountPoint || absPath.startsWith(`${mountPoint.replace(/\/$/, '')}/`)) &&
+			mountPoint.length > bestLen
+		) {
+			best = fsType;
+			bestLen = mountPoint.length;
+		}
+	}
+	return best;
+}
+
+function defaultReadWslInterop(deps = {}) {
+	const env = deps.env || process.env;
+	if (env.WSL_DISTRO_NAME) return true;
+	const readFileSync = deps.readFileSync || require('node:fs').readFileSync;
+	const version = String(readFileSync('/proc/version', 'utf8') || '');
+	return /microsoft/i.test(version);
+}
+
+function gatherSignals(absPath, deps = {}) {
+	const platform = deps.platform || process.platform;
+	const env = deps.env || process.env;
+	const homedirFn = deps.homedir || os.homedir;
+	const homedir = typeof homedirFn === 'function' ? homedirFn() : homedirFn;
+
+	const signals = {
+		platform,
+		absPath,
+		env,
+		homedir,
+		isUNC: isUNC(absPath),
+		driveType: null,
+		mountFsType: null,
+		mountProbeThrew: false,
+		isWslInterop: false,
+	};
+
+	if (platform === 'win32' && !signals.isUNC) {
+		const driveLetter = driveLetterOf(absPath);
+		if (driveLetter) {
+			const probe = deps.probeDriveType || (letter => defaultProbeDriveType(letter, deps));
+			try {
+				signals.driveType = probe(driveLetter);
+			} catch {
+				// G1 fail-safe: any probe failure → unknown → warn (never refuse).
+				signals.driveType = 'unknown';
+			}
+		}
+	}
+
+	if (platform === 'linux') {
+		const probeMounts = deps.probeMounts || (p => defaultProbeMounts(p, deps));
+		try {
+			signals.mountFsType = probeMounts(absPath);
+		} catch {
+			// M3: a THROWN probe is distinct from a clean no-match. Record the throw so
+			// classifyLinux maps it to unknown/warn (symmetric with win32) instead of
+			// silently fail-opening to local-ok.
+			signals.mountFsType = null;
+			signals.mountProbeThrew = true;
+		}
+		const readWsl = deps.readWslInterop || (() => defaultReadWslInterop(deps));
+		try {
+			signals.isWslInterop = Boolean(readWsl());
+		} catch {
+			signals.isWslInterop = false;
+		}
+	}
+
+	return signals;
+}
+
+function classifyFilesystem(absPath, deps = {}) {
+	return classifyFromSignals(gatherSignals(absPath, deps));
+}
+
+// --- Default-on gate helper --------------------------------------------------
+
+// The unsafe-FS override is a deliberate, explicit opt-in: only the strings "1"
+// and "true" (case-insensitive) enable it. A truthy-but-disabling value such as
+// "0" or "false" — which Boolean() would wrongly treat as enabled — leaves the
+// refuse gate ACTIVE. Anything else (unset, "", "no", "off") is also not active.
+function isUnsafeFsOverrideActive(env = {}) {
+	const raw = env.FORGE_KERNEL_ALLOW_UNSAFE_FS;
+	if (typeof raw !== 'string') return false;
+	const value = raw.trim().toLowerCase();
+	return value === '1' || value === 'true';
+}
+
+function assertFilesystemSafeForKernel(dbPath, deps = {}) {
+	const env = deps.env || process.env;
+	const warn = deps.warn || (msg => console.warn(msg));
+	const classify = deps.classifyFilesystem || classifyFilesystem;
+
+	const classification = classify(dbPath, deps);
+	const remediation = REMEDIATION[classification.remediationKey] || REMEDIATION.unknown;
+
+	if (classification.riskTier === 'safe') {
+		return classification;
+	}
+
+	if (classification.riskTier === 'warn') {
+		warn(`forge kernel filesystem warning (${classification.class}):\n${remediation}`);
+		return classification;
+	}
+
+	// refuse
+	const overrideActive = isUnsafeFsOverrideActive(env);
+	if (overrideActive) {
+		warn(
+			`forge kernel filesystem REFUSE downgraded by FORGE_KERNEL_ALLOW_UNSAFE_FS ` +
+			`(${classification.class}) — override active:\n${remediation}`,
+		);
+		return classification;
+	}
+
+	const error = new Error(
+		`Forge kernel refuses to initialize on a ${classification.class} filesystem.\n\n` +
+		`  Detected: ${classification.signal}\n` +
+		`  Path:     ${dbPath}\n` +
+		`  Class:    ${classification.class}\n\n` +
+		`${remediation}`,
+	);
+	error.code = 'FORGE_KERNEL_UNSAFE_FS';
+	error.classification = classification;
+	throw error;
+}
+
+module.exports = {
+	classifyFromSignals,
+	gatherSignals,
+	classifyFilesystem,
+	assertFilesystemSafeForKernel,
+	isUnsafeFsOverrideActive,
+	defaultProbeDriveType,
+	parseNetUseDriveType,
+	parseDisplayRoot,
+	REMEDIATION,
+};

--- a/test/commands/doctor.test.js
+++ b/test/commands/doctor.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const doctor = require('../../lib/commands/doctor');
+const { validateCommand } = require('../../lib/commands/_registry');
+
+const T = 3000;
+
+// Common injected deps so the git shell-out never runs against a temp dir.
+function depsFor(projectRoot, classification) {
+	return {
+		gitCommonDir: path.join(projectRoot, '.git'),
+		classifyFilesystem: () => classification,
+		env: {},
+	};
+}
+
+describe('forge doctor — module contract', () => {
+	test('exports a valid command module ({name, description, handler})', () => {
+		expect(doctor.name).toBe('doctor');
+		expect(typeof doctor.description).toBe('string');
+		expect(typeof doctor.handler).toBe('function');
+		expect(validateCommand(doctor).valid).toBe(true);
+	}, T);
+});
+
+describe('forge doctor — buildDoctorReport', () => {
+	test('local-ok → ok:true, single filesystem-class check, no remediation', () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-ok');
+		const report = doctor.buildDoctorReport(projectRoot, depsFor(projectRoot, {
+			class: 'local-ok', riskTier: 'safe', signal: 'none', remediationKey: 'local-ok',
+		}));
+		expect(report.command).toBe('doctor');
+		expect(report.schemaVersion).toBe(1);
+		expect(report.ok).toBe(true);
+		expect(Array.isArray(report.checks)).toBe(true);
+		expect(report.checks.length).toBe(1);
+		const check = report.checks[0];
+		expect(check.id).toBe('filesystem-class');
+		expect(check.ok).toBe(true);
+		expect(check.class).toBe('local-ok');
+		expect(check.riskTier).toBe('safe');
+		expect(check.overrideActive).toBe(false);
+		expect(check.databasePath).toContain('kernel.sqlite');
+	}, T);
+
+	test('refuse class (onedrive) → ok:false and remediation present', () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-refuse');
+		const report = doctor.buildDoctorReport(projectRoot, depsFor(projectRoot, {
+			class: 'onedrive', riskTier: 'refuse', signal: 'env OneDrive', remediationKey: 'onedrive',
+		}));
+		expect(report.ok).toBe(false);
+		expect(report.checks[0].ok).toBe(false);
+		expect(report.checks[0].class).toBe('onedrive');
+		expect(typeof report.checks[0].remediation).toBe('string');
+		expect(report.checks[0].remediation.length).toBeGreaterThan(0);
+	}, T);
+
+	test('refuse class WITH override env → ok:true and overrideActive:true', () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-override');
+		const report = doctor.buildDoctorReport(projectRoot, {
+			gitCommonDir: path.join(projectRoot, '.git'),
+			classifyFilesystem: () => ({
+				class: 'onedrive', riskTier: 'refuse', signal: 'env', remediationKey: 'onedrive',
+			}),
+			env: { FORGE_KERNEL_ALLOW_UNSAFE_FS: '1' },
+		});
+		expect(report.checks[0].overrideActive).toBe(true);
+		expect(report.checks[0].ok).toBe(true);
+		expect(report.ok).toBe(true);
+	}, T);
+
+	test('refuse class WITH override env=0 → overrideActive:false and ok:false (M4)', () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-override-zero');
+		const report = doctor.buildDoctorReport(projectRoot, {
+			gitCommonDir: path.join(projectRoot, '.git'),
+			classifyFilesystem: () => ({
+				class: 'onedrive', riskTier: 'refuse', signal: 'env', remediationKey: 'onedrive',
+			}),
+			env: { FORGE_KERNEL_ALLOW_UNSAFE_FS: '0' },
+		});
+		expect(report.checks[0].overrideActive).toBe(false);
+		expect(report.checks[0].ok).toBe(false);
+		expect(report.ok).toBe(false);
+	}, T);
+
+	test('databasePath equals buildLocalBrokerConfig().databasePath and is NOT created', () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-nopath');
+		const { buildLocalBrokerConfig } = require('../../lib/kernel/broker');
+		const gitCommonDir = path.join(projectRoot, '.git');
+		const expected = buildLocalBrokerConfig({ projectRoot, gitCommonDir }).databasePath;
+		const report = doctor.buildDoctorReport(projectRoot, depsFor(projectRoot, {
+			class: 'local-ok', riskTier: 'safe', signal: 'none', remediationKey: 'local-ok',
+		}));
+		expect(report.checks[0].databasePath).toBe(expected);
+		expect(fs.existsSync(expected)).toBe(false);
+	}, T);
+});
+
+describe('forge doctor — handler output', () => {
+	test('--json returns success:true with valid parseable JSON report', async () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-json');
+		const result = await doctor.handler(['--json'], {}, projectRoot, depsFor(projectRoot, {
+			class: 'local-ok', riskTier: 'safe', signal: 'none', remediationKey: 'local-ok',
+		}));
+		expect(result.success).toBe(true);
+		const parsed = JSON.parse(result.output);
+		expect(parsed.command).toBe('doctor');
+		expect(parsed.checks[0].id).toBe('filesystem-class');
+	}, T);
+
+	test('default text for local-ok contains check mark and class', async () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-text-ok');
+		const result = await doctor.handler([], {}, projectRoot, depsFor(projectRoot, {
+			class: 'local-ok', riskTier: 'safe', signal: 'none', remediationKey: 'local-ok',
+		}));
+		expect(result.success).toBe(true);
+		expect(result.output).toContain('local-ok');
+		expect(result.output).toContain('✓');
+	}, T);
+
+	test('refuse class sets result.error and success:false; text contains REFUSE', async () => {
+		const projectRoot = path.join(os.tmpdir(), 'forge-doctor-text-refuse');
+		const result = await doctor.handler([], {}, projectRoot, depsFor(projectRoot, {
+			class: 'onedrive', riskTier: 'refuse', signal: 'env', remediationKey: 'onedrive',
+		}));
+		expect(result.success).toBe(false);
+		expect(typeof result.error).toBe('string');
+		expect(result.output).toContain('REFUSE');
+	}, T);
+});

--- a/test/kernel/broker-fs-gate-chokepoint.test.js
+++ b/test/kernel/broker-fs-gate-chokepoint.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+// D19-B2 regression: the default-on filesystem gate must guard EVERY DB-creating
+// broker path, not just initialize(). KernelIssueAdapter.run → runIssueOperation
+// and the export consumer → listProjectionOutbox both reach driver.exec /
+// getDatabase WITHOUT calling initialize(). The gate now lives in the memoized
+// getConfig() chokepoint, so it fires (fail-closed) on first config access from
+// any entry point — and must keep firing on subsequent calls, never caching a
+// config that skipped the gate.
+
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+
+const T = 3000;
+
+const REFUSE_CLASSIFICATION = {
+	class: 'onedrive',
+	riskTier: 'refuse',
+	signal: 'injected',
+	remediationKey: 'onedrive',
+};
+
+// A driver that records driver-level DB access. issueOperation/exec are present
+// so the ONLY thing that can throw is the filesystem gate (not a missing-method
+// guard). If the gate failed to fire, these would record calls / create a file.
+function makeRecordingDriver() {
+	const calls = [];
+	return {
+		calls,
+		async exec(statement) {
+			calls.push(['exec', statement]);
+		},
+		async issueOperation(operation) {
+			calls.push(['issueOperation', operation]);
+			return { ok: true, operation };
+		},
+		async listProjectionOutbox() {
+			calls.push(['listProjectionOutbox']);
+			return [];
+		},
+	};
+}
+
+function makeRefuseBroker(driver) {
+	return createLocalBroker({
+		projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+		gitCommonDir: path.join(os.tmpdir(), 'forge-worktree', '.git'),
+		driver,
+		env: {},
+		classifyFilesystem: () => REFUSE_CLASSIFICATION,
+	});
+}
+
+describe('broker filesystem gate is a structural chokepoint (D19-B2)', () => {
+	test('runIssueOperation (read) on a refuse FS THROWS before any driver call — without initialize()', async () => {
+		const driver = makeRecordingDriver();
+		const broker = makeRefuseBroker(driver);
+
+		// A read op routes through getConfig() (4th arg to driver.issueOperation).
+		await expect(broker.runIssueOperation('list', [])).rejects.toThrow();
+		// Gate fired BEFORE driver.issueOperation / driver.exec — zero driver calls.
+		expect(driver.calls.length).toBe(0);
+	}, T);
+
+	test('the gate is fail-closed: a SECOND runIssueOperation still throws (no cached unguarded config)', async () => {
+		const driver = makeRecordingDriver();
+		const broker = makeRefuseBroker(driver);
+
+		await expect(broker.runIssueOperation('list', [])).rejects.toThrow();
+		// If getConfig cached the config BEFORE asserting, this second call would
+		// return the cached config and the read would proceed (bypass reintroduced).
+		await expect(broker.runIssueOperation('list', [])).rejects.toThrow();
+		expect(driver.calls.length).toBe(0);
+	}, T);
+
+	test('listProjectionOutbox on a refuse FS THROWS before any driver call', async () => {
+		const driver = makeRecordingDriver();
+		const broker = makeRefuseBroker(driver);
+
+		await expect(broker.listProjectionOutbox({})).rejects.toThrow();
+		expect(driver.calls.length).toBe(0);
+	}, T);
+
+	test('the config getter itself throws on a refuse FS (gate guards config access)', () => {
+		const driver = makeRecordingDriver();
+		const broker = makeRefuseBroker(driver);
+
+		expect(() => broker.config).toThrow();
+		// Repeated access must keep throwing (fail-closed, not cached-unguarded).
+		expect(() => broker.config).toThrow();
+		expect(driver.calls.length).toBe(0);
+	}, T);
+
+	test('refuse FS with FORGE_KERNEL_ALLOW_UNSAFE_FS=1 allows runIssueOperation (override path)', async () => {
+		const driver = makeRecordingDriver();
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-worktree', '.git'),
+			driver,
+			env: { FORGE_KERNEL_ALLOW_UNSAFE_FS: '1' },
+			warn: () => {},
+			classifyFilesystem: () => REFUSE_CLASSIFICATION,
+		});
+
+		const result = await broker.runIssueOperation('list', []);
+		expect(result.ok).toBe(true);
+		expect(driver.calls).toContainEqual(['issueOperation', 'list']);
+	}, T);
+
+	test('local-ok FS lets runIssueOperation proceed (regression guard)', async () => {
+		const driver = makeRecordingDriver();
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-worktree', '.git'),
+			driver,
+			env: {},
+			classifyFilesystem: () => ({
+				class: 'local-ok', riskTier: 'safe', signal: 'injected', remediationKey: 'local-ok',
+			}),
+		});
+
+		const result = await broker.runIssueOperation('list', []);
+		expect(result.ok).toBe(true);
+	}, T);
+});

--- a/test/kernel/broker-fs-gate.test.js
+++ b/test/kernel/broker-fs-gate.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+
+const T = 3000;
+
+function makeRecordingDriver() {
+	const execCalls = [];
+	return {
+		execCalls,
+		async exec(statement) {
+			execCalls.push(statement);
+		},
+		// The ledger-aware initialize() reads applied migration ids via queryAll;
+		// an empty result means every migration applies. The D19 gate under test
+		// fires in getConfig() BEFORE any driver call, so this stub only needs to let
+		// initialize() proceed past the migration-ledger read in the non-refuse cases.
+		async queryAll() {
+			return [];
+		},
+	};
+}
+
+describe('broker default-on filesystem gate (D19-T3)', () => {
+	test('refuse-class path rejects initialize() with ZERO exec calls (no file/pragma before throw)', async () => {
+		const driver = makeRecordingDriver();
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-worktree', '.git'),
+			driver,
+			env: {},
+			classifyFilesystem: () => ({
+				class: 'onedrive',
+				riskTier: 'refuse',
+				signal: 'injected',
+				remediationKey: 'onedrive',
+			}),
+		});
+
+		await expect(broker.initialize()).rejects.toThrow();
+		expect(driver.execCalls.length).toBe(0);
+	}, T);
+
+	test('refuse-class path with FORGE_KERNEL_ALLOW_UNSAFE_FS=1 resolves and runs pragmas', async () => {
+		const driver = makeRecordingDriver();
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-worktree', '.git'),
+			driver,
+			env: { FORGE_KERNEL_ALLOW_UNSAFE_FS: '1' },
+			warn: () => {},
+			classifyFilesystem: () => ({
+				class: 'onedrive',
+				riskTier: 'refuse',
+				signal: 'injected',
+				remediationKey: 'onedrive',
+			}),
+		});
+
+		const result = await broker.initialize();
+		expect(result.success).toBe(true);
+		expect(driver.execCalls.length).toBeGreaterThan(0);
+	}, T);
+
+	test('local-ok path resolves normally (regression guard)', async () => {
+		const driver = makeRecordingDriver();
+		const broker = createLocalBroker({
+			projectRoot: path.join(os.tmpdir(), 'forge-worktree'),
+			gitCommonDir: path.join(os.tmpdir(), 'forge-worktree', '.git'),
+			driver,
+			env: {},
+			classifyFilesystem: () => ({
+				class: 'local-ok',
+				riskTier: 'safe',
+				signal: 'injected',
+				remediationKey: 'local-ok',
+			}),
+		});
+
+		const result = await broker.initialize();
+		expect(result.success).toBe(true);
+		expect(driver.execCalls.length).toBeGreaterThan(0);
+	}, T);
+});

--- a/test/kernel/driver-smoke.test.js
+++ b/test/kernel/driver-smoke.test.js
@@ -10,6 +10,13 @@ const { createLocalBroker } = require('../../lib/kernel/broker');
 const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
 const { runJsonlProjectionConsumer } = require('../../lib/kernel/projection-jsonl-writer');
 
+// Deterministic local-ok classifier: keeps these DB-acceptance tests independent
+// of the host filesystem class and avoids the real Windows drive probe the D19
+// gate runs in the broker getConfig() chokepoint.
+const LOCAL_OK_CLASSIFIER = () => ({
+	class: 'local-ok', riskTier: 'safe', signal: 'test-stub', remediationKey: 'local-ok',
+});
+
 // Windows releases the SQLite WAL/SHM mmap sidecars asynchronously after close, so
 // a teardown rmSync can race the unmap and throw EBUSY/EPERM (worse for the heavy
 // 13-op test). Retry with a REAL timer yield (a sync spin would block the very
@@ -60,6 +67,12 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 		// adopts config.databasePath and caches the open connection for the run.
 		driver = createBuiltinSQLiteDriver({});
 		const execFileSync = () => path.join(tmpDir, '.git');
+		// Deterministic FS classifier: this is an acceptance test for the 13 DB ops,
+		// NOT for the D19 filesystem gate. Injecting a local-ok stub keeps it
+		// independent of the host's actual filesystem class (a tmpdir on a network
+		// mount would otherwise REFUSE) and avoids the real per-broker Windows drive
+		// probe (net use + PowerShell) that the gate now runs in getConfig().
+		const classifyFilesystem = LOCAL_OK_CLASSIFIER;
 
 		// Migrate once: the public entry point never initializes the broker.
 		const setup = createLocalBroker({
@@ -67,17 +80,20 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 			execFileSync,
 			databasePath: dbPath,
 			driver,
+			classifyFilesystem,
 		});
 		await setup.initialize();
 
 		// The deps the task names — issueBackend + kernelDatabasePath select the kernel
 		// backend; kernelDriver/execFileSync are the mechanically-required plumbing
 		// (no default driver; resolveGitCommonDir runs against projectRoot otherwise).
+		// classifyFilesystem is forwarded into each per-op broker (forge-issues).
 		deps = {
 			issueBackend: 'kernel',
 			kernelDatabasePath: dbPath,
 			kernelDriver: driver,
 			execFileSync,
+			classifyFilesystem,
 		};
 	});
 
@@ -195,6 +211,7 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 			execFileSync: () => path.join(tmpDir, '.git'),
 			databasePath: dbPath,
 			driver,
+			classifyFilesystem: LOCAL_OK_CLASSIFIER,
 		});
 
 		const projectionDir = path.join(tmpDir, 'projection');
@@ -237,6 +254,7 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 			execFileSync: () => path.join(tmpDir, '.git'),
 			databasePath: dbPath,
 			driver,
+			classifyFilesystem: LOCAL_OK_CLASSIFIER,
 		});
 
 		const pending = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T00:10:00.000Z' });

--- a/test/kernel/fs-class.test.js
+++ b/test/kernel/fs-class.test.js
@@ -1,0 +1,699 @@
+'use strict';
+
+const { describe, expect, test } = require('bun:test');
+
+const {
+	classifyFromSignals,
+	classifyFilesystem,
+	gatherSignals,
+	assertFilesystemSafeForKernel,
+	isUnsafeFsOverrideActive,
+	defaultProbeDriveType,
+	parseNetUseDriveType,
+	parseDisplayRoot,
+	REMEDIATION,
+} = require('../../lib/kernel/fs-class');
+
+const T = 3000;
+
+describe('classifyFromSignals — win32', () => {
+	test('UNC path classifies as network-unc / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: '\\\\server\\share\\repo\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: true,
+			driveType: null,
+		});
+		expect(c.class).toBe('network-unc');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('mapped network drive (driveType network) → mapped-network-drive / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'Z:\\repo\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'network',
+		});
+		expect(c.class).toBe('mapped-network-drive');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('env.OneDriveCommercial prefix → onedrive / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\Users\\x\\OneDrive - Contoso\\forge\\kernel.sqlite',
+			env: { OneDriveCommercial: 'C:\\Users\\x\\OneDrive - Contoso' },
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('onedrive');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('OneDrive - Contoso path segment (no env) → onedrive', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'D:\\Sync\\OneDrive - Contoso\\forge\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('onedrive');
+	}, T);
+
+	test('Dropbox segment → dropbox / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\Users\\x\\Dropbox\\forge\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('dropbox');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('Google Drive segment → gdrive / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'G:\\My Drive\\Google Drive\\forge\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('gdrive');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('plain C:\\dev\\repo → local-ok / safe', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\dev\\repo\\.git\\forge\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('local-ok');
+		expect(c.riskTier).toBe('safe');
+	}, T);
+
+	test('Downloads path with NO OneDrive env → local-ok (no false positive)', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\Users\\x\\Downloads\\forge\\.git\\forge\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('local-ok');
+	}, T);
+
+	test('Downloads redirected under OneDrive env → onedrive', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\Users\\x\\OneDrive\\Downloads\\forge\\kernel.sqlite',
+			env: { OneDrive: 'C:\\Users\\x\\OneDrive' },
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('onedrive');
+	}, T);
+
+	test('OneDrive env prefix is boundary-aware (OneDriveBackup is NOT onedrive)', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\Users\\x\\OneDriveBackup\\forge\\kernel.sqlite',
+			env: { OneDrive: 'C:\\Users\\x\\OneDrive' },
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('local-ok');
+	}, T);
+
+	test('driveType unknown (probe miss) does NOT suppress OneDrive env detection → onedrive / refuse', () => {
+		// Drive probe failed (G1 fallback) BUT the path is positively under the
+		// OneDrive sync root. Cloud detection is path/env-based and independent of
+		// the drive probe; it must still fire and REFUSE (never downgrade to warn).
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\Users\\x\\OneDrive\\forge\\kernel.sqlite',
+			env: { OneDrive: 'C:\\Users\\x\\OneDrive' },
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'unknown',
+		});
+		expect(c.class).toBe('onedrive');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('driveType unknown (probe miss) does NOT suppress Dropbox segment detection → dropbox / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'C:\\Users\\x\\Dropbox\\forge\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'unknown',
+		});
+		expect(c.class).toBe('dropbox');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('driveType unknown (probe miss) on plain letter → unknown / warn (fail-open)', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: 'Z:\\repo\\kernel.sqlite',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'unknown',
+		});
+		expect(c.class).toBe('unknown');
+		expect(c.riskTier).toBe('warn');
+	}, T);
+});
+
+describe('classifyFromSignals — darwin', () => {
+	test('iCloud Mobile Documents → icloud / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'darwin',
+			absPath: '/Users/x/Library/Mobile Documents/com~apple~CloudDocs/forge/kernel.sqlite',
+			env: {},
+			homedir: '/Users/x',
+			isUNC: false,
+			driveType: null,
+		});
+		expect(c.class).toBe('icloud');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('~/Dropbox → dropbox', () => {
+		const c = classifyFromSignals({
+			platform: 'darwin',
+			absPath: '/Users/x/Dropbox/forge/kernel.sqlite',
+			env: {},
+			homedir: '/Users/x',
+			isUNC: false,
+			driveType: null,
+		});
+		expect(c.class).toBe('dropbox');
+	}, T);
+
+	test('~/Google Drive → gdrive', () => {
+		const c = classifyFromSignals({
+			platform: 'darwin',
+			absPath: '/Users/x/Google Drive/forge/kernel.sqlite',
+			env: {},
+			homedir: '/Users/x',
+			isUNC: false,
+			driveType: null,
+		});
+		expect(c.class).toBe('gdrive');
+	}, T);
+
+	test('~/Library/CloudStorage/OneDrive-Contoso → onedrive', () => {
+		const c = classifyFromSignals({
+			platform: 'darwin',
+			absPath: '/Users/x/Library/CloudStorage/OneDrive-Contoso/forge/kernel.sqlite',
+			env: {},
+			homedir: '/Users/x',
+			isUNC: false,
+			driveType: null,
+		});
+		expect(c.class).toBe('onedrive');
+	}, T);
+
+	test('plain ~/dev/repo → local-ok', () => {
+		const c = classifyFromSignals({
+			platform: 'darwin',
+			absPath: '/Users/x/dev/repo/.git/forge/kernel.sqlite',
+			env: {},
+			homedir: '/Users/x',
+			isUNC: false,
+			driveType: null,
+		});
+		expect(c.class).toBe('local-ok');
+	}, T);
+});
+
+describe('classifyFromSignals — linux / WSL', () => {
+	test('WSL interop + /mnt/c → wsl-cross / warn', () => {
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: '/mnt/c/Users/x/forge/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: 'drvfs',
+			isWslInterop: true,
+		});
+		expect(c.class).toBe('wsl-cross');
+		expect(c.riskTier).toBe('warn');
+	}, T);
+
+	test('cifs mount → network-unc / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: '/mnt/share/forge/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: 'cifs',
+			isWslInterop: false,
+		});
+		expect(c.class).toBe('network-unc');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('fuse.rclone mount → gdrive / refuse', () => {
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: '/home/x/mnt/rclone/forge/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: 'fuse.rclone',
+			isWslInterop: false,
+		});
+		expect(c.class).toBe('gdrive');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('native ext4 → local-ok', () => {
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: '/home/x/dev/repo/.git/forge/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: 'ext4',
+			isWslInterop: false,
+		});
+		expect(c.class).toBe('local-ok');
+	}, T);
+});
+
+describe('classifyFromSignals — unknown / fail-open + non-path inputs', () => {
+	test('unmatched platform → unknown / warn', () => {
+		const c = classifyFromSignals({
+			platform: 'sunos',
+			absPath: '/weird/path/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+		});
+		expect(c.class).toBe('unknown');
+		expect(c.riskTier).toBe('warn');
+	}, T);
+
+	test(':memory: classifies local-ok / safe', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: ':memory:',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('local-ok');
+		expect(c.riskTier).toBe('safe');
+	}, T);
+
+	test('file: URI classifies local-ok / safe', () => {
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: 'file:kernel?mode=memory',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: 'ext4',
+			isWslInterop: false,
+		});
+		expect(c.class).toBe('local-ok');
+	}, T);
+
+	test('empty path → local-ok / safe', () => {
+		const c = classifyFromSignals({
+			platform: 'win32',
+			absPath: '',
+			env: {},
+			homedir: 'C:\\Users\\x',
+			isUNC: false,
+			driveType: 'fixed',
+		});
+		expect(c.class).toBe('local-ok');
+	}, T);
+});
+
+describe('every Classification has a resolvable remediation', () => {
+	test('refuse/warn classes resolve to non-empty REMEDIATION text', () => {
+		const samples = [
+			{ platform: 'win32', absPath: '\\\\s\\sh\\k.sqlite', env: {}, homedir: 'C:\\u', isUNC: true, driveType: null },
+			{ platform: 'win32', absPath: 'Z:\\k.sqlite', env: {}, homedir: 'C:\\u', isUNC: false, driveType: 'network' },
+			{ platform: 'win32', absPath: 'C:\\u\\OneDrive\\k.sqlite', env: { OneDrive: 'C:\\u\\OneDrive' }, homedir: 'C:\\u', isUNC: false, driveType: 'fixed' },
+			{ platform: 'darwin', absPath: '/Users/x/Library/Mobile Documents/k.sqlite', env: {}, homedir: '/Users/x', isUNC: false, driveType: null },
+			{ platform: 'linux', absPath: '/mnt/c/k.sqlite', env: {}, homedir: '/home/x', isUNC: false, driveType: null, mountFsType: 'drvfs', isWslInterop: true },
+		];
+		for (const s of samples) {
+			const c = classifyFromSignals(s);
+			expect(typeof c.remediationKey).toBe('string');
+			expect(c.remediationKey.length).toBeGreaterThan(0);
+			expect(typeof REMEDIATION[c.remediationKey]).toBe('string');
+			expect(REMEDIATION[c.remediationKey].length).toBeGreaterThan(0);
+		}
+	}, T);
+});
+
+describe('assertFilesystemSafeForKernel', () => {
+	const refuseDeps = {
+		classifyFilesystem: () => ({ class: 'onedrive', riskTier: 'refuse', signal: 'env', remediationKey: 'onedrive' }),
+	};
+
+	test('refuse class throws when override unset', () => {
+		expect(() => assertFilesystemSafeForKernel('C:\\u\\OneDrive\\k.sqlite', {
+			...refuseDeps,
+			env: {},
+		})).toThrow();
+	}, T);
+
+	test('refuse class does NOT throw with FORGE_KERNEL_ALLOW_UNSAFE_FS=1 (warns)', () => {
+		const warnings = [];
+		expect(() => assertFilesystemSafeForKernel('C:\\u\\OneDrive\\k.sqlite', {
+			...refuseDeps,
+			env: { FORGE_KERNEL_ALLOW_UNSAFE_FS: '1' },
+			warn: msg => warnings.push(msg),
+		})).not.toThrow();
+		expect(warnings.length).toBeGreaterThan(0);
+	}, T);
+
+	test('warn class never throws', () => {
+		const warnings = [];
+		expect(() => assertFilesystemSafeForKernel('/mnt/c/k.sqlite', {
+			classifyFilesystem: () => ({ class: 'wsl-cross', riskTier: 'warn', signal: 'wsl', remediationKey: 'wsl-cross' }),
+			env: {},
+			warn: msg => warnings.push(msg),
+		})).not.toThrow();
+		expect(warnings.length).toBeGreaterThan(0);
+	}, T);
+
+	test('safe class never throws and does not warn', () => {
+		const warnings = [];
+		expect(() => assertFilesystemSafeForKernel('C:\\dev\\repo\\k.sqlite', {
+			classifyFilesystem: () => ({ class: 'local-ok', riskTier: 'safe', signal: 'none', remediationKey: 'local-ok' }),
+			env: {},
+			warn: msg => warnings.push(msg),
+		})).not.toThrow();
+		expect(warnings.length).toBe(0);
+	}, T);
+});
+
+describe('isUnsafeFsOverrideActive — only "1"/"true" enable the override (M4)', () => {
+	test('"1" → active', () => {
+		expect(isUnsafeFsOverrideActive({ FORGE_KERNEL_ALLOW_UNSAFE_FS: '1' })).toBe(true);
+	}, T);
+
+	test('"true"/"TRUE" (case-insensitive) → active', () => {
+		expect(isUnsafeFsOverrideActive({ FORGE_KERNEL_ALLOW_UNSAFE_FS: 'true' })).toBe(true);
+		expect(isUnsafeFsOverrideActive({ FORGE_KERNEL_ALLOW_UNSAFE_FS: 'TRUE' })).toBe(true);
+	}, T);
+
+	test('"0" → NOT active (truthy-string bug regression)', () => {
+		expect(isUnsafeFsOverrideActive({ FORGE_KERNEL_ALLOW_UNSAFE_FS: '0' })).toBe(false);
+	}, T);
+
+	test('"false" → NOT active', () => {
+		expect(isUnsafeFsOverrideActive({ FORGE_KERNEL_ALLOW_UNSAFE_FS: 'false' })).toBe(false);
+	}, T);
+
+	test('unset / empty → NOT active', () => {
+		expect(isUnsafeFsOverrideActive({})).toBe(false);
+		expect(isUnsafeFsOverrideActive({ FORGE_KERNEL_ALLOW_UNSAFE_FS: '' })).toBe(false);
+	}, T);
+});
+
+describe('assertFilesystemSafeForKernel — override env honors "1"/"true" only (M4)', () => {
+	const refuseDeps = {
+		classifyFilesystem: () => ({ class: 'onedrive', riskTier: 'refuse', signal: 'env', remediationKey: 'onedrive' }),
+	};
+
+	test('refuse class with FORGE_KERNEL_ALLOW_UNSAFE_FS=0 STILL throws (override not applied)', () => {
+		expect(() => assertFilesystemSafeForKernel('C:\\u\\OneDrive\\k.sqlite', {
+			...refuseDeps,
+			env: { FORGE_KERNEL_ALLOW_UNSAFE_FS: '0' },
+		})).toThrow();
+	}, T);
+
+	test('refuse class with FORGE_KERNEL_ALLOW_UNSAFE_FS=false STILL throws', () => {
+		expect(() => assertFilesystemSafeForKernel('C:\\u\\OneDrive\\k.sqlite', {
+			...refuseDeps,
+			env: { FORGE_KERNEL_ALLOW_UNSAFE_FS: 'false' },
+		})).toThrow();
+	}, T);
+});
+
+describe('gatherSignals — injected probes (no real FS) + G1 fallback', () => {
+	test('win32: probeDriveType returning network yields driveType network', () => {
+		const s = gatherSignals('Z:\\repo\\kernel.sqlite', {
+			platform: 'win32',
+			env: {},
+			homedir: () => 'C:\\Users\\x',
+			probeDriveType: () => 'network',
+		});
+		expect(s.platform).toBe('win32');
+		expect(s.driveType).toBe('network');
+		expect(s.isUNC).toBe(false);
+	}, T);
+
+	test('win32 UNC path flags isUNC without probing a drive letter', () => {
+		const s = gatherSignals('\\\\server\\share\\kernel.sqlite', {
+			platform: 'win32',
+			env: {},
+			homedir: () => 'C:\\Users\\x',
+			probeDriveType: () => { throw new Error('should not probe UNC'); },
+		});
+		expect(s.isUNC).toBe(true);
+	}, T);
+
+	test('G1: probeDriveType THROWS → driveType unknown (fail-safe fallback, never refuse)', () => {
+		const s = gatherSignals('Z:\\repo\\kernel.sqlite', {
+			platform: 'win32',
+			env: {},
+			homedir: () => 'C:\\Users\\x',
+			probeDriveType: () => { throw new Error('net use failed'); },
+		});
+		expect(s.driveType).toBe('unknown');
+		const c = classifyFromSignals(s);
+		expect(c.class).toBe('unknown');
+		expect(c.riskTier).toBe('warn');
+	}, T);
+
+	test('linux: probeMounts/readWslInterop injected', () => {
+		const s = gatherSignals('/mnt/c/repo/kernel.sqlite', {
+			platform: 'linux',
+			env: {},
+			homedir: () => '/home/x',
+			probeMounts: () => 'drvfs',
+			readWslInterop: () => true,
+		});
+		expect(s.mountFsType).toBe('drvfs');
+		expect(s.isWslInterop).toBe(true);
+	}, T);
+
+	test('linux: probeMounts THROWS → mountProbeThrew set → unknown/warn (M3, symmetric w/ win32)', () => {
+		const s = gatherSignals('/srv/data/kernel.sqlite', {
+			platform: 'linux',
+			env: {},
+			homedir: () => '/home/x',
+			probeMounts: () => { throw new Error('cannot read /proc/mounts'); },
+			readWslInterop: () => false,
+		});
+		expect(s.mountFsType).toBeNull();
+		expect(s.mountProbeThrew).toBe(true);
+		// A THROWN probe must NOT silently fail-open to local-ok; it is unknown/warn.
+		const c = classifyFromSignals(s);
+		expect(c.class).toBe('unknown');
+		expect(c.riskTier).toBe('warn');
+	}, T);
+
+	test('linux: probeMounts returns null with NO match → local-ok (no warn)', () => {
+		// Distinct from a throw: the probe ran fine and simply matched no network/cloud
+		// mount. This is genuinely a local path and must stay local-ok / safe.
+		const s = gatherSignals('/srv/data/kernel.sqlite', {
+			platform: 'linux',
+			env: {},
+			homedir: () => '/home/x',
+			probeMounts: () => null,
+			readWslInterop: () => false,
+		});
+		expect(s.mountFsType).toBeNull();
+		expect(s.mountProbeThrew).toBe(false);
+		const c = classifyFromSignals(s);
+		expect(c.class).toBe('local-ok');
+		expect(c.riskTier).toBe('safe');
+	}, T);
+});
+
+describe('classifyLinux — mountProbeThrew distinguishes threw vs no-match (M3)', () => {
+	test('mountProbeThrew=true with no other signal → unknown / warn', () => {
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: '/srv/data/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: null,
+			isWslInterop: false,
+			mountProbeThrew: true,
+		});
+		expect(c.class).toBe('unknown');
+		expect(c.riskTier).toBe('warn');
+	}, T);
+
+	test('mountProbeThrew=true STILL yields a cloud class when a path segment matches (path signal survives)', () => {
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: '/home/x/Dropbox/forge/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: null,
+			isWslInterop: false,
+			mountProbeThrew: true,
+		});
+		expect(c.class).toBe('dropbox');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+
+	test('mountProbeThrew=true STILL yields network-unc when a mount fs type was found', () => {
+		// Defensive: even if a throw flag is set, a concrete network fs wins over unknown.
+		const c = classifyFromSignals({
+			platform: 'linux',
+			absPath: '/mnt/share/forge/kernel.sqlite',
+			env: {},
+			homedir: '/home/x',
+			isUNC: false,
+			driveType: null,
+			mountFsType: 'cifs',
+			isWslInterop: false,
+			mountProbeThrew: true,
+		});
+		expect(c.class).toBe('network-unc');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+});
+
+describe('defaultProbeDriveType — bounded exec (B1) + canned-stdout parsing (M5)', () => {
+	test('B1: both net use and PowerShell execs pass timeout=1500 + killSignal SIGKILL', () => {
+		const seenOptions = [];
+		const fakeExec = (_file, _args, options) => {
+			seenOptions.push(options);
+			// Return empty so net use misses and the PowerShell fallback also runs,
+			// exercising BOTH exec calls in one probe.
+			return '';
+		};
+		const result = defaultProbeDriveType('Z:', { execFileSync: fakeExec });
+		// Both probes ran (net use, then PowerShell DisplayRoot).
+		expect(seenOptions.length).toBe(2);
+		for (const options of seenOptions) {
+			expect(options.timeout).toBe(1500);
+			expect(options.killSignal).toBe('SIGKILL');
+			// The pre-existing encoding option must be preserved.
+			expect(options.encoding).toBe('utf8');
+		}
+		// No network backing detected → fixed.
+		expect(result).toBe('fixed');
+	}, T);
+
+	test('B1: a hanging exec that throws (timeout-style) propagates so gather maps it to unknown/warn', () => {
+		// execFileSync with { timeout } throws on a hang; the probe does NOT catch it.
+		// gatherSignals catches and maps to driveType=unknown → warn (symmetric w/ G1).
+		const hangingExec = () => { throw new Error('spawnSync net ETIMEDOUT'); };
+		const s = gatherSignals('Z:\\repo\\kernel.sqlite', {
+			platform: 'win32',
+			env: {},
+			homedir: () => 'C:\\Users\\x',
+			probeDriveType: letter => defaultProbeDriveType(letter, { execFileSync: hangingExec }),
+		});
+		expect(s.driveType).toBe('unknown');
+		const c = classifyFromSignals(s);
+		expect(c.class).toBe('unknown');
+		expect(c.riskTier).toBe('warn');
+	}, T);
+
+	test('M5: parseNetUseDriveType detects a mapped letter from real net use stdout', () => {
+		const stdout = [
+			'New connections will be remembered.',
+			'',
+			'Status       Local     Remote                    Network',
+			'-------------------------------------------------------------------------------',
+			'OK           Z:        \\\\fileserver\\team        Microsoft Windows Network',
+			'OK           Y:        \\\\nas\\backups            Microsoft Windows Network',
+			'The command completed successfully.',
+			'',
+		].join('\r\n');
+		expect(parseNetUseDriveType(stdout, 'Z:')).toBe('network');
+		expect(parseNetUseDriveType(stdout, 'Y:')).toBe('network');
+	}, T);
+
+	test('M5: parseNetUseDriveType returns null when the letter is absent', () => {
+		const stdout = [
+			'Status       Local     Remote                    Network',
+			'OK           Y:        \\\\nas\\backups            Microsoft Windows Network',
+			'The command completed successfully.',
+		].join('\r\n');
+		expect(parseNetUseDriveType(stdout, 'Z:')).toBeNull();
+		// Must not partial-match (e.g. a line mentioning Z elsewhere).
+		expect(parseNetUseDriveType('OK  AZ:  ...', 'Z:')).toBeNull();
+	}, T);
+
+	test('M5: parseDisplayRoot treats a non-empty DisplayRoot as network, empty/whitespace as null', () => {
+		expect(parseDisplayRoot('\\\\fileserver\\share\r\n')).toBe('network');
+		expect(parseDisplayRoot('   \r\n')).toBeNull();
+		expect(parseDisplayRoot('')).toBeNull();
+	}, T);
+
+	test('M5: defaultProbeDriveType returns network when net use stdout lists the letter', () => {
+		const stdout = 'OK           Z:        \\\\fileserver\\team        Microsoft Windows Network\r\n';
+		const fakeExec = (file) => (file === 'net' ? stdout : '');
+		expect(defaultProbeDriveType('Z:', { execFileSync: fakeExec })).toBe('network');
+	}, T);
+
+	test('M5: defaultProbeDriveType returns network when PowerShell DisplayRoot is non-empty', () => {
+		const fakeExec = (file) => (file === 'net' ? '' : '\\\\nas\\share\r\n');
+		expect(defaultProbeDriveType('Z:', { execFileSync: fakeExec })).toBe('network');
+	}, T);
+});
+
+describe('classifyFilesystem — end-to-end with injected probes', () => {
+	test('win32 mapped drive via injected probe → mapped-network-drive / refuse', () => {
+		const c = classifyFilesystem('Z:\\repo\\kernel.sqlite', {
+			platform: 'win32',
+			env: {},
+			homedir: () => 'C:\\Users\\x',
+			probeDriveType: () => 'network',
+		});
+		expect(c.class).toBe('mapped-network-drive');
+		expect(c.riskTier).toBe('refuse');
+	}, T);
+});


### PR DESCRIPTION
## Problem

The Forge Kernel stores its SQLite DB at `.git/forge/kernel.sqlite`. SQLite **WAL mode corrupts** when a cloud-sync client (OneDrive/Dropbox/Google Drive/iCloud) or a network filesystem (UNC/SMB/NFS/mapped drive) rewrites the file mid-write. This is not theoretical — the primary dev machine for this repo lives under `Downloads`, a plausible OneDrive-sync path. There was no guard.

## What this does (D19)

A **default-on filesystem safety gate** plus a `forge doctor` reporter.

- **`lib/kernel/fs-class.js`** — a path classifier split for testability: pure `classifyFromSignals(signals)` (zero I/O, 100% synthetic-tested) + a thin `gatherSignals(absPath, deps)` with every OS probe injectable. Per-OS detection: Windows env (`OneDrive`/…), UNC, and mapped-drive (`net use` + PowerShell, **timeout-bounded, fail-safe** → any probe failure ⇒ `unknown`/warn, never a silent allow, never a hang); macOS iCloud `Mobile Documents` / `CloudStorage`; Linux/WSL `/mnt/<letter>` + `/proc/mounts` fs-type.
- **Gate at the memoized `getConfig()` chokepoint** (`broker.js`) — every DB-creating path (`initialize`, `runIssueOperation`, the projection outbox) funnels through `getConfig()`, so asserting there guards them **all**, not just `initialize()`. Fail-closed ordering: build config → assert → *then* populate the memo. Refuses high-corruption classes **before any file is created**; warns on `wsl-cross`/`unknown` (fail-open).
- **`forge doctor [--json]`** (`commands/doctor.js`, auto-discovered) — resolves the exact kernel DB path the gate guards and reports its class **without creating any file**.
- **Escape hatch** `FORGE_KERNEL_ALLOW_UNSAFE_FS=1` downgrades every `refuse` to a warning (reliable network homes / CI / incident recovery).

## Already adversarially reviewed

This work went through an independent code review during development; the fixes are included: probe **timeout** (no startup hang), the **structural** chokepoint gate (closes the `runIssueOperation`/`listProjectionOutbox` bypass), Linux probe-failure → `unknown` (no silent fail-open), strict `'1'`/`'true'` override parsing, and a real-`net use`-parser test.

## Note on the branch

Rebuilt cleanly on `origin/master`. The original branch was accidentally created off **local** `master` (which carries unpushable local-only commits) — see the closed/cleaned PR #232 for the same root cause. This branch contains **only** the D19 commit; `.gitignore` is untouched.

## Validation

Kernel suite + `forge doctor` + release (audit artifact) **380 / 0**, ESLint `--max-warnings 0` clean. The per-broker probe adds ~28s to `test/kernel/` on Windows (deterministic classifier injected in DB-acceptance tests to keep them fast; production cost is one probe per process) — noted as a perf follow-up, not a blocker.

Design: [D19-filesystem-doctor-design.md](docs/work/2026-06-06-kernel-backlog-memory-roadmap/D19-filesystem-doctor-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `forge doctor` to report the kernel database filesystem classification and whether initialization will proceed or be blocked.
  * Provides both human-readable output and `--json`, including override status and guidance for unsafe locations.
* **Security / Reliability**
  * Strengthened the default-on filesystem safety gate to prevent kernel database creation on unsafe or network/cloud-synced filesystems.
  * Ensures safety checks run before broker initialization reaches database operations.
* **Documentation**
  * Updated CLI reference and added documentation on filesystem safety behavior and `FORGE_KERNEL_ALLOW_UNSAFE_FS`.
* **Tests**
  * Added coverage for `forge doctor` output and the default-on gate behavior across filesystem tiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->