### PR TITLE
feat(memory): forge remember/recall commands (clears forge-remember-recall)

### DIFF
--- a/lib/commands/recall.js
+++ b/lib/commands/recall.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const memoryStore = require('../memory-store');
+
+const usage = 'Usage: forge recall [query] [--limit N] [--json]';
+
+/**
+ * Separate the optional positional query from `--limit N` and `--json`.
+ *
+ * @param {string[]} args - Raw command arguments.
+ * @returns {{ query: string, limit: (number|undefined), json: boolean }}
+ */
+function parseArgs(args) {
+  const words = [];
+  let limit;
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--limit') {
+      const value = Number(args[index + 1]);
+      if (Number.isInteger(value) && value > 0) {
+        limit = value;
+        index += 1;
+      }
+    } else if (arg.startsWith('--limit=')) {
+      const value = Number(arg.slice('--limit='.length));
+      if (Number.isInteger(value) && value > 0) {
+        limit = value;
+      }
+    } else {
+      words.push(arg);
+    }
+  }
+
+  return { query: words.join(' ').trim(), limit, json };
+}
+
+function formatEntry(entry) {
+  const date = entry.timestamp ? entry.timestamp.slice(0, 10) : '';
+  const tagSuffix = entry.tags.length > 0 ? ` [${entry.tags.join(', ')}]` : '';
+  const prefix = date ? `${date}  ` : '';
+  return `- ${prefix}${entry.note}${tagSuffix}`;
+}
+
+async function handler(args, _flags, projectRoot) {
+  const { query, limit, json } = parseArgs(args);
+
+  let entries = query
+    ? memoryStore.search(projectRoot, query)
+    : memoryStore.list(projectRoot);
+
+  if (limit !== undefined) {
+    entries = entries.slice(0, limit);
+  }
+
+  if (json) {
+    return { success: true, output: `${JSON.stringify(entries, null, 2)}\n` };
+  }
+
+  if (entries.length === 0) {
+    const reason = query
+      ? `No notes match "${query}".`
+      : 'No notes remembered yet. Use "forge remember <note>" to add one.';
+    return { success: true, output: reason };
+  }
+
+  const header = query
+    ? `${entries.length} note(s) matching "${query}":`
+    : `${entries.length} remembered note(s):`;
+  const lines = entries.map(formatEntry);
+  return {
+    success: true,
+    output: [header, ...lines].join('\n'),
+  };
+}
+
+module.exports = {
+  name: 'recall',
+  description: 'Retrieve project-memory notes from the file-backed store',
+  usage,
+  flags: {
+    '--limit': 'Cap the number of notes returned',
+    '--json': 'Emit machine-readable JSON output',
+  },
+  handler,
+};

--- a/lib/commands/remember.js
+++ b/lib/commands/remember.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const memoryStore = require('../memory-store');
+
+const usage = 'Usage: forge remember <note> [--tag <label>]... [--json]';
+
+/**
+ * Split positional note words from `--tag <label>` pairs and the `--json` flag.
+ *
+ * @param {string[]} args - Raw command arguments.
+ * @returns {{ note: string, tags: string[], json: boolean }}
+ */
+function parseArgs(args) {
+  const words = [];
+  const tags = [];
+  let json = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--json') {
+      json = true;
+    } else if (arg === '--tag') {
+      const value = args[index + 1];
+      if (value && !value.startsWith('--')) {
+        tags.push(value);
+        index += 1;
+      }
+    } else if (arg.startsWith('--tag=')) {
+      tags.push(arg.slice('--tag='.length));
+    } else {
+      words.push(arg);
+    }
+  }
+
+  return { note: words.join(' ').trim(), tags, json };
+}
+
+async function handler(args, _flags, projectRoot) {
+  const { note, tags, json } = parseArgs(args);
+
+  if (!note) {
+    return {
+      success: false,
+      error: `No note provided.\n${usage}`,
+    };
+  }
+
+  const entry = memoryStore.append(projectRoot, note, { tags });
+
+  if (json) {
+    return { success: true, output: `${JSON.stringify(entry, null, 2)}\n` };
+  }
+
+  const tagSuffix = entry.tags.length > 0 ? ` [${entry.tags.join(', ')}]` : '';
+  return {
+    success: true,
+    output: `Remembered: ${entry.note}${tagSuffix}`,
+  };
+}
+
+module.exports = {
+  name: 'remember',
+  description: 'Persist a project-memory note to a file-backed store',
+  usage,
+  flags: {
+    '--tag': 'Attach a search label (repeatable)',
+    '--json': 'Emit machine-readable JSON output',
+  },
+  handler,
+};

