### PR TITLE
feat(kernel): migrate project memory off Beads to the kernel read model (Stage A)

### DIFF
--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -8,7 +8,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 | Group | Call sites | Files |
 | --- | ---: | ---: |
 | command | 108 | 11 |
-| runtime | 351 | 48 |
+| runtime | 347 | 47 |
 | docs | 452 | 68 |
 | skills | 22 | 9 |
 | hooks | 0 | 0 |
@@ -76,8 +76,6 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 26 (.beads)
 - [ ] lib/plugin-catalog.js (1)
   - lines: 102 (bd)
-- [ ] lib/project-memory.js (4)
-  - lines: 17 (bd), 138 (bd), 149 (bd), 176 (bd)
 - [ ] lib/protected-path-manifest.js (2)
   - lines: 23 (bd), 33 (bd)
 - [ ] lib/protected-state-surfaces.js (4)

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -53,6 +53,13 @@ function renderDropTable(table) {
 	return `DROP TABLE IF EXISTS ${table.sqlName};`;
 }
 
+// Whole tables created by a LATER migration (not by the 001 initial schema). schema.js
+// stays the full current schema; the named tables are filtered out of 001 so they are
+// created exactly once by their dedicated migration (both on a fresh DB and, via the
+// ledger, on an existing DB). KEEP IN SYNC with every new table-creating migration.
+//   memories → 005
+const MIGRATION_ADDED_TABLES = ['memories'];
+
 function getInitialKernelSchema() {
 	const schema = getKernelSchema();
 	// Columns added by a later migration MUST be excluded from the initial (001)
@@ -68,14 +75,16 @@ function getInitialKernelSchema() {
 	};
 	return {
 		...schema,
-		tables: schema.tables.map(table => {
-			const excluded = MIGRATION_ADDED_COLUMNS[table.name];
-			if (!excluded) return table;
-			return {
-				...table,
-				fields: table.fields.filter(field => !excluded.includes(field.name)),
-			};
-		}),
+		tables: schema.tables
+			.filter(table => !MIGRATION_ADDED_TABLES.includes(table.name))
+			.map(table => {
+				const excluded = MIGRATION_ADDED_COLUMNS[table.name];
+				if (!excluded) return table;
+				return {
+					...table,
+					fields: table.fields.filter(field => !excluded.includes(field.name)),
+				};
+			}),
 	};
 }
 
@@ -159,6 +168,29 @@ function buildIssueContentFieldsMigration() {
 	};
 }
 
+// 005: the project-memory read-model table (kernel_memories). Rendered from the
+// schema.js table definition so the DDL never drifts from the registry. Excluded from
+// the 001 initial schema (MIGRATION_ADDED_TABLES), so a fresh DB creates it exactly
+// once here and an existing DB picks it up through the broker's per-migration ledger.
+// CREATE … IF NOT EXISTS keeps a re-run idempotent.
+function buildMemoryProjectionMigration() {
+	const memories = getKernelSchema().tables.find(table => table.name === 'memories');
+	if (!memories) {
+		throw new Error('Kernel schema is missing the memories read-model table');
+	}
+	return {
+		id: '005_kernel_memories',
+		apply: [
+			renderCreateTable(memories),
+			...memories.indexes.map(memoryIndex => renderCreateIndex(memories, memoryIndex)),
+		],
+		rollback: [
+			...[...memories.indexes].reverse().map(memoryIndex => renderDropIndex(memoryIndex)),
+			renderDropTable(memories),
+		],
+	};
+}
+
 function validateKernelMigrations(migrations) {
 	const ids = new Set();
 	for (const migration of migrations) {
@@ -185,6 +217,7 @@ function buildKernelMigrationPlan(migrations = [
 	buildEventExpectedRevisionMigration(),
 	buildClaimActiveLeaseMigration(),
 	buildIssueContentFieldsMigration(),
+	buildMemoryProjectionMigration(),
 ]) {
 	validateKernelMigrations(migrations);
 
@@ -200,6 +233,7 @@ module.exports = {
 	buildEventExpectedRevisionMigration,
 	buildIssueContentFieldsMigration,
 	buildKernelMigrationPlan,
+	buildMemoryProjectionMigration,
 	buildSchemaMigration,
 	validateKernelMigrations,
 };

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -244,6 +244,26 @@ const TABLE_LIST = deepFreeze([
 	], [
 		index('idx_kernel_dead_letters_status', ['status']),
 	]),
+	// Project memory is a Forge read model: durable key/value notes written DIRECTLY
+	// (NOT through the issue CAS/guarded-event path). `key` is the stable identity;
+	// value_json holds the serialized memory value, and the *_json columns carry the
+	// optional list fields. Created by migration 005 (excluded from the 001 initial
+	// schema), so a fresh DB creates it exactly once and an existing DB picks it up
+	// via the broker ledger.
+	table('memories', 'read_model', [
+		field('key', 'TEXT', { primaryKey: true }),
+		field('value_json', 'TEXT', { notNull: true }),
+		field('source_agent', 'TEXT', { notNull: true }),
+		field('scope', 'TEXT'),
+		field('confidence', 'REAL'),
+		field('tags_json', 'TEXT'),
+		field('supersedes_json', 'TEXT'),
+		field('beads_refs_json', 'TEXT'),
+		field('created_at', 'TEXT', { notNull: true }),
+		field('updated_at', 'TEXT', { notNull: true }),
+	], [
+		index('idx_kernel_memories_source_agent', ['source_agent']),
+	]),
 ]);
 
 const KERNEL_TABLES = deepFreeze(Object.fromEntries(TABLE_LIST.map(candidate => [candidate.name, candidate])));

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -1417,6 +1417,7 @@ function createDriver(runtime, configuredDatabasePath) {
 			closeDatabase(db);
 			db = null;
 			openedDatabasePath = null;
+			memorySchemaEnsured = false;
 		},
 	};
 }

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -12,6 +12,7 @@ const {
 	resolveNextCommands,
 } = require('./issue-command-contract');
 const { buildReadinessIndex } = require('./readiness-model');
+const { buildMemoryProjectionMigration } = require('./migrations');
 
 const BUILTIN_SQLITE_RUNTIME_ORDER = Object.freeze(['bun:sqlite', 'node:sqlite']);
 let probeCounter = 0;
@@ -1124,6 +1125,124 @@ function applyAcceptedMutation(runtime, db, event, context = {}) {
 	return null;
 }
 
