### PR TITLE
feat(review): monitor-driven PR shepherd (cross-harness utility command)

### DIFF
--- a/.claude/commands/shepherd.md
+++ b/.claude/commands/shepherd.md
@@ -2,7 +2,7 @@
 description: Monitor-driven PR shepherd — one bounded pass per invocation; never merges, never resolves review threads
 ---
 
-Run one bounded monitor pass over a pull request: read CI/check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
+Run one bounded monitor pass over a pull request: read CI and check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
 
 # Shepherd
 

--- a/.claude/commands/shepherd.md
+++ b/.claude/commands/shepherd.md
@@ -1,0 +1,53 @@
+---
+description: Monitor-driven PR shepherd — one bounded pass per invocation; never merges, never resolves review threads
+---
+
+Run one bounded monitor pass over a pull request: read CI/check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
+
+# Shepherd
+
+`shepherd` is a **utility command, not a workflow stage.** It automates the polling / rerun / escalation loop that today is done by hand after `/review`. It does **not** replace `/review` (which still owns semantic review and its stage transition) and does **not** touch `/premerge`.
+
+## Usage
+
+```bash
+forge shepherd <pr-number>
+forge shepherd <pr-number> --auto-rebase   # opt-in, default OFF
+```
+
+## Bounded-pass model (one pass = one invocation)
+
+Each `forge shepherd <pr>` invocation is **ONE discrete bounded pass**: it reads PR state, takes at most the allowed Tier-A action, then **exits**. It never sits in-process polling "until merge-ready."
+
+This mirrors the project's documented ergonomic from `/review`, `/premerge`, and the Greptile process: **poll briefly, then stop and hand off.** Any pass that finds checks still pending exits as `PENDING`, and the next scheduled pass picks up where it left off.
+
+A `--watch` affordance, if you want one, lives in an **external scheduler** (e.g. cron or a `/loop`) that re-invokes the bounded pass on an interval with debounce (>= 60s between passes, cancel-in-progress). There is no in-process infinite loop.
+
+## What it never does
+
+- **Never merges.** There is no merge action and no server-side auto-merge latch. The shepherd terminates at `MERGE_READY` and hands off to the human, who merges in the GitHub UI (mirroring the `/premerge` handoff).
+- **Never resolves review threads.** It may post a status **reply** to a thread (via the existing `.claude/scripts/greptile-resolve.sh reply` helper), but thread **resolution** is semantic and stays with `/review`.
+
+## Action ladder
+
+- **Tier-A (autonomous, idempotent, reversible):** re-run a flaky **required** check via `gh run rerun --failed` (capped by a rerun budget). Post status replies to threads (reply only).
+- **Tier-B (opt-in per-flag, default OFF):** `--auto-rebase` rebases onto the base and force-pushes with lease. Preconditions: clean working tree, HEAD unchanged during the pass. A lease rejection is a **hard-stop + escalate** — the shepherd never re-arms the lease, because doing so would clobber the concurrent human push the lease exists to protect.
+- **Tier-C (human escalation):** merge conflicts, required-check failures a rerun did not fix, an unreadable required-check set, unknown mergeability, auth/scope failures, oscillation, and budget exhaustion all stop and escalate with context posted to the PR.
+
+## Merge-readiness gate
+
+Merge-ready is declared **only** when the branch-protection required-check set is **known** AND all of it is green AND the branch is not behind base. The required set is read from `gh api repos/{owner}/{repo}/branches/{base}/protection/required_status_checks`. If branch protection is unreadable (insufficient token scope, or the branch is not protected), the shepherd does **not** guess — it escalates with the readable rollup attached.
+
+## Concurrency & safety
+
+- The advisory `shepherd:active` marker is **not** mutual exclusion. The real guard is a per-action HEAD-SHA re-read: before any mutating action the shepherd re-reads the head SHA, and if HEAD moved since the pass started it **aborts** the action.
+- Auth taxonomy: token expiry (401) pauses and surfaces; insufficient scope (403) is a permanent **hard-stop**; a secondary rate limit (403 + `Retry-After`) honors the delay and resumes on the next pass.
+
+## Per-harness behavior
+
+- **Claude Code / Codex:** invoke `forge shepherd <pr>` directly; an external scheduler may drive repeated bounded passes.
+- **Cursor:** manually-invoked only. Run `forge shepherd <pr>` from a terminal — there is no polling-loop affordance and no hook reliance on this surface.
+
+## State
+
+Progress is durable in GitHub: PR **comments** and **labels** plus `git`. There is no separate local state store.

--- a/.codex/skills/shepherd/SKILL.md
+++ b/.codex/skills/shepherd/SKILL.md
@@ -2,7 +2,7 @@
 description: Monitor-driven PR shepherd — one bounded pass per invocation; never merges, never resolves review threads
 ---
 
-Run one bounded monitor pass over a pull request: read CI/check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
+Run one bounded monitor pass over a pull request: read CI and check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
 
 # Shepherd
 

--- a/.codex/skills/shepherd/SKILL.md
+++ b/.codex/skills/shepherd/SKILL.md
@@ -1,0 +1,53 @@
+---
+description: Monitor-driven PR shepherd — one bounded pass per invocation; never merges, never resolves review threads
+---
+
+Run one bounded monitor pass over a pull request: read CI/check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
+
+# Shepherd
+
+`shepherd` is a **utility command, not a workflow stage.** It automates the polling / rerun / escalation loop that today is done by hand after `/review`. It does **not** replace `/review` (which still owns semantic review and its stage transition) and does **not** touch `/premerge`.
+
+## Usage
+
+```bash
+forge shepherd <pr-number>
+forge shepherd <pr-number> --auto-rebase   # opt-in, default OFF
+```
+
+## Bounded-pass model (one pass = one invocation)
+
+Each `forge shepherd <pr>` invocation is **ONE discrete bounded pass**: it reads PR state, takes at most the allowed Tier-A action, then **exits**. It never sits in-process polling "until merge-ready."
+
+This mirrors the project's documented ergonomic from `/review`, `/premerge`, and the Greptile process: **poll briefly, then stop and hand off.** Any pass that finds checks still pending exits as `PENDING`, and the next scheduled pass picks up where it left off.
+
+A `--watch` affordance, if you want one, lives in an **external scheduler** (e.g. cron or a `/loop`) that re-invokes the bounded pass on an interval with debounce (>= 60s between passes, cancel-in-progress). There is no in-process infinite loop.
+
+## What it never does
+
+- **Never merges.** There is no merge action and no server-side auto-merge latch. The shepherd terminates at `MERGE_READY` and hands off to the human, who merges in the GitHub UI (mirroring the `/premerge` handoff).
+- **Never resolves review threads.** It may post a status **reply** to a thread (via the existing `.claude/scripts/greptile-resolve.sh reply` helper), but thread **resolution** is semantic and stays with `/review`.
+
+## Action ladder
+
+- **Tier-A (autonomous, idempotent, reversible):** re-run a flaky **required** check via `gh run rerun --failed` (capped by a rerun budget). Post status replies to threads (reply only).
+- **Tier-B (opt-in per-flag, default OFF):** `--auto-rebase` rebases onto the base and force-pushes with lease. Preconditions: clean working tree, HEAD unchanged during the pass. A lease rejection is a **hard-stop + escalate** — the shepherd never re-arms the lease, because doing so would clobber the concurrent human push the lease exists to protect.
+- **Tier-C (human escalation):** merge conflicts, required-check failures a rerun did not fix, an unreadable required-check set, unknown mergeability, auth/scope failures, oscillation, and budget exhaustion all stop and escalate with context posted to the PR.
+
+## Merge-readiness gate
+
+Merge-ready is declared **only** when the branch-protection required-check set is **known** AND all of it is green AND the branch is not behind base. The required set is read from `gh api repos/{owner}/{repo}/branches/{base}/protection/required_status_checks`. If branch protection is unreadable (insufficient token scope, or the branch is not protected), the shepherd does **not** guess — it escalates with the readable rollup attached.
+
+## Concurrency & safety
+
+- The advisory `shepherd:active` marker is **not** mutual exclusion. The real guard is a per-action HEAD-SHA re-read: before any mutating action the shepherd re-reads the head SHA, and if HEAD moved since the pass started it **aborts** the action.
+- Auth taxonomy: token expiry (401) pauses and surfaces; insufficient scope (403) is a permanent **hard-stop**; a secondary rate limit (403 + `Retry-After`) honors the delay and resumes on the next pass.
+
+## Per-harness behavior
+
+- **Claude Code / Codex:** invoke `forge shepherd <pr>` directly; an external scheduler may drive repeated bounded passes.
+- **Cursor:** manually-invoked only. Run `forge shepherd <pr>` from a terminal — there is no polling-loop affordance and no hook reliance on this surface.
+
+## State
+
+Progress is durable in GitHub: PR **comments** and **labels** plus `git`. There is no separate local state store.

--- a/.cursor/commands/shepherd.md
+++ b/.cursor/commands/shepherd.md
@@ -1,5 +1,5 @@
 
-Run one bounded monitor pass over a pull request: read CI/check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
+Run one bounded monitor pass over a pull request: read CI and check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
 
 # Shepherd
 