--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * File-backed project memory store.
+ *
+ * Notes are persisted as newline-delimited JSON under
+ * `.forge/memory/notes.jsonl`, which lives inside the repository so memory
+ * travels with the project through normal git history. The store has no
+ * external service or database dependency: every operation is a plain
+ * filesystem read or append.
+ *
+ * @module memory-store
+ */
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const MEMORY_DIR = path.join('.forge', 'memory');
+const STORE_FILENAME = 'notes.jsonl';
+
+/**
+ * Resolve the default newline-delimited store path for a project.
+ *
+ * @param {string} projectRoot - Absolute path to the project root.
+ * @returns {string} Absolute path to the notes store file.
+ */
+function defaultStorePath(projectRoot) {
+  return path.join(projectRoot, MEMORY_DIR, STORE_FILENAME);
+}
+
+function resolveStorePath(projectRoot, options = {}) {
+  return options.filePath || defaultStorePath(projectRoot);
+}
+
+function normalizeTags(tags) {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+  return tags
+    .filter(tag => typeof tag === 'string')
+    .map(tag => tag.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Append a note to the store and return the persisted entry.
+ *
+ * @param {string} projectRoot - Absolute path to the project root.
+ * @param {string} note - Free-form note text. Leading/trailing space is trimmed.
+ * @param {Object} [options]
+ * @param {string[]} [options.tags] - Optional search/grouping labels.
+ * @param {string} [options.timestamp] - ISO timestamp; generated when omitted.
+ * @param {string} [options.filePath] - Override the storage location (tests).
+ * @returns {{ id: string, note: string, timestamp: string, tags: string[] }}
+ */
+function append(projectRoot, note, options = {}) {
+  if (typeof note !== 'string' || note.trim() === '') {
+    throw new TypeError('memory note must be a non-empty string');
+  }
+
+  const entry = {
+    id: crypto.randomUUID(),
+    note: note.trim(),
+    timestamp: options.timestamp || new Date().toISOString(),
+    tags: normalizeTags(options.tags),
+  };
+
+  const storePath = resolveStorePath(projectRoot, options);
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.appendFileSync(storePath, `${JSON.stringify(entry)}\n`, 'utf8');
+
+  return entry;
+}
+
+function readEntries(storePath) {
+  if (!fs.existsSync(storePath)) {
+    return [];
+  }
+
+  const raw = fs.readFileSync(storePath, 'utf8');
+  const entries = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object' && typeof parsed.note === 'string') {
+        entries.push({
+          id: typeof parsed.id === 'string' ? parsed.id : '',
+          note: parsed.note,
+          timestamp: typeof parsed.timestamp === 'string' ? parsed.timestamp : '',
+          tags: normalizeTags(parsed.tags),
+        });
+      }
+    } catch (_error) {
+      // Skip unparseable lines so one bad record cannot break recall.
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * List all stored notes, newest first.
+ *
+ * @param {string} projectRoot - Absolute path to the project root.
+ * @param {Object} [options]
+ * @param {string} [options.filePath] - Override the storage location (tests).
+ * @returns {Array<{ id: string, note: string, timestamp: string, tags: string[] }>}
+ */
+function list(projectRoot, options = {}) {
+  return readEntries(resolveStorePath(projectRoot, options)).reverse();
+}
+
+/**
+ * Search stored notes by case-insensitive substring across note text and tags.
+ * An empty query returns every entry (newest first).
+ *
+ * @param {string} projectRoot - Absolute path to the project root.
+ * @param {string} query - Search term.
+ * @param {Object} [options]
+ * @param {string} [options.filePath] - Override the storage location (tests).
+ * @returns {Array<{ id: string, note: string, timestamp: string, tags: string[] }>}
+ */
+function search(projectRoot, query, options = {}) {
+  const entries = list(projectRoot, options);
+  if (typeof query !== 'string' || query.trim() === '') {
+    return entries;
+  }
+
+  const needle = query.trim().toLowerCase();
+  return entries.filter(entry => {
+    const haystack = `${entry.note} ${entry.tags.join(' ')}`.toLowerCase();
+    return haystack.includes(needle);
+  });
+}
+
+module.exports = {
+  defaultStorePath,
+  append,
+  list,
+  search,
+};

--- a/test/commands/recall.test.js
+++ b/test/commands/recall.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { afterEach, describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const recall = require('../../lib/commands/recall');
+const memoryStore = require('../../lib/memory-store');
+
+const tempDirs = [];
+
+function makeProjectRoot() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-recall-cmd-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('forge recall command', () => {
+  test('exports the registry command contract', () => {
+    expect(recall.name).toBe('recall');
+    expect(typeof recall.description).toBe('string');
+    expect(recall.description.length).toBeGreaterThan(0);
+    expect(typeof recall.handler).toBe('function');
+    expect(recall.usage).toContain('recall');
+    expect(recall.usage).toContain('[query]');
+  });
+
+  test('lists all stored notes when no query is given', async () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'first note');
+    memoryStore.append(projectRoot, 'second note');
+
+    const result = await recall.handler([], {}, projectRoot);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('first note');
+    expect(result.output).toContain('second note');
+  });
+
+  test('filters notes by query', async () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'Use Bun for tests');
+    memoryStore.append(projectRoot, 'Lint with eslint');
+
+    const result = await recall.handler(['bun'], {}, projectRoot);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Use Bun for tests');
+    expect(result.output).not.toContain('Lint with eslint');
+  });
+
+  test('reports an empty store gracefully', async () => {
+    const projectRoot = makeProjectRoot();
+    const result = await recall.handler([], {}, projectRoot);
+    expect(result.success).toBe(true);
+    expect(result.output.toLowerCase()).toContain('no');
+  });
+
+  test('reports when a query matches nothing', async () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'something');
+    const result = await recall.handler(['nonexistent'], {}, projectRoot);
+    expect(result.success).toBe(true);
+    expect(result.output.toLowerCase()).toContain('no');
+  });
+
+  test('emits JSON output with --json', async () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'alpha note');
+
+    const result = await recall.handler(['--json'], {}, projectRoot);
+    expect(result.success).toBe(true);
+    const parsed = JSON.parse(result.output);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].note).toBe('alpha note');
+  });
+
+  test('honors --limit', async () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'one');
+    memoryStore.append(projectRoot, 'two');
+    memoryStore.append(projectRoot, 'three');
+
+    const result = await recall.handler(['--json', '--limit', '2'], {}, projectRoot);
+    const parsed = JSON.parse(result.output);
+    expect(parsed).toHaveLength(2);
+  });
+});

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -37,7 +37,6 @@ describe('forge release check command', () => {
       'kernel-backed-forge-issue',
       'forge-orient-issue-recap',
       'forge-skills-pack',
-      'forge-remember-recall',
       'premerge-embedded-gate',
       'fresh-clone-no-beads-acceptance',
     ]);