+// --- Project-memory read-model primitives -------------------------------------
+// kernel_memories is a Forge read model written DIRECTLY (NOT through the guarded-event
+// path), so these are plain synchronous SQL helpers. project-memory.js owns the memory
+// entry shape; here we (de)serialize the JSON columns and upsert by key. The driver
+// methods are synchronous so the (synchronous) project-memory facade can persist without
+// awaiting the async broker.initialize().
+const KERNEL_MEMORY_COLUMNS = Object.freeze([
+	'key',
+	'value_json',
+	'source_agent',
+	'scope',
+	'confidence',
+	'tags_json',
+	'supersedes_json',
+	'beads_refs_json',
+	'created_at',
+	'updated_at',
+]);
+
+function parseMemoryJsonColumn(raw, fallback) {
+	if (raw === null || raw === undefined || raw === '') return fallback;
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return fallback;
+	}
+}
+
+// Map a stored row back to the memory entry shape. Optional fields are omitted when
+// unset (matches the legacy entry shape); tags and timestamp are always present.
+function memoryRowToEntry(row) {
+	if (!row) return null;
+	const entry = {
+		key: row.key,
+		value: parseMemoryJsonColumn(row.value_json, row.value_json),
+		sourceAgent: row.source_agent,
+		tags: parseMemoryJsonColumn(row.tags_json, []),
+		timestamp: row.created_at,
+	};
+	if (row.scope !== null && row.scope !== undefined) entry.scope = row.scope;
+	if (row.confidence !== null && row.confidence !== undefined) entry.confidence = Number(row.confidence);
+	const supersedes = parseMemoryJsonColumn(row.supersedes_json, undefined);
+	if (Array.isArray(supersedes)) entry.supersedes = supersedes;
+	const beadsRefs = parseMemoryJsonColumn(row.beads_refs_json, undefined);
+	if (Array.isArray(beadsRefs)) entry.beadsRefs = beadsRefs;
+	return entry;
+}
+
+function memoryEntryToRow(entry, now) {
+	const tags = Array.isArray(entry.tags) ? entry.tags : [];
+	return {
+		key: entry.key,
+		value_json: JSON.stringify(entry.value ?? null),
+		source_agent: entry.sourceAgent ?? entry['source-agent'] ?? '',
+		scope: entry.scope ?? null,
+		confidence: entry.confidence ?? null,
+		tags_json: JSON.stringify(tags),
+		supersedes_json: Array.isArray(entry.supersedes) ? JSON.stringify(entry.supersedes) : null,
+		beads_refs_json: Array.isArray(entry.beadsRefs) ? JSON.stringify(entry.beadsRefs) : null,
+		created_at: entry.timestamp || now,
+		updated_at: now,
+	};
+}
+
+// Upsert by key: insert a fresh row, or refresh every value column on a key collision
+// while keeping the original created_at (only updated_at advances).
+function upsertMemoryRow(runtime, db, entry) {
+	const now = new Date().toISOString();
+	const row = memoryEntryToRow(entry, now);
+	const placeholders = KERNEL_MEMORY_COLUMNS.map(() => '?').join(', ');
+	runParams(
+		runtime,
+		db,
+		`INSERT INTO kernel_memories (${KERNEL_MEMORY_COLUMNS.join(', ')}) VALUES (${placeholders})
+			ON CONFLICT(key) DO UPDATE SET
+				value_json = excluded.value_json,
+				source_agent = excluded.source_agent,
+				scope = excluded.scope,
+				confidence = excluded.confidence,
+				tags_json = excluded.tags_json,
+				supersedes_json = excluded.supersedes_json,
+				beads_refs_json = excluded.beads_refs_json,
+				updated_at = excluded.updated_at`,
+		KERNEL_MEMORY_COLUMNS.map(column => row[column]),
+	);
+	return memoryRowToEntry(row);
+}
+
+function loadMemoryRow(runtime, db, key) {
+	const rows = allParams(runtime, db, 'SELECT * FROM kernel_memories WHERE key = ?', [key]);
+	return memoryRowToEntry(rows[0] || null);
+}
+
+function listMemoryRows(runtime, db) {
+	return allParams(runtime, db, 'SELECT * FROM kernel_memories ORDER BY key ASC').map(memoryRowToEntry);
+}
+
+// Token-AND LIKE search across key + value_json. Each whitespace-separated token must
+// appear (in either column); an empty query lists everything. Parameterized, so the
+// tokens never interpolate into SQL.
+function searchMemoryRows(runtime, db, query) {
+	const tokens = String(query ?? '').trim().split(/\s+/).filter(Boolean);
+	if (tokens.length === 0) {
+		return listMemoryRows(runtime, db);
+	}
+	const clauses = tokens.map(() => '(key LIKE ? OR value_json LIKE ?)').join(' AND ');
+	const params = tokens.flatMap(token => {
+		const like = `%${token}%`;
+		return [like, like];
+	});
+	return allParams(
+		runtime,
+		db,
+		`SELECT * FROM kernel_memories WHERE ${clauses} ORDER BY key ASC`,
+		params,
+	).map(memoryRowToEntry);
+}
+
 function closeDatabase(db) {
 	if (db && typeof db.close === 'function') {
 		db.close();
@@ -1133,6 +1252,20 @@ function closeDatabase(db) {
 function createDriver(runtime, configuredDatabasePath) {
 	let db;
 	let openedDatabasePath;
+	let memorySchemaEnsured = false;
+
+	// kernel_memories is created by migration 005 through broker.initialize(), but the
+	// synchronous project-memory facade writes WITHOUT first running migrations. Lazily
+	// ensure the table (idempotent CREATE IF NOT EXISTS, rendered from the same migration)
+	// plus a busy_timeout for the second connection the issue backend may hold open.
+	function ensureMemorySchema(database) {
+		if (memorySchemaEnsured) return;
+		execSql(runtime, database, 'PRAGMA busy_timeout=5000;');
+		for (const statement of buildMemoryProjectionMigration().apply) {
+			execSql(runtime, database, statement);
+		}
+		memorySchemaEnsured = true;
+	}
 
 	function resolveDatabasePath(config) {
 		const brokerDatabasePath = config && config.databasePath;
@@ -1248,6 +1381,30 @@ function createDriver(runtime, configuredDatabasePath) {
 		// runGuardedEvent's result so runIssueOperation can shape the mutation response.
 		async applyAcceptedIssueMutation(event, context = {}, config = {}) {
 			return applyAcceptedMutation(runtime, getDatabase(config), event, context);
+		},
+		// --- Project-memory read model (written directly, not via the guarded path).
+		// Synchronous by design: the project-memory facade is synchronous, and these
+		// lazily ensure the kernel_memories table so a write never needs a prior
+		// (async) broker.initialize().
+		recordMemory(entry, config = {}) {
+			const database = getDatabase(config);
+			ensureMemorySchema(database);
+			return upsertMemoryRow(runtime, database, entry);
+		},
+		loadMemory(key, config = {}) {
+			const database = getDatabase(config);
+			ensureMemorySchema(database);
+			return loadMemoryRow(runtime, database, key);
+		},
+		searchMemories(query, config = {}) {
+			const database = getDatabase(config);
+			ensureMemorySchema(database);
+			return searchMemoryRows(runtime, database, query);
+		},
+		listMemories(config = {}) {
+			const database = getDatabase(config);
+			ensureMemorySchema(database);
+			return listMemoryRows(runtime, database);
 		},
 		close() {
 			closeDatabase(db);

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -1154,7 +1154,11 @@ function parseMemoryJsonColumn(raw, fallback) {
 }
 
 // Map a stored row back to the memory entry shape. Optional fields are omitted when
-// unset (matches the legacy entry shape); tags and timestamp are always present.
+// unset (matches the legacy entry shape); tags and timestamp are always present. The
+// entry's logical `timestamp` is the mutable "as-of" time (updated_at), so re-writing a
+// key surfaces the latest write — matching the legacy single-timestamp behavior, where
+// every write refreshed the stored timestamp. created_at stays as immutable first-seen
+// provenance and is intentionally not part of the entry shape.
 function memoryRowToEntry(row) {
 	if (!row) return null;
 	const entry = {
@@ -1162,7 +1166,7 @@ function memoryRowToEntry(row) {
 		value: parseMemoryJsonColumn(row.value_json, row.value_json),
 		sourceAgent: row.source_agent,
 		tags: parseMemoryJsonColumn(row.tags_json, []),
-		timestamp: row.created_at,
+		timestamp: row.updated_at,
 	};
 	if (row.scope !== null && row.scope !== undefined) entry.scope = row.scope;
 	if (row.confidence !== null && row.confidence !== undefined) entry.confidence = Number(row.confidence);
@@ -1184,8 +1188,11 @@ function memoryEntryToRow(entry, now) {
 		tags_json: JSON.stringify(tags),
 		supersedes_json: Array.isArray(entry.supersedes) ? JSON.stringify(entry.supersedes) : null,
 		beads_refs_json: Array.isArray(entry.beadsRefs) ? JSON.stringify(entry.beadsRefs) : null,
+		// created_at is first-seen provenance (kept across upserts); updated_at is the
+		// entry's logical timestamp (the "as-of" the read model surfaces). Both default to
+		// the wall clock when the caller omits a timestamp (e.g. a direct driver write).
 		created_at: entry.timestamp || now,
-		updated_at: now,
+		updated_at: entry.timestamp || now,
 	};
 }
 

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -1,20 +1,33 @@
-const { execFileSync } = require('node:child_process');
+'use strict';
 
-const EXEC_TIMEOUT = 30_000;
-const EXEC_MAX_BUFFER = 10 * 1024 * 1024;
+const { resolveKernelDatabasePath } = require('./kernel/cli-broker-factory');
+const { createBuiltinSQLiteDriver } = require('./kernel/sqlite-driver');
 
-function defaultRunner(command, args, options = {}) {
-  return execFileSync(command, args, {
-    cwd: options.projectRoot,
-    encoding: 'utf8',
-    maxBuffer: options.maxBuffer ?? EXEC_MAX_BUFFER,
-    timeout: options.timeoutMs ?? EXEC_TIMEOUT,
+// Project memory is a Forge read model persisted in the kernel store (kernel_memories),
+// written DIRECTLY rather than through the issue CAS/guarded-event path. The store seam
+// (options.store) is a driver-like object — { recordMemory, loadMemory, searchMemories,
+// listMemories } — so hermetic tests stay in-memory. The default seam resolves the
+// per-repo kernel database path and reuses one driver per database path (the CLI process
+// is short-lived, so the connection closing on exit is sufficient cleanup).
+
+const storeCache = new Map();
+
+function defaultStore(projectRoot, options = {}) {
+  const databasePath = resolveKernelDatabasePath({
+    projectRoot,
+    gitCommonDir: options.gitCommonDir,
+    databasePath: options.databasePath,
   });
+  let store = storeCache.get(databasePath);
+  if (!store) {
+    store = createBuiltinSQLiteDriver({ databasePath });
+    storeCache.set(databasePath, store);
+  }
+  return store;
 }
 
-function runBd(projectRoot, args, options = {}) {
-  const runner = options.runner ?? defaultRunner;
-  return runner('bd', args, { projectRoot, timeoutMs: options.timeoutMs, maxBuffer: options.maxBuffer });
+function resolveStore(projectRoot, options = {}) {
+  return options.store ?? defaultStore(projectRoot, options);
 }
 
 function assertEntryObject(entry) {
@@ -62,138 +75,49 @@ function validateEntry(entry) {
   if (entry['beads-refs'] !== undefined) assertStringArray(entry['beads-refs'], 'beads-refs');
 }
 
-function payloadFromEntry(entry) {
-  const payload = {
+// Canonicalize an entry for storage: resolve the snake-case input aliases, default the
+// timestamp and tags, and carry the optional fields only when present (so the persisted
+// shape matches the legacy entry exactly).
+function normalizeEntry(key, entry) {
+  const normalized = {
+    key,
     value: entry.value,
     sourceAgent: entry.sourceAgent || entry['source-agent'],
     tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
+    timestamp: entry.timestamp ?? new Date().toISOString(),
   };
 
-  if (entry.timestamp !== undefined) payload.timestamp = entry.timestamp;
-  if (entry.scope !== undefined) payload.scope = entry.scope;
-  if (entry.confidence !== undefined) payload.confidence = entry.confidence;
-  if (entry.supersedes !== undefined) payload.supersedes = [...entry.supersedes];
+  if (entry.scope !== undefined) normalized.scope = entry.scope;
+  if (entry.confidence !== undefined) normalized.confidence = entry.confidence;
+  if (entry.supersedes !== undefined) normalized.supersedes = [...entry.supersedes];
   if (entry.beadsRefs !== undefined || entry['beads-refs'] !== undefined) {
-    payload.beadsRefs = [...(entry.beadsRefs || entry['beads-refs'])];
+    normalized.beadsRefs = [...(entry.beadsRefs || entry['beads-refs'])];
   }
 
-  return payload;
-}
-
-function entryFromPayload(key, payload = {}) {
-  const entry = {
-    key,
-    value: payload.value,
-    sourceAgent: payload.sourceAgent || payload['source-agent'],
-    tags: Array.isArray(payload.tags) ? [...payload.tags] : [],
-  };
-
-  if (payload.timestamp !== undefined) entry.timestamp = payload.timestamp;
-  if (payload.scope !== undefined) entry.scope = payload.scope;
-  if (payload.confidence !== undefined) entry.confidence = payload.confidence;
-  if (payload.supersedes !== undefined) entry.supersedes = [...payload.supersedes];
-  if (payload.beadsRefs !== undefined || payload['beads-refs'] !== undefined) {
-    entry.beadsRefs = [...(payload.beadsRefs || payload['beads-refs'])];
-  }
-
-  return entry;
-}
-
-function parseJsonOutput(commandName, output) {
-  const text = String(output ?? '').trim();
-  if (text === '') return null;
-  try {
-    return JSON.parse(text);
-  } catch (err) {
-    throw new Error(`Invalid ${commandName} JSON: ${err.message}`);
-  }
-}
-
-function tryParseJsonOutput(output) {
-  const text = String(output ?? '').trim();
-  if (text === '') return { ok: true, value: null };
-  try {
-    return { ok: true, value: JSON.parse(text) };
-  } catch {
-    return { ok: false, text };
-  }
-}
-
-function parseMemoryRecord(record, fallbackKey) {
-  if (!record) return null;
-  if (record.found === false) return null;
-
-  const key = record.key || fallbackKey;
-  const content = record.content ?? record.value ?? record.memory ?? record.insight;
-  if (typeof content === 'string') {
-    const trimmed = content.trim();
-    if (trimmed.startsWith('{')) {
-      const parsedContent = tryParseJsonOutput(trimmed);
-      if (parsedContent.ok) {
-        return entryFromPayload(key, parsedContent.value);
-      }
-    }
-    return entryFromPayload(key, {
-      value: content,
-      sourceAgent: record.sourceAgent || record.actor || 'bd',
-      tags: Array.isArray(record.tags) ? record.tags : [],
-    });
-  }
-
-  if (content && typeof content === 'object') {
-    return entryFromPayload(key, content);
-  }
-
-  return entryFromPayload(key, {
-    value: record.value,
-    sourceAgent: record.sourceAgent || record.actor || 'bd',
-    tags: Array.isArray(record.tags) ? record.tags : [],
-  });
+  return normalized;
 }
 
 function write(projectRoot, entry, options = {}) {
   validateEntry(entry);
-  const key = entry.key.trim();
-  const payload = payloadFromEntry({
-    ...entry,
-    key,
-    timestamp: entry.timestamp ?? new Date().toISOString(),
-  });
-  runBd(projectRoot, ['remember', JSON.stringify(payload), '--key', key], options);
-  return entryFromPayload(key, payload);
+  const normalized = normalizeEntry(entry.key.trim(), entry);
+  resolveStore(projectRoot, options).recordMemory(normalized);
+  return normalized;
 }
 
 function read(projectRoot, key, options = {}) {
   assertRequiredString(key, 'read key');
-  const normalizedKey = key.trim();
-  const output = runBd(projectRoot, ['recall', normalizedKey, '--json'], options);
-  const parsedOutput = tryParseJsonOutput(output);
-  const parsed = parsedOutput.ok ? parsedOutput.value : { key: normalizedKey, content: parsedOutput.text };
-  return parseMemoryRecord(parsed, normalizedKey);
-}
-
-function entriesFromMemoriesOutput(output) {
-  const parsed = parseJsonOutput('bd memories', output);
-  if (parsed === null) return [];
-  let rows = Array.isArray(parsed) ? parsed : (parsed.memories || parsed.items);
-  if (!rows && typeof parsed === 'object') {
-    rows = Object.entries(parsed)
-      .filter(([key]) => key !== 'schema_version')
-      .map(([key, value]) => ({ key, value }));
-  }
-  if (!Array.isArray(rows)) return [];
-  return rows.map(row => parseMemoryRecord(row, row.key)).filter(Boolean);
+  return resolveStore(projectRoot, options).loadMemory(key.trim());
 }
 
 function search(projectRoot, query, options = {}) {
   if (typeof query !== 'string' || query.trim() === '') {
     return [];
   }
-  return entriesFromMemoriesOutput(runBd(projectRoot, ['memories', query.trim(), '--json'], options));
+  return resolveStore(projectRoot, options).searchMemories(query.trim());
 }
 
 function list(projectRoot, options = {}) {
-  return entriesFromMemoriesOutput(runBd(projectRoot, ['memories', '--json'], options));
+  return resolveStore(projectRoot, options).listMemories();
 }
 
 module.exports = {

--- a/test/e2e/kernel-memory.test.js
+++ b/test/e2e/kernel-memory.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// E2E: project memory persists to the KERNEL store by default — no Beads, no
+// FORGE_ISSUE_BACKEND. Mirrors kernel-default-cli.test.js: a throwaway git repo with a
+// scrubbed env, exercising the real lib/project-memory write/read path in a child
+// process (so the SQLite connection closes on exit). The data must land in a fresh
+// `.git/forge/kernel.sqlite` and round-trip, and NO `.beads` store may be created —
+// proof the path never shells out to the old Beads command runner.
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const PROJECT_MEMORY = path.join(__dirname, '..', '..', 'lib', 'project-memory.js');
+const TIMEOUT = 30000;
+
+// Windows can hold a transient WAL lock on the just-written DB; retry the rm.
+function rmrfWithRetry(dir) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 4 || (error.code !== 'EBUSY' && error.code !== 'EPERM')) {
+        return; // best-effort cleanup; never fail a test on a temp-dir lock
+      }
+      const until = Date.now() + 100;
+      while (Date.now() < until) { /* brief spin before retry */ }
+    }
+  }
+}
+
+// Run the real project-memory facade in a child process rooted at the temp repo. A
+// scrubbed env strips any ambient FORGE_ISSUE_BACKEND so the run exercises the pure
+// default kernel path. The child writes then reads back one entry and prints it.
+function runMemoryRoundTrip(cwd) {
+  const env = { ...process.env };
+  delete env.FORGE_ISSUE_BACKEND;
+  const script = `
+    const pm = require(${JSON.stringify(PROJECT_MEMORY)});
+    const root = process.cwd();
+    pm.write(root, {
+      key: 'e2e.kernel',
+      value: { hello: 'kernel' },
+      sourceAgent: 'e2e',
+      tags: ['e2e'],
+    });
+    process.stdout.write(JSON.stringify(pm.read(root, 'e2e.kernel')));
+  `;
+  try {
+    const stdout = execFileSync('node', ['-e', script], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env,
+    });
+    return { stdout, status: 0 };
+  } catch (error) {
+    return {
+      stdout: `${error.stdout || ''}${error.stderr || ''}`,
+      status: typeof error.status === 'number' ? error.status : 1,
+    };
+  }
+}
+
+describe('project memory persists to the kernel store by default (no Beads)', () => {
+  let repo;
+  let dbPath;
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-memory-e2e-'));
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    dbPath = path.join(repo, '.git', 'forge', 'kernel.sqlite');
+  });
+
+  afterEach(() => {
+    rmrfWithRetry(repo);
+  });
+
+  test(
+    'write/read round-trips through .git/forge/kernel.sqlite and creates no Beads store',
+    () => {
+      expect(fs.existsSync(dbPath)).toBe(false);
+
+      const { stdout, status } = runMemoryRoundTrip(repo);
+      expect(status).toBe(0);
+
+      // The entry round-trips through the kernel read model.
+      const entry = JSON.parse(stdout);
+      expect(entry).toMatchObject({
+        key: 'e2e.kernel',
+        value: { hello: 'kernel' },
+        sourceAgent: 'e2e',
+        tags: ['e2e'],
+      });
+
+      // The kernel DB was materialized by the default path — proof of routing.
+      expect(fs.existsSync(dbPath)).toBe(true);
+      // The legacy Beads store is never created: the path shells out to no Beads CLI.
+      expect(fs.existsSync(path.join(repo, '.beads'))).toBe(false);
+    },
+    TIMEOUT,
+  );
+});

--- a/test/kernel/broker-migration-ledger.test.js
+++ b/test/kernel/broker-migration-ledger.test.js
@@ -57,6 +57,21 @@ describe('Kernel broker — migration ledger', () => {
 		expect(Number(count[0].n)).toBe(expectedIds.length);
 	});
 
+	test('initialize() creates the kernel_memories read-model table and a re-run is idempotent', async () => {
+		const first = await makeBroker().initialize();
+		expect(first.migrationsNewlyApplied).toContain('005_kernel_memories');
+
+		// The read-model table is queryable after the first initialize().
+		const empty = await driver.queryAll('SELECT COUNT(*) AS n FROM kernel_memories;', config);
+		expect(Number(empty[0].n)).toBe(0);
+
+		// A second initialize() applies nothing new and does not error (idempotent).
+		const second = await makeBroker().initialize();
+		expect(second.migrationsNewlyApplied).toEqual([]);
+		const ids = await ledgerIds();
+		expect(ids.filter(id => id === '005_kernel_memories')).toEqual(['005_kernel_memories']);
+	});
+
 	test('a second initialize applies nothing (the ledger short-circuits)', async () => {
 		await makeBroker().initialize();
 		const before = await ledgerIds();

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -21,8 +21,11 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.apply).toContain('ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
-		// Rollback runs migrations in reverse, so 004's last column drop comes first.
-		expect(plan.rollback[0]).toBe('ALTER TABLE kernel_issues DROP COLUMN assignee;');
+		// Rollback runs migrations in reverse, so 005 (the latest migration) rolls back
+		// first: its search index drop precedes the kernel_memories table drop.
+		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_memories_source_agent;');
+		expect(plan.rollback).toContain('DROP TABLE IF EXISTS kernel_memories;');
+		expect(plan.rollback).toContain('ALTER TABLE kernel_issues DROP COLUMN assignee;');
 		expect(plan.rollback).toContain('DROP INDEX IF EXISTS idx_kernel_claims_active_lease;');
 		expect(plan.rollback).toContain('CREATE TABLE IF NOT EXISTS kernel_events_002_rollback (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.rollback).toContain('INSERT INTO kernel_events_002_rollback (id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at) SELECT id, entity_type, entity_id, event_type, idempotency_key, actor, origin, payload_json, created_at FROM kernel_events;');
@@ -33,7 +36,40 @@ describe('kernel migration plans', () => {
 			'002_kernel_events_expected_revision',
 			'003_kernel_claims_active_lease',
 			'004_kernel_issues_content_fields',
+			'005_kernel_memories',
 		]);
+	});
+
+	test('migration 005 creates the kernel_memories read-model table and drops it on rollback', () => {
+		const { buildMemoryProjectionMigration } = require('../../lib/kernel/migrations');
+		const migration = buildMemoryProjectionMigration();
+
+		expect(migration.id).toBe('005_kernel_memories');
+		// Idempotent CREATE IF NOT EXISTS so a fresh DB and an existing DB both migrate
+		// cleanly through the broker ledger.
+		expect(migration.apply[0]).toContain('CREATE TABLE IF NOT EXISTS kernel_memories');
+		expect(migration.apply[0]).toContain('key TEXT NOT NULL PRIMARY KEY');
+		expect(migration.apply).toContain(
+			'CREATE INDEX IF NOT EXISTS idx_kernel_memories_source_agent ON kernel_memories (source_agent);',
+		);
+		expect(migration.rollback).toEqual([
+			'DROP INDEX IF EXISTS idx_kernel_memories_source_agent;',
+			'DROP TABLE IF EXISTS kernel_memories;',
+		]);
+
+		// Registered in the default plan so the broker's initialize() creates it.
+		const plan = buildKernelMigrationPlan();
+		expect(plan.apply).toContain(
+			'CREATE INDEX IF NOT EXISTS idx_kernel_memories_source_agent ON kernel_memories (source_agent);',
+		);
+	});
+
+	test('the initial (001) schema migration excludes kernel_memories (created by 005)', () => {
+		const plan = buildKernelMigrationPlan();
+		const schemaMigration = plan.migrations.find(migration => migration.id === '001_kernel_schema');
+		// kernel_memories must NOT be created by 001 — it is owned by migration 005 so a
+		// fresh DB creates it exactly once and an existing DB picks it up via the ledger.
+		expect(schemaMigration.apply.some(statement => statement.includes('kernel_memories'))).toBe(false);
 	});
 
 	test('KAP-10/11: migration 004 adds design/notes/assignee content fields and drops them on rollback', () => {

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -26,6 +26,7 @@ const REQUIRED_TABLES = [
 	'events',
 	'outbox',
 	'dead_letters',
+	'memories',
 ];
 
 describe('kernel schema registry', () => {
@@ -54,6 +55,34 @@ describe('kernel schema registry', () => {
 		expect(issueFieldNames).toContain('design');
 		expect(issueFieldNames).toContain('notes');
 		expect(issueFieldNames).toContain('assignee');
+	});
+
+	test('registers the project-memory read-model table (kernel_memories)', () => {
+		const memories = KERNEL_TABLES.memories;
+		expect(memories).toBeDefined();
+		// Project memory is a read model, written directly (not via the issue CAS path).
+		expect(memories.storageClass).toBe('read_model');
+		expect(memories.sqlName).toBe('kernel_memories');
+
+		const fieldNames = memories.fields.map(field => field.name);
+		expect(fieldNames).toEqual([
+			'key',
+			'value_json',
+			'source_agent',
+			'scope',
+			'confidence',
+			'tags_json',
+			'supersedes_json',
+			'beads_refs_json',
+			'created_at',
+			'updated_at',
+		]);
+		expect(memories.fields.find(field => field.name === 'key').primaryKey).toBe(true);
+		expect(memories.indexes.map(index => index.name)).toContain('idx_kernel_memories_source_agent');
+		expect(classifyKernelStorage('memories')).toMatchObject({
+			storageClass: 'read_model',
+			authority: 'forge',
+		});
 	});
 
 	test('classifies every table and field with valid storage and authority metadata', () => {

--- a/test/kernel/sqlite-driver-memory.test.js
+++ b/test/kernel/sqlite-driver-memory.test.js
@@ -101,6 +101,14 @@ describe('Kernel SQLite driver — project-memory read model', () => {
 		expect(driver.loadMemory('nope')).toBe(null);
 	});
 
+	test('a re-write refreshes the surfaced timestamp (as-of), matching legacy behavior', () => {
+		const driver = makeDriver();
+		driver.recordMemory({ key: 'k', value: 'v1', sourceAgent: 'Codex', tags: [], timestamp: '2026-05-16T10:00:00.000Z' });
+		driver.recordMemory({ key: 'k', value: 'v2', sourceAgent: 'Codex', tags: [], timestamp: '2026-06-01T12:00:00.000Z' });
+		// The entry timestamp reflects the LATEST write, not the first-seen time.
+		expect(driver.loadMemory('k').timestamp).toBe('2026-06-01T12:00:00.000Z');
+	});
+
 	test('searchMemories matches all whitespace tokens across key and value', () => {
 		const driver = makeDriver();
 		driver.recordMemory({ key: 'decisions:one', value: 'pick the kernel store', sourceAgent: 'Codex', tags: [] });

--- a/test/kernel/sqlite-driver-memory.test.js
+++ b/test/kernel/sqlite-driver-memory.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+// Project-memory read-model driver primitives. Memory rows are written DIRECTLY to
+// kernel_memories (NOT through the issue CAS/guarded-event path), so these methods are
+// synchronous and self-sufficient: each lazily ensures the table exists, which lets
+// project-memory persist without first awaiting the async broker.initialize().
+const { afterEach, describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+const tmpDirs = [];
+const drivers = [];
+
+function makeDriver() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-kernel-memory-'));
+	tmpDirs.push(dir);
+	const driver = createBuiltinSQLiteDriver({ databasePath: path.join(dir, 'kernel.sqlite') });
+	drivers.push(driver);
+	return driver;
+}
+
+afterEach(() => {
+	while (drivers.length > 0) {
+		try {
+			drivers.pop().close();
+		} catch {
+			// best-effort close
+		}
+	}
+	while (tmpDirs.length > 0) {
+		fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+	}
+});
+
+describe('Kernel SQLite driver — project-memory read model', () => {
+	test('records and loads an entry round-trip without a prior broker.initialize()', () => {
+		const driver = makeDriver();
+		driver.recordMemory({
+			key: 'policy.memory',
+			value: 'Use the kernel for durable memory.',
+			sourceAgent: 'Codex',
+			tags: ['memory'],
+			timestamp: '2026-05-16T10:00:00.000Z',
+			scope: 'project',
+			confidence: 0.9,
+			supersedes: ['policy.old'],
+			beadsRefs: ['forge-1gry'],
+		});
+
+		expect(driver.loadMemory('policy.memory')).toEqual({
+			key: 'policy.memory',
+			value: 'Use the kernel for durable memory.',
+			sourceAgent: 'Codex',
+			tags: ['memory'],
+			timestamp: '2026-05-16T10:00:00.000Z',
+			scope: 'project',
+			confidence: 0.9,
+			supersedes: ['policy.old'],
+			beadsRefs: ['forge-1gry'],
+		});
+	});
+
+	test('preserves object values and omits absent optional fields', () => {
+		const driver = makeDriver();
+		driver.recordMemory({
+			key: 'decisions:topic',
+			value: { category: 'decisions', data: { choice: 'kernel' } },
+			sourceAgent: 'forge insights',
+			tags: ['decisions'],
+		});
+
+		const entry = driver.loadMemory('decisions:topic');
+		expect(entry.value).toEqual({ category: 'decisions', data: { choice: 'kernel' } });
+		expect(entry.tags).toEqual(['decisions']);
+		// Absent optionals are not surfaced (matches the legacy entry shape).
+		expect('scope' in entry).toBe(false);
+		expect('confidence' in entry).toBe(false);
+		expect('supersedes' in entry).toBe(false);
+		expect('beadsRefs' in entry).toBe(false);
+		// A stored entry always carries a timestamp and a tags array.
+		expect(typeof entry.timestamp).toBe('string');
+	});
+
+	test('upserts by key (a second record overwrites the value)', () => {
+		const driver = makeDriver();
+		driver.recordMemory({ key: 'k', value: 'first', sourceAgent: 'Codex', tags: [] });
+		driver.recordMemory({ key: 'k', value: 'second', sourceAgent: 'Claude', tags: ['x'] });
+
+		const entry = driver.loadMemory('k');
+		expect(entry.value).toBe('second');
+		expect(entry.sourceAgent).toBe('Claude');
+		expect(entry.tags).toEqual(['x']);
+		expect(driver.listMemories()).toHaveLength(1);
+	});
+
+	test('loadMemory returns null for a missing key', () => {
+		const driver = makeDriver();
+		expect(driver.loadMemory('nope')).toBe(null);
+	});
+
+	test('searchMemories matches all whitespace tokens across key and value', () => {
+		const driver = makeDriver();
+		driver.recordMemory({ key: 'decisions:one', value: 'pick the kernel store', sourceAgent: 'Codex', tags: [] });
+		driver.recordMemory({ key: 'decisions:two', value: 'keep beads export only', sourceAgent: 'Codex', tags: [] });
+		driver.recordMemory({ key: 'episodes:three', value: 'kernel migration shipped', sourceAgent: 'Codex', tags: [] });
+
+		// AND semantics: both tokens must be present (in key or value).
+		expect(driver.searchMemories('decisions kernel').map(entry => entry.key)).toEqual(['decisions:one']);
+		// Whole-prefix substring matches the key.
+		expect(driver.searchMemories('decisions').map(entry => entry.key)).toEqual([
+			'decisions:one',
+			'decisions:two',
+		]);
+		// An empty query lists everything (ordered by key).
+		expect(driver.searchMemories('').map(entry => entry.key)).toEqual([
+			'decisions:one',
+			'decisions:two',
+			'episodes:three',
+		]);
+	});
+
+	test('listMemories returns every entry ordered by key', () => {
+		const driver = makeDriver();
+		driver.recordMemory({ key: 'b', value: '2', sourceAgent: 'Codex', tags: [] });
+		driver.recordMemory({ key: 'a', value: '1', sourceAgent: 'Codex', tags: [] });
+		expect(driver.listMemories().map(entry => entry.key)).toEqual(['a', 'b']);
+	});
+});

--- a/test/project-memory.test.js
+++ b/test/project-memory.test.js
@@ -2,166 +2,169 @@ const { describe, test, expect } = require('bun:test');
 
 const projectMemory = require('../lib/project-memory');
 
-function runner(responses = {}) {
-  const calls = [];
+// A driver-like store stub: project-memory speaks the memory entry shape to the store
+// (entry-in / entry-out), so the stub keeps everything in a Map and mirrors the real
+// kernel driver's token-AND search semantics.
+function fakeStore(seed = {}) {
+  const records = [];
+  const memories = new Map(Object.entries(seed));
   return {
-    calls,
-    run(command, args) {
-      calls.push({ command, args });
-      const key = `${command} ${args.join(' ')}`;
-      if (responses[key] instanceof Error) {
-        throw responses[key];
-      }
-      return responses[key] ?? '{}';
+    records,
+    memories,
+    recordMemory(entry) {
+      records.push(entry);
+      memories.set(entry.key, entry);
+      return entry;
+    },
+    loadMemory(key) {
+      return memories.has(key) ? memories.get(key) : null;
+    },
+    searchMemories(query) {
+      const tokens = query.split(/\s+/).filter(Boolean);
+      return [...memories.values()].filter(entry => {
+        const hay = `${entry.key} ${JSON.stringify(entry.value)}`.toLowerCase();
+        return tokens.every(token => hay.includes(token.toLowerCase()));
+      });
+    },
+    listMemories() {
+      return [...memories.values()];
     },
   };
 }
 
-describe('project memory Beads adapter', () => {
-  test('writes entries with bd remember and a stable key', () => {
-    const beads = runner({
-      'bd remember {"value":"Use Beads for durable memory.","sourceAgent":"Codex","tags":["memory"],"timestamp":"2026-05-16T10:00:00.000Z","scope":"project"} --key policy.memory': '{"key":"policy.memory","value":"stored"}',
-    });
+describe('project memory kernel adapter', () => {
+  test('writes a canonical entry to the store and returns it', () => {
+    const store = fakeStore();
 
     const entry = projectMemory.write(process.cwd(), {
-      key: 'policy.memory',
-      value: 'Use Beads for durable memory.',
+      key: ' policy.memory ',
+      value: 'Use the kernel for durable memory.',
       sourceAgent: 'Codex',
       tags: ['memory'],
       timestamp: '2026-05-16T10:00:00.000Z',
       scope: 'project',
-    }, { runner: beads.run });
+    }, { store });
 
-    expect(beads.calls).toEqual([{
-      command: 'bd',
-      args: [
-        'remember',
-        JSON.stringify({
-          value: 'Use Beads for durable memory.',
-          sourceAgent: 'Codex',
-          tags: ['memory'],
-          timestamp: '2026-05-16T10:00:00.000Z',
-          scope: 'project',
-        }),
-        '--key',
-        'policy.memory',
-      ],
-    }]);
+    expect(store.records).toHaveLength(1);
+    expect(store.records[0]).toEqual({
+      key: 'policy.memory',
+      value: 'Use the kernel for durable memory.',
+      sourceAgent: 'Codex',
+      tags: ['memory'],
+      timestamp: '2026-05-16T10:00:00.000Z',
+      scope: 'project',
+    });
     expect(entry.key).toBe('policy.memory');
-    expect(entry.value).toBe('Use Beads for durable memory.');
+    expect(entry.value).toBe('Use the kernel for durable memory.');
   });
 
-  test('reads entries with bd recall and returns null when missing', () => {
-    const beads = runner({
-      'bd recall policy.memory --json': JSON.stringify({
+  test('reads an entry by trimmed key and returns null when missing', () => {
+    const store = fakeStore({
+      'policy.memory': {
         key: 'policy.memory',
-        content: '{"value":"stored","sourceAgent":"Codex","tags":["memory"]}',
-      }),
-      'bd recall missing.key --json': '',
+        value: 'stored',
+        sourceAgent: 'Codex',
+        tags: ['memory'],
+        timestamp: '2026-05-16T10:00:00.000Z',
+      },
     });
 
-    expect(projectMemory.read(process.cwd(), ' policy.memory ', { runner: beads.run })).toMatchObject({
+    expect(projectMemory.read(process.cwd(), ' policy.memory ', { store })).toMatchObject({
       key: 'policy.memory',
       value: 'stored',
       sourceAgent: 'Codex',
       tags: ['memory'],
     });
-    expect(projectMemory.read(process.cwd(), 'missing.key', { runner: beads.run })).toBe(null);
+    expect(projectMemory.read(process.cwd(), 'missing.key', { store })).toBe(null);
   });
 
-  test('searches and lists entries through bd memories', () => {
-    const memoryRows = JSON.stringify({
-      'decision.one': '{"value":"one","sourceAgent":"Codex","tags":["decision"]}',
-      'decision.two': '{"value":"two","sourceAgent":"Claude","tags":["decision"]}',
-      schema_version: 1,
-    });
-    const beads = runner({
-      'bd memories decision --json': memoryRows,
-      'bd memories --json': memoryRows,
+  test('searches and lists entries through the store', () => {
+    const store = fakeStore({
+      'decision.one': { key: 'decision.one', value: 'one', sourceAgent: 'Codex', tags: ['decision'] },
+      'decision.two': { key: 'decision.two', value: 'two', sourceAgent: 'Claude', tags: ['decision'] },
     });
 
-    expect(projectMemory.search(process.cwd(), 'decision', { runner: beads.run }).map(entry => entry.key)).toEqual([
+    expect(projectMemory.search(process.cwd(), 'decision', { store }).map(entry => entry.key)).toEqual([
       'decision.one',
       'decision.two',
     ]);
-    expect(projectMemory.list(process.cwd(), { runner: beads.run })).toHaveLength(2);
+    // An empty / whitespace query short-circuits to [] without touching the store.
+    expect(projectMemory.search(process.cwd(), '   ', { store })).toEqual([]);
+    expect(projectMemory.list(process.cwd(), { store })).toHaveLength(2);
   });
 
-  test('falls back to plain text recall output and surfaces Beads command failures', () => {
-    const failed = runner({
-      'bd recall policy.memory --json': new Error('bd failed'),
-    });
-    const plainText = runner({
-      'bd recall policy.memory --json': 'Use Beads for durable memory.',
-    });
-
-    expect(() => projectMemory.read(process.cwd(), 'policy.memory', { runner: failed.run })).toThrow('bd failed');
-    expect(projectMemory.read(process.cwd(), 'policy.memory', { runner: plainText.run })).toMatchObject({
-      key: 'policy.memory',
-      value: 'Use Beads for durable memory.',
-      sourceAgent: 'bd',
-    });
-  });
-
-  test('keeps brace-prefixed plain text memory content readable', () => {
-    const beads = runner({
-      'bd recall draft.memory --json': JSON.stringify({
-        key: 'draft.memory',
-        content: '{draft notes',
-      }),
-    });
-
-    expect(projectMemory.read(process.cwd(), 'draft.memory', { runner: beads.run })).toMatchObject({
-      key: 'draft.memory',
-      value: '{draft notes',
-      sourceAgent: 'bd',
-    });
-  });
-
-  test('adds a timestamp to compatibility memory writes when omitted', () => {
-    const beads = runner();
+  test('adds a timestamp and a tags array to writes when omitted', () => {
+    const store = fakeStore();
 
     projectMemory.write(process.cwd(), {
       key: 'decision.timestamped',
       value: 'timestamp should be generated',
       sourceAgent: 'Codex',
-    }, { runner: beads.run });
+    }, { store });
 
-    const payload = JSON.parse(beads.calls[0].args[1]);
-    expect(Number.isNaN(Date.parse(payload.timestamp))).toBe(false);
+    const entry = store.records[0];
+    expect(Number.isNaN(Date.parse(entry.timestamp))).toBe(false);
+    expect(entry.tags).toEqual([]);
   });
 
-  test('validates beads-refs alias before writing', () => {
+  test('carries optional fields (object value, confidence, supersedes, beadsRefs) through', () => {
+    const store = fakeStore();
+
+    const entry = projectMemory.write(process.cwd(), {
+      key: 'decision.full',
+      value: { category: 'decisions', data: { choice: 'kernel' } },
+      sourceAgent: 'forge insights',
+      tags: ['decisions'],
+      confidence: 0.5,
+      supersedes: ['decision.old'],
+      beadsRefs: ['forge-1gry'],
+    }, { store });
+
+    expect(entry).toMatchObject({
+      key: 'decision.full',
+      confidence: 0.5,
+      supersedes: ['decision.old'],
+      beadsRefs: ['forge-1gry'],
+    });
+    expect(store.records[0].value).toEqual({ category: 'decisions', data: { choice: 'kernel' } });
+  });
+
+  test('validates the beads-refs alias before writing', () => {
+    const store = fakeStore();
+
     expect(() => projectMemory.write(process.cwd(), {
       key: 'decision.bad-ref',
       value: 'invalid alias refs must fail',
       sourceAgent: 'Codex',
-      'beads-refs': ['forge-besw.19', 42],
-    }, { runner: runner().run })).toThrow('beads-refs');
+      'beads-refs': ['forge-1gry', 42],
+    }, { store })).toThrow('beads-refs');
+    expect(store.records).toHaveLength(0);
   });
 
   test('validates compatibility metadata before writing', () => {
-    const beads = runner();
+    const store = fakeStore();
 
     expect(() => projectMemory.write(process.cwd(), {
       key: 'decision.bad-confidence',
       value: 'bad confidence must fail',
       sourceAgent: 'Codex',
       confidence: Number.POSITIVE_INFINITY,
-    }, { runner: beads.run })).toThrow('confidence');
+    }, { store })).toThrow('confidence');
 
     expect(() => projectMemory.write(process.cwd(), {
       key: 'decision.bad-scope',
       value: 'bad scope must fail',
       sourceAgent: 'Codex',
       scope: '',
-    }, { runner: beads.run })).toThrow('scope');
+    }, { store })).toThrow('scope');
 
     expect(() => projectMemory.write(process.cwd(), {
       key: 'decision.bad-timestamp',
       value: 'bad timestamp must fail',
       sourceAgent: 'Codex',
       timestamp: 'not-a-date',
-    }, { runner: beads.run })).toThrow('timestamp');
+    }, { store })).toThrow('timestamp');
+
+    expect(store.records).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Migrates Forge's **project memory off Beads onto the kernel** — Stage A of the memory migration (kernel backlog issue `5225980e`), and the next file cleared from the `bd-hot-path-issue-commands` retirement gate.

Follow-up to #240 (kernel = default issue backend). Part of retiring Beads: migrating **all** of its data domains, not just issues.

## Scope & decisions
- **Read-model projection table** (`kernel_memories`), written **directly** — not through the issue CAS/guarded-event path. Memory is a read model, not authority (per the repo's own `storage-and-concurrency-risks.md` / storage matrix).
- **Stage A only**: rewrite `project-memory.js` onto the kernel, **start data fresh** (the CLI never wrote bd; only `insights.writeSkill` did, so existing bd memory is effectively empty).
- **Out of scope (untouched)**: `lib/memory-store.js` / `forge remember`/`recall` — already bd-free and **git-synced**. Only the agent-insights memory (`project-memory.js` → `typed-api.js` → `insights.js`) moves.

## What changed
- `lib/kernel/schema.js` + `lib/kernel/migrations.js`: new `kernel_memories` table + migration 005 (idempotent via the `kernel_migrations` ledger).
- `lib/kernel/sqlite-driver.js`: `recordMemory` / `loadMemory` / `searchMemories` / `listMemories` (upsert-by-key).
- `lib/project-memory.js`: rewired onto the kernel store; **exports + entry shape preserved exactly**, so `typed-api.js` and `insights.js` need zero changes. Injection seam switched `runner` → `store` for hermetic tests. **Zero `bd`/`.beads`/`dolt` tokens.**
- New e2e test (kernel persistence, no bd invoked) + existing memory/typed-api/insights tests pass unchanged.
- Regenerated `docs/work/.../bd-call-site-kill-list.md` so `d20-audit-artifact-current` stays green.

## Gate impact
`project-memory.js` is now **removed from the bd-hot-path blocker evidence** (0 matching tokens). Verified via `forge release check --target 0.1.0` (no project-memory line) and `test/commands/release.test.js`.

## Tests
- Gate + memory tests: **13 pass / 0 fail**; ESLint clean. Full suite via CI.

## Caveat (tracked)
The kernel store (`.git/forge/kernel.sqlite`) is **local-only, not git-synced**, so agent-insights memory becomes single-machine. User-facing `forge remember`/`recall` remains git-synced and untouched. Cross-machine kernel sync is tracked separately (kernel issue `b75a1552`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project memory now uses the kernel storage layer by default, with support for saving, reading, searching, and listing memories.
  * Added a new kernel-backed memory table that is created automatically when needed.

* **Bug Fixes**
  * Memory data now round-trips more reliably, with consistent key trimming, default timestamps, and empty tag handling.
  * Improved handling of memory searches and missing entries, including better validation for invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->