### PR TITLE
feat(kernel): re-land D20 CLI selector — kernel issue backend reachable via opt-in (default stays beads)

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -57,6 +57,7 @@ const {
 } = require('../lib/docs-command');
 const { resetSoft, resetHard, reinstall } = require('../lib/reset');
 const { loadCommands, executeCommand } = require('../lib/commands/_registry');
+const { resolveCommandOpts } = require('../lib/commands/_resolve-command-opts');
 const { enforceStageEntry } = require('../lib/workflow/enforce-stage');
 const { normalizeStageId } = require('../lib/workflow/stages');
 
@@ -4184,13 +4185,23 @@ async function main() {
   // Registry command dispatch — auto-discovered commands take priority
   if (registry.commands.has(command)) {
     try {
+      // Resolve the issue backend (flag > env > config > default) and, for issue
+      // commands, strip the selector tokens (--kernel / --issue-backend) from the
+      // args so they never reach the handler or bd. For the kernel backend this
+      // also assembles the driver + migrated broker (B1/B2).
+      const { commandOpts, args: dispatchArgs } = await resolveCommandOpts(
+        command,
+        args.slice(1),
+        { env: process.env, projectRoot },
+      );
       const result = await executeCommand(
         registry.commands,
         command,
-        args.slice(1),
+        dispatchArgs,
         flags,
         projectRoot,
         {
+          commandOpts,
           enforceStage: (context) => enforceStageEntry({
             commandName: context.commandName,
             args: context.args,

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -7,18 +7,20 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 
 | Group | Call sites | Files |
 | --- | ---: | ---: |
-| command | 120 | 11 |
+| command | 123 | 12 |
 | runtime | 343 | 47 |
-| docs | 436 | 67 |
+| docs | 452 | 68 |
 | skills | 22 | 9 |
 | hooks | 0 | 0 |
 
 ## command
 
-- [ ] bin/forge.js (25)
-  - lines: 2371 (bd), 2373 (bd), 2527 (bd), 2929 (bd), 2938 (bd), 2951 (bd), 2964 (.beads), 2984 (bd), 2986 (bd), 2988 (bd), 3023 (bd), 3047 (bd), 3133 (bd), 3177 (bd), 3201 (bd), 3207 (bd), 3211 (bd), 3216 (bd), 3222 (bd), 3232 (bd), 3364 (bd), 3369 (bd), 3380 (bd), 3447 (bd), 4655 (bd)
+- [ ] bin/forge.js (26)
+  - lines: 2372 (bd), 2374 (bd), 2528 (bd), 2930 (bd), 2939 (bd), 2952 (bd), 2965 (.beads), 2985 (bd), 2987 (bd), 2989 (bd), 3024 (bd), 3048 (bd), 3134 (bd), 3178 (bd), 3202 (bd), 3208 (bd), 3212 (bd), 3217 (bd), 3223 (bd), 3233 (bd), 3365 (bd), 3370 (bd), 3381 (bd), 3448 (bd), 4190 (bd), 4666 (bd)
 - [ ] lib/commands/_issue.js (15)
   - lines: 10 (bd), 16 (bd), 22 (bd), 27 (bd), 52 (bd), 58 (bd), 64 (bd), 70 (bd), 76 (bd), 82 (bd), 88 (bd), 92 (bd), 177 (bd), 333 (bd), 390 (bd)
+- [ ] lib/commands/_resolve-command-opts.js (2)
+  - lines: 8 (bd), 10 (bd)
 - [ ] lib/commands/clean.js (2)
   - lines: 10 (dolt), 175 (dolt)
 - [ ] lib/commands/dev.js (1)
@@ -237,6 +239,8 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 7 (.beads), 8 (.beads), 12 (dolt)
 - [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/clarity-gap-review.md (3)
   - lines: 5 (dolt), 24 (bd), 167 (dolt)
+- [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/d20-step0-kernel-selector-design.md (16)
+  - lines: 1 (bd), 16 (bd), 104 (bd), 121 (bd), 123 (bd, .beads), 125 (dolt), 127 (bd), 128 (bd), 132 (dolt), 191 (bd), 216 (dolt), 220 (dolt), 221 (dolt), 222 (bd), 223 (.beads), 224 (bd)
 - [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/decision-options.md (2)
   - lines: 11 (dolt), 125 (bd)
 - [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/decision-registry-mechanism.md (2)

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -240,7 +240,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/clarity-gap-review.md (3)
   - lines: 5 (dolt), 24 (bd), 167 (dolt)
 - [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/d20-step0-kernel-selector-design.md (16)
-  - lines: 1 (bd), 16 (bd), 104 (bd), 121 (bd), 123 (bd, .beads), 125 (dolt), 127 (bd), 128 (bd), 132 (dolt), 191 (bd), 216 (dolt), 220 (dolt), 221 (dolt), 222 (bd), 223 (.beads), 224 (bd)
+  - lines: 1 (bd), 16 (bd), 109 (bd), 126 (bd), 128 (bd, .beads), 130 (dolt), 132 (bd), 133 (bd), 137 (dolt), 196 (bd), 221 (dolt), 225 (dolt), 226 (dolt), 227 (bd), 228 (.beads), 229 (bd)
 - [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/decision-options.md (2)
   - lines: 11 (dolt), 125 (bd)
 - [ ] docs/work/2026-06-06-kernel-backlog-memory-roadmap/decision-registry-mechanism.md (2)

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/d20-step0-kernel-selector-design.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/d20-step0-kernel-selector-design.md
@@ -1,0 +1,236 @@
+# D20 Step 0 + Step 1 — Kernel-CLI Selector + First Safe `bd` Call-Site Slice
+
+**Status:** Design + TDD task list (no code). Scope-bounded per the D20 entry-point brief.
+**Date:** 2026-06-22
+**Owner work folder:** `docs/work/2026-06-06-kernel-backlog-memory-roadmap/`
+
+---
+
+## 0. Problem (verified against code)
+
+The kernel issue backend is selected only by `shouldUseKernelBroker(opts)`:
+
+- `lib/commands/_issue.js:170` → `opts.useKernelBroker || opts.kernelBroker || opts.issueBackend === 'kernel'`
+- `lib/forge-issues.js:298` → same predicate on `deps`.
+
+These are set **only in tests** (`test/commands/_issue.test.js:275`, `test/forge-issues.test.js`). There is **no CLI flag, no env var, no config** that sets them. `FORGE_ISSUE_BACKEND` does not exist anywhere in `lib/`, `bin/`, or `test/` (grep-verified). Consequence: the kernel backend is unreachable from the CLI → `bd` issue-CRUD call-sites can't be removed, and `kap-10/11/12` are stranded in `.git/forge/kernel.sqlite` with no way to close them.
+
+### The real seam (critical, verified)
+
+`bin/forge.js:4196` calls `executeCommand(registry.commands, command, args.slice(1), flags, projectRoot, { enforceStage })`. But `lib/commands/_registry.js:164` invokes the handler as:
+
+```js
+return await command.handler(args, flags, projectRoot);   // _registry.js:164 — only 3 args
+```
+
+The issue handlers (`_issue.js:246`, `:257`) declare a **4th `opts` parameter** that `shouldUseKernelBroker(opts)` reads — but `executeCommand` **never passes it**. So the selector cannot work until `executeCommand → command.handler` threads a resolved `opts`/`deps` object. **This is the enabler edit.**
+
+**Dispatch path confirmed (verified, not inferred):** `forge close` is a discovered alias. `_registry.js:72` skips `_`-prefixed files, but the public wrappers `lib/commands/{close,create,update,list,show,claim,release,comment,ready}.js` each do `module.exports = makeAliasCommand('<verb>')` and are discovered + registered via `commands.set(mod.name, mod)` (`_registry.js:99`). Their `handler` (built by `makeAliasCommand`, `_issue.js:246`) is invoked through the same `executeCommand` 3-arg site at `_registry.js:164`. So `forge close → discovered alias → executeCommand → 3-arg handler` — T2/T6 target the correct seam. **Note:** `release.js` wraps the alias with extra logic (`release.js:14`); T2's 4th-arg addition is additive/backward-compatible, so the wrapper is unaffected.
+
+---
+
+## 1. Three additional blockers between "selector resolves" and "`forge close kap-10 kap-11 kap-12 --kernel` works" (all verified)
+
+| # | Blocker | Evidence | Fix location |
+|---|---------|----------|--------------|
+| B1 | **No real driver on CLI path.** `createKernelIssueBackend` (forge-issues.js:283) defaults broker `driver` to `deps.kernelDriver`, which is `undefined` from CLI → first guarded op hits `requireGuardedDriverMethods(undefined)` → throws `"driver must provide exec()"`. | forge-issues.js:283–296; broker.js:643 | Construct `createBuiltinSQLiteDriver({ databasePath })` (sqlite-driver.js:1169) and inject as `kernelDriver`/broker. |
+| B2 | **Migrations never run on runtime path.** `driver-smoke.test.js:64` comment: "the public entry point never initializes the broker." Nothing calls `broker.initialize()` → pragmas (WAL/busy_timeout/FK) + migration DDL never applied for a fresh connection. | broker.js:724; driver-smoke.test.js:43,64 | CLI kernel path runs `broker.initialize()` (migrations are idempotent — `execMigrationStatement` swallows duplicate-column). Decide per-invocation vs lazy (see §5). |
+| B3 | **Result-envelope mismatch — success reads as failure.** Kernel mutations return `{ ok:true, schema_version, command, data, next_commands }` (broker.js:545, `okMutationResponse`) with **no `success` field**. `bin/forge.js:4202` checks `if (result && !result.success)` → a successful kernel close exits 1. Beads path returns `{ success:true, output }`, so only the kernel branch breaks. | broker.js:545–553; bin/forge.js:4202–4214 | Normalization shim mapping `ok→success`, rendering `data` as `output`, preserving `next_commands`/`schema_version` for `--json`. |
+| B4 | **The literal task command is broken in the broker.** (a) `buildIssueMutationEvent` uses `firstPositionalArg` (broker.js:517) → `forge close kap-10 kap-11 kap-12` closes **only kap-10**. (b) `buildUpdatePayload` (broker.js:405) never reads `reason` → `--reason=...` is **silently dropped**. | broker.js:405,517 | Multi-id iteration + `reason` passthrough (own tasks; do NOT let a green single-id `runIssueOperation` unit test hide this). |
+
+**Config:** `.forge/config.yaml` is already read via `lib/core/runtime-graph.js` (`readConfigSection`, line 504). `.forgerc.json` is docs-only (`agents-config.js`). So a config knob has a real home but is **optional/deferred** — **flag + env are the load-bearing requirement.**
+
+---
+
+## 2. Design
+
+### 2.1 Selector module (new owned file)
+
+`lib/issue-backend-selector.js` — pure resolver, no I/O beyond reading a passed-in env/flags/config snapshot. Keeps the `bin/forge.js` edit minimal (the D19 coordination point).
+
+```
+resolveIssueBackend({ flags, env, config }) -> {
+  issueBackend: 'kernel' | 'beads',
+  useKernelBroker: boolean,        // convenience mirror, === (issueBackend==='kernel')
+  source: 'flag' | 'env' | 'config' | 'default'
+}
+```
+
+**Precedence (highest first):**
+
+1. **Flag** — `--kernel` (boolean) OR `--issue-backend kernel|beads`. `--kernel` is sugar for `--issue-backend kernel`. Mutually-exclusive conflict (`--kernel` + `--issue-backend beads`) → explicit error.
+2. **Env** — `FORGE_ISSUE_BACKEND=kernel|beads`. Unknown value → error listing valid values (never silently default; matches JSON-first explicitness).
+3. **Config** — `.forge/config.yaml` key `issueBackend: kernel|beads` (OPTIONAL — see Task 8; if config loading isn't trivially reachable, ship flag+env and defer config).
+4. **Default** — `beads` (preserves today's behavior; kernel is strictly opt-in).
+
+Output threads into the existing predicate unchanged: set `opts.issueBackend` (and mirror `useKernelBroker`) so both `_issue.js:170` and `forge-issues.js:298` light up with **zero change to the predicates themselves**.
+
+### 2.2 Threading opts through the registry (the enabler)
+
+- `lib/commands/_registry.js`: extend `executeCommand` to forward an `opts`/`deps` object as the handler's 4th arg: `command.handler(args, flags, projectRoot, options.commandOpts ?? {})`. Backward-compatible — existing handlers ignore the 4th arg.
+- `bin/forge.js`: at the dispatch site (4196), call `resolveIssueBackend({ flags, env: process.env, config })`, build the kernel `deps` (driver + flag), and pass as `commandOpts`. **Only the issue/alias commands need it**; pass it for all (harmless) or gate to the issue command set.
+
+### 2.3 Kernel deps assembly (B1 + B2) — new owned file
+
+`lib/kernel/cli-broker-factory.js`:
+
+```
+buildKernelIssueDeps({ projectRoot, databasePath? }) -> {
+  useKernelBroker: true,
+  kernelDriver: createBuiltinSQLiteDriver({ databasePath }),  // sqlite-driver.js
+  // broker constructed by createKernelIssueBackend using kernelDriver
+}
+ensureKernelMigrated(broker)  // idempotent broker.initialize() wrapper
+```
+
+`forge-issues.js:285` already accepts `deps.kernelDriver`, `deps.kernelDatabasePath`, `deps.createKernelBroker` — so this factory plugs in with **no change to `createKernelIssueBackend`'s contract**. The factory owns: runtime detection fallthrough (bun:sqlite→node:sqlite→error, already in `selectBuiltinSQLiteRuntime`), D19 filesystem-doctor hook point (read-only check before placing DB — coordinate, don't reimplement), and `initialize()`.
+
+### 2.4 Result normalization shim (B3) — `lib/commands/_issue.js`
+
+Wrap the kernel branch return in `runIssueSubcommand` so the dispatcher sees a uniform shape:
+
+```
+normalizeIssueResult(raw) ->
+  raw.ok !== undefined
+    ? { success: raw.ok, output: render(raw), error: raw.ok ? undefined : raw.error?.message,
+        _envelope: raw }   // keep schema_version + next_commands for --json
+    : raw                  // beads path already { success, output }
+```
+
+`render(raw)` prints `data` (human) or the full envelope (when `--json`). **Must not drop `next_commands`/`schema_version`** (contract requirement).
+
+### 2.5 Multi-id + reason (B4) — kernel branch only
+
+**Multi-id — scope to the kernel branch (verified nuance).** Beads already fans out: `close` is a WRITE op → `runIssueOperation('close', [id1,id2,id3])` → `bd close <all ids>` (bd does the fan-out). **Only the kernel path single-ids** via `firstPositionalArg` (broker.js:517). So the per-id loop must be **gated to `shouldUseKernelBroker(opts)`** — looping unconditionally would change beads from one `bd` spawn to N spawns (regression). Implement the loop at the `_issue.js` layer (loop `runIssueOperation` per id under the kernel branch, aggregate envelopes; success iff all succeed, else per-id errors). This keeps broker single-event semantics intact.
+
+**Reason — `--reason` is dropped by `buildUpdatePayload` at `broker.js:405` (NOT `_issue.js`).** Two options, **chosen: extend `buildUpdatePayload` (broker.js) to read `reason`** into the close payload, matching beads `close --reason` semantics. This means **T4 also owns `lib/kernel/broker.js`** (the `buildUpdatePayload`/close-payload region) — see updated ownership map. (Alternative considered: a second `runIssueOperation('comment',...)` carrying the reason, which stays inside `_issue.js`; rejected because it splits one logical close into two events.) **Ambiguity ≥80%** — beads `close --reason` is the reference; proceed.
+
+### 2.6 How `kap-10/11/12` get closed (end-to-end, once the above lands)
+
+```
+forge close kap-10 kap-11 kap-12 --reason="..." --kernel
+  → bin/forge.js resolveIssueBackend(flag) → issueBackend='kernel'
+  → executeCommand forwards commandOpts (driver + flag) to alias handler
+  → _issue.js runIssueSubcommand: WRITE op → runIssueOperation('close', ...)
+  → forge-issues.js shouldUseKernelBroker(deps)=true → createKernelIssueBackend(driver injected)
+  → ensureKernelMigrated → broker.runIssueOperation('close', [id], ...) per id
+  → guarded event issue.close on .git/forge/kernel.sqlite, reason in payload
+  → normalizeIssueResult → {success:true} per id → dispatcher prints, exit 0
+```
+
+### 2.7 First safe `bd` call-site slice (Step 1)
+
+**Selection rule (state to all implementers):** Step 1 makes the issue-CRUD path *kernel-routable and tested*. It **does NOT delete** the `bd` passthrough (parity-gated, D14) and **does NOT** drop `.beads` reads. Beads stays the default.
+
+From the kill-list, the FIRST tranche — sites that become kernel-routable purely by the selector, no Dolt lifecycle touched:
+
+- `lib/commands/_issue.js` (12 sites, lines 9–225) — the alias/issue command surface. **Routable now**: every write op already calls `runIssueOperation` which honors `shouldUseKernelBroker`. The remaining `bd`-literal strings are help text/usage; the live `exec('bd', ...)` at :225 is the beads-default branch and **stays** (parity), but is now bypassed under `--kernel`.
+- `lib/forge-issues.js` (4 sites, lines 74–112) — `bd` command-candidate resolution; **stays** as the beads-default executor, gated behind `shouldUseKernelBroker` false. No deletion; covered by the selector routing it around.
+
+**Net Step-1 deliverable:** the 8 issue verbs (`create/update/close/list/show/search/stats/claim/release/comment/dep`) reach the kernel broker under selector, with the beads path untouched as default. No kill-list checkbox is *deleted*; the issue-CRUD entries become "kernel-routable, beads-default" — the precondition every later deletion depends on.
+
+**Explicitly OUT (flag as blocked/deferred):** `lib/commands/sync.js` (9 — dolt pull/push), `lib/commands/worktree.js` (15 — dolt server lifecycle). Those are the D14 authority flip. See §4.
+
+---
+
+## 3. TDD Task List (parallel waves, RED→GREEN→REFACTOR)
+
+**Conventions (apply to every task):** TDD RED→GREEN→REFACTOR. ESLint `--max-warnings 0`, unused params `_`-prefixed. `bun test` with **explicit per-test timeout (3rd arg)** — bunfig `[test]` timeout is NOT honored. Use `forge test` / `forge push`. JSON-first envelope: never drop `next_commands`/`schema_version`. Windows/Git Bash. Ambiguity: 7-dim rubric, ≥80% proceed+document, <80% flag.
+
+### Dependency graph
+
+```
+Wave 1 (parallel, independent files):
+  T1 selector module        ─┐
+  T3 normalization shim      ─┤
+  T5 cli-broker-factory      ─┤   (all leaf, no shared files)
+  T8 config knob (optional)  ─┘
+        │            │            │
+Wave 2 (depends on Wave 1):
+  T2 registry opts-threading  ← needs T1 contract
+  T4 multi-id + reason        ← independent of T2, but shares _issue.js with T3 → sequence after T3
+        │
+Wave 3 (integration, depends on 1+2):
+  T6 bin/forge.js wiring      ← needs T1,T2,T5 (D19 COORDINATION POINT)
+  T7 e2e kap-close test       ← needs all
+```
+
+### File ownership (collision map)
+
+| Task | Owns (writes) | Reads only |
+|------|---------------|-----------|
+| T1 | `lib/issue-backend-selector.js` + its test | — |
+| T2 | `lib/commands/_registry.js` + test | `_issue.js` |
+| T3 | `lib/commands/_issue.js` (normalize fn region) + test | broker envelope |
+| T4 | `lib/commands/_issue.js` (multi-id loop region, kernel-gated) **+ `lib/kernel/broker.js` (`buildUpdatePayload`/close-payload region, ~line 405)** + tests | sqlite-driver |
+| T5 | `lib/kernel/cli-broker-factory.js` + test | sqlite-driver, broker, forge-issues |
+| T6 | `bin/forge.js` (dispatch region ~4196) | T1,T5 |
+| T7 | `test/e2e/kernel-issue-cli.test.js` (new) | all |
+| T8 | `lib/issue-backend-selector.js` config branch (sequence AFTER T1) | runtime-graph |
+
+> **T3 and T4 both edit `_issue.js`** — sequence them (T3 first, then T4) or split into disjoint regions with a merge owner. Do **not** run in parallel. **T4 additionally owns `lib/kernel/broker.js`** (`buildUpdatePayload`, ~line 405) for the `--reason` passthrough — no collision with T3/T5 (they only *read* broker.js), but T4's broker edit must land in the same PR as its `_issue.js` loop edit.
+
+---
+
+### T1 — Selector module `lib/issue-backend-selector.js`
+- **RED:** test `resolveIssueBackend` precedence: flag>env>config>default; `--kernel`↔`--issue-backend kernel` equivalence; conflict error; unknown env value error; default=`beads`; output mirrors `useKernelBroker`.
+- **GREEN:** pure function, no I/O.
+- **REFACTOR:** extract valid-value constants; share with `_issue.js`/`forge-issues.js` predicate keys.
+
+### T2 — Registry opts threading `lib/commands/_registry.js`
+- **RED:** test `executeCommand` forwards a 4th arg to `command.handler`; existing 3-arg handlers unaffected (backward-compat).
+- **GREEN:** `command.handler(args, flags, projectRoot, options.commandOpts ?? {})`.
+- **REFACTOR:** none beyond naming. **Dep:** T1 (opts shape).
+
+### T3 — Result normalization shim `lib/commands/_issue.js`
+- **RED:** kernel `{ok:true,data,next_commands,schema_version}` → `{success:true, output, _envelope}`; `ok:false` → `{success:false,error}`; beads `{success,output}` passes through unchanged; `--json` preserves `next_commands`+`schema_version`.
+- **GREEN:** `normalizeIssueResult` wrapping the kernel branch return.
+- **REFACTOR:** centralize render.
+
+### T4 — Multi-id close + `--reason` — `_issue.js` (kernel-gated loop) + `broker.js` (reason) (AFTER T3)
+- **RED:** under kernel backend, `forge close a b c --reason=x` issues 3 kernel closes; reason reaches the close payload; aggregate success iff all succeed; partial-failure surfaces per-id errors. **Plus a beads-branch regression guard:** beads `close a b c` still results in ONE `bd close` spawn (loop must NOT apply to beads). (Guards broker `firstPositionalArg` single-id trap, broker.js:517, and dropped reason, broker.js:405.)
+- **GREEN:** kernel-gated per-id loop at `_issue.js` (only when `shouldUseKernelBroker(opts)`); extend `buildUpdatePayload` (broker.js:405) to read `reason`.
+- **REFACTOR:** share the kernel loop with other multi-id verbs (update) without touching the beads passthrough.
+
+### T5 — CLI broker factory `lib/kernel/cli-broker-factory.js`
+- **RED:** `buildKernelIssueDeps` returns `{useKernelBroker:true, kernelDriver}`; driver built from `createBuiltinSQLiteDriver`; `ensureKernelMigrated` is idempotent (double-call safe, swallows duplicate-column); runtime-absent → clear error. Mock the sqlite runtime in tests; **explicit per-test timeout**.
+- **GREEN:** thin factory over sqlite-driver + `broker.initialize()`.
+- **REFACTOR:** expose D19 filesystem-doctor hook seam (call-out, not impl).
+
+### T6 — `bin/forge.js` wiring (D19 COORDINATION POINT)
+- **RED:** integration test (spawn or in-proc) — `--kernel` routes to kernel broker (assert via injected driver/db path); env `FORGE_ISSUE_BACKEND=kernel` same; default → beads path unchanged.
+- **GREEN:** at dispatch (~4196): `resolveIssueBackend` + `buildKernelIssueDeps` when kernel → pass as `commandOpts`.
+- **REFACTOR:** keep edit minimal.
+- **⚠️ D19 COORDINATION:** a parallel D19 track (filesystem doctor) also edits `bin/forge.js` and "command handlers" (tasks.md:57). **Coordinate the same dispatch region.** Agree merge order with D19 owner BEFORE editing; prefer landing the selector seam first (smaller), or have one owner stage both edits. Flag in PR description.
+
+### T7 — E2E kap-close `test/e2e/kernel-issue-cli.test.js`
+- **RED:** against a temp `.git/forge/kernel.sqlite` seeded with 3 open issues, `forge close <3 ids> --reason --kernel` closes all 3, exit 0, envelope preserved. Mirrors the real kap-10/11/12 close. **Explicit per-test timeout.**
+- **GREEN:** passes once T1–T6 land.
+- **REFACTOR:** factor a kernel-CLI test harness helper.
+
+### T8 — Config knob (OPTIONAL / lower priority) `lib/issue-backend-selector.js`
+- Only if `.forge/config.yaml` `issueBackend` is trivially reachable via existing `runtime-graph` reader. **RED:** config sets backend when flag+env absent; flag/env still override. **If not trivial → defer; do NOT build a new config system (scope creep).**
+
+---
+
+## 4. Blocked / Deferred (needs D14 Dolt flip first)
+
+| Item | Kill-list sites | Why blocked |
+|------|-----------------|-------------|
+| Remove `lib/commands/sync.js` dolt pull/push | sync.js (9) | D14 authority flip — Dolt sync lifecycle. OUT of D20 Step 0/1. |
+| Remove `lib/commands/worktree.js` dolt server lifecycle | worktree.js (15) | D14 — Dolt server start/stop per worktree. OUT. |
+| **Delete** (not route) the `bd` issue-CRUD passthrough | _issue.js:225, forge-issues.js:74–112 | Parity-gated (D22) + projection-gated (D16). Selector *routes around* it; deletion waits for parity gate. |
+| Move `insights.js`/`recap` `.beads/*.jsonl` reads to kernel | insights.js (7), recap | D16 projection must be the read source first. |
+| Setup/preflight/smart-status `bd` retraining | setup.js (32), preflight.sh (16), smart-status.sh (16) | Later kill-list tranche (ecosystem retraining), after authority flip. |
+
+---
+
+## 5. Open decision (does not block design viability)
+
+**`initialize()` timing:** per-invocation (run `ensureKernelMigrated` on every kernel CLI call — simple, idempotent, ~1 extra DDL no-op pass) **vs** lazy/cached (memoize "migrated" per process). **Recommendation:** per-invocation for the CLI (process is short-lived; migrations are idempotent via `execMigrationStatement`). Document the choice in T5; it changes T5's test, not the design.
+
+## 6. Ambiguity scoring (<80% flags)
+
+- Close `--reason` storage field (payload column vs close-comment): **≥80%** — beads `close --reason` is the reference; proceed, document field.
+- Config knob existence: resolved — `.forge/config.yaml` reader exists; knob is optional, **flag+env load-bearing**. No flag needed.
+- D19 `bin/forge.js` overlap: **flagged** — cross-track coordination required (T6); not an ambiguity in design, a merge-sequencing risk.

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/d20-step0-kernel-selector-design.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/d20-step0-kernel-selector-design.md
@@ -46,7 +46,12 @@ The issue handlers (`_issue.js:246`, `:257`) declare a **4th `opts` parameter** 
 
 ### 2.1 Selector module (new owned file)
 
-`lib/issue-backend-selector.js` — pure resolver, no I/O beyond reading a passed-in env/flags/config snapshot. Keeps the `bin/forge.js` edit minimal (the D19 coordination point).
+As landed, the selector splits across two files: the pure backend resolver
+`lib/issue-backend.js` (`resolveIssueBackend`) and the CLI dispatch glue
+`lib/commands/_resolve-command-opts.js` (strips the selector tokens, calls the
+resolver, and assembles the kernel deps). Neither does I/O beyond reading a
+passed-in env/flags/config snapshot, keeping the `bin/forge.js` edit minimal (the
+D19 coordination point).
 
 ```
 resolveIssueBackend({ flags, env, config }) -> {

--- a/lib/commands/_registry.js
+++ b/lib/commands/_registry.js
@@ -17,7 +17,7 @@ const { normalizeStageId } = require('../workflow/stages');
  * @typedef {Object} CommandModule
  * @property {string} name - Command name used for routing
  * @property {string} description - Human-readable description
- * @property {function(Array, Object, string): Promise<*>} handler - Async command handler
+ * @property {function(Array, Object, string, Object=): Promise<*>} handler - Async command handler (4th arg: resolved command opts)
  * @property {string} [usage] - Usage string (optional)
  * @property {Object<string, string>} [flags] - Flag descriptions (optional)
  */
@@ -161,7 +161,11 @@ async function executeCommand(commands, commandName, args, flags, projectRoot, o
       }
     }
 
-    return await command.handler(args, flags, projectRoot);
+    // Forward a resolved per-command opts object as the handler's 4th arg. Issue/
+    // alias handlers read it (shouldUseKernelBroker(opts)); other handlers ignore
+    // it. Backward-compatible: defaults to {} so existing 3-arg handlers are
+    // unaffected.
+    return await command.handler(args, flags, projectRoot, options.commandOpts ?? {});
   } catch (err) {
     return {
       success: false,

--- a/lib/commands/_resolve-command-opts.js
+++ b/lib/commands/_resolve-command-opts.js
@@ -68,16 +68,26 @@ function stripSelectorTokens(rawArgs = []) {
       continue;
     }
     if (token === ISSUE_BACKEND_FLAG) {
-      // Space form: consume the following value token as the backend name.
+      // Space form: consume the following value token as the backend name. Only a
+      // non-flag token counts — a missing value or a following flag (e.g.
+      // `--issue-backend --reason=x`) must throw rather than silently swallow the
+      // next flag and fall back to the default backend.
       const next = rawArgs[i + 1];
-      if (typeof next === 'string') {
+      if (typeof next === 'string' && !next.startsWith('--')) {
         flags.issueBackend = next;
         i += 1;
+      } else {
+        throw new Error(`${ISSUE_BACKEND_FLAG} requires a value: kernel or beads.`);
       }
       continue;
     }
     if (typeof token === 'string' && token.startsWith(`${ISSUE_BACKEND_FLAG}=`)) {
-      flags.issueBackend = token.slice(ISSUE_BACKEND_FLAG.length + 1);
+      // Equals form: reject an empty value (`--issue-backend=`) for the same reason.
+      const value = token.slice(ISSUE_BACKEND_FLAG.length + 1).trim();
+      if (!value) {
+        throw new Error(`${ISSUE_BACKEND_FLAG} requires a value: kernel or beads.`);
+      }
+      flags.issueBackend = value;
       continue;
     }
     args.push(token);

--- a/lib/commands/_resolve-command-opts.js
+++ b/lib/commands/_resolve-command-opts.js
@@ -1,0 +1,175 @@
+'use strict';
+
+/**
+ * Resolve the per-command opts object that bin/forge.js threads to the registry
+ * handler (the 4th arg). For issue/alias commands this:
+ *
+ *   1. Strips the selector tokens (`--kernel`, `--issue-backend <val>`) from the
+ *      args BEFORE they reach the handler / bd. This is load-bearing: bin
+ *      parseFlags() early-returns for issue passthrough commands, so these tokens
+ *      otherwise flow untouched into the handler and (beads path) into bd, which
+ *      rejects the unknown flag — and the positional `kernel`/`beads` value would
+ *      be mistaken for an issue id.
+ *   2. Resolves the backend (flag > env > config > default) via the backend
+ *      authority module (lib/issue-backend.js). The CLI flag tokens are mapped to
+ *      that module's `deps.issueBackend` signal; env/config/default precedence is
+ *      applied by the resolver itself.
+ *   3. When kernel, assembles the kernel deps (driver + flag) via the CLI broker
+ *      factory so createKernelIssueBackend has a real driver (B1).
+ *
+ * Non-issue commands get an empty opts object and untouched args.
+ *
+ * @module commands/resolve-command-opts
+ */
+
+const { resolveIssueBackend } = require('../issue-backend');
+const {
+  buildMigratedKernelIssueDeps: defaultBuildKernelIssueDeps,
+} = require('../kernel/cli-broker-factory');
+
+// Commands that route issue operations and therefore honor the selector. Mirrors
+// the alias wrappers in lib/commands/ plus the `issue`/`issues` grouping commands.
+const ISSUE_COMMANDS = new Set([
+  'create',
+  'update',
+  'claim',
+  'release',
+  'comment',
+  'close',
+  'show',
+  'list',
+  'ready',
+  'search',
+  'stats',
+  'dep',
+  'issue',
+  'issues',
+]);
+
+const ISSUE_BACKEND_FLAG = '--issue-backend';
+const KERNEL_FLAG = '--kernel';
+const KERNEL = 'kernel';
+
+/**
+ * Remove the issue-backend selector tokens from an args array and report what
+ * they selected. Handles `--kernel`, `--issue-backend <val>` (space form), and
+ * `--issue-backend=<val>` (= form). All other tokens pass through unchanged.
+ *
+ * @param {string[]} rawArgs
+ * @returns {{ args: string[], flags: { kernel?: boolean, issueBackend?: string } }}
+ */
+function stripSelectorTokens(rawArgs = []) {
+  const args = [];
+  const flags = {};
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const token = rawArgs[i];
+    if (token === KERNEL_FLAG) {
+      flags.kernel = true;
+      continue;
+    }
+    if (token === ISSUE_BACKEND_FLAG) {
+      // Space form: consume the following value token as the backend name.
+      const next = rawArgs[i + 1];
+      if (typeof next === 'string') {
+        flags.issueBackend = next;
+        i += 1;
+      }
+      continue;
+    }
+    if (typeof token === 'string' && token.startsWith(`${ISSUE_BACKEND_FLAG}=`)) {
+      flags.issueBackend = token.slice(ISSUE_BACKEND_FLAG.length + 1);
+      continue;
+    }
+    args.push(token);
+  }
+  return { args, flags };
+}
+
+/**
+ * Reduce the stripped selector flags to a single explicit backend value (or null
+ * when no flag selects one), honoring `--kernel` / `--issue-backend` equivalence
+ * and rejecting a mutually-exclusive conflict. Returned values are NOT validated
+ * here — the backend authority module normalizes/warns on unknown values.
+ *
+ * @param {{ kernel?: boolean, issueBackend?: string }} flags
+ * @returns {string|null}
+ * @throws {Error} when --kernel and --issue-backend select different backends.
+ */
+function resolveFlagBackend(flags = {}) {
+  const fromBackend = typeof flags.issueBackend === 'string' && flags.issueBackend.trim()
+    ? flags.issueBackend.trim()
+    : null;
+  const fromKernel = flags.kernel === true ? KERNEL : null;
+
+  if (fromKernel && fromBackend && fromKernel !== fromBackend.toLowerCase()) {
+    throw new Error(
+      `Conflicting issue backend flags: --kernel selects '${KERNEL}' but `
+      + `--issue-backend selects '${fromBackend}'. These are mutually exclusive.`,
+    );
+  }
+
+  return fromKernel || fromBackend || null;
+}
+
+/**
+ * Resolve the command opts and selector-stripped args for a dispatched command.
+ *
+ * @param {string} command - The command name (e.g. 'close').
+ * @param {string[]} rawArgs - The command args (already `args.slice(1)`).
+ * @param {Object} [deps]
+ * @param {Object} [deps.env] - Environment snapshot (default process.env).
+ * @param {string} [deps.projectRoot] - Repo root for env/config resolution + kernel DB.
+ * @param {Function} [deps.buildKernelIssueDeps] - Factory override (tests). May be
+ *   sync or async; its result is awaited.
+ * @returns {Promise<{ commandOpts: Object, args: string[] }>}
+ * @throws {Error} on conflicting flags (surfaced to user).
+ */
+async function resolveCommandOpts(command, rawArgs = [], deps = {}) {
+  if (!ISSUE_COMMANDS.has(command)) {
+    return { commandOpts: {}, args: rawArgs };
+  }
+
+  const env = deps.env || process.env;
+  const buildKernelIssueDeps = deps.buildKernelIssueDeps || defaultBuildKernelIssueDeps;
+
+  const { args, flags } = stripSelectorTokens(rawArgs);
+  const flagBackend = resolveFlagBackend(flags);
+  const issueBackend = resolveIssueBackend({
+    deps: flagBackend ? { issueBackend: flagBackend } : {},
+    env,
+    projectRoot: deps.projectRoot,
+  });
+
+  if (issueBackend !== KERNEL) {
+    return {
+      commandOpts: {
+        issueBackend,
+        useKernelBroker: false,
+      },
+      args,
+    };
+  }
+
+  // Kernel backend: assemble the driver (B1) + migrated broker (B2). The factory
+  // builder constructs the driver, builds the broker, and runs initialize().
+  const kernelDeps = await buildKernelIssueDeps({
+    projectRoot: deps.projectRoot,
+    databasePath: deps.databasePath,
+    gitCommonDir: deps.gitCommonDir,
+  });
+
+  return {
+    commandOpts: {
+      issueBackend: KERNEL,
+      ...kernelDeps,
+    },
+    args,
+  };
+}
+
+module.exports = {
+  resolveCommandOpts,
+  stripSelectorTokens,
+  resolveFlagBackend,
+  ISSUE_COMMANDS,
+};

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -366,11 +366,12 @@ function createKernelIssueBackend(context = {}) {
 }
 
 function createIssueService({ backend } = {}) {
-  // Default issue backend is the Kernel (D20). Beads is opt-out via the selector
-  // (--issue-backend beads / FORGE_ISSUE_BACKEND=beads), which resolves to an
-  // explicit `backend` upstream in runIssueOperation; this fallback only fires for
-  // a no-backend direct call and now defaults to the Kernel adapter.
-  const resolvedBackend = backend || createKernelIssueBackend();
+  // Default issue backend stays Beads (D20 ships the CLI selector only). The Kernel
+  // is reachable opt-in via the selector (--kernel / --issue-backend kernel /
+  // FORGE_ISSUE_BACKEND=kernel), which resolves to an explicit `backend` upstream in
+  // runIssueOperation. This no-arg fallback fires only for a no-backend direct call.
+  // The global default → kernel flip lands in a dedicated follow-up PR.
+  const resolvedBackend = backend || createBeadsIssueBackend();
 
   return {
     async run(operation, args = [], context = {}) {

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -366,7 +366,11 @@ function createKernelIssueBackend(context = {}) {
 }
 
 function createIssueService({ backend } = {}) {
-  const resolvedBackend = backend || createBeadsIssueBackend();
+  // Default issue backend is the Kernel (D20). Beads is opt-out via the selector
+  // (--issue-backend beads / FORGE_ISSUE_BACKEND=beads), which resolves to an
+  // explicit `backend` upstream in runIssueOperation; this fallback only fires for
+  // a no-backend direct call and now defaults to the Kernel adapter.
+  const resolvedBackend = backend || createKernelIssueBackend();
 
   return {
     async run(operation, args = [], context = {}) {

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -412,14 +412,25 @@ function firstPositionalArg(args = []) {
 	return (args || []).find(value => typeof value === 'string' && !value.startsWith('-'));
 }
 
-// Parse the long-flag pairs CLI mutations carry (e.g. --title "x" --type task).
-// Only --key value pairs are captured; bare positionals are ignored here.
+// Parse the long-flag pairs CLI mutations carry. Supports BOTH forms:
+//   --key value   (space-separated)
+//   --key=value   (=-joined, e.g. --reason="...")
+// Only --key flags are captured; bare positionals are ignored here. The =-form
+// is required because the CLI delegates issue flags verbatim (bin parseFlags
+// early-returns for passthrough commands), so --reason=... arrives as one token.
 function parseFlagPairs(args = []) {
 	const flags = {};
 	for (let index = 0; index < args.length; index += 1) {
 		const token = args[index];
 		if (typeof token !== 'string' || !token.startsWith('--')) continue;
-		const key = token.slice(2);
+		const body = token.slice(2);
+		const eq = body.indexOf('=');
+		if (eq !== -1) {
+			// --key=value (value may itself contain '='; only split on the first).
+			flags[body.slice(0, eq)] = body.slice(eq + 1);
+			continue;
+		}
+		const key = body;
 		const next = args[index + 1];
 		if (typeof next === 'string' && !next.startsWith('--')) {
 			flags[key] = next;

--- a/lib/kernel/cli-broker-factory.js
+++ b/lib/kernel/cli-broker-factory.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * CLI kernel broker factory.
+ *
+ * Assembles the kernel issue `deps` the CLI path needs so `createKernelIssueBackend`
+ * (lib/forge-issues.js) can construct a working broker:
+ *
+ *   B1 — No real driver on the CLI path. We construct `createBuiltinSQLiteDriver`
+ *        and inject it as `kernelDriver`, so the broker stops hitting
+ *        `requireGuardedDriverMethods(undefined)`.
+ *   B2 — Migrations never run on the runtime path. `ensureKernelMigrated` wraps
+ *        `broker.initialize()` (pragmas + idempotent migration DDL).
+ *
+ * The factory does NOT change `createKernelIssueBackend`'s contract — it only
+ * supplies the `deps.kernelDriver` / `deps.kernelDatabasePath` it already reads.
+ *
+ * D19 coordination: the filesystem-doctor (read-only DB-location check) belongs
+ * just before the driver opens the file. We expose `resolveKernelDatabasePath`
+ * as that seam — D19 hooks the path, this factory does not reimplement it.
+ *
+ * @module kernel/cli-broker-factory
+ */
+
+const path = require('node:path');
+const {
+  createBuiltinSQLiteDriver,
+  selectBuiltinSQLiteRuntime,
+} = require('./sqlite-driver');
+const { resolveGitCommonDir, createLocalBroker } = require('./broker');
+
+const KERNEL_DB_FILE = 'kernel.sqlite';
+const KERNEL_DB_SUBDIR = 'forge';
+
+/**
+ * Resolve the kernel database path. Mirrors `buildLocalBrokerConfig`:
+ * explicit `databasePath` wins; otherwise `<gitCommonDir>/forge/kernel.sqlite`,
+ * where `gitCommonDir` defaults to the resolved git common dir for `projectRoot`.
+ *
+ * @param {Object} options
+ * @param {string} [options.projectRoot]
+ * @param {string} [options.gitCommonDir]
+ * @param {string} [options.databasePath]
+ * @returns {string}
+ */
+function resolveKernelDatabasePath(options = {}) {
+  if (typeof options.databasePath === 'string' && options.databasePath) {
+    return options.databasePath;
+  }
+  const gitCommonDir = options.gitCommonDir
+    || resolveGitCommonDir(options.projectRoot, options);
+  return path.join(gitCommonDir, KERNEL_DB_SUBDIR, KERNEL_DB_FILE);
+}
+
+/**
+ * Build the kernel issue deps for the CLI path.
+ *
+ * @param {Object} options
+ * @param {string} [options.projectRoot] - Repo root (used to resolve the git common dir).
+ * @param {string} [options.gitCommonDir] - Git common dir (overrides resolution).
+ * @param {string} [options.databasePath] - Explicit kernel DB path (overrides default).
+ * @param {Object} [options.runtime] - Pre-selected SQLite runtime (tests inject this).
+ * @param {Function} [options.requireModule] - Module loader for runtime detection (tests).
+ * @returns {{ useKernelBroker: true, kernelDriver: Object, kernelDatabasePath: string, gitCommonDir?: string }}
+ * @throws {Error} when no builtin SQLite runtime is available (message names the runtimes).
+ */
+function buildKernelIssueDeps(options = {}) {
+  const databasePath = resolveKernelDatabasePath(options);
+  const runtime = options.runtime
+    || selectBuiltinSQLiteRuntime({ requireModule: options.requireModule });
+
+  const kernelDriver = createBuiltinSQLiteDriver({ databasePath, runtime });
+
+  return {
+    useKernelBroker: true,
+    kernelDriver,
+    kernelDatabasePath: databasePath,
+    gitCommonDir: options.gitCommonDir,
+  };
+}
+
+/**
+ * Run the broker's migrations/pragmas (B2). Idempotent: per-invocation policy —
+ * the CLI process is short-lived and `broker.initialize()` swallows
+ * duplicate-column DDL, so calling it on every kernel CLI invocation is safe.
+ *
+ * @param {{ initialize?: Function }} broker
+ * @returns {Promise<Object>} the broker.initialize() result.
+ * @throws {Error} when the broker cannot be initialized.
+ */
+async function ensureKernelMigrated(broker) {
+  if (!broker || typeof broker.initialize !== 'function') {
+    throw new Error('Cannot initialize kernel broker: broker is missing initialize().');
+  }
+  return broker.initialize();
+}
+
+/**
+ * Build the kernel deps AND a migrated broker ready for issue ops. Constructs the
+ * driver (B1), builds the broker over it, runs `broker.initialize()` so pragmas +
+ * migrations are applied (B2), and returns deps carrying the initialized broker as
+ * `kernelBroker` — which `createKernelIssueBackend` (forge-issues.js) uses directly
+ * instead of constructing a second broker.
+ *
+ * @param {Object} options - Same shape as buildKernelIssueDeps.
+ * @returns {Promise<{ useKernelBroker: true, kernelBroker: Object, kernelDriver: Object, kernelDatabasePath: string }>}
+ */
+async function buildMigratedKernelIssueDeps(options = {}) {
+  const deps = buildKernelIssueDeps(options);
+  const broker = createLocalBroker({
+    projectRoot: options.projectRoot,
+    gitCommonDir: options.gitCommonDir,
+    databasePath: deps.kernelDatabasePath,
+    driver: deps.kernelDriver,
+  });
+  await ensureKernelMigrated(broker);
+  return {
+    useKernelBroker: true,
+    kernelBroker: broker,
+    kernelDriver: deps.kernelDriver,
+    kernelDatabasePath: deps.kernelDatabasePath,
+  };
+}
+
+module.exports = {
+  buildKernelIssueDeps,
+  buildMigratedKernelIssueDeps,
+  ensureKernelMigrated,
+  resolveKernelDatabasePath,
+};

--- a/test/commands/_registry-opts.test.js
+++ b/test/commands/_registry-opts.test.js
@@ -38,7 +38,7 @@ describe('executeCommand — opts/commandOpts threading (T2)', () => {
     'passes an empty object as the 4th arg when no commandOpts supplied (backward-compat)',
     async () => {
       let received;
-      const commands = registryWith(async (args, flags, projectRoot, opts) => {
+      const commands = registryWith(async (_args, _flags, _projectRoot, opts) => {
         received = opts;
         return { success: true };
       });
@@ -53,7 +53,7 @@ describe('executeCommand — opts/commandOpts threading (T2)', () => {
   test(
     'existing 3-arg handlers are unaffected (ignore the 4th arg)',
     async () => {
-      const commands = registryWith(async (args, flags, projectRoot) => ({
+      const commands = registryWith(async (args, _flags, projectRoot) => ({
         success: true,
         echo: `${args.join(',')}|${projectRoot}`,
       }));

--- a/test/commands/_registry-opts.test.js
+++ b/test/commands/_registry-opts.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const { executeCommand } = require('../../lib/commands/_registry');
+
+const TIMEOUT = 5000;
+
+function registryWith(handler) {
+  return new Map([
+    ['probe', { name: 'probe', description: 'probe', handler }],
+  ]);
+}
+
+describe('executeCommand — opts/commandOpts threading (T2)', () => {
+  test(
+    'forwards options.commandOpts to the handler as the 4th argument',
+    async () => {
+      let received;
+      const commands = registryWith(async (args, flags, projectRoot, opts) => {
+        received = { args, flags, projectRoot, opts };
+        return { success: true };
+      });
+
+      await executeCommand(commands, 'probe', ['x'], { f: 1 }, '/repo', {
+        commandOpts: { useKernelBroker: true, issueBackend: 'kernel' },
+      });
+
+      expect(received.args).toEqual(['x']);
+      expect(received.flags).toEqual({ f: 1 });
+      expect(received.projectRoot).toBe('/repo');
+      expect(received.opts).toEqual({ useKernelBroker: true, issueBackend: 'kernel' });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'passes an empty object as the 4th arg when no commandOpts supplied (backward-compat)',
+    async () => {
+      let received;
+      const commands = registryWith(async (args, flags, projectRoot, opts) => {
+        received = opts;
+        return { success: true };
+      });
+
+      await executeCommand(commands, 'probe', [], {}, '/repo');
+
+      expect(received).toEqual({});
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'existing 3-arg handlers are unaffected (ignore the 4th arg)',
+    async () => {
+      const commands = registryWith(async (args, flags, projectRoot) => ({
+        success: true,
+        echo: `${args.join(',')}|${projectRoot}`,
+      }));
+
+      const result = await executeCommand(commands, 'probe', ['a', 'b'], {}, '/repo', {
+        commandOpts: { useKernelBroker: true },
+      });
+
+      expect(result).toEqual({ success: true, echo: 'a,b|/repo' });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'unknown command still returns the standard error shape',
+    async () => {
+      const commands = registryWith(async () => ({ success: true }));
+      const result = await executeCommand(commands, 'nope', [], {}, '/repo', {
+        commandOpts: { useKernelBroker: true },
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('nope');
+    },
+    TIMEOUT,
+  );
+});

--- a/test/commands/_resolve-command-opts.test.js
+++ b/test/commands/_resolve-command-opts.test.js
@@ -33,6 +33,23 @@ describe('stripSelectorTokens — consume + remove --kernel / --issue-backend', 
     const { args } = stripSelectorTokens(['a', 'b', '--reason=Merged on master']);
     expect(args).toEqual(['a', 'b', '--reason=Merged on master']);
   });
+
+  test('throws when --issue-backend (space form) is followed by a flag, not a value', () => {
+    // Without the guard this would swallow `--reason=x` as the backend value and
+    // silently fall back to the default backend.
+    expect(() => stripSelectorTokens(['kap-10', '--issue-backend', '--reason=x']))
+      .toThrow(/--issue-backend requires a value/);
+  });
+
+  test('throws when --issue-backend (space form) has no following value', () => {
+    expect(() => stripSelectorTokens(['kap-10', '--issue-backend']))
+      .toThrow(/--issue-backend requires a value/);
+  });
+
+  test('throws when --issue-backend= (= form) value is empty', () => {
+    expect(() => stripSelectorTokens(['kap-10', '--issue-backend=']))
+      .toThrow(/--issue-backend requires a value/);
+  });
 });
 
 describe('resolveCommandOpts — issue commands', () => {

--- a/test/commands/_resolve-command-opts.test.js
+++ b/test/commands/_resolve-command-opts.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const {
+  resolveCommandOpts,
+  ISSUE_COMMANDS,
+  stripSelectorTokens,
+} = require('../../lib/commands/_resolve-command-opts');
+
+const TIMEOUT = 5000;
+
+describe('stripSelectorTokens — consume + remove --kernel / --issue-backend', () => {
+  test('removes --kernel boolean flag from args', () => {
+    const { args, flags } = stripSelectorTokens(['kap-10', '--kernel', '--reason=x']);
+    expect(args).toEqual(['kap-10', '--reason=x']);
+    expect(flags.kernel).toBe(true);
+  });
+
+  test('removes --issue-backend kernel (space form) and its value', () => {
+    const { args, flags } = stripSelectorTokens(['kap-10', '--issue-backend', 'kernel']);
+    expect(args).toEqual(['kap-10']);
+    expect(flags.issueBackend).toBe('kernel');
+  });
+
+  test('removes --issue-backend=kernel (= form)', () => {
+    const { args, flags } = stripSelectorTokens(['kap-10', '--issue-backend=beads']);
+    expect(args).toEqual(['kap-10']);
+    expect(flags.issueBackend).toBe('beads');
+  });
+
+  test('leaves non-selector flags (e.g. --reason) untouched', () => {
+    const { args } = stripSelectorTokens(['a', 'b', '--reason=Merged on master']);
+    expect(args).toEqual(['a', 'b', '--reason=Merged on master']);
+  });
+});
+
+describe('resolveCommandOpts — issue commands', () => {
+  test(
+    'default (no flag/env) → beads, no kernel deps, args unchanged',
+    async () => {
+      const { commandOpts, args } = await resolveCommandOpts('close', ['kap-10', '--reason=x'], {
+        env: {},
+        projectRoot: '/repo',
+      });
+      expect(commandOpts.issueBackend).toBe('beads');
+      expect(commandOpts.useKernelBroker).toBeFalsy();
+      expect(commandOpts.kernelDriver).toBeUndefined();
+      expect(args).toEqual(['kap-10', '--reason=x']);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    '--kernel flag → kernel deps assembled, selector token stripped from args',
+    async () => {
+      const built = [];
+      const { commandOpts, args } = await resolveCommandOpts('close', ['kap-10', '--kernel', '--reason=x'], {
+        env: {},
+        projectRoot: '/repo',
+        // Inject the factory so the test does not touch a real SQLite runtime.
+        buildKernelIssueDeps: (opts) => {
+          built.push(opts);
+          return { useKernelBroker: true, kernelDriver: { exec() {} }, kernelDatabasePath: ':memory:' };
+        },
+      });
+
+      expect(commandOpts.useKernelBroker).toBe(true);
+      expect(commandOpts.kernelDriver).toBeDefined();
+      expect(commandOpts.issueBackend).toBe('kernel');
+      // selector token removed; the real close args remain
+      expect(args).toEqual(['kap-10', '--reason=x']);
+      expect(built).toHaveLength(1);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'FORGE_ISSUE_BACKEND=kernel env → kernel deps (no flag needed)',
+    async () => {
+      const { commandOpts } = await resolveCommandOpts('close', ['kap-10'], {
+        env: { FORGE_ISSUE_BACKEND: 'kernel' },
+        projectRoot: '/repo',
+        buildKernelIssueDeps: () => ({ useKernelBroker: true, kernelDriver: { exec() {} } }),
+      });
+      expect(commandOpts.useKernelBroker).toBe(true);
+      expect(commandOpts.issueBackend).toBe('kernel');
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'non-issue commands get an empty opts object and untouched args',
+    async () => {
+      const { commandOpts, args } = await resolveCommandOpts('validate', ['--kernel'], {
+        env: {},
+        projectRoot: '/repo',
+      });
+      expect(commandOpts).toEqual({});
+      expect(args).toEqual(['--kernel']);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'ISSUE_COMMANDS includes the alias verbs and the issue grouping command',
+    () => {
+      for (const verb of ['close', 'create', 'update', 'claim', 'release', 'comment', 'show', 'list', 'ready', 'issue']) {
+        expect(ISSUE_COMMANDS.has(verb)).toBe(true);
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'conflicting --kernel + --issue-backend beads rejects (surfaced to the user)',
+    async () => {
+      await expect(
+        resolveCommandOpts('close', ['kap-10', '--kernel', '--issue-backend', 'beads'], {
+          env: {},
+          projectRoot: '/repo',
+          buildKernelIssueDeps: () => ({ useKernelBroker: true }),
+        }),
+      ).rejects.toThrow(/conflict|mutually.exclusive/i);
+    },
+    TIMEOUT,
+  );
+});

--- a/test/e2e/kernel-issue-cli.test.js
+++ b/test/e2e/kernel-issue-cli.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// E2E: the kernel CLI close path end to end (T7). Spawns the real `forge` bin
+// against a throwaway git repo so a fresh `.git/forge/kernel.sqlite` is created,
+// seeds 3 open issues via `forge create --kernel`, then closes all three with one
+// `forge close <ids> --reason --kernel` invocation. Mirrors the real
+// kap-10/11/12 close, but on synthetic ids we control (stronger + repeatable).
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const FORGE_BIN = path.join(__dirname, '..', '..', 'bin', 'forge.js');
+const TIMEOUT = 30000;
+
+function runForge(cwd, args) {
+  return execFileSync('node', [FORGE_BIN, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env },
+  });
+}
+
+// Open one read driver, run a reader against it, and ALWAYS close it so the
+// SQLite (WAL) file lock is released before Windows tries to rm the temp dir.
+// The real builtin SQLite runtime is selected (not a fake): these helpers read
+// the SAME authority tables / event log the spawned `forge` bin just wrote, so a
+// green assertion proves the persisted on-disk state, not an in-memory echo.
+async function withReadDriver(dbPath, fn) {
+  const {
+    createBuiltinSQLiteDriver,
+    selectBuiltinSQLiteRuntime,
+  } = require('../../lib/kernel/sqlite-driver');
+  const driver = createBuiltinSQLiteDriver({
+    databasePath: dbPath,
+    runtime: selectBuiltinSQLiteRuntime({}),
+  });
+  try {
+    return await fn(driver, { databasePath: dbPath });
+  } finally {
+    if (typeof driver.close === 'function') driver.close();
+  }
+}
+
+// Read the persisted issue row (authority table) via the driver's `show` read-op.
+// Returns a normalized `{ status }` (or null when the id is absent), so the close
+// assertion reads the SAME read-model the rest of Forge reads. The close event
+// drives status to the terminal 'done'.
+async function loadIssueStatus(dbPath, id) {
+  return withReadDriver(dbPath, async (driver) => {
+    const response = await driver.issueOperation('show', [id], {}, {});
+    if (!response || response.ok === false || !response.data) return null;
+    return { status: response.data.status };
+  });
+}
+
+// Read the immutable `issue.close` event for an id from the event log. The CLI
+// `--reason` has no column on kernel_issues (the read-model whitelist drops it),
+// so its event-sourced home is kernel_events.payload_json — this is where the
+// close annotation must be asserted. Returns the raw event row (carrying
+// `payload_json`) or null when no close event exists.
+async function loadCloseEvent(dbPath, id) {
+  return withReadDriver(dbPath, async (driver) => {
+    const events = await driver.listKernelEvents('issue', id, {}, {});
+    return events.find(event => event.event_type === 'issue.close') || null;
+  });
+}
+
+// Windows can hold a transient lock on the just-closed DB; retry the rm a few times.
+function rmrfWithRetry(dir) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 4 || (error.code !== 'EBUSY' && error.code !== 'EPERM')) {
+        return; // best-effort cleanup; do not fail the test on a temp-dir lock
+      }
+      const until = Date.now() + 100;
+      while (Date.now() < until) { /* brief spin before retry */ }
+    }
+  }
+}
+
+describe('kernel issue CLI — multi-id close E2E', () => {
+  let repo;
+  let dbPath;
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-e2e-'));
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    // AGENTS.md bypasses the first-run setup gate.
+    fs.writeFileSync(path.join(repo, 'AGENTS.md'), '# test\n');
+    dbPath = path.join(repo, '.git', 'forge', 'kernel.sqlite');
+  });
+
+  afterEach(() => {
+    // Driver is closed by withReadDriver before the test returns, but Windows can
+    // still hold a transient WAL lock — retry the rm so cleanup never flakes.
+    rmrfWithRetry(repo);
+  });
+
+  test(
+    'forge close <3 ids> --reason --kernel closes all three, exit 0, reason persisted',
+    async () => {
+      // Seed three open issues on the fresh kernel DB.
+      for (const id of ['kap-10', 'kap-11', 'kap-12']) {
+        runForge(repo, ['create', '--id', id, '--title', `Seed ${id}`, '--kernel']);
+      }
+
+      // The acceptance invocation.
+      const output = runForge(repo, [
+        'close',
+        'kap-10',
+        'kap-11',
+        'kap-12',
+        '--reason=Merged and verified on master (PR #229)',
+        '--kernel',
+      ]);
+
+      // All three reported back (one envelope per id).
+      expect(output).toContain('kap-10');
+      expect(output).toContain('kap-11');
+      expect(output).toContain('kap-12');
+
+      // Authority table: all three are terminal.
+      for (const id of ['kap-10', 'kap-11', 'kap-12']) {
+        const issue = await loadIssueStatus(dbPath, id);
+        expect(issue).toBeTruthy();
+        expect(issue.status).toBe('done');
+      }
+
+      // Reason persisted in the immutable event log for each close.
+      for (const id of ['kap-10', 'kap-11', 'kap-12']) {
+        const closeEvent = await loadCloseEvent(dbPath, id);
+        expect(closeEvent).toBeTruthy();
+        const payload = JSON.parse(closeEvent.payload_json);
+        expect(payload.reason).toBe('Merged and verified on master (PR #229)');
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'exit code is 0 for the multi-id kernel close',
+    () => {
+      runForge(repo, ['create', '--id', 'solo-1', '--title', 'Solo', '--kernel']);
+      // execFileSync throws on non-zero exit; reaching the assertion means exit 0.
+      const output = runForge(repo, ['close', 'solo-1', '--reason=done', '--kernel']);
+      expect(output).toContain('solo-1');
+    },
+    TIMEOUT,
+  );
+});

--- a/test/e2e/kernel-issue-cli.test.js
+++ b/test/e2e/kernel-issue-cli.test.js
@@ -147,10 +147,14 @@ describe('kernel issue CLI — multi-id close E2E', () => {
   test(
     'exit code is 0 for the multi-id kernel close',
     () => {
-      runForge(repo, ['create', '--id', 'solo-1', '--title', 'Solo', '--kernel']);
+      runForge(repo, ['create', '--id', 'solo-1', '--title', 'Solo 1', '--kernel']);
+      runForge(repo, ['create', '--id', 'solo-2', '--title', 'Solo 2', '--kernel']);
       // execFileSync throws on non-zero exit; reaching the assertion means exit 0.
-      const output = runForge(repo, ['close', 'solo-1', '--reason=done', '--kernel']);
+      // Two leading ids exercises the batched (fan-out) close branch, not the
+      // single-id path.
+      const output = runForge(repo, ['close', 'solo-1', 'solo-2', '--reason=done', '--kernel']);
       expect(output).toContain('solo-1');
+      expect(output).toContain('solo-2');
     },
     TIMEOUT,
   );

--- a/test/kernel/cli-broker-factory.test.js
+++ b/test/kernel/cli-broker-factory.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const {
+  buildKernelIssueDeps,
+  ensureKernelMigrated,
+  resolveKernelDatabasePath,
+} = require('../../lib/kernel/cli-broker-factory');
+
+const TIMEOUT = 5000;
+
+function fakeRuntime() {
+  // Minimal in-memory stand-in honoring the bun:sqlite Database shape the driver
+  // uses (selectBuiltinSQLiteRuntime → runtime.module.Database).
+  class FakeDb {
+    constructor() {
+      this.statements = [];
+    }
+    exec(sql) {
+      this.statements.push(sql);
+    }
+    query() {
+      return { all: () => [], get: () => undefined, run: () => ({}) };
+    }
+    prepare() {
+      return { all: () => [], get: () => undefined, run: () => ({}) };
+    }
+    close() {}
+  }
+  return { kind: 'bun', module: { Database: FakeDb } };
+}
+
+describe('buildKernelIssueDeps', () => {
+  test(
+    'returns kernel deps with useKernelBroker + an injected driver',
+    () => {
+      const deps = buildKernelIssueDeps({
+        projectRoot: '/repo',
+        databasePath: ':memory:',
+        runtime: fakeRuntime(),
+      });
+
+      expect(deps.useKernelBroker).toBe(true);
+      expect(deps.kernelDriver).toBeDefined();
+      expect(typeof deps.kernelDriver.exec).toBe('function');
+      expect(deps.kernelDatabasePath).toBe(':memory:');
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'defaults databasePath under .git/forge/kernel.sqlite when not supplied',
+    () => {
+      const deps = buildKernelIssueDeps({
+        projectRoot: '/repo',
+        gitCommonDir: '/repo/.git',
+        runtime: fakeRuntime(),
+      });
+
+      expect(deps.kernelDatabasePath.replace(/\\/g, '/')).toContain('.git/forge/kernel.sqlite');
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'surfaces a clear error when no SQLite runtime is available',
+    () => {
+      // Force the builtin runtime selector to find nothing: requireModule throws
+      // MODULE_NOT_FOUND for every candidate (bun:sqlite / node:sqlite).
+      const missing = () => {
+        const error = new Error("Cannot find module");
+        error.code = 'MODULE_NOT_FOUND';
+        throw error;
+      };
+      expect(() =>
+        buildKernelIssueDeps({
+          projectRoot: '/repo',
+          databasePath: ':memory:',
+          requireModule: missing,
+        }),
+      ).toThrow(/sqlite|runtime/i);
+    },
+    TIMEOUT,
+  );
+});
+
+describe('ensureKernelMigrated', () => {
+  test(
+    'invokes broker.initialize once and returns its result',
+    async () => {
+      let calls = 0;
+      const broker = {
+        async initialize() {
+          calls += 1;
+          return { success: true, migrationsApplied: ['001'] };
+        },
+      };
+
+      const result = await ensureKernelMigrated(broker);
+      expect(calls).toBe(1);
+      expect(result.success).toBe(true);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'is idempotent — double call is safe and re-runs initialize (migrations idempotent)',
+    async () => {
+      let calls = 0;
+      const broker = {
+        async initialize() {
+          calls += 1;
+          return { success: true };
+        },
+      };
+
+      await ensureKernelMigrated(broker);
+      await ensureKernelMigrated(broker);
+      // Per-invocation policy: each call re-runs initialize (migrations swallow
+      // duplicate-column). Double call must not throw.
+      expect(calls).toBe(2);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'throws a clear error when broker lacks initialize',
+    async () => {
+      await expect(ensureKernelMigrated({})).rejects.toThrow(/initialize/i);
+    },
+    TIMEOUT,
+  );
+});
+
+describe('resolveKernelDatabasePath', () => {
+  test(
+    'prefers an explicit databasePath',
+    () => {
+      const p = resolveKernelDatabasePath({
+        projectRoot: '/repo',
+        databasePath: '/custom/k.sqlite',
+      });
+      expect(p).toBe('/custom/k.sqlite');
+    },
+    TIMEOUT,
+  );
+
+  test(
+    'derives from gitCommonDir when no explicit path',
+    () => {
+      const p = resolveKernelDatabasePath({
+        projectRoot: '/repo',
+        gitCommonDir: '/repo/.git',
+      });
+      expect(p.replace(/\\/g, '/')).toBe('/repo/.git/forge/kernel.sqlite');
+    },
+    TIMEOUT,
+  );
+});

--- a/test/release-readiness.test.js
+++ b/test/release-readiness.test.js
@@ -155,6 +155,20 @@ afterEach(() => {
   }
 });
 
+describe('default issue backend is the Kernel (D20)', () => {
+  test('the real repo createIssueService defaults to the Kernel backend (gate detects it)', () => {
+    // Locks the D20 default flip: createIssueService's resolvedBackend must default
+    // to createKernelIssueBackend. The readiness gate reads lib/forge-issues.js and
+    // clears the issue surface's "Kernel evidence missing" signal once it does.
+    // Reverting the default to createBeadsIssueBackend regresses this assertion.
+    const report = buildReadinessReport(repoRoot, { target: '0.1.0' });
+    const blocker = report.blockers.find(item => item.id === 'kernel-backed-forge-issue');
+
+    expect(blocker).toBeDefined();
+    expect(blocker.detail).toContain('Kernel evidence missing for issue surface: no');
+  });
+});
+
 describe('release readiness bd call-site audit', () => {
   test('groups concrete bd, .beads, and dolt surfaces without counting generic Beads prose', () => {
     const root = makeRepo();

--- a/test/release-readiness.test.js
+++ b/test/release-readiness.test.js
@@ -155,20 +155,6 @@ afterEach(() => {
   }
 });
 
-describe('default issue backend is the Kernel (D20)', () => {
-  test('the real repo createIssueService defaults to the Kernel backend (gate detects it)', () => {
-    // Locks the D20 default flip: createIssueService's resolvedBackend must default
-    // to createKernelIssueBackend. The readiness gate reads lib/forge-issues.js and
-    // clears the issue surface's "Kernel evidence missing" signal once it does.
-    // Reverting the default to createBeadsIssueBackend regresses this assertion.
-    const report = buildReadinessReport(repoRoot, { target: '0.1.0' });
-    const blocker = report.blockers.find(item => item.id === 'kernel-backed-forge-issue');
-
-    expect(blocker).toBeDefined();
-    expect(blocker.detail).toContain('Kernel evidence missing for issue surface: no');
-  });
-});
-
 describe('release readiness bd call-site audit', () => {
   test('groups concrete bd, .beads, and dolt surfaces without counting generic Beads prose', () => {
     const root = makeRepo();


### PR DESCRIPTION
Re-lands the D20 kernel CLI selector cleanly on origin/master (supersedes closed #232; no local-only Turso commits). This is a **selector-only** PR: it makes the Kernel issue backend reachable from the CLI via opt-in (`--kernel` / `--issue-backend kernel` / `FORGE_ISSUE_BACKEND=kernel`). **The default issue backend remains beads** — the global default → kernel flip lands in a dedicated follow-up PR.

- New: `lib/kernel/cli-broker-factory.js`, `lib/commands/_resolve-command-opts.js`, `_registry.js` 4th-arg commandOpts, `bin/forge.js` dispatch + tests + design doc
- `broker.js` parseFlagPairs now accepts `--key=value` (so `--reason=` reaches the close payload)
- `_resolve-command-opts.js` rejects an empty/flag `--issue-backend` value instead of silently swallowing the next token
- Kernel-backed `forge close` supports multi-id closes while preserving `--reason`
- `forge-issues.js` createIssueService no-arg fallback stays beads (kernel is opt-in only)

Note: the `kernel-backed-forge-issue` readiness gate's "Kernel evidence missing" signal stays unsatisfied here by design; it is cleared by the follow-up default-flip PR + the dep/de-bead spine, not by this selector-only PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue-related CLI commands can route to the Kernel backend via `--kernel` or `--issue-backend` (including env-based selection); the default backend remains beads.
  * Kernel-backed `forge close` supports multi-id closes while preserving `--reason`.
* **Bug Fixes**
  * `--issue-backend` now requires an explicit value (kernel or beads) instead of silently falling back.
  * Improved long-flag parsing to handle both `--key value` and `--key=value`.
* **Documentation**
  * Updated Kernel selector/command-routing design notes and related backlog call-site tracking.
* **Tests**
  * Added unit and E2E coverage for backend option handling and `forge close --kernel` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->