### PR TITLE
refactor(debead): route scattered lib/shell issue refs through forge (4 hot-path files)

### DIFF
--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -8,7 +8,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 | Group | Call sites | Files |
 | --- | ---: | ---: |
 | command | 108 | 11 |
-| runtime | 351 | 48 |
+| runtime | 321 | 44 |
 | docs | 452 | 68 |
 | skills | 22 | 9 |
 | hooks | 0 | 0 |
@@ -46,8 +46,6 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 78 (bd)
 - [ ] lib/adapters/beads-kernel-compat.js (1)
   - lines: 670 (.beads)
-- [ ] lib/agents-config.js (2)
-  - lines: 232 (bd), 233 (bd, dolt)
 - [ ] lib/audit-evidence.js (3)
   - lines: 148 (bd), 214 (bd), 240 (bd)
 - [ ] lib/beads-bootstrap.js (6)
@@ -58,8 +56,6 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 17 (.beads), 18 (dolt), 19 (.beads), 76 (.beads), 78 (.beads), 86 (.beads), 94 (dolt), 102 (.beads, dolt), 104 (.beads), 109 (.beads), 117 (dolt), 118 (dolt), 160 (.beads), 161 (dolt), 162 (.beads), 187 (.beads), 188 (dolt), 189 (.beads), 237 (.beads), 238 (.beads), 241 (bd, dolt), 244 (bd), 250 (.beads), 262 (bd), 278 (dolt), 286 (.beads), 312 (.beads), 319 (dolt), 323 (bd), 411 (bd), 417 (bd), 424 (bd), 425 (bd), 430 (.beads, dolt), 432 (bd), 440 (bd), 441 (bd), 476 (.beads, dolt), 480 (.beads), 487 (bd), 496 (bd)
 - [ ] lib/beads-sync-scaffold.js (3)
   - lines: 65 (bd), 76 (bd), 86 (bd)
-- [ ] lib/dep-guard/keyword-ripple.js (2)
-  - lines: 163 (bd), 165 (bd)
 - [ ] lib/deprecated-sync-cleanup.js (4)
   - lines: 20 (bd), 31 (bd), 92 (bd), 118 (bd)
 - [ ] lib/forge-issues.js (11)
@@ -86,10 +82,6 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 176 (bd), 217 (.beads), 276 (.beads), 334 (.beads), 490 (bd), 518 (bd), 521 (bd), 522 (bd), 561 (bd)
 - [ ] lib/status/beads-snapshot.js (1)
   - lines: 31 (.beads)
-- [ ] lib/workflow/state-manager.js (2)
-  - lines: 108 (bd), 155 (bd)
-- [ ] scripts/beads-context.sh (24)
-  - lines: 47 (bd), 48 (bd), 105 (bd), 106 (bd), 110 (bd), 111 (bd), 116 (bd), 117 (bd), 118 (bd), 119 (bd), 142 (bd), 148 (bd), 151 (bd), 152 (bd), 155 (bd), 158 (bd), 159 (bd), 172 (bd), 183 (bd), 300 (bd), 301 (bd), 306 (bd), 314 (bd), 453 (bd)
 - [ ] scripts/beads-migrate-to-dolt.sh (1)
   - lines: 7 (dolt)
 - [ ] scripts/beads-upgrade-smoke.sh (1)