--- a/.cursor/commands/shepherd.md
+++ b/.cursor/commands/shepherd.md
@@ -1,0 +1,50 @@
+
+Run one bounded monitor pass over a pull request: read CI/check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
+
+# Shepherd
+
+`shepherd` is a **utility command, not a workflow stage.** It automates the polling / rerun / escalation loop that today is done by hand after `/review`. It does **not** replace `/review` (which still owns semantic review and its stage transition) and does **not** touch `/premerge`.
+
+## Usage
+
+```bash
+forge shepherd <pr-number>
+forge shepherd <pr-number> --auto-rebase   # opt-in, default OFF
+```
+
+## Bounded-pass model (one pass = one invocation)
+
+Each `forge shepherd <pr>` invocation is **ONE discrete bounded pass**: it reads PR state, takes at most the allowed Tier-A action, then **exits**. It never sits in-process polling "until merge-ready."
+
+This mirrors the project's documented ergonomic from `/review`, `/premerge`, and the Greptile process: **poll briefly, then stop and hand off.** Any pass that finds checks still pending exits as `PENDING`, and the next scheduled pass picks up where it left off.
+
+A `--watch` affordance, if you want one, lives in an **external scheduler** (e.g. cron or a `/loop`) that re-invokes the bounded pass on an interval with debounce (>= 60s between passes, cancel-in-progress). There is no in-process infinite loop.
+
+## What it never does
+
+- **Never merges.** There is no merge action and no server-side auto-merge latch. The shepherd terminates at `MERGE_READY` and hands off to the human, who merges in the GitHub UI (mirroring the `/premerge` handoff).
+- **Never resolves review threads.** It may post a status **reply** to a thread (via the existing `.claude/scripts/greptile-resolve.sh reply` helper), but thread **resolution** is semantic and stays with `/review`.
+
+## Action ladder
+
+- **Tier-A (autonomous, idempotent, reversible):** re-run a flaky **required** check via `gh run rerun --failed` (capped by a rerun budget). Post status replies to threads (reply only).
+- **Tier-B (opt-in per-flag, default OFF):** `--auto-rebase` rebases onto the base and force-pushes with lease. Preconditions: clean working tree, HEAD unchanged during the pass. A lease rejection is a **hard-stop + escalate** — the shepherd never re-arms the lease, because doing so would clobber the concurrent human push the lease exists to protect.
+- **Tier-C (human escalation):** merge conflicts, required-check failures a rerun did not fix, an unreadable required-check set, unknown mergeability, auth/scope failures, oscillation, and budget exhaustion all stop and escalate with context posted to the PR.
+
+## Merge-readiness gate
+
+Merge-ready is declared **only** when the branch-protection required-check set is **known** AND all of it is green AND the branch is not behind base. The required set is read from `gh api repos/{owner}/{repo}/branches/{base}/protection/required_status_checks`. If branch protection is unreadable (insufficient token scope, or the branch is not protected), the shepherd does **not** guess — it escalates with the readable rollup attached.
+
+## Concurrency & safety
+
+- The advisory `shepherd:active` marker is **not** mutual exclusion. The real guard is a per-action HEAD-SHA re-read: before any mutating action the shepherd re-reads the head SHA, and if HEAD moved since the pass started it **aborts** the action.
+- Auth taxonomy: token expiry (401) pauses and surfaces; insufficient scope (403) is a permanent **hard-stop**; a secondary rate limit (403 + `Retry-After`) honors the delay and resumes on the next pass.
+
+## Per-harness behavior
+
+- **Claude Code / Codex:** invoke `forge shepherd <pr>` directly; an external scheduler may drive repeated bounded passes.
+- **Cursor:** manually-invoked only. Run `forge shepherd <pr>` from a terminal — there is no polling-loop affordance and no hook reliance on this surface.
+
+## State
+
+Progress is durable in GitHub: PR **comments** and **labels** plus `git`. There is no separate local state store.

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-24T10:38:25.818Z",
+  "generatedAt": "2026-06-25T09:02:46.075Z",
   "files": [
     ".cursor/commands/dev.md",
     ".codex/skills/dev/SKILL.md",

--- a/.forge/sync-manifest.json
+++ b/.forge/sync-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-11T13:49:47.549Z",
+  "generatedAt": "2026-06-24T10:38:25.818Z",
   "files": [
     ".cursor/commands/dev.md",
     ".codex/skills/dev/SKILL.md",
@@ -13,6 +13,8 @@
     ".codex/skills/review/SKILL.md",
     ".cursor/commands/rollback.md",
     ".codex/skills/rollback/SKILL.md",
+    ".cursor/commands/shepherd.md",
+    ".codex/skills/shepherd/SKILL.md",
     ".cursor/commands/ship.md",
     ".codex/skills/ship/SKILL.md",
     ".cursor/commands/sonarcloud.md",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This project ships a **default TDD-first workflow template** with 7 named stage 
 
 **Utility**: `/status` — Context check before starting work (not a numbered stage)
 
-**Utility**: `/shepherd <pr>` — Monitor-driven PR shepherd: one bounded pass that reads CI/check state, re-runs a flaky required check (Tier-A), or escalates, then hands off. It is a utility command, **not** a workflow stage, and does not sit between `/review` and the handoff. It **never merges** (the human merges in the GitHub UI) and **never resolves review threads** (that stays with `/review`). `--auto-rebase` is opt-in and default OFF. See [docs/reference/shepherd.md](docs/reference/shepherd.md).
+**Utility**: `/shepherd <pr>` — Monitor-driven PR shepherd: one bounded pass that reads CI and check state, re-runs a flaky required check (Tier-A), or escalates, then hands off. It is a utility command, **not** a workflow stage, and does not sit between `/review` and the handoff. It **never merges** (the human merges in the GitHub UI) and **never resolves review threads** (that stays with `/review`). `--auto-rebase` is opt-in and default OFF. See [docs/reference/shepherd.md](docs/reference/shepherd.md).
 
 ## Automatic Change Classification
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ This project ships a **default TDD-first workflow template** with 7 named stage 
 
 **Utility**: `/status` — Context check before starting work (not a numbered stage)
 
+**Utility**: `/shepherd <pr>` — Monitor-driven PR shepherd: one bounded pass that reads CI/check state, re-runs a flaky required check (Tier-A), or escalates, then hands off. It is a utility command, **not** a workflow stage, and does not sit between `/review` and the handoff. It **never merges** (the human merges in the GitHub UI) and **never resolves review threads** (that stays with `/review`). `--auto-rebase` is opt-in and default OFF. See [docs/reference/shepherd.md](docs/reference/shepherd.md).
+
 ## Automatic Change Classification
 
 When the user requests work, **you MUST automatically classify** the change type:
@@ -159,6 +161,7 @@ Task 2: Validation logic
 - [.claude/commands/validate.md](.claude/commands/validate.md) - How to run validation (with HARD-GATE exit)
 - [.claude/commands/ship.md](.claude/commands/ship.md) - How to create PRs
 - [.claude/commands/review.md](.claude/commands/review.md) - How to address PR feedback (with HARD-GATE exit)
+- [.claude/commands/shepherd.md](.claude/commands/shepherd.md) - How to run a bounded PR monitor pass (utility; never merges, never resolves threads)
 - [.claude/commands/premerge.md](.claude/commands/premerge.md) - How to complete docs and hand off PR for merge
 - [.claude/commands/verify.md](.claude/commands/verify.md) - How to verify post-merge health
 

--- a/bin/forge-cmd.js
+++ b/bin/forge-cmd.js
@@ -97,6 +97,14 @@ const REQUIRED_ARGS = {
 	verify: [],
 };
 
+// Allowed flags per command. Commands listed here have their flags strictly
+// validated — an unknown flag is rejected rather than silently forwarded
+// (e.g. a typo like `--auto-reabse` must not run shepherd with default
+// behaviour). Commands NOT listed here keep their permissive flag handling.
+const ALLOWED_FLAGS = {
+	shepherd: ['--auto-rebase'],
+};
+
 /**
  * Parse command line arguments
  * @param {string[]} argv - Process arguments
@@ -184,6 +192,19 @@ function validateArgs(command, args) {
 		const slugValidation = validateSlug(positionalArgs[0]);
 		if (!slugValidation.valid) {
 			return slugValidation;
+		}
+	}
+
+	// Reject unknown flags for commands with a strict flag allow-list, so typos
+	// fail loudly instead of running with default behaviour.
+	const allowedFlags = ALLOWED_FLAGS[command];
+	if (allowedFlags) {
+		const unknownFlag = args.find(a => a.startsWith('--') && !allowedFlags.includes(a));
+		if (unknownFlag) {
+			return {
+				valid: false,
+				error: `Error: Unknown flag '${unknownFlag}' for 'forge ${command}'\n\nAllowed flags: ${allowedFlags.join(', ') || '(none)'}`,
+			};
 		}
 	}
 
@@ -367,4 +388,5 @@ module.exports = {
 	getHelpText,
 	findWorkPlanDoc,
 	findPlanDocForBranch,
+	ALLOWED_FLAGS,
 };

--- a/bin/forge-cmd.js
+++ b/bin/forge-cmd.js
@@ -15,6 +15,7 @@ const HANDLERS = {
 	dev: require('../lib/commands/dev'),
 	validate: require('../lib/commands/validate'),
 	ship: require('../lib/commands/ship'),
+	shepherd: require('../lib/commands/shepherd'),
 };
 
 const VALID_COMMANDS = [
@@ -25,6 +26,7 @@ const VALID_COMMANDS = [
 	'check', // backward-compat alias for validate
 	'ship',
 	'review',
+	'shepherd',
 	'merge',
 	'verify',
 ];
@@ -76,6 +78,7 @@ const COMMAND_DESCRIPTIONS = {
 	check: 'Alias for validate (deprecated — use validate)',
 	ship: 'Auto-generate PR body and create PR',
 	review: 'Aggregate all review feedback',
+	shepherd: 'Run one bounded monitor pass over a PR (never merges)',
 	merge: 'Update docs, merge PR, cleanup',
 	verify: 'Final documentation verification',
 };
@@ -84,6 +87,7 @@ const REQUIRED_ARGS = {
 	plan: ['feature-slug'],
 	ship: ['feature-slug', 'title'],
 	review: [],
+	shepherd: ['pr'],
 	merge: [],
 	// Other commands don't require arguments
 	status: [],
@@ -316,6 +320,18 @@ async function main() { // NOSONAR S3776
 				if (result.prUrl) console.log(`  PR: ${result.prUrl}`);
 			} else {
 				console.error(`✗ Ship failed: ${result.error}`);
+				process.exit(1);
+			}
+
+		} else if (command === 'shepherd') {
+			result = await HANDLERS.shepherd.handler(args, {}, process.cwd());
+			if (result.success) {
+				console.log(`✓ shepherd: ${result.state}`);
+				if (result.reason) console.log(`  ${result.reason}`);
+			} else {
+				console.error(`✗ shepherd: ${result.state || 'failed'}`);
+				if (result.error) console.error(`  ${result.error}`);
+				if (result.reason) console.error(`  ${result.reason}`);
 				process.exit(1);
 			}
 

--- a/docs/reference/shepherd.md
+++ b/docs/reference/shepherd.md
@@ -1,0 +1,83 @@
+# PR Shepherd
+
+The shepherd is a **monitor-driven utility command** that automates the manual
+polling / rerun / escalation loop a human otherwise runs by hand after
+`/review`. It is **not** a workflow stage and does not replace `/review` or
+`/premerge`.
+
+```bash
+forge shepherd <pr-number>
+forge shepherd <pr-number> --auto-rebase   # opt-in, default OFF
+```
+
+## Why it is a utility, not a stage
+
+Stages are a frozen, ordered ladder (`plan → dev → validate → ship → review →
+premerge → verify`). Inserting a polling step into that ladder would break the
+stage-transition chain and the harness parity model. The shepherd instead runs
+*alongside* the review handoff: `/review` keeps owning semantic review and its
+stage transition; the shepherd only automates the mechanical waiting and
+re-running.
+
+It is registered as a utility skill in the harness capability matrix
+(`UTILITY_SKILL_IDS`), so cross-harness parity tests cover it without touching
+the frozen stage list.
+
+## Bounded-pass model
+
+Each invocation is **one discrete bounded pass**: read PR state, take at most
+one Tier-A action, then exit. There is no in-process loop. This preserves the
+project's documented ergonomic — poll briefly, then stop and hand off. A pass
+that finds checks still pending returns `PENDING`; the next scheduled pass picks
+up from there.
+
+`--watch`-style behavior, if desired, belongs in an external scheduler (cron, or
+a `/loop`) that re-invokes the bounded pass with a debounce of at least 60
+seconds and cancel-in-progress. The shepherd itself never waits in-process.
+
+## Terminal states
+
+| State         | Meaning |
+| ------------- | ------- |
+| `MERGE_READY` | Required checks are green and the branch is up to date. The shepherd hands off — **a human merges in the GitHub UI.** |
+| `ESCALATE`    | A Tier-C condition (conflict, unreadable required set, persistent failure, oscillation, budget exhaustion). Context is posted to the PR. |
+| `PENDING`     | A Tier-A action was taken, or checks are still pending. Exit and await the next scheduled pass. |
+| `HARD_STOP`   | A permanent auth/scope failure that retrying cannot fix. Escalate to a human to widen token scope. |
+
+## Action ladder
+
+- **Tier-A (autonomous):** re-run a flaky **required** check via
+  `gh run rerun --failed` (capped by a rerun budget). Post status replies to
+  review threads (reply only).
+- **Tier-B (opt-in, default OFF):** `--auto-rebase` rebases onto base and
+  force-pushes with lease, given a clean tree and an unchanged HEAD. A lease
+  rejection is a hard-stop — the shepherd never re-arms the lease.
+- **Tier-C (escalate):** everything else.
+
+## Safety invariants
+
+- **Never merges.** No merge action, no server-side auto-merge latch.
+- **Never resolves review threads.** It may post a status reply; resolution is
+  semantic and stays with `/review`.
+- **Required-check gate.** Merge-ready is declared only when the
+  branch-protection required-check set is *known* (read from
+  `gh api repos/{owner}/{repo}/branches/{base}/protection/required_status_checks`)
+  and all of it is green. If protection is unreadable, the shepherd escalates
+  rather than guessing.
+- **HEAD-changed abort.** Before any mutating action it re-reads the head SHA; if
+  HEAD moved during the pass, the action aborts. The `shepherd:active` marker is
+  advisory only — it is not mutual exclusion.
+- **Auth taxonomy.** 401 (expiry) pauses and surfaces; 403 insufficient-scope is
+  a hard-stop; 403 with `Retry-After` honors the delay and resumes next pass.
+
+## Per-harness behavior
+
+- **Claude Code / Codex:** invoke `forge shepherd <pr>` directly; an external
+  scheduler may drive repeated bounded passes.
+- **Cursor:** manually-invoked only — run it from a terminal. No polling-loop
+  affordance and no hook reliance on this surface.
+
+## State
+
+Progress is durable in GitHub PR comments and labels plus `git`. There is no
+separate local state store.

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -176,7 +176,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] .cursorrules (1)
   - lines: 34 (bd)
 - [ ] AGENTS.md (6)
-  - lines: 121 (bd), 178 (dolt), 236 (bd), 249 (bd, dolt), 250 (bd), 251 (bd)
+  - lines: 123 (bd), 181 (dolt), 239 (bd), 252 (bd, dolt), 253 (bd), 254 (bd)
 - [ ] CLAUDE.md (2)
   - lines: 99 (dolt), 100 (dolt)
 - [ ] docs/guides/BEADS_GITHUB_SYNC.md (3)

--- a/docs/work/2026-06-24-pr-shepherd-review/plan.md
+++ b/docs/work/2026-06-24-pr-shepherd-review/plan.md
@@ -1,0 +1,252 @@
+# Monitor-Driven PR Shepherd — FINAL Implementation Plan
+
+Status: implementation-ready. Hand to agents working in isolated worktrees off `origin/master`.
+All claims below were re-verified against the main worktree at `C:/Users/harsha_befach/Downloads/forge`. File:line citations are load-bearing.
+
+---
+
+## 0. What changed from the draft, and why (contradiction resolutions)
+
+The draft was wrong or unsafe on several points the adversarial review caught. Verified findings forced the following **binding decisions**. These are not optional; every wave task inherits them.
+
+### D-1. NO auto-merge. Ever. (resolves flow-regression #1, scope-feasibility #1)
+The harness structurally forbids the agent from merging:
+- `.claude/settings.json:11` — `"Bash(gh pr merge:*)"` is a PreToolUse deny rule.
+- `.claude/commands/premerge.md:9` — "The actual merge is always done by the user in the GitHub UI — never by this command."
+- `.claude/commands/premerge.md:107,138,169` — "DO NOT run `gh pr merge`"; "NEVER run `gh pr merge` — blocked by PreToolUse hook".
+
+**Decision:** Shepherd terminates at a `MERGE_READY` terminal state and hands off to the human, mirroring premerge Step 5. The `--auto-merge` rung is DELETED from the design. The gh-pr-merge PreToolUse block is **out of scope** and must not be touched. No server-side `gh pr merge --auto` latch is ever set (it would outlive the loop's caps — safety-edgecases #9 — and violate the invariant).
+
+### D-2. Auto-rebase + force-push is NET-NEW high-risk machinery, gated OFF by default. (resolves safety-edgecases #1, #5, #6)
+Verified: there is **zero** rebase/force-push machinery in the repo. `grep -rIn "git rebase|force-with-lease|push --force"` over `lib/ scripts/ .claude/scripts/` returns nothing. `ship.js:146` only *detects* divergence via `git rev-list --left-right --count` (`getBranchReadiness`, ship.js:114-199); it never rebases or pushes. `push.js:188` writes a nonce so lefthook's pre-push hook skips re-running the suite — a raw force-push would NOT carry that nonce and would re-trigger the full local suite every push (safety-edgecases #5).
+
+**Decision:**
+- BEHIND-base handling default = **detect + escalate to human**, NOT auto-rebase.
+- An opt-in `--auto-rebase` flag may perform `git rebase` + `git push --force-with-lease`, but it is classed Tier-B (see D-4), default OFF, and is genuinely new code with its own preconditions and tests (clean working tree, worktree-aware cwd, HEAD-unchanged check, lease-rejection HARD-STOP).
+- Lease rejection = **HARD-STOP + escalate**. Never auto-fetch-then-retry (re-arming the lease silently clobbers the concurrent human push the lease exists to protect — safety-edgecases #6).
+- If `--auto-rebase` is enabled, the cost model must assume each force-push re-runs the full lefthook suite (no nonce reuse in v1).
+
+### D-3. Gate on REQUIRED checks needs a real data source. (resolves safety-edgecases #2)
+`gh pr view --json statusCheckRollup` does NOT say which checks are branch-protection-required. Nothing in the repo reads `required_status_checks` today.
+
+**Decision:** Shepherd fetches required checks via `gh api repos/{owner}/{repo}/branches/{base}/protection/required_status_checks` once per run, joins against `statusCheckRollup`. If protection is unreadable (403 insufficient scope, or branch not protected) → **do not guess**: treat as "cannot determine required set" and escalate to human with the readable rollup attached. Merge-ready is only declared when the required set is known AND all of it is green.
+
+### D-4. Three-tier action ladder; only Tier-A is autonomous. (resolves safety-edgecases #4, #3)
+- **Tier-A (autonomous, idempotent, reversible):** `gh run rerun --failed` for flaky CI (capped, see caps). Status replies on threads (comment only, no resolve).
+- **Tier-B (opt-in per-flag, default OFF — trust/history affecting):** `--auto-rebase` (force-push). Thread *resolution* is NOT in v1 at all (see D-5).
+- **Tier-C (human escalation):** everything else — conflicts, required-check failures that rerun didn't fix, unknown mergeability, auth-scope failures, oscillation, too-many-issues.
+
+### D-5. Greptile thread RESOLUTION is removed from v1; shepherd only REPLIES. (resolves safety-edgecases #3, flow-regression #7)
+Verified `.claude/rules/greptile-review-process.md:201` lists "Resolve threads that haven't been fixed yet" under **❌ DON'T**, and line 5 notes the process "has been problematic for days." Mechanical fix↔thread mapping is semantic, not mechanical.
+
+**Decision:** Shepherd does not resolve threads. It may post a status reply via the existing shell-out `.claude/scripts/greptile-resolve.sh` (verified present). Resolution stays with the semantic agent (`/review`). Thread I/O is a **shell-out to greptile-resolve.sh, NOT an adapter method** — there is no adapter-registry path that composes a shell script (greptile-review-adapter.js:38,68,75 throw without an injected github client; adapter-cli.js does not wire shell scripts).
+
+### D-6. Shepherd does NOT replace /review, does NOT rewrite premerge.md, and does NOT become a stage. (resolves flow-regression #2,#6; harness-parity #1; scope-feasibility #2,#4)
+Three verified facts collide:
+1. `lib/release-readiness.js:1801-1833` `premergeEmbeddedGateBlocker` **FAILS the release gate** when `/premerge` or `premerge` appears in `lib/workflow/stages.js`, `lib/workflow-profiles.js`, or `AGENTS.md`. D22 is actively dissolving /premerge into a task-type gate. (`premerge` IS currently present in stages.js:18 etc., so the gate is already designed to push removal.)
+2. `review.md:372` emits `bash scripts/beads-context.sh stage-transition <id> review premerge`; `premerge.md:130` emits `premerge verify`. These transitions are beads-based and D22 is retiring beads — they are an in-flight migration, not a contract the shepherd should perpetuate or silently drop.
+3. `lib/harness-capability-matrix.js:23` derives `STAGE_IDS` from `lib/workflow/stages.js`; any new STAGE must be added there AND given per-harness renderTargets, or it is invisible to parity tests.
+
+**Decision:** Shepherd is a **standalone utility command**, not a workflow stage.
+- It does NOT edit `lib/workflow/stages.js`, `lib/workflow-profiles.js`, `WORKFLOW_STAGE_MATRIX`, or add itself to `STAGE_SUBSKILLS` as a stage. (Verified safe: `_registry.js` `normalizeStageId()` is a classifier, not a registration gate; many commands — audit, board, insights, status, claim — are not in `STAGE_IDS`.)
+- It is registered as a UTILITY skill in the capability matrix (`UTILITY_SKILL_IDS`, harness-capability-matrix.js:24) so parity tests cover it, WITHOUT touching the frozen stage list.
+- It does **not** rewrite `premerge.md` and does **not** "replace /review". `/review` keeps owning semantic review + the `review→premerge` stage-transition emission. `/premerge` is left untouched (its dissolution is D22 scope). Shepherd **wraps and automates the polling/rerun/escalation loop** that today is done by hand after `/review`; it explicitly defers semantic actions (thread resolve, fact fixes) back to `/review`.
+- Shepherd does NOT emit any `beads-context.sh stage-transition`. Because it is not a stage and does not claim to replace review, it does not break the `review→premerge→verify` chain — `/review` still emits `review→premerge`, `/premerge` still emits `premerge→verify`. (resolves flow-regression #2: the chain is preserved by NOT inserting shepherd into it.)
+
+### D-7. The "fresh-clone-no-beads.test.js" the draft cited DOES NOT EXIST. (resolves flow-regression #5, harness-parity #2, scope-feasibility low-2)
+Verified: `find test -iname "*fresh-clone*"` returns nothing. The string `expect(bdInvocations).toEqual([])` is a **detector regex inside lib/release-readiness.js**, not a runnable asset. `bdInvocations` assertions live only in `test/release-readiness.test.js` and `test/beads-migrate-to-dolt.test.js`. `freshCloneBlocker` (release-readiness.js:1835) currently FAILS the gate because the file is missing — that is an open **D22** blocker, NOT a safety net shepherd inherits.
+
+**Decision:** Authoring the fresh-clone acceptance test is **D22 scope, decoupled from shepherd.** Shepherd does NOT claim `forge release check` is or will be green. Shepherd's own zero-beads guarantee is enforced by (a) its files containing zero `bd`/`.beads`/`dolt` tokens, and (b) a dedicated shepherd test that statically scans the new source files. Acceptance is NOT coupled to `forge release check` (which is manual-only — verified NOT in `lefthook.yml` or `.github/workflows`).
+
+### D-8. Beads non-regression: correct constraint, correct mechanism. (resolves flow-regression #4, harness-parity low-1, scope-feasibility low-2)
+Verified `STATIC_SCAN_ROOTS` (release-readiness.js:23-35) already contains `'lib'`, `'bin'`, `'scripts'` — so all new files are auto-scanned; **no "add to STATIC_SCAN_ROOTS" step is needed.** `findBdTerms` (release-readiness.js:447-453) is **case-insensitive** (`/\bbd\b/i`, `/\.beads\b/i`, `/\bdolt\b/i`).
+
+**Decision:** All new JS (`lib/pr-shepherd.js`, `lib/adapters/pr-state-adapter.js`, `lib/commands/shepherd.js`, `lib/pr-state-validator.js`) and the synced skill files must contain **zero** `bd`/`.beads`/`dolt` tokens (case-insensitive) and zero bare identifiers like `bd`. State persists via `gh` PR comments + labels and `git` only. A shepherd unit test asserts zero tokens in the source files directly (the test tree is NOT scanned — `STATIC_SCAN_ROOTS` excludes `test/` — so the in-test scan is the guard).
+
+### D-9. PRStateAdapter has its own kind and its own validator. (resolves harness-parity #5, flow-regression #7)
+`lib/review-adapter.js:51-52` — `validateReviewAdapter` hard-requires `kind === 'review'`. PRStateAdapter uses `kind: 'pr-state'`. It is never fed to `validateReviewAdapter`. A new `validatePrStateAdapter()` (own module) enforces its contract, mirroring the review validator, and is registered in `adapter-cli.js`.
+
+### D-10. Codex sync: keepDescription only; injectForgeAdapter is install-time. (resolves harness-parity #4, scope-feasibility low-1, scope-feasibility missing-1)
+Verified two distinct mechanisms:
+- `scripts/sync-commands.js` AGENT_ADAPTERS.codex (lines 182-187) uses `keepDescription` and writes `.codex/skills/<name>/SKILL.md`. It does NOT call `injectForgeAdapter`.
+- `lib/codex-skills.js:5` `injectForgeAdapter` is applied at **install time** when Codex skills are materialized, and it literally emits: ``Before executing this workflow, invoke `forge <commandName>` ...`` (codex-skills.js:9).
+
+**Consequence (load-bearing):** because injectForgeAdapter auto-emits ``invoke `forge shepherd` ``, a working `forge shepherd` CLI dispatch **MUST exist** or Codex agents get a dead command. The draft omitted CLI wiring. **`bin/forge-cmd.js` is added to the file inventory** (`VALID_COMMANDS` lacks shepherd today — verified lines 20-30; `HANDLERS` map lines 12-18).
+
+### D-11. The 60s-poll-then-handoff rule. (resolves flow-regression #3, missing-1)
+Verified repeated across `review.md:301,304`, `premerge.md:97`, `greptile-review-process.md:191,274`: "poll for at most 60 seconds, then stop and hand off." An in-process loop "until merge-ready" inverts this documented invariant.
+
+**Decision:** Shepherd is an **EXTERNAL scheduler driving discrete bounded passes.** Each `forge shepherd <pr>` invocation = ONE bounded pass: read state, take at most the allowed Tier-A actions, then **exit** (it does not sit in-process burning a session). `--watch` is a thin loop *in the scheduler layer* (cron / external `loop`) that re-invokes the bounded pass on an interval with debounce, NOT an in-process infinite poll. This preserves the 60s ergonomic: any single pass that hits "pending" exits and lets the next scheduled pass pick up. The three rule files are therefore **not modified** (shepherd does not contradict them — it composes discrete handoff-style passes). No rule-file edits in scope.
+
+### D-12. Hermes: hand-authored skill, not a sync target; observes via PR state, not orient. (resolves harness-parity #3, #6)
+Verified: `.hermes/skills/hermes-forge/SKILL.md` exists, declared via `hermes.plugin.json` (`directories.skills='.hermes/skills'`), hand-authored, intentionally excluded from `sync-commands.js` AGENT_ADAPTERS (only `claude-code`/`cursor`/`codex` — verified lines 169-187). `lib/commands/orient.js:10` is "bounded project orientation from **deterministic source files**" with no PR/CI awareness (grep confirms no pull/PR/mergeab/checks in orient.js).
+
+**Decision:** Hermes is NOT a sync target and gets NO synced shepherd command. The Hermes touchpoint is the EXISTING hand-authored `.hermes/skills/hermes-forge/SKILL.md` (or `skills/hermes-forge/SKILL.md`), updated to document "an external scheduler invokes `forge shepherd <pr>`." Shepherd progress is surfaced to Hermes via PR comments/labels (the durable state) — NOT via `orient` (deterministic-source contract). If a forge read-surface is desired, it would extend `recap` (which already has PR awareness), but that is **explicitly out of v1 scope** to keep blast radius small.
+
+### D-13. Cursor degradation is manual-invoke only. (resolves harness-parity missing-6)
+The matrix marks Cursor skills/stages as unproven and hooks unsupported. **Decision:** On Cursor, shepherd is a manually-invoked `.cursor/commands/shepherd.md` (frontmatter-stripped by the cursor adapter, sync-commands.js:176-180) documenting how to run `forge shepherd <pr>` from a terminal. No polling-loop affordance, no hook reliance. Documented in the skill body.
+
+---
+
+## 1. Architecture (final)
+
+Harness-agnostic core + thin CLI + own-kind adapter + own validator. Dependency-injected for parallel testability.
+
+| File | Role | Notes |
+|------|------|-------|
+| `lib/pr-shepherd.js` | Core: one **bounded pass** state machine. Reads PR state, decides action, returns a decision + side-effect plan. Pure-ish: all IO via injected `gh`/`git` runners. | NO `bd`/`dolt`. NO in-process infinite loop. NO merge. NO rebase unless `autoRebase` opt-in passed. |
+| `lib/adapters/pr-state-adapter.js` | `kind: 'pr-state'`. Wraps `gh pr view --json`, `gh api .../protection/required_status_checks`, `gh pr checks`, `git rev-list --left-right --count`. Returns normalized `{ checks[], required[], mergeStateStatus, headSha, behind, ahead, threads[] }`. | Does NOT extend `ReviewAdapter`. Composes greptile-resolve.sh for thread *reply* only. |
+| `lib/pr-state-validator.js` | `validatePrStateAdapter(adapter)` — own kind contract, mirrors `validateReviewAdapter` shape. | Registered in `adapter-cli.js`. |
+| `lib/commands/shepherd.js` | Command handler. Exports `{ name:'shepherd', description, handler }` (the `_registry` contract). One pass per invocation; `--watch` documented as scheduler-driven. | Wires core + adapter + validator. |
+| `bin/forge-cmd.js` (EDIT) | Add `'shepherd'` to `VALID_COMMANDS` and dispatch in the switch / `HANDLERS`. | Required so injected Codex ``invoke `forge shepherd` `` is not dead. |
+
+**State machine terminal states:** `MERGE_READY` (hand off to human, never merge), `ESCALATE` (Tier-C, post comment + label, exit), `PENDING` (took a Tier-A action or nothing actionable; exit, await next scheduled pass).
+
+**Per-pass safety preamble (every mutating action):** read `headSha` first; if HEAD moved since pass start, ABORT the action (safety-edgecases #8 — the HEAD-changed abort is the *real* concurrency guard; the label lock is advisory only).
+
+**Concurrency:** `shepherd:active` label / marker comment is **advisory, NOT mutual exclusion** (TOCTOU — gh has no CAS). True guard = per-action HEAD-SHA check. Debounce ≥60s between scheduled passes; scheduler uses cancel-in-progress.
+
+**Auth taxonomy (startup scope probe + per-error):**
+- 401 / token expiry → pause + surface (transient).
+- 403 insufficient-scope → **HARD-STOP**, message "token lacks <permission>" (permanent; retry never recovers). Probe required scopes once at pass start so it fails fast.
+- 403 + `Retry-After` (secondary rate limit on mutations) → honor `Retry-After`, then resume.
+
+---
+
+## 2. Skill-rewrite manifest (per harness)
+
+Canonical source: `.claude/commands/*.md`. Propagation via `scripts/sync-commands.js` to the **only three** sync targets (verified AGENT_ADAPTERS keys: `claude-code`, `cursor`, `codex`).
+
+| Canonical file | Action | claude-code | cursor | codex | hermes |
+|----------------|--------|-------------|--------|-------|--------|
+| `.claude/commands/shepherd.md` | **NEW** | kept as-is (claude adapter, baseDir `.claude/commands/`) | synced → `.cursor/commands/shepherd.md`, frontmatter **stripped** (cursor adapter) | synced → `.codex/skills/shepherd/SKILL.md`, `keepDescription`; `injectForgeAdapter` applied at **install time** (emits ``invoke `forge shepherd` ``) | NOT synced |
+| `.claude/commands/review.md` | **UNCHANGED** | — | — | — | — |
+| `.claude/commands/premerge.md` | **UNCHANGED** (D-6: dissolution is D22) | — | — | — | — |
+| `.claude/commands/ship.md` | **UNCHANGED** | — | — | — | — |
+| `.hermes/skills/hermes-forge/SKILL.md` (or `skills/hermes-forge/SKILL.md`) | **EDIT** (hand-authored; document external `forge shepherd <pr>` invocation) | — | — | — | hand-edited, NOT via sync |
+
+`shepherd.md` body MUST: (a) contain zero `bd`/`.beads`/`dolt` tokens; (b) describe the bounded-pass model + 60s handoff philosophy (D-11); (c) state Cursor = manual terminal invoke (D-13); (d) explicitly say it never merges and never resolves Greptile threads (defers to `/review`); (e) document Tier-A/B/C ladder and that `--auto-rebase` is opt-in default-OFF.
+
+Capability-matrix: add `shepherd` to `UTILITY_SKILL_IDS` (harness-capability-matrix.js:24) with subskills (e.g. `shepherd.poll`, `shepherd.rerun`, `shepherd.escalate`) in `STAGE_SUBSKILLS`. Do NOT add to `STAGE_IDS`/stages.js (D-6).
+
+---
+
+## 3. WAVE plan (worktree-partitioned, exclusive file ownership)
+
+All waves branch off `origin/master`. Each task lists owned files (no two concurrent tasks share a file), a RED test (write first, must fail), and a DoD tied to a concrete check. W3 is **serialized** (single owner runs `sync-commands.js` and commits the generated tree to avoid collisions).
+
+### WAVE 1 — Core + adapter + validator (parallel via DI)
+
+**W1-T1: PR-state adapter**
+- Owned: `lib/adapters/pr-state-adapter.js`, `test/pr-state-adapter.test.js`
+- RED test: feed a fake `gh`/`git` runner returning a mixed required/optional check rollup + behind=2; assert adapter returns normalized `{required:[...], behind:2, headSha, mergeStateStatus}` and that it calls `gh api repos/.../protection/required_status_checks`. Fails (no file).
+- DoD: `node --test test/pr-state-adapter.test.js` green; adapter never imports merge/rebase; in-test grep of adapter source → zero `bd|dolt`.
+
+**W1-T2: PR-state validator**
+- Owned: `lib/pr-state-validator.js`, `test/pr-state-validator.test.js`
+- RED test: assert `validatePrStateAdapter({kind:'review',...})` returns error "kind must be \"pr-state\""; a valid `pr-state` adapter passes; assert `validateReviewAdapter` is NOT called. Fails (no file).
+- DoD: tests green; shape mirrors `lib/review-adapter.js:40-62`.
+
+**W1-T3: Core bounded-pass state machine**
+- Owned: `lib/pr-shepherd.js`, `test/pr-shepherd.test.js`
+- RED tests (table-driven, injected adapter):
+  1. all required green + behind=0 → `MERGE_READY`, NO merge call emitted.
+  2. failed flaky required check, rerun budget left → emits ONE `gh run rerun --failed`, returns `PENDING`.
+  3. behind>0, `autoRebase:false` → `ESCALATE` (no git push emitted).
+  4. behind>0, `autoRebase:true`, clean tree, HEAD unchanged → emits `git rebase`+`push --force-with-lease`; lease-reject → `ESCALATE` (no auto-retry).
+  5. required set unreadable (protection 403) → `ESCALATE`, never `MERGE_READY`.
+  6. HEAD moved mid-pass → action aborted.
+  7. 403 insufficient-scope → HARD-STOP; 403+Retry-After → honor; 401 → pause.
+  8. rerun budget exhausted / oscillation detected → `ESCALATE`.
+  9. NEVER emits `gh pr merge` or `gh pr merge --auto` in any branch.
+  10. NEVER emits a greptile thread *resolve* (reply allowed).
+- DoD: all 10 green; in-test scan `/\bbd\b|\.beads|\bdolt\b|gh pr merge/` of `lib/pr-shepherd.js` → empty.
+
+### WAVE 2 — CLI command + dispatch wiring (parallel after W1)
+
+**W2-T1: shepherd command handler**
+- Owned: `lib/commands/shepherd.js`, `test/commands-shepherd.test.js`
+- RED test: handler exports `{name:'shepherd',description,handler}`; one invocation = one bounded pass (assert core called once, no loop); `--auto-rebase` default false; exits after pass. Fails (no file).
+- DoD: tests green; `_registry` contract satisfied.
+
+**W2-T2: bin dispatch**
+- Owned: `bin/forge-cmd.js`, `test/forge-cmd-shepherd.test.js`
+- RED test: `VALID_COMMANDS.includes('shepherd')` true; dispatching `shepherd` routes to handler; unknown-command path unchanged. Fails (shepherd absent from VALID_COMMANDS:20-30).
+- DoD: tests green; `forge shepherd --help` resolves (no dead command for Codex injection).
+
+### WAVE 3 — SERIALIZED: canonical skill + sync generation (single owner)
+
+**W3-T1 (sole owner of generated tree):**
+- Owned: `.claude/commands/shepherd.md` (new), and ALL sync outputs it produces: `.cursor/commands/shepherd.md`, `.codex/skills/shepherd/SKILL.md`, plus any manifest/lockfile sync-commands touches (`skills-lock.json` if applicable). `test/shepherd-skill-sync.test.js`.
+- Steps: author `shepherd.md` per §2 manifest rules; run `node scripts/sync-commands.js`; commit generated files.
+- RED test:
+  - `node scripts/sync-commands.js --check` exits 0 (in sync).
+  - `.cursor/commands/shepherd.md` has frontmatter stripped.
+  - `.codex/skills/shepherd/SKILL.md` exists with kept description.
+  - `shepherd.md` contains zero `bd|.beads|dolt` (case-insensitive).
+  - no `.hermes/...shepherd` file created (Hermes not a sync target).
+- DoD: `--check` exits 0; token scan empty; assertions pass.
+
+### WAVE 4 — Cross-harness docs + matrix + Hermes (one owner each, parallel)
+
+**W4-T1: capability matrix**
+- Owned: `lib/harness-capability-matrix.js`, `test/harness-capability-matrix.test.js` (exclusive edit window)
+- RED test: `shepherd` present in `UTILITY_SKILL_IDS` with subskills; `getSkillsFirstStageGraph()` emits shepherd utility renderTargets for claude/cursor/codex; `STAGE_IDS` UNCHANGED (shepherd NOT a stage — assert deep-equal to frozen list). Fails (shepherd absent).
+- DoD: matrix self-consistency test green; stages.js untouched.
+
+**W4-T2: AGENTS.md / capability docs**
+- Owned: `AGENTS.md` (shepherd section only — must NOT add `premerge` text that would trip premergeEmbeddedGateBlocker; shepherd section is bd-free), `docs/reference/shepherd.md` (new).
+- RED test: `test/docs-shepherd.test.js` asserts AGENTS.md documents shepherd as utility (not stage) and contains no new `gh pr merge`/auto-merge promise; in-test grep `/\bbd\b|\bdolt\b/i` on the new doc → empty.
+- DoD: tests green.
+
+**W4-T3: Hermes consumption skill**
+- Owned: `.hermes/skills/hermes-forge/SKILL.md` (and/or `skills/hermes-forge/SKILL.md`) — Hermes-only edit.
+- RED test: `test/plugins/hermes-plugin.test.js` (extend) asserts the skill documents external `forge shepherd <pr>` invocation AND that Hermes remains absent from `sync-commands.js` AGENT_ADAPTERS.
+- DoD: test green; sync target set still exactly `{claude-code,cursor,codex}`.
+
+### WAVE 5 — Acceptance (after W1–W4)
+
+**W5-T1:** owns `test/shepherd-acceptance.test.js` — see §5.
+
+---
+
+## 4. Reuse table (corrected)
+
+| Need | Reuse? | Reality |
+|------|--------|---------|
+| ahead/behind detect | YES (read pattern) | `git rev-list --left-right --count` per ship.js:146. Re-implement the read in pr-state-adapter; do NOT import ship's writer. |
+| rebase + force-push | NO | Net-new (D-2). Zero existing machinery. |
+| pre-push lint/test | NO direct reuse | push.js:188 writes a nonce so lefthook skips; a raw force-push won't carry it → full lefthook re-runs each forced push. Fold into cost budget. |
+| greptile thread reply | YES (shell-out) | `.claude/scripts/greptile-resolve.sh` (verified present). Reply only, no resolve (D-5). |
+| merge | NO | Forbidden (D-1). |
+| stage-transition | NO | Not a stage (D-6); `/review` and `/premerge` keep emitting their transitions. |
+
+---
+
+## 5. Acceptance test (`test/shepherd-acceptance.test.js`)
+
+Drives `lib/pr-shepherd.js` + `lib/commands/shepherd.js` with a scripted fake `gh`/`git` runner. Asserts, in one suite:
+
+1. **Happy path (zero manual steps to READY):** PR with one flaky failed *required* check + behind=2 + an unresolved Greptile thread. Pass 1: rerun the failed check (Tier-A) → `PENDING`. Pass 2 (rerun now green) but behind=2 with `autoRebase:false` → `ESCALATE` (human rebases). Re-run pass 3 with behind=0 → `MERGE_READY`. Assert NO `gh pr merge` ever emitted; thread never resolved (only reply).
+2. **autoRebase path:** same but `autoRebase:true`, clean tree, HEAD unchanged → emits `git rebase`+`push --force-with-lease`; on lease reject → `ESCALATE`, no retry.
+3. **Caps honored:** rerun budget = N; (N+1)th flaky failure → `ESCALATE`, not another rerun.
+4. **No auto-merge by default / ever:** assert across all branches `gh pr merge` and `gh pr merge --auto` are never in the emitted side-effect log.
+5. **Unknown/unreadable required set → wait/escalate, not merge-ready:** protection 403 → `ESCALATE`; mergeStateStatus UNKNOWN → `PENDING`/wait (UNKNOWN ≠ conflict).
+6. **Auth taxonomy:** 403 insufficient-scope → HARD-STOP (no retries logged); 403+Retry-After → resume after delay; 401 → pause.
+7. **Zero-beads static scan (the strongest non-regression guard):** read the four source files (`lib/pr-shepherd.js`, `lib/adapters/pr-state-adapter.js`, `lib/pr-state-validator.js`, `lib/commands/shepherd.js`) from disk and assert `/\bbd\b/i`, `/\.beads\b/i`, `/\bdolt\b/i` return ZERO matches. (Mirrors release-readiness.js:447-453 but runs in the test tree, which the release scanner does NOT cover.)
+8. **Sync integrity:** `node scripts/sync-commands.js --check` exits 0.
+9. **NOT coupled to `forge release check`:** the suite explicitly does NOT assert the release gate is green (it is RED for unrelated D22 reasons — freshClone + premergeEmbeddedGate — verified). Decoupled per D-7.
+10. **HEAD-changed abort:** simulate HEAD moving mid-pass → mutating action aborted.
+
+**Test-tree note:** the literal tokens used as scan inputs in §5.7 are SAFE — `STATIC_SCAN_ROOTS` excludes `test/` (verified) — so embedding the regex strings does not trip the release scanner. Conversely, the release gate will NOT catch a stray token in any new test helper; §5.7 scanning the *source* files is therefore the authoritative guard.
+
+---
+
+## 6. Out of scope (explicit, to prevent scope creep)
+
+- Removing/altering the `Bash(gh pr merge:*)` PreToolUse block (D-1).
+- Authoring `fresh-clone-no-beads` acceptance test or making `forge release check` green (D-7 — that is D22).
+- Dissolving `/premerge` / editing stages.js / workflow-profiles.js (D-6 — D22).
+- Greptile thread auto-resolution (D-5 — stays with `/review`).
+- Extending `orient`/`recap` for live PR state (D-12 — deferred).
+- In-process infinite watch loop (D-11 — scheduler-driven bounded passes only).

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -186,7 +186,7 @@ class PrStateAdapter {
    * @returns {Promise<object[]>}
    */
   async readComments({ owner, repo, pr }) {
-    const query = 'query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:20){nodes{author{login} body}}}}}}}';
+    const query = 'query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:100){nodes{author{login} body}}}}}}}';
     const raw = this._gh('gh', [
       'api', 'graphql', '-f', `query=${query}`,
       '-F', `o=${owner}`, '-F', `n=${repo}`, '-F', `pr=${pr}`,

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -67,9 +67,10 @@ class PrStateAdapter {
     this.id = options.id || 'pr-state-adapter';
     this.kind = 'pr-state';
     this.name = options.name || this.id;
-    const defaultRunner = (cmd, args) => execFileSync(cmd, args, {
+    const defaultRunner = (cmd, args, opts = {}) => execFileSync(cmd, args, {
       encoding: 'utf8',
       timeout: options.timeout || 30000,
+      ...(opts.cwd ? { cwd: opts.cwd } : {}),
     });
     this._gh = options.gh || defaultRunner;
     this._git = options.git || defaultRunner;
@@ -103,8 +104,9 @@ class PrStateAdapter {
    * Read the branch-protection required-checks set.
    *
    * Returns `null` when the protection endpoint is unreadable (e.g. 403
-   * insufficient scope, or the branch is not protected) so the caller can
-   * escalate rather than guess. Re-throws non-auth errors.
+   * insufficient scope, the branch is not protected, or the payload shape is
+   * unexpected) so the caller can escalate rather than guess. Re-throws non-auth
+   * errors.
    *
    * @param {{ owner: string, repo: string, base: string }} ctx
    * @returns {Promise<string[] | null>}
@@ -115,8 +117,10 @@ class PrStateAdapter {
       const raw = this._gh('gh', ['api', apiPath]);
       const data = JSON.parse(raw || '{}');
       if (Array.isArray(data.contexts)) return data.contexts;
-      if (Array.isArray(data.checks)) return data.checks.map((c) => c.context);
-      return [];
+      if (Array.isArray(data.checks)) return data.checks.map((c) => c.context).filter(Boolean);
+      // Unexpected/changed payload shape — treat as unreadable, not "no required
+      // checks", so merge readiness is never computed from bad data.
+      return null;
     } catch (error) {
       const auth = classifyAuthError(error);
       if (auth) {
@@ -130,11 +134,18 @@ class PrStateAdapter {
   /**
    * Read ahead/behind divergence against the base ref.
    *
+   * `cwd` is threaded through to the git runner so divergence is computed
+   * against the target worktree/checkout, not the process directory.
+   *
    * @param {{ baseRef: string, cwd?: string }} ctx
    * @returns {Promise<{ behind: number, ahead: number }>}
    */
-  async readDivergence({ baseRef }) {
-    const out = this._git('git', ['rev-list', '--left-right', '--count', `${baseRef}...HEAD`]);
+  async readDivergence({ baseRef, cwd }) {
+    const out = this._git(
+      'git',
+      ['rev-list', '--left-right', '--count', `${baseRef}...HEAD`],
+      cwd ? { cwd } : undefined,
+    );
     const [behindRaw = '0', aheadRaw = '0'] = String(out).trim().split(/\s+/);
     return {
       behind: Number.parseInt(behindRaw, 10) || 0,

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -27,6 +27,7 @@ const { execFileSync } = require('node:child_process');
 const PR_VIEW_FIELDS = [
   'headRefOid',
   'mergeStateStatus',
+  'state',
   'statusCheckRollup',
   'reviewThreads',
 ].join(',');
@@ -88,6 +89,7 @@ class PrStateAdapter {
     const rollup = Array.isArray(data.statusCheckRollup) ? data.statusCheckRollup : [];
     return {
       headSha: data.headRefOid || '',
+      state: String(data.state || 'OPEN').toUpperCase(),
       mergeStateStatus: data.mergeStateStatus || 'UNKNOWN',
       checks: rollup.map((check) => ({
         name: check.name || check.context || '',

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * PR-state adapter (`kind: 'pr-state'`).
+ *
+ * Wraps read-only GitHub/git inspection plus a small set of idempotent,
+ * reversible side-effects used by the PR shepherd:
+ *   - `readState`           → `gh pr view --json ...`
+ *   - `readRequiredChecks`  → `gh api repos/{o}/{r}/branches/{base}/protection/required_status_checks`
+ *   - `readDivergence`      → `git rev-list --left-right --count {baseRef}...HEAD`
+ *   - `rerunFailedChecks`   → `gh run rerun <id> --failed`
+ *   - `replyToThread`       → shell-out to `.claude/scripts/greptile-resolve.sh reply` (reply ONLY,
+ *                             never resolve — resolution stays with the semantic `/review` agent)
+ *
+ * This adapter is its own SPI; it does NOT extend the review adapter and is
+ * validated by `validatePrStateAdapter` (lib/pr-state-validator.js).
+ *
+ * It contains no merge or rebase machinery. Divergence handling (rebase) lives
+ * in the core/CLI behind an opt-in flag and is injected as `rebaseOntoBase`
+ * when enabled — it is never a default capability of this read surface.
+ *
+ * @module adapters/pr-state-adapter
+ */
+
+const { execFileSync } = require('node:child_process');
+
+const PR_VIEW_FIELDS = [
+  'headRefOid',
+  'mergeStateStatus',
+  'statusCheckRollup',
+  'reviewThreads',
+].join(',');
+
+/**
+ * Classify an error thrown by the `gh` runner so the core can react.
+ * Returns `null` when the error is not auth/rate related.
+ *
+ * @param {Error} error
+ * @returns {{ class: string, retryAfter?: number } | null}
+ */
+function classifyAuthError(error) {
+  if (!error) return null;
+  const status = error.httpStatus
+    || (typeof error.status === 'number' ? error.status : undefined);
+  const text = `${error.stderr || ''} ${error.message || ''}`;
+  const retryAfter = Number(error.retryAfter) || undefined;
+
+  if (status === 401 || /HTTP 401|bad credentials|token expired/i.test(text)) {
+    return { class: 'expired' };
+  }
+  if (status === 403 || /HTTP 403/i.test(text)) {
+    if (retryAfter || /rate limit|secondary rate/i.test(text)) {
+      return { class: 'rate-limit', retryAfter };
+    }
+    return { class: 'insufficient-scope' };
+  }
+  return null;
+}
+
+class PrStateAdapter {
+  /**
+   * @param {object} [options]
+   * @param {Function} [options.gh] - Runner for `gh` (cmd, args[]) → string.
+   * @param {Function} [options.git] - Runner for `git` (cmd, args[]) → string.
+   */
+  constructor(options = {}) {
+    this.id = options.id || 'pr-state-adapter';
+    this.kind = 'pr-state';
+    this.name = options.name || this.id;
+    const defaultRunner = (cmd, args) => execFileSync(cmd, args, {
+      encoding: 'utf8',
+      timeout: options.timeout || 30000,
+    });
+    this._gh = options.gh || defaultRunner;
+    this._git = options.git || defaultRunner;
+  }
+
+  /**
+   * Read normalized PR/CI state.
+   *
+   * @param {string} pr - PR number or URL.
+   * @returns {Promise<{ headSha: string, mergeStateStatus: string, checks: object[], threads: object[] }>}
+   */
+  async readState(pr) {
+    const raw = this._gh('gh', ['pr', 'view', String(pr), '--json', PR_VIEW_FIELDS]);
+    const data = JSON.parse(raw || '{}');
+    const rollup = Array.isArray(data.statusCheckRollup) ? data.statusCheckRollup : [];
+    return {
+      headSha: data.headRefOid || '',
+      mergeStateStatus: data.mergeStateStatus || 'UNKNOWN',
+      checks: rollup.map((check) => ({
+        name: check.name || check.context || '',
+        status: check.status || check.state || '',
+        conclusion: check.conclusion || check.state || '',
+        databaseId: check.databaseId,
+        detailsUrl: check.detailsUrl,
+      })),
+      threads: Array.isArray(data.reviewThreads) ? data.reviewThreads : [],
+    };
+  }
+
+  /**
+   * Read the branch-protection required-checks set.
+   *
+   * Returns `null` when the protection endpoint is unreadable (e.g. 403
+   * insufficient scope, or the branch is not protected) so the caller can
+   * escalate rather than guess. Re-throws non-auth errors.
+   *
+   * @param {{ owner: string, repo: string, base: string }} ctx
+   * @returns {Promise<string[] | null>}
+   */
+  async readRequiredChecks({ owner, repo, base }) {
+    const apiPath = `repos/${owner}/${repo}/branches/${base}/protection/required_status_checks`;
+    try {
+      const raw = this._gh('gh', ['api', apiPath]);
+      const data = JSON.parse(raw || '{}');
+      if (Array.isArray(data.contexts)) return data.contexts;
+      if (Array.isArray(data.checks)) return data.checks.map((c) => c.context);
+      return [];
+    } catch (error) {
+      const auth = classifyAuthError(error);
+      if (auth) {
+        // Unreadable protection (auth/scope/not-protected) — caller escalates.
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Read ahead/behind divergence against the base ref.
+   *
+   * @param {{ baseRef: string, cwd?: string }} ctx
+   * @returns {Promise<{ behind: number, ahead: number }>}
+   */
+  async readDivergence({ baseRef }) {
+    const out = this._git('git', ['rev-list', '--left-right', '--count', `${baseRef}...HEAD`]);
+    const [behindRaw = '0', aheadRaw = '0'] = String(out).trim().split(/\s+/);
+    return {
+      behind: Number.parseInt(behindRaw, 10) || 0,
+      ahead: Number.parseInt(aheadRaw, 10) || 0,
+    };
+  }
+
+  /**
+   * Re-run failed CI for a workflow run (Tier-A: idempotent, reversible).
+   *
+   * @param {{ runId: string }} ctx
+   * @returns {Promise<void>}
+   */
+  async rerunFailedChecks({ runId }) {
+    this._gh('gh', ['run', 'rerun', String(runId), '--failed']);
+  }
+
+  /**
+   * Post a status reply to a review thread via the existing shell helper.
+   * Reply ONLY — never resolve (resolution is the semantic `/review` agent's job).
+   *
+   * @param {{ pr: string, commentId: string, message: string, script?: string }} ctx
+   * @returns {Promise<void>}
+   */
+  async replyToThread({ pr, commentId, message, script }) {
+    const scriptPath = script || '.claude/scripts/greptile-resolve.sh';
+    this._gh('bash', [scriptPath, 'reply', String(pr), String(commentId), String(message)]);
+  }
+}
+
+module.exports = {
+  PrStateAdapter,
+  classifyAuthError,
+  PR_VIEW_FIELDS,
+};

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -176,6 +176,36 @@ class PrStateAdapter {
     const scriptPath = script || '.claude/scripts/greptile-resolve.sh';
     this._gh('bash', [scriptPath, 'reply', String(pr), String(commentId), String(message)]);
   }
+
+  /**
+   * Read review threads as actionable comments. Uses GraphQL because
+   * `gh pr view --json reviewThreads` is unsupported. Resolved/outdated threads
+   * are returned WITH flags so the core can filter them (and exclude bots/self).
+   *
+   * @param {{ owner: string, repo: string, pr: string }} ctx
+   * @returns {Promise<object[]>}
+   */
+  async readComments({ owner, repo, pr }) {
+    const query = 'query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:1){nodes{author{login} body}}}}}}}';
+    const raw = this._gh('gh', [
+      'api', 'graphql', '-f', `query=${query}`,
+      '-F', `o=${owner}`, '-F', `n=${repo}`, '-F', `pr=${pr}`,
+    ]);
+    const data = JSON.parse(raw || '{}');
+    const nodes = (data.data && data.data.repository
+      && data.data.repository.pullRequest
+      && data.data.repository.pullRequest.reviewThreads
+      && data.data.repository.pullRequest.reviewThreads.nodes) || [];
+    return nodes.map((t) => {
+      const first = (t.comments && t.comments.nodes && t.comments.nodes[0]) || {};
+      return {
+        isResolved: !!t.isResolved,
+        isOutdated: !!t.isOutdated,
+        author: (first.author && first.author.login) || '',
+        body: first.body || '',
+      };
+    });
+  }
 }
 
 module.exports = {

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -114,7 +114,7 @@ class PrStateAdapter {
    * @returns {Promise<string[] | null>}
    */
   async readRequiredChecks({ owner, repo, base }) {
-    const apiPath = `repos/${owner}/${repo}/branches/${base}/protection/required_status_checks`;
+    const apiPath = `repos/${owner}/${repo}/branches/${encodeURIComponent(base)}/protection/required_status_checks`;
     try {
       const raw = this._gh('gh', ['api', apiPath]);
       const data = JSON.parse(raw || '{}');
@@ -186,7 +186,7 @@ class PrStateAdapter {
    * @returns {Promise<object[]>}
    */
   async readComments({ owner, repo, pr }) {
-    const query = 'query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:1){nodes{author{login} body}}}}}}}';
+    const query = 'query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewThreads(first:100){nodes{isResolved isOutdated comments(first:20){nodes{author{login} body}}}}}}}';
     const raw = this._gh('gh', [
       'api', 'graphql', '-f', `query=${query}`,
       '-F', `o=${owner}`, '-F', `n=${repo}`, '-F', `pr=${pr}`,
@@ -197,12 +197,14 @@ class PrStateAdapter {
       && data.data.repository.pullRequest.reviewThreads
       && data.data.repository.pullRequest.reviewThreads.nodes) || [];
     return nodes.map((t) => {
-      const first = (t.comments && t.comments.nodes && t.comments.nodes[0]) || {};
+      const allComments = (t.comments && t.comments.nodes) || [];
       return {
         isResolved: !!t.isResolved,
         isOutdated: !!t.isOutdated,
-        author: (first.author && first.author.login) || '',
-        body: first.body || '',
+        comments: allComments.map(c => ({
+          author: (c.author && c.author.login) || '',
+          body: c.body || '',
+        })),
       };
     });
   }

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -23,17 +23,27 @@ const { validatePrStateAdapter } = require('../pr-state-validator');
 const DEFAULT_RERUN_BUDGET = 3;
 
 /**
- * Resolve owner/repo and base branch for the current checkout using `gh`/`git`.
+ * Resolve owner/repo and base branch for the shepherd pass.
+ *
+ * The base branch is read from the PR itself (`gh pr view <pr> --json
+ * baseRefName`) rather than the current checkout's default branch, so PRs
+ * targeting `release/*`/`develop` are evaluated against the correct branch.
+ * `owner`/`name` come from the repository the PR is queried in — that IS the
+ * base repository. `cwd` (the worktree root) is threaded through so divergence
+ * is computed against the right checkout.
  *
  * @param {object} deps
- * @returns {Promise<{ owner: string, repo: string, base: string, baseRef: string }>}
+ * @returns {Promise<{ pr: string, owner: string, repo: string, base: string, baseRef: string, cwd?: string }>}
  */
-async function defaultBuildContext({ pr, gh, git }) {
-  const repoJson = gh('gh', ['repo', 'view', '--json', 'owner,name,defaultBranchRef']);
+async function defaultBuildContext({ pr, gh, git, projectRoot }) {
+  const prJson = gh('gh', ['pr', 'view', String(pr), '--json', 'baseRefName']);
+  const prInfo = JSON.parse(prJson || '{}');
+  const base = prInfo.baseRefName || 'master';
+
+  const repoJson = gh('gh', ['repo', 'view', '--json', 'owner,name']);
   const repo = JSON.parse(repoJson || '{}');
-  const owner = repo.owner && repo.owner.login ? repo.owner.login : '';
+  const owner = repo.owner?.login || '';
   const name = repo.name || '';
-  const base = (repo.defaultBranchRef && repo.defaultBranchRef.name) || 'master';
 
   let baseRemote;
   try {
@@ -42,7 +52,14 @@ async function defaultBuildContext({ pr, gh, git }) {
     baseRemote = 'origin';
   }
 
-  return { pr: String(pr), owner, repo: name, base, baseRef: `${baseRemote}/${base}` };
+  return {
+    pr: String(pr),
+    owner,
+    repo: name,
+    base,
+    baseRef: `${baseRemote}/${base}`,
+    ...(projectRoot ? { cwd: projectRoot } : {}),
+  };
 }
 
 /**

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * shepherd command — one bounded monitor pass over a pull request.
+ *
+ * `forge shepherd <pr> [--auto-rebase]` reads PR/CI state, takes at most one
+ * idempotent Tier-A action (rerun a flaky required check), and exits with a
+ * terminal state. It NEVER merges and NEVER resolves review threads. A
+ * `--watch` loop, if desired, lives in an external scheduler that re-invokes
+ * this command on an interval — there is no in-process polling loop here.
+ *
+ * State persists via GitHub PR comments/labels and git only.
+ *
+ * @module commands/shepherd
+ */
+
+const { execFileSync } = require('node:child_process');
+
+const { runShepherdPass } = require('../pr-shepherd');
+const { PrStateAdapter } = require('../adapters/pr-state-adapter');
+const { validatePrStateAdapter } = require('../pr-state-validator');
+
+const DEFAULT_RERUN_BUDGET = 3;
+
+/**
+ * Resolve owner/repo and base branch for the current checkout using `gh`/`git`.
+ *
+ * @param {object} deps
+ * @returns {Promise<{ owner: string, repo: string, base: string, baseRef: string }>}
+ */
+async function defaultBuildContext({ pr, gh, git }) {
+  const repoJson = gh('gh', ['repo', 'view', '--json', 'owner,name,defaultBranchRef']);
+  const repo = JSON.parse(repoJson || '{}');
+  const owner = repo.owner && repo.owner.login ? repo.owner.login : '';
+  const name = repo.name || '';
+  const base = (repo.defaultBranchRef && repo.defaultBranchRef.name) || 'master';
+
+  let baseRemote;
+  try {
+    baseRemote = git('git', ['remote']).split(/\s+/).filter(Boolean)[0] || 'origin';
+  } catch (_err) {
+    baseRemote = 'origin';
+  }
+
+  return { pr: String(pr), owner, repo: name, base, baseRef: `${baseRemote}/${base}` };
+}
+
+/**
+ * Detect whether the working tree is clean (precondition for --auto-rebase).
+ *
+ * @param {Function} git
+ * @returns {boolean}
+ */
+function isWorkingTreeClean(git) {
+  try {
+    return git('git', ['status', '--porcelain']).trim().length === 0;
+  } catch (_err) {
+    return false;
+  }
+}
+
+/**
+ * Command handler.
+ *
+ * @param {string[]} args - Positional + flag args (first positional is the PR).
+ * @param {object} _flags - Parsed flags (unused; flags are read from args).
+ * @param {string} projectRoot - Project root.
+ * @param {object} [deps] - Injected dependencies for testing.
+ * @returns {Promise<object>} result envelope.
+ */
+async function handler(args, _flags, projectRoot, deps = {}) {
+  const positional = (args || []).filter((a) => !String(a).startsWith('--'));
+  const flags = new Set((args || []).filter((a) => String(a).startsWith('--')));
+  const pr = positional[0];
+
+  if (!pr) {
+    return { success: false, error: 'Usage: forge shepherd <pr> [--auto-rebase]' };
+  }
+
+  const gh = deps.gh || ((cmd, a) => execFileSync(cmd, a, { encoding: 'utf8', timeout: 30000 }));
+  const git = deps.git || gh;
+  const buildContext = deps.buildContext || defaultBuildContext;
+  const runPass = deps.runPass || runShepherdPass;
+
+  const autoRebase = flags.has('--auto-rebase');
+
+  const ctx = await buildContext({ pr, gh, git, projectRoot });
+
+  const adapter = deps.adapter || new PrStateAdapter({ gh, git });
+  const validation = validatePrStateAdapter(adapter);
+  if (!validation.valid) {
+    return { success: false, error: `Invalid pr-state adapter: ${validation.errors.join('; ')}` };
+  }
+
+  const result = await runPass({
+    ...ctx,
+    adapter,
+    autoRebase,
+    cleanTree: autoRebase ? isWorkingTreeClean(git) : false,
+    rerunBudget: deps.rerunBudget || DEFAULT_RERUN_BUDGET,
+    rerunsUsed: deps.rerunsUsed || 0,
+  });
+
+  return {
+    success: result.state !== 'HARD_STOP',
+    state: result.state,
+    reason: result.reason,
+    actions: result.actions || [],
+    ...(result.authClass ? { authClass: result.authClass } : {}),
+    ...(result.retryAfter ? { retryAfter: result.retryAfter } : {}),
+  };
+}
+
+module.exports = {
+  name: 'shepherd',
+  description: 'Run one bounded monitor pass over a PR (rerun flaky checks, escalate, hand off — never merges)',
+  usage: 'Usage: forge shepherd <pr> [--auto-rebase]',
+  handler,
+  defaultBuildContext,
+  isWorkingTreeClean,
+};

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -21,7 +21,7 @@ const CAPABILITY_IDS = [
 ];
 
 const STAGE_IDS = [...WORKFLOW_STAGE_IDS];
-const UTILITY_SKILL_IDS = ['status'];
+const UTILITY_SKILL_IDS = ['status', 'shepherd'];
 
 const SOURCE_ROWS = [
   ['S1', 'Claude Code skills', 'https://code.claude.com/docs/en/skills', 'Claude Code skills use SKILL.md frontmatter descriptions for automatic invocation; commands remain compatible but skills are recommended.'],
@@ -169,6 +169,7 @@ function buildHarnessCapabilityMatrix() {
 
 const STAGE_SUBSKILLS = {
   status: ['status.context_scan', 'status.issue_scan', 'status.git_scan'],
+  shepherd: ['shepherd.poll', 'shepherd.rerun', 'shepherd.escalate'],
   plan: ['plan.intent_capture', 'plan.parallel_research', 'plan.parallel_critics', 'plan.synthesis', 'plan.final_lock'],
   dev: ['dev.red', 'dev.green', 'dev.refactor', 'dev.spec_review', 'dev.quality_review'],
   validate: ['validate.typecheck', 'validate.lint', 'validate.tests', 'validate.security', 'validate.context'],

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -55,6 +55,150 @@ function result(state, extra = {}) {
 }
 
 /**
+ * Map a classified auth error to a decision envelope, or return `null` when the
+ * error is not an auth/rate-limit shape (caller should re-throw).
+ *
+ * @param {Error} error
+ * @param {object[]} actions
+ * @returns {object | null}
+ */
+function authOutcome(error, actions) {
+  const auth = classifyAuthError(error);
+  if (!auth) return null;
+  if (auth.class === 'insufficient-scope') {
+    return result('HARD_STOP', {
+      actions,
+      authClass: 'insufficient-scope',
+      reason: 'Token lacks the permission required (branch protection / PR state). Retry will not recover; escalate to a human to widen the token scope.',
+    });
+  }
+  if (auth.class === 'rate-limit') {
+    return result('PENDING', {
+      actions,
+      authClass: 'rate-limit',
+      retryAfter: auth.retryAfter,
+      reason: 'Secondary rate limit hit; honor Retry-After then resume on the next pass.',
+    });
+  }
+  // 'expired' (401) — transient: pause and surface for re-auth.
+  return result('PENDING', {
+    actions,
+    authClass: 'expired',
+    reason: 'Token appears expired/unauthorized (transient); pause and surface for re-auth.',
+  });
+}
+
+/**
+ * Run an adapter call, mapping auth/rate-limit failures to a decision envelope
+ * via the documented taxonomy instead of letting them escape as generic errors.
+ * Non-auth errors are re-thrown.
+ *
+ * Returns `{ outcome }` when the call should short-circuit the pass, or
+ * `{ value }` with the call's resolved value otherwise.
+ *
+ * @param {() => Promise<*>} call
+ * @param {object[]} actions
+ * @returns {Promise<{ outcome: object } | { value: * }>}
+ */
+async function guardAuth(call, actions) {
+  try {
+    return { value: await call() };
+  } catch (error) {
+    const outcome = authOutcome(error, actions);
+    if (outcome) return { outcome };
+    throw error;
+  }
+}
+
+/**
+ * Handle a failed required check: rerun once (capped, idempotent) or escalate.
+ *
+ * @param {object} args
+ * @returns {Promise<object>} decision envelope.
+ */
+async function handleFailedRequired({
+  failedRequired, rerunsUsed, rerunBudget, headUnchanged, adapter, actions,
+}) {
+  if (rerunsUsed >= rerunBudget) {
+    return result('ESCALATE', {
+      actions,
+      reason: `Rerun budget exhausted (${rerunsUsed}/${rerunBudget}). Required check still failing — escalating.`,
+      failed: failedRequired.map((c) => c.name),
+    });
+  }
+  if (!(await headUnchanged())) {
+    return result('PENDING', {
+      actions,
+      aborted: true,
+      reason: 'HEAD moved during the pass; aborted the rerun. Next scheduled pass will re-evaluate.',
+    });
+  }
+  const runId = failedRequired[0].databaseId || failedRequired[0].name;
+  await adapter.rerunFailedChecks({ runId });
+  actions.push({ type: 'rerun', runId });
+  return result('PENDING', {
+    actions,
+    reason: `Re-ran failed required check '${failedRequired[0].name}'. Awaiting next scheduled pass.`,
+  });
+}
+
+/**
+ * Handle a branch that is behind base: opt-in Tier-B rebase, or escalate.
+ *
+ * @param {object} args
+ * @returns {Promise<object>} decision envelope.
+ */
+async function handleBehindBase({
+  behind, autoRebase, cleanTree, adapter, baseRef, headUnchanged, actions,
+}) {
+  if (!autoRebase) {
+    return result('ESCALATE', {
+      actions,
+      reason: `Branch is ${behind} commit(s) behind base. Auto-rebase is opt-in (default OFF) — a human should rebase, or re-run with --auto-rebase.`,
+      behind,
+    });
+  }
+  if (!cleanTree) {
+    return result('ESCALATE', {
+      actions,
+      reason: 'Auto-rebase requested but the working tree is not clean. Escalating rather than rebasing over local changes.',
+    });
+  }
+  if (typeof adapter.rebaseOntoBase !== 'function') {
+    return result('ESCALATE', {
+      actions,
+      reason: 'Auto-rebase requested but no rebase capability is wired. Escalating.',
+    });
+  }
+  if (!(await headUnchanged())) {
+    return result('PENDING', {
+      actions,
+      aborted: true,
+      reason: 'HEAD moved during the pass; aborted the rebase. Next scheduled pass will re-evaluate.',
+    });
+  }
+  try {
+    await adapter.rebaseOntoBase({ baseRef });
+    actions.push({ type: 'rebase', baseRef });
+    return result('PENDING', {
+      actions,
+      reason: 'Rebased onto base and force-pushed with lease. Awaiting CI on the next scheduled pass.',
+    });
+  } catch (error) {
+    if (error?.leaseRejected) {
+      return result('ESCALATE', {
+        actions,
+        reason: 'Force-with-lease was rejected — a concurrent push exists. HARD-STOP: never re-arm the lease. A human must reconcile.',
+      });
+    }
+    return result('ESCALATE', {
+      actions,
+      reason: `Rebase failed: ${error.message}. Escalating to a human.`,
+    });
+  }
+}
+
+/**
  * Run a single bounded shepherd pass.
  *
  * @param {object} ctx
@@ -77,6 +221,7 @@ async function runShepherdPass(ctx) {
     repo,
     base,
     baseRef,
+    cwd,
     adapter,
     autoRebase = false,
     cleanTree = false,
@@ -86,39 +231,22 @@ async function runShepherdPass(ctx) {
 
   const actions = [];
 
+  // Every read goes through the auth guard so 401/403-scope/rate-limit map to
+  // the documented PENDING/HARD_STOP states instead of escaping as a generic
+  // failure. Non-auth errors still propagate.
+
   // --- Read required-checks set first; this is where auth/scope fails fast. ---
-  let required;
-  try {
-    required = await adapter.readRequiredChecks({ owner, repo, base });
-  } catch (error) {
-    const auth = classifyAuthError(error);
-    if (auth && auth.class === 'insufficient-scope') {
-      return result('HARD_STOP', {
-        actions,
-        authClass: 'insufficient-scope',
-        reason: 'Token lacks the permission required to read branch protection. Retry will not recover; escalate to a human to widen the token scope.',
-      });
-    }
-    if (auth && auth.class === 'rate-limit') {
-      return result('PENDING', {
-        actions,
-        authClass: 'rate-limit',
-        retryAfter: auth.retryAfter,
-        reason: 'Secondary rate limit hit; honor Retry-After then resume on the next pass.',
-      });
-    }
-    if (auth && auth.class === 'expired') {
-      return result('PENDING', {
-        actions,
-        authClass: 'expired',
-        reason: 'Token appears expired/unauthorized (transient); pause and surface for re-auth.',
-      });
-    }
-    throw error;
-  }
+  const requiredRead = await guardAuth(
+    () => adapter.readRequiredChecks({ owner, repo, base }),
+    actions,
+  );
+  if (requiredRead.outcome) return requiredRead.outcome;
+  const required = requiredRead.value;
 
   // --- Read current PR/CI state. ---
-  const startState = await adapter.readState(pr);
+  const stateRead = await guardAuth(() => adapter.readState(pr), actions);
+  if (stateRead.outcome) return stateRead.outcome;
+  const startState = stateRead.value;
   const startSha = startState.headSha;
 
   // Unreadable required set → escalate, never declare merge-ready.
@@ -130,14 +258,22 @@ async function runShepherdPass(ctx) {
     });
   }
 
-  const divergence = await adapter.readDivergence({ baseRef });
-  const behind = divergence.behind || 0;
+  const divergenceRead = await guardAuth(
+    () => adapter.readDivergence({ baseRef, cwd }),
+    actions,
+  );
+  if (divergenceRead.outcome) return divergenceRead.outcome;
+  const behind = divergenceRead.value.behind || 0;
 
   const requiredChecks = startState.checks.filter((c) => required.includes(c.name));
   const failedRequired = requiredChecks.filter(isFailed);
-  const allRequiredGreen = required.length > 0
-    ? requiredChecks.length >= required.length && requiredChecks.every(isGreen)
-    : startState.checks.length > 0 && startState.checks.every(isGreen);
+  // Merge-readiness is evaluated against the REQUIRED set only. An empty
+  // required set is ready by definition — optional checks (red or pending)
+  // never gate merge readiness, and a PR with zero required checks is never
+  // stuck PENDING waiting for checks that will never run.
+  const allRequiredGreen = required.every((name) => (
+    startState.checks.some((check) => check.name === name && isGreen(check))
+  ));
 
   // Helper: re-read HEAD immediately before a mutating action. If HEAD moved
   // since the pass started, abort (concurrency guard).
@@ -156,76 +292,16 @@ async function runShepherdPass(ctx) {
 
   // --- Tier-A: flaky required check → rerun (capped, idempotent). ---
   if (failedRequired.length > 0) {
-    if (rerunsUsed >= rerunBudget) {
-      return result('ESCALATE', {
-        actions,
-        reason: `Rerun budget exhausted (${rerunsUsed}/${rerunBudget}). Required check still failing — escalating.`,
-        failed: failedRequired.map((c) => c.name),
-      });
-    }
-    if (!(await headUnchanged())) {
-      return result('PENDING', {
-        actions,
-        aborted: true,
-        reason: 'HEAD moved during the pass; aborted the rerun. Next scheduled pass will re-evaluate.',
-      });
-    }
-    const runId = failedRequired[0].databaseId || failedRequired[0].name;
-    await adapter.rerunFailedChecks({ runId });
-    actions.push({ type: 'rerun', runId });
-    return result('PENDING', {
-      actions,
-      reason: `Re-ran failed required check '${failedRequired[0].name}'. Awaiting next scheduled pass.`,
+    return handleFailedRequired({
+      failedRequired, rerunsUsed, rerunBudget, headUnchanged, adapter, actions,
     });
   }
 
-  // --- Behind base. ---
+  // --- Behind base (Tier-B opt-in rebase, else escalate). ---
   if (behind > 0) {
-    if (!autoRebase) {
-      return result('ESCALATE', {
-        actions,
-        reason: `Branch is ${behind} commit(s) behind base. Auto-rebase is opt-in (default OFF) — a human should rebase, or re-run with --auto-rebase.`,
-        behind,
-      });
-    }
-    if (!cleanTree) {
-      return result('ESCALATE', {
-        actions,
-        reason: 'Auto-rebase requested but the working tree is not clean. Escalating rather than rebasing over local changes.',
-      });
-    }
-    if (typeof adapter.rebaseOntoBase !== 'function') {
-      return result('ESCALATE', {
-        actions,
-        reason: 'Auto-rebase requested but no rebase capability is wired. Escalating.',
-      });
-    }
-    if (!(await headUnchanged())) {
-      return result('PENDING', {
-        actions,
-        aborted: true,
-        reason: 'HEAD moved during the pass; aborted the rebase. Next scheduled pass will re-evaluate.',
-      });
-    }
-    try {
-      await adapter.rebaseOntoBase({ baseRef });
-      actions.push({ type: 'rebase', baseRef });
-      return result('PENDING', {
-        actions,
-        reason: 'Rebased onto base and force-pushed with lease. Awaiting CI on the next scheduled pass.',
-      });
-    } catch (error) {
-      if (error && error.leaseRejected) {
-        return result('ESCALATE', {
-          actions,
-          reason: 'Force-with-lease was rejected — a concurrent push exists. HARD-STOP: never re-arm the lease. A human must reconcile.',
-        });
-      }
-      return result('ESCALATE', {
-        actions,
-        reason: `Rebase failed: ${error.message}. Escalating to a human.`,
-      });
-    }
+    return handleBehindBase({
+      behind, autoRebase, cleanTree, adapter, baseRef, headUnchanged, actions,
+    });
   }
 
   // --- Terminal: all required green + not behind → merge-ready handoff. ---

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -30,7 +30,43 @@
 const { classifyAuthError } = require('./adapters/pr-state-adapter');
 
 /** Non-erroring terminal states a pass can settle into. */
-const TERMINAL_STATES = ['MERGE_READY', 'ESCALATE', 'PENDING', 'MERGED', 'CLOSED'];
+const TERMINAL_STATES = ['MERGE_READY', 'ESCALATE', 'PENDING', 'MERGED', 'CLOSED', 'NEEDS_REVIEW'];
+
+/** Bot/automation logins whose comments are not human review feedback. */
+const BOT_LOGINS = new Set([
+  'coderabbitai', 'coderabbitai[bot]', 'sonarqubecloud', 'sonarqubecloud[bot]',
+  'github-actions', 'github-actions[bot]', 'qodo-merge-pro', 'qodo-merge-pro[bot]',
+  'codecov', 'codecov[bot]', 'greptile-apps', 'greptile-apps[bot]',
+  'dependabot', 'dependabot[bot]',
+]);
+
+function commentAuthor(c) {
+  return String(
+    c.author || c.login || (c.comments && c.comments[0] && c.comments[0].author) || '',
+  ).toLowerCase();
+}
+
+function commentBody(c) {
+  return String(c.body || (c.comments && c.comments[0] && c.comments[0].body) || '');
+}
+
+/**
+ * Filter a comment/thread list to the ones that genuinely need human/semantic
+ * attention: unresolved, not outdated, and not authored by a bot or by self.
+ *
+ * @param {object[]} comments
+ * @param {string} [self] - the shepherd's own login (excluded to avoid self-wake).
+ * @returns {object[]}
+ */
+function actionableComments(comments, self) {
+  const selfLogin = String(self || '').toLowerCase();
+  return (Array.isArray(comments) ? comments : []).filter((c) => {
+    if (c.resolved || c.isResolved || c.outdated || c.isOutdated) return false;
+    const author = commentAuthor(c);
+    if (!author || author === selfLogin) return false;
+    return !BOT_LOGINS.has(author);
+  });
+}
 
 const SUCCESS_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
 
@@ -319,6 +355,34 @@ async function runShepherdPass(ctx) {
     return handleBehindBase({
       behind, autoRebase, cleanTree, adapter, baseRef, headUnchanged, actions,
     });
+  }
+
+  // --- Review feedback: new actionable comments need the semantic /review
+  // agent or a human. The shepherd DETECTS and hands off — it NEVER resolves
+  // threads. Flood-capped so "too many comments" can't blow up a single pass. ---
+  if (typeof adapter.readComments === 'function') {
+    const commentsRead = await guardAuth(
+      () => adapter.readComments({ owner, repo, pr }),
+      actions,
+    );
+    if (commentsRead.outcome) return commentsRead.outcome;
+    const actionable = actionableComments(commentsRead.value, ctx.self);
+    if (actionable.length > 0) {
+      const CAP = 20;
+      const capped = actionable.length > CAP;
+      return result('NEEDS_REVIEW', {
+        actions,
+        commentCount: actionable.length,
+        capped,
+        sample: actionable.slice(0, CAP).map((c) => ({
+          author: commentAuthor(c),
+          body: commentBody(c).slice(0, 200),
+        })),
+        reason: capped
+          ? `${actionable.length} unresolved review comments (showing the first ${CAP}). Too many to act on in one pass — handing off to /review. The shepherd never resolves threads.`
+          : `${actionable.length} unresolved review comment(s) need attention — handing off to /review. The shepherd never resolves threads.`,
+      });
+    }
   }
 
   // --- Terminal: all required green + not behind → merge-ready handoff. ---

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -30,7 +30,7 @@
 const { classifyAuthError } = require('./adapters/pr-state-adapter');
 
 /** Non-erroring terminal states a pass can settle into. */
-const TERMINAL_STATES = ['MERGE_READY', 'ESCALATE', 'PENDING'];
+const TERMINAL_STATES = ['MERGE_READY', 'ESCALATE', 'PENDING', 'MERGED', 'CLOSED'];
 
 const SUCCESS_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
 
@@ -248,6 +248,23 @@ async function runShepherdPass(ctx) {
   if (stateRead.outcome) return stateRead.outcome;
   const startState = stateRead.value;
   const startSha = startState.headSha;
+
+  // --- Lifecycle: a merged/closed PR is terminal. The external scheduler must
+  // stop re-invoking the shepherd once the PR lands or is closed; without this
+  // it would keep re-deciding MERGE_READY forever on an already-merged PR. ---
+  const prState = String(startState.state || 'OPEN').toUpperCase();
+  if (prState === 'MERGED') {
+    return result('MERGED', {
+      actions,
+      reason: 'PR is merged — shepherd work is complete; the scheduler should stop re-invoking this PR.',
+    });
+  }
+  if (prState === 'CLOSED') {
+    return result('CLOSED', {
+      actions,
+      reason: 'PR is closed without merging — shepherd work is complete; the scheduler should stop re-invoking this PR.',
+    });
+  }
 
   // Unreadable required set → escalate, never declare merge-ready.
   if (required === null) {

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -1,0 +1,251 @@
+'use strict';
+
+/**
+ * PR shepherd — one bounded pass of the monitor-driven state machine.
+ *
+ * Each `runShepherdPass` call is ONE discrete pass: read PR/CI state, decide a
+ * single action, take at most the allowed Tier-A action, then return. It never
+ * loops in-process and never sits waiting; an external scheduler re-invokes it.
+ *
+ * Invariants (enforced by tests):
+ *   - NEVER merges. There is no merge action and no `--auto` latch — handoff to
+ *     the human is the only way a PR merges.
+ *   - NEVER resolves Greptile threads. It may post a status REPLY; resolution
+ *     stays with the semantic `/review` agent.
+ *   - Tier-A (autonomous): `rerun --failed` for flaky required checks (capped).
+ *   - Tier-B (opt-in, default OFF): rebase + force-with-lease via `autoRebase`.
+ *     Lease rejection is a HARD-STOP + escalate, never auto-retry.
+ *   - Tier-C (escalate): conflicts, unknown/unreadable required set, persistent
+ *     failures, auth-scope failures, oscillation, budget exhaustion.
+ *   - Merge-ready is declared only when the required set is KNOWN and all of it
+ *     is green and the branch is not behind.
+ *   - Before any mutating action, HEAD SHA is re-read; if it moved since the
+ *     pass started, the action is aborted (the real concurrency guard).
+ *
+ * State persists via GitHub PR comments/labels and git only.
+ *
+ * @module pr-shepherd
+ */
+
+const { classifyAuthError } = require('./adapters/pr-state-adapter');
+
+/** Non-erroring terminal states a pass can settle into. */
+const TERMINAL_STATES = ['MERGE_READY', 'ESCALATE', 'PENDING'];
+
+const SUCCESS_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
+
+function isGreen(check) {
+  const c = String(check.conclusion || '').toUpperCase();
+  return SUCCESS_CONCLUSIONS.has(c);
+}
+
+function isFailed(check) {
+  const c = String(check.conclusion || '').toUpperCase();
+  return c === 'FAILURE' || c === 'TIMED_OUT' || c === 'CANCELLED' || c === 'ACTION_REQUIRED';
+}
+
+/**
+ * Build a decision result envelope.
+ *
+ * @param {string} state
+ * @param {object} extra
+ */
+function result(state, extra = {}) {
+  return { state, actions: extra.actions || [], reason: extra.reason || '', ...extra };
+}
+
+/**
+ * Run a single bounded shepherd pass.
+ *
+ * @param {object} ctx
+ * @param {string} ctx.pr - PR number.
+ * @param {string} ctx.owner
+ * @param {string} ctx.repo
+ * @param {string} ctx.base - Base branch name (for protection lookup).
+ * @param {string} ctx.baseRef - Base ref for divergence (e.g. `origin/master`).
+ * @param {object} ctx.adapter - A validated pr-state adapter.
+ * @param {boolean} [ctx.autoRebase=false] - Opt-in Tier-B rebase.
+ * @param {boolean} [ctx.cleanTree=false] - Precondition for rebase.
+ * @param {number} [ctx.rerunBudget=3] - Max reruns across the shepherd session.
+ * @param {number} [ctx.rerunsUsed=0] - Reruns already spent.
+ * @returns {Promise<object>} decision envelope.
+ */
+async function runShepherdPass(ctx) {
+  const {
+    pr,
+    owner,
+    repo,
+    base,
+    baseRef,
+    adapter,
+    autoRebase = false,
+    cleanTree = false,
+    rerunBudget = 3,
+    rerunsUsed = 0,
+  } = ctx;
+
+  const actions = [];
+
+  // --- Read required-checks set first; this is where auth/scope fails fast. ---
+  let required;
+  try {
+    required = await adapter.readRequiredChecks({ owner, repo, base });
+  } catch (error) {
+    const auth = classifyAuthError(error);
+    if (auth && auth.class === 'insufficient-scope') {
+      return result('HARD_STOP', {
+        actions,
+        authClass: 'insufficient-scope',
+        reason: 'Token lacks the permission required to read branch protection. Retry will not recover; escalate to a human to widen the token scope.',
+      });
+    }
+    if (auth && auth.class === 'rate-limit') {
+      return result('PENDING', {
+        actions,
+        authClass: 'rate-limit',
+        retryAfter: auth.retryAfter,
+        reason: 'Secondary rate limit hit; honor Retry-After then resume on the next pass.',
+      });
+    }
+    if (auth && auth.class === 'expired') {
+      return result('PENDING', {
+        actions,
+        authClass: 'expired',
+        reason: 'Token appears expired/unauthorized (transient); pause and surface for re-auth.',
+      });
+    }
+    throw error;
+  }
+
+  // --- Read current PR/CI state. ---
+  const startState = await adapter.readState(pr);
+  const startSha = startState.headSha;
+
+  // Unreadable required set → escalate, never declare merge-ready.
+  if (required === null) {
+    return result('ESCALATE', {
+      actions,
+      reason: 'Required-check set is unreadable (branch protection not accessible). Cannot determine merge readiness — escalating with the readable rollup.',
+      rollup: startState.checks,
+    });
+  }
+
+  const divergence = await adapter.readDivergence({ baseRef });
+  const behind = divergence.behind || 0;
+
+  const requiredChecks = startState.checks.filter((c) => required.includes(c.name));
+  const failedRequired = requiredChecks.filter(isFailed);
+  const allRequiredGreen = required.length > 0
+    ? requiredChecks.length >= required.length && requiredChecks.every(isGreen)
+    : startState.checks.length > 0 && startState.checks.every(isGreen);
+
+  // Helper: re-read HEAD immediately before a mutating action. If HEAD moved
+  // since the pass started, abort (concurrency guard).
+  const headUnchanged = async () => {
+    const now = await adapter.readState(pr);
+    return now.headSha === startSha;
+  };
+
+  // --- Tier-C: hard conflict. ---
+  if (String(startState.mergeStateStatus).toUpperCase() === 'DIRTY') {
+    return result('ESCALATE', {
+      actions,
+      reason: 'Merge conflict (mergeStateStatus=DIRTY). A human must resolve the conflict.',
+    });
+  }
+
+  // --- Tier-A: flaky required check → rerun (capped, idempotent). ---
+  if (failedRequired.length > 0) {
+    if (rerunsUsed >= rerunBudget) {
+      return result('ESCALATE', {
+        actions,
+        reason: `Rerun budget exhausted (${rerunsUsed}/${rerunBudget}). Required check still failing — escalating.`,
+        failed: failedRequired.map((c) => c.name),
+      });
+    }
+    if (!(await headUnchanged())) {
+      return result('PENDING', {
+        actions,
+        aborted: true,
+        reason: 'HEAD moved during the pass; aborted the rerun. Next scheduled pass will re-evaluate.',
+      });
+    }
+    const runId = failedRequired[0].databaseId || failedRequired[0].name;
+    await adapter.rerunFailedChecks({ runId });
+    actions.push({ type: 'rerun', runId });
+    return result('PENDING', {
+      actions,
+      reason: `Re-ran failed required check '${failedRequired[0].name}'. Awaiting next scheduled pass.`,
+    });
+  }
+
+  // --- Behind base. ---
+  if (behind > 0) {
+    if (!autoRebase) {
+      return result('ESCALATE', {
+        actions,
+        reason: `Branch is ${behind} commit(s) behind base. Auto-rebase is opt-in (default OFF) — a human should rebase, or re-run with --auto-rebase.`,
+        behind,
+      });
+    }
+    if (!cleanTree) {
+      return result('ESCALATE', {
+        actions,
+        reason: 'Auto-rebase requested but the working tree is not clean. Escalating rather than rebasing over local changes.',
+      });
+    }
+    if (typeof adapter.rebaseOntoBase !== 'function') {
+      return result('ESCALATE', {
+        actions,
+        reason: 'Auto-rebase requested but no rebase capability is wired. Escalating.',
+      });
+    }
+    if (!(await headUnchanged())) {
+      return result('PENDING', {
+        actions,
+        aborted: true,
+        reason: 'HEAD moved during the pass; aborted the rebase. Next scheduled pass will re-evaluate.',
+      });
+    }
+    try {
+      await adapter.rebaseOntoBase({ baseRef });
+      actions.push({ type: 'rebase', baseRef });
+      return result('PENDING', {
+        actions,
+        reason: 'Rebased onto base and force-pushed with lease. Awaiting CI on the next scheduled pass.',
+      });
+    } catch (error) {
+      if (error && error.leaseRejected) {
+        return result('ESCALATE', {
+          actions,
+          reason: 'Force-with-lease was rejected — a concurrent push exists. HARD-STOP: never re-arm the lease. A human must reconcile.',
+        });
+      }
+      return result('ESCALATE', {
+        actions,
+        reason: `Rebase failed: ${error.message}. Escalating to a human.`,
+      });
+    }
+  }
+
+  // --- Terminal: all required green + not behind → merge-ready handoff. ---
+  if (allRequiredGreen) {
+    return result('MERGE_READY', {
+      actions,
+      reason: 'All required checks are green and the branch is up to date. Handing off to the human to merge in the GitHub UI — the shepherd never merges.',
+    });
+  }
+
+  // --- Otherwise: checks still pending/unknown → wait. ---
+  return result('PENDING', {
+    actions,
+    reason: 'Required checks are not all green yet (still pending) and nothing is actionable this pass. Awaiting the next scheduled pass.',
+  });
+}
+
+module.exports = {
+  runShepherdPass,
+  TERMINAL_STATES,
+  isGreen,
+  isFailed,
+};

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -40,31 +40,40 @@ const BOT_LOGINS = new Set([
   'dependabot', 'dependabot[bot]',
 ]);
 
-function commentAuthor(c) {
-  return String(
-    c.author || c.login || (c.comments && c.comments[0] && c.comments[0].author) || '',
-  ).toLowerCase();
+/**
+ * Normalize a review thread (or a flat comment object) into its list of
+ * `{ author, body }` comments. A thread carries ALL its comments, so a later
+ * human reply on a bot-opened thread is visible (not just the first comment).
+ */
+function threadComments(t) {
+  if (Array.isArray(t.comments) && t.comments.length > 0) {
+    return t.comments.map((c) => ({
+      author: String((c.author && c.author.login) || c.author || '').toLowerCase(),
+      body: String(c.body || ''),
+    }));
+  }
+  return [{ author: String(t.author || t.login || '').toLowerCase(), body: String(t.body || '') }];
 }
 
-function commentBody(c) {
-  return String(c.body || (c.comments && c.comments[0] && c.comments[0].body) || '');
+function isHumanAuthor(author, self) {
+  const a = String(author || '').toLowerCase();
+  return Boolean(a) && a !== String(self || '').toLowerCase() && !BOT_LOGINS.has(a);
 }
 
 /**
- * Filter a comment/thread list to the ones that genuinely need human/semantic
- * attention: unresolved, not outdated, and not authored by a bot or by self.
+ * Filter review threads to the ones that need human/semantic attention:
+ * unresolved, not outdated, and with at least one comment from a non-bot,
+ * non-self participant. Inspecting ALL comments (not just the first) means a
+ * bot-opened thread with a later human reply is still treated as actionable.
  *
- * @param {object[]} comments
+ * @param {object[]} threads
  * @param {string} [self] - the shepherd's own login (excluded to avoid self-wake).
  * @returns {object[]}
  */
-function actionableComments(comments, self) {
-  const selfLogin = String(self || '').toLowerCase();
-  return (Array.isArray(comments) ? comments : []).filter((c) => {
-    if (c.resolved || c.isResolved || c.outdated || c.isOutdated) return false;
-    const author = commentAuthor(c);
-    if (!author || author === selfLogin) return false;
-    return !BOT_LOGINS.has(author);
+function actionableComments(threads, self) {
+  return (Array.isArray(threads) ? threads : []).filter((t) => {
+    if (t.resolved || t.isResolved || t.outdated || t.isOutdated) return false;
+    return threadComments(t).some((c) => isHumanAuthor(c.author, self));
   });
 }
 
@@ -271,15 +280,10 @@ async function runShepherdPass(ctx) {
   // the documented PENDING/HARD_STOP states instead of escaping as a generic
   // failure. Non-auth errors still propagate.
 
-  // --- Read required-checks set first; this is where auth/scope fails fast. ---
-  const requiredRead = await guardAuth(
-    () => adapter.readRequiredChecks({ owner, repo, base }),
-    actions,
-  );
-  if (requiredRead.outcome) return requiredRead.outcome;
-  const required = requiredRead.value;
-
-  // --- Read current PR/CI state. ---
+  // --- Read PR/CI state FIRST so a merged/closed PR is detected as terminal
+  // even when the branch-protection (required-checks) read would fail with an
+  // auth/scope error — the scheduler must always get the terminal signal for a
+  // landed/closed PR. ---
   const stateRead = await guardAuth(() => adapter.readState(pr), actions);
   if (stateRead.outcome) return stateRead.outcome;
   const startState = stateRead.value;
@@ -301,6 +305,15 @@ async function runShepherdPass(ctx) {
       reason: 'PR is closed without merging — shepherd work is complete; the scheduler should stop re-invoking this PR.',
     });
   }
+
+  // --- Required-checks set (only matters for non-terminal PRs); this is where
+  // auth/scope fails fast. ---
+  const requiredRead = await guardAuth(
+    () => adapter.readRequiredChecks({ owner, repo, base }),
+    actions,
+  );
+  if (requiredRead.outcome) return requiredRead.outcome;
+  const required = requiredRead.value;
 
   // Unreadable required set → escalate, never declare merge-ready.
   if (required === null) {
@@ -374,10 +387,11 @@ async function runShepherdPass(ctx) {
         actions,
         commentCount: actionable.length,
         capped,
-        sample: actionable.slice(0, CAP).map((c) => ({
-          author: commentAuthor(c),
-          body: commentBody(c).slice(0, 200),
-        })),
+        sample: actionable.slice(0, CAP).map((t) => {
+          const cs = threadComments(t);
+          const human = cs.find((c) => isHumanAuthor(c.author, ctx.self)) || cs[0] || {};
+          return { author: human.author || '', body: String(human.body || '').slice(0, 200) };
+        }),
         reason: capped
           ? `${actionable.length} unresolved review comments (showing the first ${CAP}). Too many to act on in one pass — handing off to /review. The shepherd never resolves threads.`
           : `${actionable.length} unresolved review comment(s) need attention — handing off to /review. The shepherd never resolves threads.`,

--- a/lib/pr-state-validator.js
+++ b/lib/pr-state-validator.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * PR-state adapter contract validator.
+ *
+ * Mirrors the shape of `validateReviewAdapter` in lib/review-adapter.js but
+ * enforces its own `kind: 'pr-state'`. The pr-state adapter is a distinct SPI
+ * from the review adapter — it wraps read-only PR/CI state plus a small set of
+ * idempotent, reversible side-effects (rerun a failed check, post a status
+ * reply). It is never fed to `validateReviewAdapter`.
+ *
+ * State persists via GitHub PR comments/labels and git only.
+ *
+ * @module pr-state-validator
+ */
+
+/** Methods every PR-state adapter must implement. */
+const REQUIRED_PR_STATE_ADAPTER_METHODS = [
+  'readState',
+  'readRequiredChecks',
+  'readDivergence',
+  'rerunFailedChecks',
+  'replyToThread',
+];
+
+/**
+ * Validate that an object satisfies the PR-state adapter contract.
+ *
+ * @param {*} adapter - Candidate adapter.
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validatePrStateAdapter(adapter) {
+  if (!adapter || typeof adapter !== 'object') {
+    return { valid: false, errors: ['adapter must be an object'] };
+  }
+
+  const errors = [];
+
+  if (!adapter.id || typeof adapter.id !== 'string') {
+    errors.push('id must be a non-empty string');
+  }
+
+  if (adapter.kind !== 'pr-state') {
+    errors.push('kind must be "pr-state"');
+  }
+
+  for (const method of REQUIRED_PR_STATE_ADAPTER_METHODS) {
+    if (typeof adapter[method] !== 'function') {
+      errors.push(`${method} must be a function`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+module.exports = {
+  REQUIRED_PR_STATE_ADAPTER_METHODS,
+  validatePrStateAdapter,
+};

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -166,3 +166,17 @@ stays in Hermes' own store.
 If a piece of context only matters to Hermes, it belongs in Hermes-native
 memory. If it is a project fact, decision, or evidence item, write it through
 the Forge CLI so it becomes part of the shared, cited source of truth.
+
+## PR shepherd (external scheduler, not orientation)
+
+The PR shepherd runs **outside** Hermes. An external scheduler invokes
+`forge shepherd <pr>` as discrete bounded passes — each pass reads CI/check
+state, takes at most one idempotent action (re-run a flaky required check), or
+escalates, then exits. It **never merges** (the human merges in the GitHub UI)
+and **never resolves review threads**.
+
+Hermes does not run the shepherd and does not learn shepherd progress through
+`forge orient` (which is deterministic-source orientation with no live PR
+awareness). Shepherd progress is durable on the **PR itself** — its comments and
+labels. When a Hermes session needs PR/CI status, read the PR directly; do not
+expect `orient` to carry it.

--- a/test/commands/shepherd.test.js
+++ b/test/commands/shepherd.test.js
@@ -53,6 +53,45 @@ describe('shepherd command handler', () => {
     expect(out.error).toMatch(/pr/i);
   });
 
+  test('defaultBuildContext derives base from the PR target, not the current checkout', async () => {
+    const ghCalls = [];
+    const gh = (cmd, args) => {
+      ghCalls.push(args.join(' '));
+      if (args.includes('pr') && args.includes('view')) {
+        return JSON.stringify({ baseRefName: 'release/2.0' });
+      }
+      if (args.includes('repo') && args.includes('view')) {
+        return JSON.stringify({ owner: { login: 'acme' }, name: 'widget' });
+      }
+      return '{}';
+    };
+    const git = () => 'origin\n';
+
+    const ctx = await shepherdCmd.defaultBuildContext({ pr: '42', gh, git });
+
+    expect(ctx.base).toBe('release/2.0');
+    expect(ctx.baseRef).toBe('origin/release/2.0');
+    expect(ctx.owner).toBe('acme');
+    expect(ctx.repo).toBe('widget');
+    // It MUST consult the PR, not just `gh repo view` defaultBranchRef.
+    expect(ghCalls.some((c) => c.includes('pr view') && c.includes('42'))).toBe(true);
+  });
+
+  test('defaultBuildContext threads the worktree root through as ctx.cwd', async () => {
+    const gh = (cmd, args) => {
+      if (args.includes('pr') && args.includes('view')) {
+        return JSON.stringify({ baseRefName: 'master' });
+      }
+      return JSON.stringify({ owner: { login: 'o' }, name: 'r' });
+    };
+    const git = () => 'origin\n';
+
+    const ctx = await shepherdCmd.defaultBuildContext({
+      pr: '9', gh, git, projectRoot: '/work/tree',
+    });
+    expect(ctx.cwd).toBe('/work/tree');
+  });
+
   test('MERGE_READY result never carries a merge side-effect', async () => {
     const out = await shepherdCmd.handler(['7'], {}, process.cwd(), {
       runPass: async () => ({ state: 'MERGE_READY', actions: [], reason: 'ready' }),

--- a/test/commands/shepherd.test.js
+++ b/test/commands/shepherd.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const shepherdCmd = require('../../lib/commands/shepherd');
+const { validateCommand } = require('../../lib/commands/_registry');
+
+describe('shepherd command handler', () => {
+  test('satisfies the _registry { name, description, handler } contract', () => {
+    expect(validateCommand(shepherdCmd)).toEqual({ valid: true });
+    expect(shepherdCmd.name).toBe('shepherd');
+    expect(typeof shepherdCmd.description).toBe('string');
+    expect(shepherdCmd.description.length).toBeGreaterThan(0);
+    expect(typeof shepherdCmd.handler).toBe('function');
+  });
+
+  test('one invocation runs exactly ONE bounded pass (no in-process loop)', async () => {
+    let passCount = 0;
+    const fakeRun = async () => {
+      passCount += 1;
+      return { state: 'PENDING', actions: [], reason: 'pending' };
+    };
+    const out = await shepherdCmd.handler(['123'], {}, process.cwd(), {
+      runPass: fakeRun,
+      buildContext: async () => ({ pr: '123', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master' }),
+    });
+    expect(passCount).toBe(1);
+    expect(out.success).toBe(true);
+    expect(out.state).toBe('PENDING');
+  });
+
+  test('--auto-rebase defaults to false and is opt-in via flag', async () => {
+    let seenAutoRebase;
+    const fakeRun = async (ctx) => {
+      seenAutoRebase = ctx.autoRebase;
+      return { state: 'PENDING', actions: [], reason: '' };
+    };
+    const buildContext = async () => ({ pr: '5', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master' });
+
+    await shepherdCmd.handler(['5'], {}, process.cwd(), { runPass: fakeRun, buildContext });
+    expect(seenAutoRebase).toBe(false);
+
+    await shepherdCmd.handler(['5', '--auto-rebase'], {}, process.cwd(), { runPass: fakeRun, buildContext });
+    expect(seenAutoRebase).toBe(true);
+  });
+
+  test('requires a PR argument', async () => {
+    const out = await shepherdCmd.handler([], {}, process.cwd(), {
+      runPass: async () => ({ state: 'PENDING' }),
+      buildContext: async () => ({}),
+    });
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/pr/i);
+  });
+
+  test('MERGE_READY result never carries a merge side-effect', async () => {
+    const out = await shepherdCmd.handler(['7'], {}, process.cwd(), {
+      runPass: async () => ({ state: 'MERGE_READY', actions: [], reason: 'ready' }),
+      buildContext: async () => ({ pr: '7', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master' }),
+    });
+    expect(out.state).toBe('MERGE_READY');
+    expect((out.actions || []).some((a) => a.type === 'merge')).toBe(false);
+  });
+});

--- a/test/docs-shepherd.test.js
+++ b/test/docs-shepherd.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+describe('shepherd documentation', () => {
+  test('AGENTS.md documents shepherd as a utility, not a numbered stage', () => {
+    const agents = read('AGENTS.md');
+    expect(/shepherd/i.test(agents)).toBe(true);
+    // Must describe it as a utility / not-a-stage.
+    expect(/shepherd[\s\S]{0,200}not\b[\s\S]{0,40}stage/i.test(agents)
+      || /utility[\s\S]{0,120}shepherd/i.test(agents)).toBe(true);
+  });
+
+  test('AGENTS.md shepherd text makes no auto-merge promise', () => {
+    const agents = read('AGENTS.md');
+    expect(/gh pr merge/.test(agents)).toBe(false);
+    expect(/--auto-merge/.test(agents)).toBe(false);
+    expect(/never merges/i.test(agents)).toBe(true);
+  });
+
+  test('docs/reference/shepherd.md exists and is token-clean', () => {
+    const doc = read('docs/reference/shepherd.md');
+    expect(doc.length).toBeGreaterThan(0);
+    expect(/\bbd\b/i.test(doc)).toBe(false);
+    expect(/\bdolt\b/i.test(doc)).toBe(false);
+    expect(/\.beads\b/i.test(doc)).toBe(false);
+  });
+
+  test('docs/reference/shepherd.md states the never-merge / never-resolve invariants', () => {
+    const doc = read('docs/reference/shepherd.md');
+    expect(/never merges/i.test(doc)).toBe(true);
+    expect(/never resolves/i.test(doc)).toBe(true);
+    expect(/gh pr merge/.test(doc)).toBe(false);
+  });
+});

--- a/test/forge-cmd-shepherd.test.js
+++ b/test/forge-cmd-shepherd.test.js
@@ -4,7 +4,7 @@ const { describe, test, expect } = require('bun:test');
 const { spawnSync } = require('node:child_process');
 const path = require('node:path');
 
-const { isValidCommand, getHelpText } = require('../bin/forge-cmd.js');
+const { isValidCommand, getHelpText, validateArgs } = require('../bin/forge-cmd.js');
 
 const CLI = path.join(__dirname, '..', 'bin', 'forge-cmd.js');
 
@@ -33,5 +33,23 @@ describe('forge-cmd shepherd dispatch', () => {
     const combined = `${res.stdout || ''}${res.stderr || ''}`;
     expect(combined.toLowerCase()).toContain('shepherd');
     expect(res.status).not.toBe(0);
+  });
+
+  test('validateArgs rejects an unknown shepherd flag (typo) instead of forwarding it', () => {
+    const v = validateArgs('shepherd', ['123', '--auto-reabse']);
+    expect(v.valid).toBe(false);
+    expect(v.error).toContain('--auto-reabse');
+  });
+
+  test('validateArgs accepts the documented --auto-rebase shepherd flag', () => {
+    const v = validateArgs('shepherd', ['123', '--auto-rebase']);
+    expect(v.valid).toBe(true);
+  });
+
+  test('forge shepherd with an unknown flag exits non-zero before running a pass', () => {
+    const res = spawnSync('node', [CLI, 'shepherd', '123', '--auto-reabse'], { encoding: 'utf8', timeout: 20000 });
+    const combined = `${res.stdout || ''}${res.stderr || ''}`;
+    expect(res.status).not.toBe(0);
+    expect(combined).toContain('--auto-reabse');
   });
 });

--- a/test/forge-cmd-shepherd.test.js
+++ b/test/forge-cmd-shepherd.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const { isValidCommand, getHelpText } = require('../bin/forge-cmd.js');
+
+const CLI = path.join(__dirname, '..', 'bin', 'forge-cmd.js');
+
+describe('forge-cmd shepherd dispatch', () => {
+  test('shepherd is a valid command', () => {
+    expect(isValidCommand('shepherd')).toBe(true);
+  });
+
+  test('help text lists shepherd with a description', () => {
+    const help = getHelpText();
+    expect(help).toContain('shepherd');
+  });
+
+  test('existing commands remain valid (no regression)', () => {
+    for (const cmd of ['status', 'plan', 'dev', 'validate', 'ship', 'review', 'merge', 'verify']) {
+      expect(isValidCommand(cmd)).toBe(true);
+    }
+  });
+
+  test('unknown command path is unchanged', () => {
+    expect(isValidCommand('definitely-not-a-command')).toBe(false);
+  });
+
+  test('forge shepherd with no PR argument reports usage and exits non-zero', () => {
+    const res = spawnSync('node', [CLI, 'shepherd'], { encoding: 'utf8', timeout: 20000 });
+    const combined = `${res.stdout || ''}${res.stderr || ''}`;
+    expect(combined.toLowerCase()).toContain('shepherd');
+    expect(res.status).not.toBe(0);
+  });
+});

--- a/test/harness-capability-matrix-shepherd.test.js
+++ b/test/harness-capability-matrix-shepherd.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const {
+  STAGE_IDS,
+  UTILITY_SKILL_IDS,
+  getSkillsFirstStageGraph,
+} = require('../lib/harness-capability-matrix');
+
+describe('shepherd in the harness capability matrix', () => {
+  test('shepherd is registered as a UTILITY skill, not a stage', () => {
+    expect(UTILITY_SKILL_IDS).toContain('shepherd');
+    expect(STAGE_IDS).not.toContain('shepherd');
+  });
+
+  test('shepherd appears in the utilitySkills graph with subskills and render targets', () => {
+    const graph = getSkillsFirstStageGraph();
+
+    const ids = graph.utilitySkills.map((s) => s.id);
+    expect(ids).toContain('shepherd');
+    // utilitySkills set is exactly UTILITY_SKILL_IDS (auto-derived)
+    expect(ids).toEqual(UTILITY_SKILL_IDS);
+
+    const shepherd = graph.utilitySkills.find((s) => s.id === 'shepherd');
+    expect(shepherd.workflowStage).toBe(false);
+    expect(shepherd.superSkill).toBe('shepherd');
+    expect(shepherd.subskills.length).toBeGreaterThan(0);
+    expect(shepherd.renderTargets.claude.skill).toBe('.claude/skills/shepherd/SKILL.md');
+    expect(shepherd.renderTargets.cursor.skill).toBe('.cursor/skills/shepherd/SKILL.md');
+    expect(shepherd.renderTargets.codex.skill).toBe('.codex/skills/shepherd/SKILL.md');
+  });
+
+  test('shepherd is NOT a workflow stage in the stage graph', () => {
+    const graph = getSkillsFirstStageGraph();
+    expect(graph.stages.map((s) => s.id)).not.toContain('shepherd');
+  });
+});

--- a/test/plugins/hermes-plugin.test.js
+++ b/test/plugins/hermes-plugin.test.js
@@ -104,3 +104,26 @@ describe('docs/reference/HERMES_INTEGRATION.md — memory boundary', () => {
     expect(body).toContain('Hermes');
   });
 });
+
+describe('hermes-forge SKILL.md — shepherd consumption', () => {
+  test('documents that an external scheduler invokes `forge shepherd <pr>`', () => {
+    const body = fs.readFileSync(skillPath, 'utf8');
+    expect(body).toContain('forge shepherd');
+    expect(/external scheduler/i.test(body)).toBe(true);
+  });
+
+  test('keeps shepherd progress on the PR, not in orient', () => {
+    const body = fs.readFileSync(skillPath, 'utf8');
+    expect(/never merges/i.test(body)).toBe(true);
+    expect(/never resolves/i.test(body)).toBe(true);
+    // Shepherd is not surfaced via the deterministic orient envelope.
+    expect(/not[\s\S]{0,40}orient|orient[\s\S]{0,80}no live PR/i.test(body)).toBe(true);
+  });
+
+  test('Hermes remains absent from sync-commands AGENT_ADAPTERS', () => {
+    const { AGENT_ADAPTERS } = require('../../scripts/sync-commands');
+    const keys = Object.keys(AGENT_ADAPTERS).sort();
+    expect(keys).toEqual(['claude-code', 'codex', 'cursor']);
+    expect(keys).not.toContain('hermes');
+  });
+});

--- a/test/pr-shepherd.test.js
+++ b/test/pr-shepherd.test.js
@@ -21,6 +21,7 @@ function makeAdapter(spec = {}) {
       kind: 'pr-state',
       async readState() {
         readCount += 1;
+        if (spec.stateAuthError) throw spec.stateAuthError;
         const headSha = typeof spec.headSha === 'function' ? spec.headSha(readCount) : (spec.headSha || 'sha-1');
         return {
           headSha,
@@ -33,7 +34,9 @@ function makeAdapter(spec = {}) {
         if (spec.requiredAuthError) throw spec.requiredAuthError;
         return spec.required === undefined ? [] : spec.required;
       },
-      async readDivergence() {
+      async readDivergence(divArgs) {
+        actions.push({ type: 'readDivergence', ...divArgs });
+        if (spec.divergenceAuthError) throw spec.divergenceAuthError;
         return { behind: spec.behind || 0, ahead: spec.ahead || 0 };
       },
       async rerunFailedChecks(args) {
@@ -169,6 +172,93 @@ describe('runShepherdPass — bounded pass state machine', () => {
     const expiredResult = await runShepherdPass({ ...BASE_CTX, adapter: expired.adapter });
     expect(expiredResult.authClass).toBe('expired');
     expect(expiredResult.state).toBe('PENDING'); // pause + surface, transient
+  });
+
+  // 7b — known-empty required set must not be gated by optional checks.
+  test('required:[] with no checks → MERGE_READY (not stuck PENDING)', async () => {
+    const { adapter } = makeAdapter({
+      required: [],
+      checks: [],
+      behind: 0,
+      mergeStateStatus: 'CLEAN',
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter });
+    expect(result.state).toBe('MERGE_READY');
+  });
+
+  test('required:[] with a RED optional check → still MERGE_READY (optional checks do not gate)', async () => {
+    const { adapter } = makeAdapter({
+      required: [],
+      checks: [{ name: 'optional-bench', conclusion: 'FAILURE' }],
+      behind: 0,
+      mergeStateStatus: 'CLEAN',
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter });
+    expect(result.state).toBe('MERGE_READY');
+  });
+
+  // 7c — auth taxonomy is applied to readState and readDivergence too, not
+  // just readRequiredChecks. Otherwise the CLI throws a generic failure.
+  test('readState 403 insufficient-scope → HARD_STOP (auth taxonomy applied)', async () => {
+    const scopeErr = new Error('forbidden');
+    scopeErr.httpStatus = 403;
+    scopeErr.stderr = 'HTTP 403: Resource not accessible by integration';
+    const { adapter } = makeAdapter({ required: ['unit'], stateAuthError: scopeErr });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter });
+    expect(result.state).toBe('HARD_STOP');
+    expect(result.authClass).toBe('insufficient-scope');
+  });
+
+  test('readState 401 expired → PENDING (auth taxonomy applied)', async () => {
+    const expiredErr = new Error('unauthorized');
+    expiredErr.httpStatus = 401;
+    const { adapter } = makeAdapter({ required: ['unit'], stateAuthError: expiredErr });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter });
+    expect(result.state).toBe('PENDING');
+    expect(result.authClass).toBe('expired');
+  });
+
+  test('readDivergence 403 rate-limit → PENDING with retryAfter (auth taxonomy applied)', async () => {
+    const rateErr = new Error('rate limited');
+    rateErr.httpStatus = 403;
+    rateErr.retryAfter = 42;
+    const { adapter } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      divergenceAuthError: rateErr,
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter });
+    expect(result.state).toBe('PENDING');
+    expect(result.authClass).toBe('rate-limit');
+    expect(result.retryAfter).toBe(42);
+  });
+
+  test('readDivergence non-auth error propagates (still throws)', async () => {
+    const boom = new Error('git exploded');
+    const { adapter } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      divergenceAuthError: boom,
+    });
+    let threw = false;
+    try {
+      await runShepherdPass({ ...BASE_CTX, adapter });
+    } catch (err) {
+      threw = err === boom;
+    }
+    expect(threw).toBe(true);
+  });
+
+  // 7d — cwd from the context is threaded into the divergence read.
+  test('ctx.cwd is passed through to readDivergence', async () => {
+    const { adapter, actions } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      behind: 0,
+    });
+    await runShepherdPass({ ...BASE_CTX, adapter, cwd: '/work/tree' });
+    const div = actions.find((a) => a.type === 'readDivergence');
+    expect(div.cwd).toBe('/work/tree');
   });
 
   // 8

--- a/test/pr-shepherd.test.js
+++ b/test/pr-shepherd.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { runShepherdPass, TERMINAL_STATES } = require('../lib/pr-shepherd');
+
+/**
+ * Build a fake pr-state adapter from a declarative spec. Every mutating action
+ * is recorded so tests can assert the exact side-effect log. `headSha` may be a
+ * function of the read-count to simulate HEAD moving mid-pass.
+ */
+function makeAdapter(spec = {}) {
+  let readCount = 0;
+  const actions = [];
+  return {
+    actions,
+    adapter: {
+      id: 'fake-pr-state',
+      kind: 'pr-state',
+      async readState() {
+        readCount += 1;
+        const headSha = typeof spec.headSha === 'function' ? spec.headSha(readCount) : (spec.headSha || 'sha-1');
+        return {
+          headSha,
+          mergeStateStatus: spec.mergeStateStatus || 'CLEAN',
+          checks: spec.checks || [],
+          threads: spec.threads || [],
+        };
+      },
+      async readRequiredChecks() {
+        if (spec.requiredAuthError) throw spec.requiredAuthError;
+        return spec.required === undefined ? [] : spec.required;
+      },
+      async readDivergence() {
+        return { behind: spec.behind || 0, ahead: spec.ahead || 0 };
+      },
+      async rerunFailedChecks(args) {
+        actions.push({ type: 'rerun', ...args });
+      },
+      async replyToThread(args) {
+        actions.push({ type: 'reply', ...args });
+      },
+      async rebaseOntoBase(args) {
+        if (spec.leaseReject) {
+          const err = new Error('lease reject');
+          err.leaseRejected = true;
+          throw err;
+        }
+        actions.push({ type: 'rebase', ...args });
+      },
+    },
+  };
+}
+
+const BASE_CTX = { pr: '123', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master' };
+
+describe('runShepherdPass — bounded pass state machine', () => {
+  // 1
+  test('all required green + behind=0 → MERGE_READY, NO merge emitted', async () => {
+    const { adapter, actions } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      behind: 0,
+      mergeStateStatus: 'CLEAN',
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter });
+    expect(result.state).toBe('MERGE_READY');
+    expect(actions.some((a) => a.type === 'merge')).toBe(false);
+  });
+
+  // 2
+  test('failed flaky required check with budget left → ONE rerun, PENDING', async () => {
+    const { adapter, actions } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', status: 'COMPLETED', conclusion: 'FAILURE', databaseId: '777' }],
+      behind: 0,
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter, rerunBudget: 3, rerunsUsed: 0 });
+    expect(result.state).toBe('PENDING');
+    expect(actions.filter((a) => a.type === 'rerun')).toHaveLength(1);
+  });
+
+  // 3
+  test('behind>0 with autoRebase:false → ESCALATE, no rebase/push', async () => {
+    const { adapter, actions } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      behind: 2,
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter, autoRebase: false });
+    expect(result.state).toBe('ESCALATE');
+    expect(actions.some((a) => a.type === 'rebase')).toBe(false);
+  });
+
+  // 4
+  test('behind>0 autoRebase:true clean tree HEAD unchanged → rebase emitted; lease reject → ESCALATE no retry', async () => {
+    const ok = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      behind: 2,
+    });
+    await runShepherdPass({
+      ...BASE_CTX, adapter: ok.adapter, autoRebase: true, cleanTree: true,
+    });
+    expect(ok.actions.filter((a) => a.type === 'rebase')).toHaveLength(1);
+
+    const lease = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      behind: 2,
+      leaseReject: true,
+    });
+    const leaseResult = await runShepherdPass({
+      ...BASE_CTX, adapter: lease.adapter, autoRebase: true, cleanTree: true,
+    });
+    expect(leaseResult.state).toBe('ESCALATE');
+    // lease reject is a hard-stop: never auto-fetch-then-retry
+    expect(lease.actions.filter((a) => a.type === 'rebase')).toHaveLength(0);
+  });
+
+  // 5
+  test('required set unreadable (protection 403) → ESCALATE, never MERGE_READY', async () => {
+    const { adapter } = makeAdapter({
+      required: null, // adapter returns null = cannot determine
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      behind: 0,
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter });
+    expect(result.state).toBe('ESCALATE');
+    expect(result.state).not.toBe('MERGE_READY');
+  });
+
+  // 6
+  test('HEAD moved mid-pass → mutating action aborted', async () => {
+    const { adapter, actions } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'FAILURE', databaseId: '777' }],
+      behind: 0,
+      headSha: (n) => (n === 1 ? 'sha-1' : 'sha-2'), // changes on the pre-action re-read
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter, rerunBudget: 3, rerunsUsed: 0 });
+    expect(actions.some((a) => a.type === 'rerun')).toBe(false);
+    expect(result.aborted).toBe(true);
+  });
+
+  // 7
+  test('auth taxonomy: 403 insufficient-scope → HARD_STOP; 403+Retry-After → honored; 401 → pause', async () => {
+    const scopeErr = new Error('forbidden');
+    scopeErr.httpStatus = 403;
+    scopeErr.stderr = 'HTTP 403: Resource not accessible by integration';
+    const scope = makeAdapter({ requiredAuthError: scopeErr });
+    const scopeResult = await runShepherdPass({ ...BASE_CTX, adapter: scope.adapter });
+    expect(scopeResult.state).toBe('HARD_STOP');
+    expect(scopeResult.authClass).toBe('insufficient-scope');
+
+    const rateErr = new Error('rate limited');
+    rateErr.httpStatus = 403;
+    rateErr.retryAfter = 30;
+    const rate = makeAdapter({ requiredAuthError: rateErr });
+    const rateResult = await runShepherdPass({ ...BASE_CTX, adapter: rate.adapter });
+    expect(rateResult.authClass).toBe('rate-limit');
+    expect(rateResult.retryAfter).toBe(30);
+
+    const expiredErr = new Error('unauthorized');
+    expiredErr.httpStatus = 401;
+    const expired = makeAdapter({ requiredAuthError: expiredErr });
+    const expiredResult = await runShepherdPass({ ...BASE_CTX, adapter: expired.adapter });
+    expect(expiredResult.authClass).toBe('expired');
+    expect(expiredResult.state).toBe('PENDING'); // pause + surface, transient
+  });
+
+  // 8
+  test('rerun budget exhausted / oscillation → ESCALATE', async () => {
+    const { adapter, actions } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'FAILURE', databaseId: '777' }],
+      behind: 0,
+    });
+    const result = await runShepherdPass({ ...BASE_CTX, adapter, rerunBudget: 2, rerunsUsed: 2 });
+    expect(result.state).toBe('ESCALATE');
+    expect(actions.some((a) => a.type === 'rerun')).toBe(false);
+  });
+
+  // 9
+  test('NEVER emits gh pr merge or gh pr merge --auto in any branch', async () => {
+    const scenarios = [
+      { required: ['u'], checks: [{ name: 'u', conclusion: 'SUCCESS' }], behind: 0 },
+      { required: ['u'], checks: [{ name: 'u', conclusion: 'FAILURE', databaseId: '1' }], behind: 0 },
+      { required: ['u'], checks: [{ name: 'u', conclusion: 'SUCCESS' }], behind: 3 },
+      { required: null, checks: [], behind: 0 },
+    ];
+    for (const spec of scenarios) {
+      const { adapter, actions } = makeAdapter(spec);
+      await runShepherdPass({ ...BASE_CTX, adapter, rerunBudget: 5, rerunsUsed: 0, autoRebase: true, cleanTree: true });
+      expect(actions.some((a) => a.type === 'merge')).toBe(false);
+    }
+  });
+
+  // 10
+  test('NEVER emits a greptile thread resolve (reply allowed)', async () => {
+    const { adapter, actions } = makeAdapter({
+      required: ['unit'],
+      checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      behind: 2, // escalation path, where a status reply may be posted
+      threads: [{ id: 't1', commentId: 'c1', resolved: false }],
+    });
+    await runShepherdPass({ ...BASE_CTX, adapter, autoRebase: false });
+    expect(actions.some((a) => a.type === 'resolve')).toBe(false);
+  });
+
+  test('TERMINAL_STATES exposes the documented terminal set', () => {
+    expect(TERMINAL_STATES).toContain('MERGE_READY');
+    expect(TERMINAL_STATES).toContain('ESCALATE');
+    expect(TERMINAL_STATES).toContain('PENDING');
+  });
+
+  test('source contains zero bd/.beads/dolt tokens and no gh pr merge', () => {
+    const src = fs.readFileSync(path.join(__dirname, '..', 'lib', 'pr-shepherd.js'), 'utf8');
+    expect(/\bbd\b/i.test(src)).toBe(false);
+    expect(/\.beads\b/i.test(src)).toBe(false);
+    expect(/\bdolt\b/i.test(src)).toBe(false);
+    expect(/gh pr merge/.test(src)).toBe(false);
+  });
+});

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { PrStateAdapter } = require('../lib/adapters/pr-state-adapter');
+const { validatePrStateAdapter } = require('../lib/pr-state-validator');
+
+/**
+ * Build a fake command runner whose behaviour is keyed off the first token of
+ * the argv. Records every invocation in `calls` for assertions.
+ */
+function makeRunner(responses) {
+  const calls = [];
+  const run = (cmd, args) => {
+    calls.push({ cmd, args });
+    const argv = [cmd, ...args];
+    const joined = argv.join(' ');
+    for (const [match, value] of responses) {
+      if (joined.includes(match)) {
+        if (typeof value === 'function') return value(argv);
+        return value;
+      }
+    }
+    return '';
+  };
+  return { run, calls };
+}
+
+const PR_VIEW_JSON = JSON.stringify({
+  headRefOid: 'abc123',
+  mergeStateStatus: 'BLOCKED',
+  statusCheckRollup: [
+    { name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' },
+    { name: 'lint', status: 'COMPLETED', conclusion: 'FAILURE' },
+    { name: 'optional-bench', status: 'COMPLETED', conclusion: 'FAILURE' },
+  ],
+  reviewThreads: [],
+});
+
+const REQUIRED_CHECKS_JSON = JSON.stringify({ contexts: ['unit', 'lint'] });
+
+describe('PrStateAdapter', () => {
+  test('satisfies the pr-state adapter contract', () => {
+    const { run } = makeRunner([]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    expect(adapter.kind).toBe('pr-state');
+    expect(validatePrStateAdapter(adapter)).toEqual({ valid: true, errors: [] });
+  });
+
+  test('readState normalizes the rollup, head SHA and merge state', async () => {
+    const { run } = makeRunner([
+      ['pr view', PR_VIEW_JSON],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const state = await adapter.readState('123');
+
+    expect(state.headSha).toBe('abc123');
+    expect(state.mergeStateStatus).toBe('BLOCKED');
+    expect(state.checks).toHaveLength(3);
+    expect(state.checks.find((c) => c.name === 'lint').conclusion).toBe('FAILURE');
+  });
+
+  test('readRequiredChecks calls the branch protection API and returns required contexts', async () => {
+    const { run, calls } = makeRunner([
+      ['protection/required_status_checks', REQUIRED_CHECKS_JSON],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const required = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master' });
+
+    expect(required).toEqual(['unit', 'lint']);
+    const apiCall = calls.find((c) => c.args.join(' ').includes('protection/required_status_checks'));
+    expect(apiCall).toBeTruthy();
+    expect(apiCall.args.join(' ')).toContain('repos/o/r/branches/master/protection/required_status_checks');
+  });
+
+  test('readRequiredChecks surfaces unreadable protection (403) instead of guessing', async () => {
+    const err = new Error('403');
+    err.stderr = 'HTTP 403: Resource not accessible by integration';
+    const { run } = makeRunner([
+      ['protection/required_status_checks', () => { throw err; }],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const result = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master' });
+
+    expect(result).toBeNull(); // null = "cannot determine required set"
+  });
+
+  test('readDivergence parses git rev-list --left-right --count as { behind, ahead }', async () => {
+    const { run, calls } = makeRunner([
+      ['rev-list --left-right --count', '2\t5\n'],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const d = await adapter.readDivergence({ baseRef: 'origin/master' });
+
+    expect(d).toEqual({ behind: 2, ahead: 5 });
+    const call = calls.find((c) => c.args.join(' ').includes('rev-list'));
+    expect(call.args.join(' ')).toContain('--left-right');
+    expect(call.args.join(' ')).toContain('--count');
+  });
+
+  test('rerunFailedChecks shells out to gh run rerun --failed', async () => {
+    const { run, calls } = makeRunner([['run rerun', '']]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    await adapter.rerunFailedChecks({ runId: '999' });
+
+    const call = calls.find((c) => c.args.join(' ').includes('rerun'));
+    expect(call.args).toContain('--failed');
+  });
+
+  test('the adapter source imports no merge or rebase machinery and is token-clean', () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'lib', 'adapters', 'pr-state-adapter.js'),
+      'utf8',
+    );
+    expect(/gh pr merge/.test(src)).toBe(false);
+    expect(/git rebase/.test(src)).toBe(false);
+    expect(/push --force/.test(src)).toBe(false);
+    expect(/\bbd\b/i.test(src)).toBe(false);
+    expect(/\.beads\b/i.test(src)).toBe(false);
+    expect(/\bdolt\b/i.test(src)).toBe(false);
+  });
+});

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -75,6 +75,28 @@ describe('PrStateAdapter', () => {
     expect(apiCall.args.join(' ')).toContain('repos/o/r/branches/master/protection/required_status_checks');
   });
 
+  test('readRequiredChecks returns null for an unexpected payload shape (not [])', async () => {
+    // A malformed/changed protection payload must NOT look like "no required
+    // checks" — that would let the shepherd compute merge readiness from bad data.
+    const { run } = makeRunner([
+      ['protection/required_status_checks', JSON.stringify({ unexpected: true })],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const result = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master' });
+
+    expect(result).toBeNull();
+  });
+
+  test('readRequiredChecks returns [] for a valid empty contexts payload', async () => {
+    const { run } = makeRunner([
+      ['protection/required_status_checks', JSON.stringify({ contexts: [] })],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const result = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master' });
+
+    expect(result).toEqual([]);
+  });
+
   test('readRequiredChecks surfaces unreadable protection (403) instead of guessing', async () => {
     const err = new Error('403');
     err.stderr = 'HTTP 403: Resource not accessible by integration';
@@ -98,6 +120,32 @@ describe('PrStateAdapter', () => {
     const call = calls.find((c) => c.args.join(' ').includes('rev-list'));
     expect(call.args.join(' ')).toContain('--left-right');
     expect(call.args.join(' ')).toContain('--count');
+  });
+
+  test('readDivergence threads cwd through to the git runner', async () => {
+    const calls = [];
+    const run = (cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      return '0\t0\n';
+    };
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    await adapter.readDivergence({ baseRef: 'origin/master', cwd: '/work/tree' });
+
+    const call = calls.find((c) => c.args.join(' ').includes('rev-list'));
+    expect(call.opts && call.opts.cwd).toBe('/work/tree');
+  });
+
+  test('readDivergence omits cwd when none is supplied (runs in process dir)', async () => {
+    const calls = [];
+    const run = (cmd, args, opts) => {
+      calls.push({ cmd, args, opts });
+      return '0\t0\n';
+    };
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    await adapter.readDivergence({ baseRef: 'origin/master' });
+
+    const call = calls.find((c) => c.args.join(' ').includes('rev-list'));
+    expect(call.opts === undefined || call.opts.cwd === undefined).toBe(true);
   });
 
   test('rerunFailedChecks shells out to gh run rerun --failed', async () => {

--- a/test/pr-state-validator.test.js
+++ b/test/pr-state-validator.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const { validatePrStateAdapter } = require('../lib/pr-state-validator');
+const { validateReviewAdapter } = require('../lib/review-adapter');
+
+function makeValidAdapter(overrides = {}) {
+  return {
+    id: 'pr-state-test',
+    kind: 'pr-state',
+    readState() {},
+    readRequiredChecks() {},
+    readDivergence() {},
+    rerunFailedChecks() {},
+    replyToThread() {},
+    ...overrides,
+  };
+}
+
+describe('validatePrStateAdapter', () => {
+  test('rejects a non-object', () => {
+    expect(validatePrStateAdapter(null)).toEqual({
+      valid: false,
+      errors: ['adapter must be an object'],
+    });
+  });
+
+  test('rejects the review kind with a clear message', () => {
+    const result = validatePrStateAdapter(makeValidAdapter({ kind: 'review' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('kind must be "pr-state"');
+  });
+
+  test('accepts a complete pr-state adapter', () => {
+    expect(validatePrStateAdapter(makeValidAdapter())).toEqual({ valid: true, errors: [] });
+  });
+
+  test('reports every missing required method', () => {
+    const result = validatePrStateAdapter({ id: 'broken', kind: 'pr-state' });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual([
+      'readState must be a function',
+      'readRequiredChecks must be a function',
+      'readDivergence must be a function',
+      'rerunFailedChecks must be a function',
+      'replyToThread must be a function',
+    ]);
+  });
+
+  test('requires a non-empty id', () => {
+    const result = validatePrStateAdapter(makeValidAdapter({ id: '' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('id must be a non-empty string');
+  });
+
+  test('a pr-state adapter is NOT accepted by validateReviewAdapter (different SPI)', () => {
+    // The pr-state adapter must never be fed to the review validator.
+    const result = validateReviewAdapter(makeValidAdapter());
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('kind must be "review"');
+  });
+});

--- a/test/shepherd-acceptance.test.js
+++ b/test/shepherd-acceptance.test.js
@@ -291,4 +291,21 @@ describe('shepherd acceptance §5', () => {
     expect(res.capped).toBe(true);
     expect(res.sample.length).toBe(20);
   });
+
+  // Regression (CodeRabbit): a bot-OPENED thread with a later HUMAN reply must
+  // still be actionable — readComments returns ALL thread comments and
+  // actionableComments detects any non-bot/non-self participant (not just the
+  // first comment's author).
+  test('comments: bot-opened thread with a later human reply → NEEDS_REVIEW', async () => {
+    const s = scriptedAdapter([{
+      required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      comments: [{ isResolved: false, comments: [
+        { author: 'coderabbitai', body: 'nit: rename' },
+        { author: 'carol', body: 'good catch — also fix Y' },
+      ] }],
+    }]);
+    const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter });
+    expect(res.state).toBe('NEEDS_REVIEW');
+    expect(res.commentCount).toBe(1);
+  });
 });

--- a/test/shepherd-acceptance.test.js
+++ b/test/shepherd-acceptance.test.js
@@ -58,6 +58,7 @@ function scriptedAdapter(steps) {
         }
         actions.push({ type: 'rebase', ...a });
       },
+      async readComments() { return cur().comments || []; },
     },
   };
 }
@@ -252,5 +253,42 @@ describe('shepherd acceptance §5', () => {
     const s = scriptedAdapter([{ state: 'CLOSED' }]);
     const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter });
     expect(res.state).toBe('CLOSED');
+  });
+
+  // Comments — new actionable feedback → NEEDS_REVIEW; bots/self ignored;
+  // flood-capped so "too many comments" can't blow up a single pass. The
+  // shepherd detects + hands off to /review and NEVER resolves threads.
+  test('comments: unresolved human comment → NEEDS_REVIEW (never resolves)', async () => {
+    const s = scriptedAdapter([{
+      required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      comments: [{ author: 'alice', body: 'please fix X', isResolved: false }],
+    }]);
+    const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter });
+    expect(res.state).toBe('NEEDS_REVIEW');
+    expect(res.commentCount).toBe(1);
+    expect(noResolve(res.actions)).toBe(true);
+  });
+
+  test('comments: bot- and self-authored / resolved → not actionable (MERGE_READY)', async () => {
+    const s = scriptedAdapter([{
+      required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+      comments: [
+        { author: 'coderabbitai', body: 'nit', isResolved: false },
+        { author: 'me-bot', body: 'self', isResolved: false },
+        { author: 'bob', body: 'done', isResolved: true },
+      ],
+    }]);
+    const res = await runShepherdPass({ ...BASE_CTX, self: 'me-bot', adapter: s.adapter });
+    expect(res.state).toBe('MERGE_READY');
+  });
+
+  test('comments: too many → NEEDS_REVIEW, capped sample', async () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({ author: `u${i}`, body: `c${i}`, isResolved: false }));
+    const s = scriptedAdapter([{ required: [], comments: many }]);
+    const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter });
+    expect(res.state).toBe('NEEDS_REVIEW');
+    expect(res.commentCount).toBe(25);
+    expect(res.capped).toBe(true);
+    expect(res.sample.length).toBe(20);
   });
 });

--- a/test/shepherd-acceptance.test.js
+++ b/test/shepherd-acceptance.test.js
@@ -35,6 +35,7 @@ function scriptedAdapter(steps) {
         const s = cur();
         return {
           headSha: typeof s.headSha === 'function' ? s.headSha() : (s.headSha || 'sha-1'),
+          state: s.state || 'OPEN',
           mergeStateStatus: s.mergeStateStatus || 'CLEAN',
           checks: s.checks || [],
           threads: s.threads || [],
@@ -236,5 +237,20 @@ describe('shepherd acceptance §5', () => {
     });
     expect(out.state).toBe('MERGE_READY');
     expect((out.actions || []).some((a) => a.type === 'merge')).toBe(false);
+  });
+
+  // Lifecycle — a merged/closed PR is terminal so the external scheduler stops
+  // re-invoking it (previously the pass would keep returning MERGE_READY).
+  test('lifecycle: merged PR → MERGED terminal, no merge action', async () => {
+    const s = scriptedAdapter([{ state: 'MERGED', required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }] }]);
+    const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter });
+    expect(res.state).toBe('MERGED');
+    expect(noMerge(res.actions)).toBe(true);
+  });
+
+  test('lifecycle: closed PR → CLOSED terminal', async () => {
+    const s = scriptedAdapter([{ state: 'CLOSED' }]);
+    const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter });
+    expect(res.state).toBe('CLOSED');
   });
 });

--- a/test/shepherd-acceptance.test.js
+++ b/test/shepherd-acceptance.test.js
@@ -1,0 +1,233 @@
+'use strict';
+
+/**
+ * PR shepherd acceptance suite (plan §5).
+ *
+ * Drives lib/pr-shepherd.js + lib/commands/shepherd.js with a scripted fake
+ * adapter and asserts the end-to-end invariants in one place. This suite is
+ * decoupled from `forge release check` (§5.9): it never asserts the release gate
+ * is green (it is RED for unrelated D22 reasons).
+ */
+
+const { describe, test, expect } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { runShepherdPass } = require('../lib/pr-shepherd');
+const shepherdCmd = require('../lib/commands/shepherd');
+
+const ROOT = path.resolve(__dirname, '..');
+const BASE_CTX = { pr: '123', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master' };
+
+/** A scripted adapter whose state can change per-pass to model a real PR. */
+function scriptedAdapter(steps) {
+  let pass = 0;
+  const actions = [];
+  const cur = () => steps[Math.min(pass, steps.length - 1)];
+  return {
+    actions,
+    nextPass() { pass += 1; },
+    adapter: {
+      id: 'scripted',
+      kind: 'pr-state',
+      async readState() {
+        const s = cur();
+        return {
+          headSha: typeof s.headSha === 'function' ? s.headSha() : (s.headSha || 'sha-1'),
+          mergeStateStatus: s.mergeStateStatus || 'CLEAN',
+          checks: s.checks || [],
+          threads: s.threads || [],
+        };
+      },
+      async readRequiredChecks() {
+        const s = cur();
+        if (s.requiredError) throw s.requiredError;
+        return s.required === undefined ? [] : s.required;
+      },
+      async readDivergence() {
+        const s = cur();
+        return { behind: s.behind || 0, ahead: s.ahead || 0 };
+      },
+      async rerunFailedChecks(a) { actions.push({ type: 'rerun', ...a }); },
+      async replyToThread(a) { actions.push({ type: 'reply', ...a }); },
+      async rebaseOntoBase(a) {
+        if (cur().leaseReject) {
+          const err = new Error('lease'); err.leaseRejected = true; throw err;
+        }
+        actions.push({ type: 'rebase', ...a });
+      },
+    },
+  };
+}
+
+const noMerge = (actions) => actions.every((a) => a.type !== 'merge');
+const noResolve = (actions) => actions.every((a) => a.type !== 'resolve');
+
+describe('shepherd acceptance §5', () => {
+  // §5.1 — Happy path to READY, zero manual steps, never merges, never resolves.
+  test('§5.1 flaky required + behind → rerun → escalate (human rebase) → MERGE_READY', async () => {
+    const s = scriptedAdapter([
+      { required: ['unit'], checks: [{ name: 'unit', conclusion: 'FAILURE', databaseId: '1' }], behind: 2,
+        threads: [{ id: 't1', commentId: 'c1', resolved: false }] },
+      { required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }], behind: 2 },
+      { required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }], behind: 0 },
+    ]);
+
+    const p1 = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter, rerunBudget: 3, rerunsUsed: 0 });
+    expect(p1.state).toBe('PENDING');
+    expect(s.actions.filter((a) => a.type === 'rerun')).toHaveLength(1);
+
+    s.nextPass();
+    const p2 = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter, autoRebase: false });
+    expect(p2.state).toBe('ESCALATE'); // behind=2, human rebases
+
+    s.nextPass();
+    const p3 = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter });
+    expect(p3.state).toBe('MERGE_READY');
+
+    expect(noMerge(s.actions)).toBe(true);
+    expect(noResolve(s.actions)).toBe(true);
+  });
+
+  // §5.2 — autoRebase path; lease reject → escalate, no retry.
+  test('§5.2 autoRebase rebases; lease reject → ESCALATE with no retry', async () => {
+    const ok = scriptedAdapter([
+      { required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }], behind: 2 },
+    ]);
+    const okRes = await runShepherdPass({ ...BASE_CTX, adapter: ok.adapter, autoRebase: true, cleanTree: true });
+    expect(okRes.state).toBe('PENDING');
+    expect(ok.actions.filter((a) => a.type === 'rebase')).toHaveLength(1);
+
+    const lease = scriptedAdapter([
+      { required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }], behind: 2, leaseReject: true },
+    ]);
+    const leaseRes = await runShepherdPass({ ...BASE_CTX, adapter: lease.adapter, autoRebase: true, cleanTree: true });
+    expect(leaseRes.state).toBe('ESCALATE');
+    expect(lease.actions.filter((a) => a.type === 'rebase')).toHaveLength(0);
+  });
+
+  // §5.3 — caps honored.
+  test('§5.3 rerun budget exhausted → ESCALATE, no extra rerun', async () => {
+    const s = scriptedAdapter([
+      { required: ['unit'], checks: [{ name: 'unit', conclusion: 'FAILURE', databaseId: '1' }], behind: 0 },
+    ]);
+    const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter, rerunBudget: 2, rerunsUsed: 2 });
+    expect(res.state).toBe('ESCALATE');
+    expect(s.actions.filter((a) => a.type === 'rerun')).toHaveLength(0);
+  });
+
+  // §5.4 — never auto-merge in any branch.
+  test('§5.4 gh pr merge / --auto never appear in any side-effect log', async () => {
+    const specs = [
+      { required: ['u'], checks: [{ name: 'u', conclusion: 'SUCCESS' }], behind: 0 },
+      { required: ['u'], checks: [{ name: 'u', conclusion: 'FAILURE', databaseId: '1' }], behind: 0 },
+      { required: ['u'], checks: [{ name: 'u', conclusion: 'SUCCESS' }], behind: 3 },
+      { required: null, checks: [], behind: 0 },
+      { mergeStateStatus: 'DIRTY', required: ['u'], checks: [], behind: 0 },
+    ];
+    for (const spec of specs) {
+      const s = scriptedAdapter([spec]);
+      const res = await runShepherdPass({ ...BASE_CTX, adapter: s.adapter, rerunBudget: 5, autoRebase: true, cleanTree: true });
+      expect(s.actions.some((a) => a.type === 'merge' || /--auto/.test(JSON.stringify(a)))).toBe(false);
+      expect(res.state).not.toBe('MERGED');
+    }
+  });
+
+  // §5.5 — unknown / unreadable required set → wait/escalate, not merge-ready.
+  test('§5.5 protection 403 → ESCALATE; UNKNOWN merge state ≠ conflict → not merge-ready', async () => {
+    const protErr = new Error('forbidden'); protErr.httpStatus = 403;
+    protErr.stderr = 'HTTP 403: Resource not accessible by integration';
+    const prot = scriptedAdapter([{ requiredError: protErr }]);
+    const protRes = await runShepherdPass({ ...BASE_CTX, adapter: prot.adapter });
+    expect(protRes.state).toBe('HARD_STOP'); // insufficient scope on protection read
+
+    const unreadable = scriptedAdapter([{ required: null, checks: [{ name: 'u', conclusion: 'SUCCESS' }], behind: 0 }]);
+    const unreadableRes = await runShepherdPass({ ...BASE_CTX, adapter: unreadable.adapter });
+    expect(unreadableRes.state).toBe('ESCALATE');
+
+    const unknown = scriptedAdapter([{ required: ['u'], checks: [{ name: 'u', conclusion: null, status: 'IN_PROGRESS' }], behind: 0, mergeStateStatus: 'UNKNOWN' }]);
+    const unknownRes = await runShepherdPass({ ...BASE_CTX, adapter: unknown.adapter });
+    expect(unknownRes.state).toBe('PENDING'); // UNKNOWN is not a conflict
+    expect(unknownRes.state).not.toBe('MERGE_READY');
+  });
+
+  // §5.6 — auth taxonomy.
+  test('§5.6 403 scope → HARD_STOP; 403+Retry-After → resume; 401 → pause', async () => {
+    const scopeErr = new Error('x'); scopeErr.httpStatus = 403;
+    scopeErr.stderr = 'HTTP 403: Resource not accessible by integration';
+    const scope = await runShepherdPass({ ...BASE_CTX, adapter: scriptedAdapter([{ requiredError: scopeErr }]).adapter });
+    expect(scope.state).toBe('HARD_STOP');
+    expect(scope.actions).toHaveLength(0); // no retries logged
+
+    const rateErr = new Error('x'); rateErr.httpStatus = 403; rateErr.retryAfter = 30;
+    const rate = await runShepherdPass({ ...BASE_CTX, adapter: scriptedAdapter([{ requiredError: rateErr }]).adapter });
+    expect(rate.authClass).toBe('rate-limit');
+    expect(rate.retryAfter).toBe(30);
+
+    const expErr = new Error('x'); expErr.httpStatus = 401;
+    const exp = await runShepherdPass({ ...BASE_CTX, adapter: scriptedAdapter([{ requiredError: expErr }]).adapter });
+    expect(exp.authClass).toBe('expired');
+    expect(exp.state).toBe('PENDING');
+  });
+
+  // §5.7 — zero-beads static scan of the four source files (strongest guard).
+  test('§5.7 source files contain zero bd/.beads/dolt tokens', () => {
+    const files = [
+      'lib/pr-shepherd.js',
+      'lib/adapters/pr-state-adapter.js',
+      'lib/pr-state-validator.js',
+      'lib/commands/shepherd.js',
+    ];
+    for (const rel of files) {
+      const src = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+      expect(/\bbd\b/i.test(src)).toBe(false);
+      expect(/\.beads\b/i.test(src)).toBe(false);
+      expect(/\bdolt\b/i.test(src)).toBe(false);
+    }
+  });
+
+  // §5.8 — sync integrity.
+  test('§5.8 node scripts/sync-commands.js --check exits 0', () => {
+    const out = execFileSync('node', ['scripts/sync-commands.js', '--check'], { cwd: ROOT, encoding: 'utf8' });
+    expect(typeof out).toBe('string');
+  });
+
+  // §5.9 — NOT coupled to forge release check (documented, asserted by omission).
+  test('§5.9 acceptance does not assert the release gate is green', () => {
+    // Intentionally empty of any release-gate assertion. The release gate is RED
+    // for unrelated D22 reasons (freshClone + premergeEmbeddedGate). Shepherd
+    // acceptance is decoupled per plan D-7.
+    expect(true).toBe(true);
+  });
+
+  // §5.10 — HEAD-changed abort.
+  test('§5.10 HEAD moving mid-pass aborts the mutating action', async () => {
+    let reads = 0;
+    const adapter = {
+      id: 'head-move', kind: 'pr-state',
+      async readState() {
+        reads += 1;
+        return { headSha: reads === 1 ? 'sha-1' : 'sha-2', mergeStateStatus: 'CLEAN',
+          checks: [{ name: 'unit', conclusion: 'FAILURE', databaseId: '1' }], threads: [] };
+      },
+      async readRequiredChecks() { return ['unit']; },
+      async readDivergence() { return { behind: 0, ahead: 1 }; },
+      async rerunFailedChecks() { throw new Error('should not be called after HEAD moved'); },
+      async replyToThread() {},
+    };
+    const res = await runShepherdPass({ ...BASE_CTX, adapter, rerunBudget: 3, rerunsUsed: 0 });
+    expect(res.aborted).toBe(true);
+  });
+
+  // Command-level happy/handoff: one invocation = one pass, no merge in actions.
+  test('command handler runs one pass and never carries a merge action', async () => {
+    const s = scriptedAdapter([{ required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }], behind: 0 }]);
+    const out = await shepherdCmd.handler(['123'], {}, ROOT, {
+      adapter: s.adapter,
+      buildContext: async () => BASE_CTX,
+    });
+    expect(out.state).toBe('MERGE_READY');
+    expect((out.actions || []).some((a) => a.type === 'merge')).toBe(false);
+  });
+});

--- a/test/shepherd-acceptance.test.js
+++ b/test/shepherd-acceptance.test.js
@@ -193,12 +193,19 @@ describe('shepherd acceptance §5', () => {
     expect(typeof out).toBe('string');
   });
 
-  // §5.9 — NOT coupled to forge release check (documented, asserted by omission).
-  test('§5.9 acceptance does not assert the release gate is green', () => {
-    // Intentionally empty of any release-gate assertion. The release gate is RED
-    // for unrelated D22 reasons (freshClone + premergeEmbeddedGate). Shepherd
-    // acceptance is decoupled per plan D-7.
-    expect(true).toBe(true);
+  // §5.9 — Shepherd is decoupled from the release gate. Observable assertion:
+  // the shepherd source references no release-gate machinery, so a RED release
+  // gate (unrelated D22 reasons) can never block or alter a shepherd pass.
+  test('§5.9 shepherd source is decoupled from the release gate', () => {
+    const sources = [
+      fs.readFileSync(path.join(ROOT, 'lib', 'pr-shepherd.js'), 'utf8'),
+      fs.readFileSync(path.join(ROOT, 'lib', 'commands', 'shepherd.js'), 'utf8'),
+    ];
+    for (const src of sources) {
+      expect(/release\s+check/i.test(src)).toBe(false);
+      expect(/premergeEmbeddedGate/.test(src)).toBe(false);
+      expect(/freshClone/.test(src)).toBe(false);
+    }
   });
 
   // §5.10 — HEAD-changed abort.

--- a/test/shepherd-skill-sync.test.js
+++ b/test/shepherd-skill-sync.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+describe('shepherd skill sync', () => {
+  test('node scripts/sync-commands.js --check exits 0 (in sync)', () => {
+    const res = execFileSync('node', ['scripts/sync-commands.js', '--check'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    // execFileSync throws on non-zero exit; reaching here means exit 0.
+    expect(typeof res).toBe('string');
+  });
+
+  test('canonical .claude/commands/shepherd.md exists and is token-clean', () => {
+    const src = read('.claude/commands/shepherd.md');
+    expect(src.length).toBeGreaterThan(0);
+    expect(/\bbd\b/i.test(src)).toBe(false);
+    expect(/\.beads\b/i.test(src)).toBe(false);
+    expect(/\bdolt\b/i.test(src)).toBe(false);
+  });
+
+  test('shepherd.md never promises merge or thread resolution', () => {
+    const src = read('.claude/commands/shepherd.md');
+    expect(/gh pr merge/.test(src)).toBe(false);
+    expect(/--auto-merge/.test(src)).toBe(false);
+    expect(/never merges/i.test(src)).toBe(true);
+    expect(/never resolves/i.test(src) || /resolution[^.]*stays with/i.test(src)).toBe(true);
+  });
+
+  test('cursor output exists with frontmatter stripped', () => {
+    const cursor = read('.cursor/commands/shepherd.md');
+    expect(cursor.startsWith('---')).toBe(false);
+    expect(cursor).toContain('Shepherd');
+  });
+
+  test('codex output exists at .codex/skills/shepherd/SKILL.md with a kept description', () => {
+    const codex = read('.codex/skills/shepherd/SKILL.md');
+    expect(codex).toContain('description:');
+    expect(codex).toContain('Shepherd');
+  });
+
+  test('no Hermes shepherd file is created by sync (Hermes is not a sync target)', () => {
+    const hermesCandidate = path.join(ROOT, '.hermes', 'skills', 'shepherd');
+    expect(fs.existsSync(hermesCandidate)).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds the monitor-driven PR-shepherd to forge's review workflow — a bounded-pass utility command (`forge shepherd [--watch]`) that polls a PR's CI/checks/comments/mergeability and takes mechanical fixes (rerun flaky CI, optional `--auto-rebase`, escalate) until merge-ready, then hands off to a human (**never merges**).

5 TDD waves: core state machine + pr-state adapter/validator, CLI + bin dispatch, skill + cross-harness sync (claude-code/cursor/codex), capability-matrix/docs/Hermes, acceptance suite. Encodes plan decisions D-1…D-13 + all edge cases: no auto-merge, required-checks via branch-protection API, auth taxonomy (403-scope HARD_STOP / Retry-After / 401), rerun caps, HEAD-moved abort, **zero bd/.beads/dolt** (beads-retirement safe). Design+plan: `docs/work/2026-06-24-pr-shepherd-review/plan.md`.

Pushed via `--quick` (review-cycle); CI runs the full suite. 36 shepherd unit/acceptance tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `shepherd` as a new `forge` utility command that performs a single bounded PR monitoring pass, with opt-in `--auto-rebase`.
  * Updated the skills/command inventory so `shepherd` is included in supported relevant harness flows.
* **Bug Fixes**
  * Strengthened merge-readiness gating and safety: `shepherd` never merges and never resolves review threads; it aborts mutating actions if the PR head changes mid-pass.
  * Improved handling for unreadable required checks, auth/scope limits, and rate-limit retry behavior.
* **Documentation**
  * Added reference and harness-specific guidance for `shepherd`, including documented terminal outcomes and behavior guarantees.
* **Tests**
  * Added/expanded command, harness, documentation, and end-to-end acceptance coverage, including sync validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->