--- a/test/commands/remember.test.js
+++ b/test/commands/remember.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const { afterEach, describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const remember = require('../../lib/commands/remember');
+const memoryStore = require('../../lib/memory-store');
+
+const tempDirs = [];
+
+function makeProjectRoot() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-remember-cmd-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('forge remember command', () => {
+  test('exports the registry command contract', () => {
+    expect(remember.name).toBe('remember');
+    expect(typeof remember.description).toBe('string');
+    expect(remember.description.length).toBeGreaterThan(0);
+    expect(typeof remember.handler).toBe('function');
+    expect(remember.usage).toContain('remember');
+    expect(remember.usage).toContain('<note>');
+  });
+
+  test('persists a note and reports success', async () => {
+    const projectRoot = makeProjectRoot();
+    const result = await remember.handler(['Run /plan before /dev'], {}, projectRoot);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Run /plan before /dev');
+
+    const entries = memoryStore.list(projectRoot);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].note).toBe('Run /plan before /dev');
+  });
+
+  test('joins multiple argument words into a single note', async () => {
+    const projectRoot = makeProjectRoot();
+    await remember.handler(['Prefer', 'Bun', 'over', 'npm'], {}, projectRoot);
+
+    const entries = memoryStore.list(projectRoot);
+    expect(entries[0].note).toBe('Prefer Bun over npm');
+  });
+
+  test('captures --tag values as tags', async () => {
+    const projectRoot = makeProjectRoot();
+    await remember.handler(['note body', '--tag', 'policy', '--tag', 'workflow'], {}, projectRoot);
+
+    const entries = memoryStore.list(projectRoot);
+    expect(entries[0].note).toBe('note body');
+    expect(entries[0].tags).toEqual(['policy', 'workflow']);
+  });
+
+  test('fails clearly when no note is provided', async () => {
+    const projectRoot = makeProjectRoot();
+    const result = await remember.handler([], {}, projectRoot);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('note');
+    expect(memoryStore.list(projectRoot)).toEqual([]);
+  });
+
+  test('emits JSON output with --json', async () => {
+    const projectRoot = makeProjectRoot();
+    const result = await remember.handler(['json note', '--json'], {}, projectRoot);
+
+    expect(result.success).toBe(true);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.note).toBe('json note');
+  });
+});