--- a/lib/agents-config.js
+++ b/lib/agents-config.js
@@ -229,8 +229,8 @@ forge close <id>                         # Complete
 forge sync                               # Sync Beads state
 \`\`\`
 
-Use \`bd\` directly only for capabilities Forge does not wrap yet, such as
-\`bd init\`, \`bd comments\`, \`bd dep\`, and \`bd dolt\`.
+Use \`forge issue\` subcommands for everything else, such as
+\`forge issue comment\`, \`forge issue dep\`, and \`forge issue stats\`.
 
 ## Git Workflow
 

--- a/lib/dep-guard/keyword-ripple.js
+++ b/lib/dep-guard/keyword-ripple.js
@@ -160,9 +160,9 @@ function renderKeywordRippleReport({ issueId, sourceTitle, activeIssues }) {
 			'  Confidence: LOW (keyword only, no contract data)',
 			'',
 			'  Options:',
-			`  (a) Add dependency: bd dep add ${issueId} ${overlap.id}`,
+			`  (a) Add dependency: forge issue dep add ${issueId} ${overlap.id}`,
 			'  (b) Proceed - no real conflict',
-			`  (c) Investigate: bd show ${overlap.id}`,
+			`  (c) Investigate: forge issue show ${overlap.id}`,
 			'',
 		);
 	}

--- a/lib/workflow/state-manager.js
+++ b/lib/workflow/state-manager.js
@@ -140,7 +140,10 @@ function readWorkflowStateFromBeads(issueId, options = {}) {
   }
 
   if (options.comments) {
-    return extractWorkflowStateFromComments(options.comments);
+    const state = extractWorkflowStateFromComments(options.comments);
+    if (state) {
+      return state;
+    }
   }
 
   // `forge issue show --json` returns the issue together with its full comment

--- a/lib/workflow/state-manager.js
+++ b/lib/workflow/state-manager.js
@@ -105,7 +105,7 @@ function readBeadsIssue(issueId, options = {}) {
 
   try {
     const { projectRoot, ...execOptions } = options;
-    const raw = secureExecFileSync('bd', ['show', issueId, '--json'], {
+    const raw = secureExecFileSync('forge', ['issue', 'show', issueId, '--json'], {
       encoding: 'utf8',
       cwd: projectRoot,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -139,30 +139,16 @@ function readWorkflowStateFromBeads(issueId, options = {}) {
     }
   }
 
-  let comments = options.comments;
-  if (!comments) {
-    try {
-      const issue = readBeadsIssue(issueId, { projectRoot: options.projectRoot });
-      const state = extractWorkflowStateFromIssue(issue);
-      if (state) {
-        return state;
-      }
-    } catch (_error) {
-      // Fall through to comments-list fallback.
-    }
+  if (options.comments) {
+    return extractWorkflowStateFromComments(options.comments);
   }
 
-  comments = comments || secureExecFileSync('bd', ['comments', 'list', issueId], {
-    encoding: 'utf8',
-    cwd: options.projectRoot,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }).trim();
-
-  if (!comments) {
-    return null;
-  }
-
-  return extractWorkflowStateFromComments(comments);
+  // `forge issue show --json` returns the issue together with its full comment
+  // history, so a single read covers both the structured issue and the raw
+  // comment text carrying the serialized WorkflowState marker. No separate
+  // comment-list read is required.
+  const issue = readBeadsIssue(issueId, { projectRoot: options.projectRoot });
+  return extractWorkflowStateFromIssue(issue);
 }
 
 function loadStateFromBeads(options, projectRoot) {

--- a/scripts/beads-context.sh
+++ b/scripts/beads-context.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# beads-context.sh — Helper script to manage Beads issue context
+# beads-context.sh — Helper script to manage issue context
 # for the Forge 7-stage workflow.
 #
 # Subcommands:
@@ -44,8 +44,8 @@ die() {
   exit 1
 }
 
-# Resolve a Windows bd.exe installation for bash-based helper flows.
-# This covers WSL/Git Bash cases where PowerShell can run bd.exe but bash PATH
+# Resolve a Windows forge.exe installation for bash-based helper flows.
+# This covers WSL/Git Bash cases where PowerShell can run forge.exe but bash PATH
 # does not include the Windows install directory.
 convert_windows_path() {
   local raw="${1%$'\r'}"
@@ -74,7 +74,7 @@ convert_windows_path() {
   printf '/mnt/%s%s' "$drive" "$rest"
 }
 
-is_runnable_bd_candidate() {
+is_runnable_forge_candidate() {
   local candidate="${1:-}"
 
   if [[ -z "$candidate" || ! -f "$candidate" ]]; then
@@ -84,41 +84,41 @@ is_runnable_bd_candidate() {
   [[ -x "$candidate" || "$candidate" == *.exe ]]
 }
 
-resolve_bd_cmd() {
+resolve_forge_cmd() {
   local candidate=""
   local converted=""
 
-  if [[ -n "${BD_CMD:-}" ]]; then
-    if [[ "${BD_CMD}" == *"/"* || "${BD_CMD}" == *"\\"* ]]; then
-      converted="$(convert_windows_path "$BD_CMD")"
-      if is_runnable_bd_candidate "$converted"; then
+  if [[ -n "${FORGE_CMD:-}" ]]; then
+    if [[ "${FORGE_CMD}" == *"/"* || "${FORGE_CMD}" == *"\\"* ]]; then
+      converted="$(convert_windows_path "$FORGE_CMD")"
+      if is_runnable_forge_candidate "$converted"; then
         printf '%s' "$converted"
         return 0
       fi
 
-      is_runnable_bd_candidate "$BD_CMD" || return 1
+      is_runnable_forge_candidate "$FORGE_CMD" || return 1
     fi
-    printf '%s' "$BD_CMD"
+    printf '%s' "$FORGE_CMD"
     return 0
   fi
 
-  if command -v bd >/dev/null 2>&1; then
-    printf '%s' "bd"
+  if command -v forge >/dev/null 2>&1; then
+    printf '%s' "forge"
     return 0
   fi
 
-  if command -v bd.exe >/dev/null 2>&1; then
-    printf '%s' "bd.exe"
+  if command -v forge.exe >/dev/null 2>&1; then
+    printf '%s' "forge.exe"
     return 0
   fi
 
   for candidate in \
-    "$HOME/.local/bin/bd" \
-    "$HOME/.local/bin/bd.exe" \
-    "$HOME/.bun/bin/bd" \
-    "$HOME/.bun/bin/bd.exe"
+    "$HOME/.local/bin/forge" \
+    "$HOME/.local/bin/forge.exe" \
+    "$HOME/.bun/bin/forge" \
+    "$HOME/.bun/bin/forge.exe"
   do
-    if is_runnable_bd_candidate "$candidate"; then
+    if is_runnable_forge_candidate "$candidate"; then
       printf '%s' "$candidate"
       return 0
     fi
@@ -130,38 +130,38 @@ resolve_bd_cmd() {
       [[ -z "$candidate" ]] && continue
 
       converted="$(convert_windows_path "$candidate")"
-      if is_runnable_bd_candidate "$converted"; then
+      if is_runnable_forge_candidate "$converted"; then
         printf '%s' "$converted"
         return 0
       fi
 
-      if is_runnable_bd_candidate "$candidate"; then
+      if is_runnable_forge_candidate "$candidate"; then
         printf '%s' "$candidate"
         return 0
       fi
-    done < <(where.exe bd 2>/dev/null || true)
+    done < <(where.exe forge 2>/dev/null || true)
   fi
 
   return 1
 }
 
-BD=""
+FORGE=""
 
-get_bd_cmd() {
-  if [[ -z "$BD" ]]; then
-    BD="$(resolve_bd_cmd)" || die "bd is required but not found"
+get_forge_cmd() {
+  if [[ -z "$FORGE" ]]; then
+    FORGE="$(resolve_forge_cmd)" || die "forge is required but not found"
   fi
 
-  printf '%s' "$BD"
+  printf '%s' "$FORGE"
 }
 
-# Run bd update and check for errors in both exit code and output.
-# bd update exits 0 even for non-existent issues, so we check stdout too.
-bd_update() {
-  local bd_cmd
-  bd_cmd="$(get_bd_cmd)"
+# Run forge issue update and check for errors in both exit code and output.
+# The update operation exits 0 even for non-existent issues, so we check stdout too.
+forge_update() {
+  local forge_cmd
+  forge_cmd="$(get_forge_cmd)"
   local output
-  output="$("$bd_cmd" update "$@" 2>&1)"
+  output="$("$forge_cmd" issue update "$@" 2>&1)"
   local rc=$?
 
   if [[ $rc -ne 0 ]]; then
@@ -169,7 +169,7 @@ bd_update() {
     return 1
   fi
 
-  # bd prints "Error resolving/updating ..." to stdout for non-existent issues
+  # Forge prints "Error resolving/updating ..." to stdout for non-existent issues
   # Use specific patterns to avoid false positives from data containing "error"
   if printf '%s' "$output" | grep -Eqi '^Error|Error resolving|Error updating'; then
     echo "$output" >&2
@@ -180,12 +180,12 @@ bd_update() {
   return 0
 }
 
-# Run bd comments add and check for errors similarly.
-bd_comment() {
-  local bd_cmd
-  bd_cmd="$(get_bd_cmd)"
+# Run forge issue comment and check for errors similarly.
+forge_comment() {
+  local forge_cmd
+  forge_cmd="$(get_forge_cmd)"
   local output
-  output="$("$bd_cmd" comments add "$@" 2>&1)"
+  output="$("$forge_cmd" issue comment "$@" 2>&1)"
   local rc=$?
 
   if [[ $rc -ne 0 ]]; then
@@ -201,6 +201,25 @@ bd_comment() {
 
   echo "$output"
   return 0
+}
+
+# Extract concatenated comment text from a `forge issue show --json` payload.
+# Forge/issue show returns comments as an array of objects ({text:...}) — matching
+# the issue-state contract in lib/workflow/state-manager.js — or, defensively, a
+# raw string. jq is preferred; a grep/sed fallback captures "text" fields.
+extract_comments_text() {
+  local json="$1"
+
+  if command -v jq &>/dev/null; then
+    printf '%s' "$json" | jq -r '
+      ((if type == "array" then .[0] else . end).comments // [])
+      | if type == "array" then (map(.text? // tostring) | join("\n"))
+        else tostring end
+    ' 2>/dev/null || true
+    return 0
+  fi
+
+  printf '%s' "$json" | grep -o '"text": *"[^"]*"' | sed 's/^"text": *"//;s/"$//' || true
 }
 
 # ── Subcommands ──────────────────────────────────────────────────────────
@@ -219,7 +238,7 @@ cmd_set_design() {
 
   local design_text="${task_count} tasks | ${task_file}"
 
-  if ! bd_update "$issue_id" --design "$design_text" > /dev/null; then
+  if ! forge_update "$issue_id" --design "$design_text" > /dev/null; then
     die "Failed to set design on issue ${issue_id}"
   fi
 
@@ -236,7 +255,7 @@ cmd_set_acceptance() {
   local criteria
   criteria="$(sanitize "$2")"
 
-  if ! bd_update "$issue_id" --acceptance "$criteria" > /dev/null; then
+  if ! forge_update "$issue_id" --acceptance "$criteria" > /dev/null; then
     die "Failed to set acceptance on issue ${issue_id}"
   fi
 
@@ -276,7 +295,7 @@ cmd_update_progress() {
 
   local note="Task ${task_num}/${total} done: ${title} | ${test_count} tests | ${commit_sha} | ${gate_count} gates"
 
-  if ! bd_update "$issue_id" --append-notes "$note" > /dev/null; then
+  if ! forge_update "$issue_id" --append-notes "$note" > /dev/null; then
     die "Failed to update progress on issue ${issue_id}"
   fi
 
@@ -290,20 +309,20 @@ cmd_parse_progress() {
   fi
 
   local issue_id="$1"
-  local bd_cmd
-  bd_cmd="$(get_bd_cmd)"
+  local forge_cmd
+  forge_cmd="$(get_forge_cmd)"
 
   # Get the issue JSON — detect non-existent issues
   local json
-  json="$("$bd_cmd" show "$issue_id" --json 2>&1)" || die "Failed to show issue ${issue_id}"
+  json="$("$forge_cmd" issue show "$issue_id" --json 2>&1)" || die "Failed to show issue ${issue_id}"
 
-  # bd show may exit 0 but print an error for non-existent issues
-  # Match specific bd error patterns, not the word "error" in data fields
+  # show may exit 0 but print an error for non-existent issues
+  # Match specific error patterns, not the word "error" in data fields
   if printf '%s' "$json" | grep -Eqi '^Error (fetching|resolving)'; then
     die "Issue not found: ${issue_id}"
   fi
 
-  # bd show returns "[]" or empty for non-existent issues
+  # show returns "[]" or empty for non-existent issues
   if [[ -z "$json" || "$json" == "[]" || "$json" == "null" ]]; then
     die "Issue not found: ${issue_id}"
   fi
@@ -311,7 +330,7 @@ cmd_parse_progress() {
   # Extract notes field from JSON — prefer jq if available, fall back to grep/sed
   local notes
   if command -v jq &>/dev/null; then
-    # Handle both array ([{...}]) and object ({...}) responses from bd show
+    # Handle both array ([{...}]) and object ({...}) show responses
     notes="$(printf '%s' "$json" | jq -r 'if type == "array" then .[0].notes else .notes end // empty' 2>/dev/null || true)"
   else
     notes="$(printf '%s' "$json" | grep -o '"notes": *"[^"]*"' | head -1 | sed 's/^"notes": *"//;s/"$//' || true)"
@@ -425,7 +444,7 @@ Next: ${flag_next}"
 WorkflowState: ${flag_workflow_state}"
   fi
 
-  if ! bd_comment "$issue_id" "$comment" > /dev/null; then
+  if ! forge_comment "$issue_id" "$comment" > /dev/null; then
     die "Failed to record stage transition on issue ${issue_id}"
   fi
 
@@ -440,17 +459,17 @@ cmd_validate() {
 
   local issue_id="$1"
   local warnings=0
-  local bd_cmd
-  bd_cmd="$(get_bd_cmd)"
+  local forge_cmd
+  forge_cmd="$(get_forge_cmd)"
 
   # Get issue JSON
   local json
-  json="$("$bd_cmd" show "$issue_id" --json 2>&1)" || {
+  json="$("$forge_cmd" issue show "$issue_id" --json 2>&1)" || {
     echo "Error: Failed to retrieve issue ${issue_id}" >&2
     exit 1
   }
 
-  # Check for bd error patterns
+  # Check for error patterns
   if printf '%s' "$json" | grep -Eqi '^Error|Error resolving|Error fetching'; then
     echo "Error: Issue not found: ${issue_id}" >&2
     exit 1
@@ -477,9 +496,11 @@ cmd_validate() {
     warnings=$((warnings + 1))
   fi
 
-  # Get comments to check for stage transitions
+  # The issue payload returned by `forge issue show --json` already includes its
+  # comment history, so the stage-transition checks read comments from that single
+  # response rather than issuing a separate comment-list query.
   local comments
-  comments="$("$bd_cmd" comments "$issue_id" 2>/dev/null || true)"
+  comments="$(extract_comments_text "$json")"
 
   # Check 2: At least one stage transition exists
   local has_transition=false

--- a/scripts/beads-context.test.js
+++ b/scripts/beads-context.test.js
@@ -64,11 +64,11 @@ async function bd(...args) {
 }
 
 describe('scripts/beads-context.sh command resolution', () => {
-	test('script includes Windows-aware bd resolution fallback', () => {
+	test('script includes Windows-aware forge resolution fallback', () => {
 		const content = fs.readFileSync(SCRIPT_PATH, 'utf8');
-		expect(content).toContain('resolve_bd_cmd');
+		expect(content).toContain('resolve_forge_cmd');
 		expect(content).toContain('where.exe');
-		expect(content).toContain('$HOME/.local/bin/bd.exe');
+		expect(content).toContain('$HOME/.local/bin/forge.exe');
 	});
 });
 

--- a/test/beads-context-transition.test.js
+++ b/test/beads-context-transition.test.js
@@ -59,8 +59,8 @@ if [ "$1" = "issue" ] && [ "$2" = "update" ]; then
   echo "Updated"
   exit 0
 fi
-echo "forge shim: unknown command $*"
-exit 0
+echo "forge shim: unknown command $*" >&2
+exit 1
 `,
     { mode: 0o755 }
   );

