### PR TITLE
feat(skills): add Forge CLI-wrapper skills pack (ready/show/claim/comment/close/recap)

### DIFF
--- a/packages/skills/forge-plugin/manifest.json
+++ b/packages/skills/forge-plugin/manifest.json
@@ -1,0 +1,45 @@
+{
+  "name": "forge-plugin",
+  "version": "0.1.0",
+  "description": "Forge CLI-wrapper skills pack. Each skill teaches an AI agent to drive one Forge issue-workflow command (forge ready, show, claim, comment, close, recap) instead of touching the underlying issue store directly.",
+  "author": "forge",
+  "compatibility": "Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo.",
+  "skills": [
+    {
+      "name": "ready",
+      "path": "skills/ready/SKILL.md",
+      "command": "forge ready",
+      "description": "List ready-to-claim issues whose dependencies are all satisfied."
+    },
+    {
+      "name": "show",
+      "path": "skills/show/SKILL.md",
+      "command": "forge show",
+      "description": "Show the full detail of a single issue by id."
+    },
+    {
+      "name": "claim",
+      "path": "skills/claim/SKILL.md",
+      "command": "forge claim",
+      "description": "Claim a ready issue and move it into in-progress for the current agent."
+    },
+    {
+      "name": "comment",
+      "path": "skills/comment/SKILL.md",
+      "command": "forge comment",
+      "description": "Append a progress note or decision to an issue's discussion thread."
+    },
+    {
+      "name": "close",
+      "path": "skills/close/SKILL.md",
+      "command": "forge close",
+      "description": "Close one or more completed issues."
+    },
+    {
+      "name": "recap",
+      "path": "skills/recap/SKILL.md",
+      "command": "forge recap",
+      "description": "Produce a bounded recap of an issue's history and current state."
+    }
+  ]
+}

--- a/packages/skills/forge-plugin/skills/claim/SKILL.md
+++ b/packages/skills/forge-plugin/skills/claim/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: claim
+description: >
+  Take ownership of a ready issue and move it into in-progress for the current
+  agent. Wraps `forge claim` so work is visibly assigned in the Forge issue
+  backend before any code is written, preventing two agents from racing on the
+  same task.
+metadata:
+  author: forge
+  command: forge claim
+---
+
+# forge claim
+
+## Purpose
+
+Mark an issue as actively worked by you. Claiming transitions the issue to
+in-progress and records ownership, which keeps the ready list accurate for every
+other agent.
+
+## When to Use
+
+- Immediately before starting implementation on a ready issue.
+- After selecting an id from `forge ready` and reviewing it with `forge show`.
+
+## Command
+
+```bash
+forge claim <id>            # claim a single ready issue
+```
+
+## Instructions
+
+1. Confirm the issue is ready (see the [ready](../ready/SKILL.md) skill).
+2. Run `forge claim <id>` to take ownership.
+3. Begin the work; record progress with [comment](../comment/SKILL.md).
+4. When finished, transition the issue with [close](../close/SKILL.md).
+
+## Example
+
+```
+$ forge claim forge-142
+Claimed forge-142 — status: in_progress (owner: current agent)
+```
+
+## Success Criteria
+
+- [ ] The issue is in-progress and owned before any edits are made.
+- [ ] No other agent is already working the same id.
+
+## Related Skills
+
+- ready: find a claimable id.
+- close: release the claim by completing the issue.

--- a/packages/skills/forge-plugin/skills/close/SKILL.md
+++ b/packages/skills/forge-plugin/skills/close/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: close
+description: >
+  Mark one or more completed issues as done. Wraps `forge close` so finishing
+  work updates the Forge issue backend, releases the claim, and unblocks any
+  issues that depended on the one you just completed.
+metadata:
+  author: forge
+  command: forge close
+---
+
+# forge close
+
+## Purpose
+
+Transition an issue to closed once its acceptance criteria are met. Closing
+removes the issue from the ready/in-progress sets and recomputes the dependency
+graph so downstream work becomes available.
+
+## When to Use
+
+- After verifying an issue's acceptance criteria (tests green, change shipped).
+- When wrapping up several finished issues at once.
+
+## Command
+
+```bash
+forge close <id>                # close a single issue
+forge close <id> <id> <id>      # close several issues at once
+forge issue close <id>          # equivalent issue-scoped form
+```
+
+## Instructions
+
+1. Confirm the work is genuinely complete — run the relevant tests first.
+2. Leave a final note with [comment](../comment/SKILL.md) if context is useful.
+3. Run `forge close <id>` (or pass multiple ids) to close the issue(s).
+4. Run [ready](../ready/SKILL.md) again to see what the closure unblocked.
+
+## Example
+
+```
+$ forge close forge-142
+Closed forge-142. Unblocked: forge-150.
+```
+
+## Success Criteria
+
+- [ ] Acceptance criteria are met and verified before closing.
+- [ ] Newly unblocked issues are checked with `forge ready`.
+
+## Related Skills
+
+- comment: leave a final note before closing.
+- ready: discover what closing this issue unblocked.