--- a/test/memory-store.test.js
+++ b/test/memory-store.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const { afterEach, describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const memoryStore = require('../lib/memory-store');
+
+const tempDirs = [];
+
+function makeProjectRoot() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-memory-store-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('memory-store', () => {
+  test('defaultStorePath points at a file-based location under .forge/memory', () => {
+    const projectRoot = makeProjectRoot();
+    const storePath = memoryStore.defaultStorePath(projectRoot);
+    expect(storePath).toBe(path.join(projectRoot, '.forge', 'memory', 'notes.jsonl'));
+  });
+
+  test('append writes a note and returns the stored entry', () => {
+    const projectRoot = makeProjectRoot();
+    const entry = memoryStore.append(projectRoot, 'Run /plan before /dev');
+
+    expect(entry.note).toBe('Run /plan before /dev');
+    expect(typeof entry.id).toBe('string');
+    expect(entry.id.length).toBeGreaterThan(0);
+    expect(typeof entry.timestamp).toBe('string');
+    expect(Array.isArray(entry.tags)).toBe(true);
+
+    const storePath = memoryStore.defaultStorePath(projectRoot);
+    expect(fs.existsSync(storePath)).toBe(true);
+    const lines = fs.readFileSync(storePath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).note).toBe('Run /plan before /dev');
+  });
+
+  test('append creates the memory directory when it does not exist', () => {
+    const projectRoot = makeProjectRoot();
+    expect(fs.existsSync(path.join(projectRoot, '.forge', 'memory'))).toBe(false);
+    memoryStore.append(projectRoot, 'first note');
+    expect(fs.existsSync(path.join(projectRoot, '.forge', 'memory'))).toBe(true);
+  });
+
+  test('append preserves tags and trims the note', () => {
+    const projectRoot = makeProjectRoot();
+    const entry = memoryStore.append(projectRoot, '  tagged note  ', { tags: ['policy', 'workflow'] });
+    expect(entry.note).toBe('tagged note');
+    expect(entry.tags).toEqual(['policy', 'workflow']);
+  });
+
+  test('append rejects empty notes', () => {
+    const projectRoot = makeProjectRoot();
+    expect(() => memoryStore.append(projectRoot, '   ')).toThrow();
+    expect(() => memoryStore.append(projectRoot, '')).toThrow();
+  });
+
+  test('list returns entries newest first', () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'first');
+    memoryStore.append(projectRoot, 'second');
+    memoryStore.append(projectRoot, 'third');
+
+    const entries = memoryStore.list(projectRoot);
+    expect(entries.map(entry => entry.note)).toEqual(['third', 'second', 'first']);
+  });
+
+  test('list returns an empty array when nothing is stored', () => {
+    const projectRoot = makeProjectRoot();
+    expect(memoryStore.list(projectRoot)).toEqual([]);
+  });
+
+  test('list tolerates malformed lines without throwing', () => {
+    const projectRoot = makeProjectRoot();
+    const storePath = memoryStore.defaultStorePath(projectRoot);
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      `${JSON.stringify({ id: 'a', note: 'valid', timestamp: '2026-01-01T00:00:00.000Z', tags: [] })}\nnot-json\n`,
+      'utf8',
+    );
+    const entries = memoryStore.list(projectRoot);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].note).toBe('valid');
+  });
+
+  test('search matches note text case-insensitively', () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'Use Bun for tests');
+    memoryStore.append(projectRoot, 'Lint with eslint');
+
+    const results = memoryStore.search(projectRoot, 'BUN');
+    expect(results).toHaveLength(1);
+    expect(results[0].note).toBe('Use Bun for tests');
+  });
+
+  test('search matches tags', () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'note with tag', { tags: ['security'] });
+    memoryStore.append(projectRoot, 'note without', { tags: [] });
+
+    const results = memoryStore.search(projectRoot, 'security');
+    expect(results).toHaveLength(1);
+    expect(results[0].note).toBe('note with tag');
+  });
+
+  test('search with empty query returns all entries', () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'alpha');
+    memoryStore.append(projectRoot, 'beta');
+    expect(memoryStore.search(projectRoot, '')).toHaveLength(2);
+  });
+
+  test('options.filePath overrides the storage location', () => {
+    const projectRoot = makeProjectRoot();
+    const custom = path.join(projectRoot, 'custom', 'memory.jsonl');
+    memoryStore.append(projectRoot, 'custom location note', { filePath: custom });
+
+    expect(fs.existsSync(custom)).toBe(true);
+    expect(memoryStore.list(projectRoot, { filePath: custom })).toHaveLength(1);
+    expect(fs.existsSync(memoryStore.defaultStorePath(projectRoot))).toBe(false);
+  });
+
+  test('entries carry unique ids', () => {
+    const projectRoot = makeProjectRoot();
+    const first = memoryStore.append(projectRoot, 'one');
+    const second = memoryStore.append(projectRoot, 'two');
+    expect(first.id).not.toBe(second.id);
+  });
+});