--- a/test/beads-context-transition.test.js
+++ b/test/beads-context-transition.test.js
@@ -36,30 +36,30 @@ function transitionTest(name, callback) {
 
 /**
  * Helper: run beads-context.sh stage-transition with given args.
- * Uses a bd shim that captures the comment text passed to `bd comments add`.
- * This avoids needing a real Beads installation for unit tests.
+ * Uses a forge shim that captures the comment text passed to `forge issue comment`.
+ * This avoids needing a real issue tracker installation for unit tests.
  */
 function runTransition(args, _env = {}) {
   const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const shimDir = path.join(ROOT, `.bd-shim-${suffix}`);
+  const shimDir = path.join(ROOT, `.forge-shim-${suffix}`);
   const captureFile = path.join(shimDir, 'capture.txt');
-  const shimPath = path.join(shimDir, 'bd');
+  const shimPath = path.join(shimDir, 'forge');
 
   fs.mkdirSync(shimDir, { recursive: true });
   fs.writeFileSync(
     shimPath,
     `#!/usr/bin/env bash
-if [ "$1" = "comments" ] && [ "$2" = "add" ]; then
+if [ "$1" = "issue" ] && [ "$2" = "comment" ]; then
   last_arg="\${!#}"
   printf '%s' "$last_arg" > ${shQuote(`./${path.basename(shimDir)}/capture.txt`)}
   echo "Comment added"
   exit 0
 fi
-if [ "$1" = "update" ]; then
+if [ "$1" = "issue" ] && [ "$2" = "update" ]; then
   echo "Updated"
   exit 0
 fi
-echo "bd shim: unknown command $*"
+echo "forge shim: unknown command $*"
 exit 0
 `,
     { mode: 0o755 }
@@ -69,7 +69,7 @@ exit 0
     cwd: ROOT,
     env: {
       ...process.env,
-      BD_CMD: shimPath,
+      FORGE_CMD: shimPath,
     },
     encoding: 'utf8',
     timeout: 45000,

--- a/test/beads-context-validate.test.js
+++ b/test/beads-context-validate.test.js
@@ -31,11 +31,15 @@ function toBashPath(filePath) {
  */
 function runValidate(issueId, shimBehavior = {}) {
   const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const shimDir = path.join(ROOT, `.bd-validate-shim-${suffix}`);
-  const shimPath = path.join(shimDir, 'bd');
+  const shimDir = path.join(ROOT, `.forge-validate-shim-${suffix}`);
+  const shimPath = path.join(shimDir, 'forge');
 
   fs.mkdirSync(shimDir, { recursive: true });
 
+  // `forge issue show --json` returns the issue with its comment history inline,
+  // so comment text is embedded in the show payload (matching the {text:...}[]
+  // shape consumed by lib/workflow/state-manager.js) instead of a separate read.
+  const commentsText = (shimBehavior.comments || '').replace(/\\n/g, '\n');
   const showJson = shimBehavior.showJson ?? JSON.stringify({
     id: issueId,
     title: 'Test issue',
@@ -43,30 +47,25 @@ function runValidate(issueId, shimBehavior = {}) {
     design: 'design' in shimBehavior ? shimBehavior.design : '5 tasks | docs/plans/test-tasks.md',
     notes: shimBehavior.notes ?? '',
     status: 'in_progress',
+    comments: commentsText ? [{ text: commentsText }] : [],
   });
 
-  const commentsOutput = shimBehavior.comments || '';
   const showExitCode = shimBehavior.showExitCode || 0;
 
-  fs.writeFileSync(path.join(shimDir, 'comments.txt'), commentsOutput.replace(/\\n/g, '\n'));
   fs.writeFileSync(path.join(shimDir, 'show.json'), showJson);
 
   fs.writeFileSync(
     shimPath,
     `#!/usr/bin/env bash
-if [ "$1" = "show" ] && [ "$3" = "--json" ]; then
+if [ "$1" = "issue" ] && [ "$2" = "show" ] && [ "$4" = "--json" ]; then
   if [ "${showExitCode}" -ne 0 ]; then
-    echo "Error resolving issue: $2" >&2
+    echo "Error resolving issue: $3" >&2
     exit ${showExitCode}
   fi
   cat ${shQuote(`./${path.basename(shimDir)}/show.json`)}
   exit 0
 fi
-if [ "$1" = "comments" ] && [ "$2" = "${issueId}" ]; then
-  cat ${shQuote(`./${path.basename(shimDir)}/comments.txt`)}
-  exit 0
-fi
-echo "bd shim: $*"
+echo "forge shim: $*"
 exit 0
 `,
     { mode: 0o755 }
@@ -76,7 +75,7 @@ exit 0
     cwd: ROOT,
     env: {
       ...process.env,
-      BD_CMD: toBashPath(shimPath),
+      FORGE_CMD: toBashPath(shimPath),
     },
     encoding: 'utf8',
     timeout: SHELL_TEST_TIMEOUT_MS,

--- a/test/beads-context-validate.test.js
+++ b/test/beads-context-validate.test.js
@@ -65,8 +65,8 @@ if [ "$1" = "issue" ] && [ "$2" = "show" ] && [ "$4" = "--json" ]; then
   cat ${shQuote(`./${path.basename(shimDir)}/show.json`)}
   exit 0
 fi
-echo "forge shim: $*"
-exit 0
+echo "forge shim: $*" >&2
+exit 1
 `,
     { mode: 0o755 }
   );

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -91,7 +91,10 @@ describe('0.1.0 readiness report', () => {
     expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/sync.js')).toBe(true);
     expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/worktree.js')).toBe(true);
     expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/setup.js')).toBe(true);
-    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/workflow/state-manager.js')).toBe(true);
+    // lib/workflow/state-manager.js is no longer hot-path evidence: its issue reads
+    // route through `forge issue show --json` (the comment-list fallback collapsed into
+    // that single read), so it carries no bd/.beads/dolt token.
+    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/workflow/state-manager.js')).toBe(false);
     expect(hotPathBlocker.evidence.some(item => item.path === 'scripts/preflight.sh')).toBe(true);
     expect(hotPathBlocker.evidence.some(item => item.path === 'scripts/smart-status.sh')).toBe(true);
     expect(hotPathBlocker.evidence.some(item => item.path.startsWith('scripts/forge-team/'))).toBe(true);

--- a/test/dep-guard/keyword-ripple.test.js
+++ b/test/dep-guard/keyword-ripple.test.js
@@ -52,7 +52,7 @@ describe('lib/dep-guard/keyword-ripple.js', () => {
     expect(report.overlapCount).toBe(1);
     expect(report.output).toContain('Potential overlap');
     expect(report.output).toContain('forge-other');
-    expect(report.output).toContain('bd dep add forge-src forge-other');
+    expect(report.output).toContain('forge issue dep add forge-src forge-other');
     expect(report.output).toContain('Confidence: LOW');
   });
 

--- a/test/scripts/dep-guard.check-ripple.analyzer.test.js
+++ b/test/scripts/dep-guard.check-ripple.analyzer.test.js
@@ -146,6 +146,6 @@ ENDJSON
     expect(result.stderr).toContain('falling back to keyword-only ripple check');
     expect(result.stdout).toContain('Potential overlap');
     expect(result.stdout).toContain('Confidence: LOW');
-    expect(result.stdout).toContain('bd dep add forge-src forge-other');
+    expect(result.stdout).toContain('forge issue dep add forge-src forge-other');
   });
 });


### PR DESCRIPTION
De-beads four scattered lib/shell surfaces, clearing them from the `bd-hot-path-issue-commands` retirement gate. Part of retiring Beads (issue #240 made the kernel the default backend).

## Cleared (0 `bd`/`.beads`/`dolt` tokens; out of the gate's hot-path evidence)
- `lib/agents-config.js`
- `lib/dep-guard/keyword-ripple.js`
- `lib/workflow/state-manager.js`
- `scripts/beads-context.sh` — routed through the `forge issue` surface

## Deferred (intentionally NOT in this PR)
- `scripts/preflight.sh` and `scripts/smart-status.sh` are **Beads bootstrap/init/health** paths (`bd init --database forge`, `.beads/config.yaml: backend: dolt`, `bd doctor`/backup-recovery, `bd list --json`). These can't be cleanly de-beaded until the **kernel init/health + sync-authority** lands — they belong with the `setup.js`/`sync.js`/`worktree.js` wave (kernel issue `b75a1552`). Left intact and reported rather than faked.

## Verification
- Gate test (`test/commands/release.test.js`): **6 pass / 0 fail**; the 4 files are gone from the bd-hot-path evidence.
- ESLint `--max-warnings 0` clean on the changed JS.
- Audit artifact regenerated (`d20-audit-artifact-current` stays green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue-tracking workflows now use the newer `forge` command set for reading, updating, commenting, and validation.

* **Bug Fixes**
  * Improved workflow state detection by reducing to a single issue lookup and eliminating inconsistent fallback reads.
  * Updated overlap and transition guidance to match the new `forge` command behavior.
  * Release readiness reporting now correctly classifies the updated issue-read flow.

* **Documentation**
  * Updated generated issue-tracking guidance to prefer `forge issue` subcommands over legacy `bd` references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->