--- a/packages/skills/forge-plugin/skills/comment/SKILL.md
+++ b/packages/skills/forge-plugin/skills/comment/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: comment
+description: >
+  Append a progress note, decision, or finding to an issue's discussion thread.
+  Wraps `forge comment` so durable context lives on the issue in the Forge issue
+  backend — recoverable across sessions and visible to every other agent —
+  rather than only in a transcript.
+metadata:
+  author: forge
+  command: forge comment
+---
+
+# forge comment
+
+## Purpose
+
+Record narrative context on an issue: what you tried, what you decided, what is
+blocked, or what the next agent needs to know. Comments are the persistent
+memory of an issue's history.
+
+## When to Use
+
+- After a meaningful step (a decision made, a blocker hit, a test passing).
+- Before pausing work, to leave a clean handoff for the next session.
+- When `forge show` reveals missing context you can now supply.
+
+## Command
+
+```bash
+forge comment <id> "<message>"        # add a comment to an issue
+forge issue comment <id> "<message>"  # equivalent issue-scoped form
+```
+
+## Instructions
+
+1. Identify the issue id you are working (from `forge claim`).
+2. Run `forge comment <id> "<message>"` with a concise, specific note.
+3. Reference commit shas or file paths so the note is actionable later.
+
+## Example
+
+```
+$ forge comment forge-142 "Selector wired in bin/forge.js; multi-id close acceptance green (commit c3bcb36)."
+Comment added to forge-142.
+```
+
+## Success Criteria
+
+- [ ] The note is specific enough to act on without re-deriving context.
+- [ ] Decisions and blockers are captured on the issue, not just in chat.
+
+## Related Skills
+
+- show: read existing comments before adding a new one.
+- recap: summarize an issue's accumulated comments.

--- a/packages/skills/forge-plugin/skills/ready/SKILL.md
+++ b/packages/skills/forge-plugin/skills/ready/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: ready
+description: >
+  Find the issues an agent can start right now — those whose dependencies are
+  all satisfied and that nobody is actively working. Wraps `forge ready` so you
+  pick the next unit of work from the Forge issue backend instead of guessing or
+  reading the issue store by hand.
+metadata:
+  author: forge
+  command: forge ready
+---
+
+# forge ready
+
+## Purpose
+
+Surface the set of issues that are unblocked and available to claim. Forge
+computes this from the issue dependency graph, so the list only contains work
+whose prerequisites are already closed.
+
+## When to Use
+
+- At the start of a session, to decide what to work on next.
+- After closing an issue, to see what its completion just unblocked.
+- Before claiming, to confirm an issue is actually ready (not still blocked).
+
+## Command
+
+```bash
+forge ready                 # human-readable list of ready issues
+forge issue ready --json    # machine-readable list for scripting/agents
+```
+
+Prefer the `--json` form when an agent needs to parse ids programmatically.
+
+## Instructions
+
+1. Run `forge ready` (or `forge issue ready --json` to parse the output).
+2. Read the issue ids, titles, and priorities in the result.
+3. Pick the highest-priority ready issue that fits the current goal.
+4. Hand the chosen id to the [claim](../claim/SKILL.md) skill.
+
+## Example
+
+```
+$ forge issue ready --json
+[
+  { "id": "forge-142", "title": "Wire kernel selector into dispatch", "priority": 1 },
+  { "id": "forge-143", "title": "Document release readiness gate", "priority": 2 }
+]
+```
+
+## Success Criteria
+
+- [ ] Only unblocked issues appear in the result.
+- [ ] The chosen id is passed on to `forge claim`.
+
+## Related Skills
+
+- claim: claim the issue you selected here.
+- show: inspect a ready issue's full detail before claiming.