### PR DESCRIPTION
Adds `forge remember` / `forge recall` project-memory commands, file/git-backed with zero Beads/Dolt dependencies. Clears the readiness blocker `forge-remember-recall`.

## What
- `lib/memory-store.js` — file-backed store; persists notes to `.forge/memory/notes.jsonl` (newline-delimited JSON, no external service/database).
- `lib/commands/remember.js` — `forge remember <note> [--tag <label>]... [--json]` appends a note.
- `lib/commands/recall.js` — `forge recall [query] [--limit N] [--json]` lists or searches notes.

Persistence is purely filesystem/git-backed so memory travels with the repository through normal git history. No `bd`/`.beads`/`dolt` tokens in shipped source (verified) — this feeds the Beads-retirement readiness gate.

## Verification
- `rememberRecallBlocker` predicate satisfied: both commands export `{ name, description, handler }` and are auto-discovered by `lib/commands/_registry.js`. `forge-remember-recall` is **gone** from `buildReadinessReport(...).blockers`.
- Did **not** activate `bd-hot-path-issue-commands` (pre-existing on `origin/master`; new files are not in its evidence list) and did **not** stale `d20-audit-artifact-current`.
- TDD: `test/memory-store.test.js`, `test/commands/remember.test.js`, `test/commands/recall.test.js` (26 cases). Convention/docs/registry suites (`commands-convention-ref`, `forge-commands`, `forge-docs-command`, `docs-command`, `command-sync-check`, `_registry`, `forge-cmd`, `adapter-cli`) all pass with the new commands added.
- ESLint clean (`--max-warnings 0`).
- Local `forge test --affected` timed out at 2m (environmentally fragile per task brief); pushed via `--quick` so CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new commands to save and retrieve project notes, with optional tags.
  * Notes support searching by text/tags, listing with an optional result limit, and machine-readable JSON output.
  * Introduced a persistent, file-backed note store to retain entries between runs.
* **Bug Fixes**
  * Improved reliability by gracefully handling empty or malformed stored entries.
  * Added validation to prevent saving missing/blank notes and improved “no results” messaging.
* **Tests**
  * Added comprehensive command and store test coverage; updated readiness gate expectations for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->