--- a/packages/skills/forge-plugin/skills/recap/SKILL.md
+++ b/packages/skills/forge-plugin/skills/recap/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: recap
+description: >
+  Produce a bounded, token-aware summary of an issue's history and current state
+  — its description, status, dependencies, and accumulated comments. Wraps
+  `forge recap` so an agent can rebuild context on a single issue after a
+  session break without re-reading the entire issue store.
+metadata:
+  author: forge
+  command: forge recap
+---
+
+# forge recap
+
+## Purpose
+
+Reconstruct context on one issue quickly. `forge recap <issue>` distills the
+issue's description, status, dependency links, and comment trail into a bounded
+summary, so you can resume work without manually scrolling its full history.
+
+## When to Use
+
+- At the start of a session that resumes a previously claimed issue.
+- After context compaction, to reload what an issue is about and where it stands.
+- Before commenting or closing, to confirm the latest state.
+
+## Command
+
+```bash
+forge recap <issue>         # bounded summary of one issue
+```
+
+## Instructions
+
+1. Run `forge recap <issue>` with the id you are resuming.
+2. Read the summarized status, decisions, and open threads.
+3. Treat the recap as the authoritative current state of the issue.
+4. Continue with [comment](../comment/SKILL.md) or [close](../close/SKILL.md).
+
+## Example
+
+```
+$ forge recap forge-142
+forge-142  Wire kernel selector into dispatch  [in_progress]
+- Selector wired in bin/forge.js (commit 467b868).
+- Multi-id close acceptance test added and green (commit c3bcb36).
+- Remaining: confirm release readiness gate clears.
+```
+
+## Success Criteria
+
+- [ ] Current issue state is understood from the recap alone.
+- [ ] No need to manually re-read the full issue history.
+
+## Related Skills
+
+- show: full raw detail when the bounded recap is not enough.
+- comment: record the next progress note after resuming.

--- a/packages/skills/forge-plugin/skills/show/SKILL.md
+++ b/packages/skills/forge-plugin/skills/show/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: show
+description: >
+  Read the full detail of a single issue — title, description, status,
+  dependencies, and discussion — by its id. Wraps `forge show` so you gather
+  complete context before claiming, commenting on, or closing an issue.
+metadata:
+  author: forge
+  command: forge show
+---
+
+# forge show
+
+## Purpose
+
+Retrieve everything Forge knows about one issue so you can act on it with full
+context: the description, acceptance criteria, current status, blocking and
+blocked-by links, and any prior comments.
+
+## When to Use
+
+- Right after picking an id from `forge ready`, to understand the task.
+- Before commenting, to see what has already been recorded.
+- Before closing, to confirm the acceptance criteria are met.
+
+## Command
+
+```bash
+forge show <id>             # full detail for one issue
+forge issue show <id>       # equivalent issue-scoped form
+```
+
+## Instructions
+
+1. Run `forge show <id>` with the issue id you want to inspect.
+2. Read the description and acceptance criteria to understand the goal.
+3. Check the dependency links to confirm the issue is actionable.
+4. Review existing comments so you do not repeat prior context.
+
+## Example
+
+```
+$ forge show forge-142
+forge-142  Wire kernel selector into dispatch
+status: in_progress
+depends on: forge-130 (closed)
+---
+Route `forge <command>` through the kernel selector when the kernel backend
+is active. Acceptance: multi-id close works end to end.
+```
+
+## Success Criteria
+
+- [ ] The issue's description and status are understood before acting.
+- [ ] Dependency state is confirmed actionable.
+
+## Related Skills
+
+- ready: find which issue id to show.
+- comment: record findings after reviewing the issue.

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -36,7 +36,6 @@ describe('forge release check command', () => {
       'bd-hot-path-issue-commands',
       'kernel-backed-forge-issue',
       'forge-orient-issue-recap',
-      'forge-skills-pack',
       'forge-remember-recall',
       'premerge-embedded-gate',
       'fresh-clone-no-beads-acceptance',

--- a/test/forge-skills-pack.test.js
+++ b/test/forge-skills-pack.test.js
@@ -1,0 +1,85 @@
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const PACK_ROOT = path.join(ROOT, 'packages', 'skills', 'forge-plugin');
+const { buildReadinessReport } = require('../lib/release-readiness.js');
+
+// Mirror REQUIRED_FORGE_SKILLS from lib/release-readiness.js (internal constant).
+// Each skill's SKILL.md must document at least one of the wrapped forge commands.
+const REQUIRED_SKILLS = [
+  { name: 'ready', commandPatterns: [/forge ready/, /forge issue ready/] },
+  { name: 'show', commandPatterns: [/forge show/, /forge issue show/] },
+  { name: 'claim', commandPatterns: [/forge claim/] },
+  { name: 'comment', commandPatterns: [/forge comment/, /forge issue comment/] },
+  { name: 'close', commandPatterns: [/forge close/, /forge issue close/] },
+  { name: 'recap', commandPatterns: [/forge recap/] },
+];
+
+/**
+ * Minimal YAML frontmatter reader: returns the `name` field of a SKILL.md so
+ * we can assert each skill declares an identity matching its directory.
+ */
+function frontmatterName(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const line = match[1].split('\n').find(entry => entry.startsWith('name:'));
+  return line ? line.slice('name:'.length).trim().replace(/^["']|["']$/g, '') : null;
+}
+
+describe('Forge CLI-wrapper skills pack', () => {
+  test('manifest.json exists at the preferred pack root', () => {
+    expect(fs.existsSync(path.join(PACK_ROOT, 'manifest.json'))).toBeTruthy();
+  });
+
+  test('manifest.json declares every required skill name', () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(PACK_ROOT, 'manifest.json'), 'utf8'));
+    const declared = JSON.stringify(manifest);
+    for (const skill of REQUIRED_SKILLS) {
+      expect(declared.includes(`"${skill.name}"`)).toBeTruthy();
+    }
+  });
+
+  for (const skill of REQUIRED_SKILLS) {
+    const skillFile = path.join(PACK_ROOT, 'skills', skill.name, 'SKILL.md');
+
+    test(`skills/${skill.name}/SKILL.md exists`, () => {
+      expect(fs.existsSync(skillFile)).toBeTruthy();
+    });
+
+    test(`skills/${skill.name}/SKILL.md frontmatter name matches directory`, () => {
+      expect(frontmatterName(skillFile)).toBe(skill.name);
+    });
+
+    test(`skills/${skill.name}/SKILL.md documents the wrapped forge command`, () => {
+      const content = fs.readFileSync(skillFile, 'utf8');
+      expect(skill.commandPatterns.some(pattern => pattern.test(content))).toBeTruthy();
+    });
+  }
+
+  test('pack files never reference retired issue-store tooling', () => {
+    const offenders = [];
+    const walk = dir => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (/\.(md|json)$/.test(entry.name)) {
+          if (/\bbd\b|\.beads\b|\bdolt\b/i.test(fs.readFileSync(full, 'utf8'))) {
+            offenders.push(path.relative(ROOT, full));
+          }
+        }
+      }
+    };
+    walk(PACK_ROOT);
+    expect(offenders).toEqual([]);
+  });
+
+  test('readiness gate no longer reports forge-skills-pack blocker', () => {
+    const report = buildReadinessReport(ROOT, { target: '0.1.0' });
+    const blockerIds = report.blockers.map(blocker => blocker.id);
+    expect(blockerIds).not.toContain('forge-skills-pack');
+  });
+});


### PR DESCRIPTION
Adds `packages/skills/forge-plugin` skills pack with CLI-wrapper skills. Clears readiness gate blocker `forge-skills-pack` (D22).

Pushed via `--quick` (review-cycle); CI runs the full suite (the `BEADS_SKIP_TESTS` local-only failure passes on CI where bd is available).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Forge skills pack with built-in guidance for readying, claiming, showing, commenting on, closing, and recapping issues.
  * Included user-facing instructions and commands for each skill to make issue workflows easier to follow.

* **Tests**
  * Added coverage for the skills pack structure and content.
  * Updated release-check expectations to reflect the latest blocker list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->