### PR TITLE
fix(shepherd): repair the monitor (invalid gh reviewThreads field) + surface pass outcome

### DIFF
--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -24,12 +24,14 @@
 
 const { execFileSync } = require('node:child_process');
 
+// NOTE: `reviewThreads` is NOT a valid `gh pr view --json` field — requesting it
+// makes `gh` exit non-zero ("Unknown JSON field"), which crashed readState on every
+// real PR. Review threads are read separately via GraphQL in readComments().
 const PR_VIEW_FIELDS = [
   'headRefOid',
   'mergeStateStatus',
   'state',
   'statusCheckRollup',
-  'reviewThreads',
 ].join(',');
 
 /**
@@ -98,7 +100,9 @@ class PrStateAdapter {
         databaseId: check.databaseId,
         detailsUrl: check.detailsUrl,
       })),
-      threads: Array.isArray(data.reviewThreads) ? data.reviewThreads : [],
+      // gh pr view cannot return review threads; the shepherd reads them via
+      // readComments() (GraphQL). Kept for return-shape stability, always empty here.
+      threads: [],
     };
   }
 

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -118,6 +118,19 @@ async function handler(args, _flags, projectRoot, deps = {}) {
     rerunsUsed: deps.rerunsUsed || 0,
   });
 
+  // Surface the pass outcome so the monitor is legible when run interactively or
+  // tailed by a scheduler (the bounded state machine is otherwise silent).
+  const passActions = result.actions || [];
+  process.stdout.write(
+    `Shepherd pass — PR #${pr}: ${result.state}${result.reason ? ` — ${result.reason}` : ''}\n`,
+  );
+  for (const action of passActions) {
+    process.stdout.write(`  • ${typeof action === 'string' ? action : JSON.stringify(action)}\n`);
+  }
+  if (!passActions.length) {
+    process.stdout.write('  • no actions this pass\n');
+  }
+
   return {
     success: result.state !== 'HARD_STOP',
     state: result.state,

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -78,15 +78,15 @@ function isWorkingTreeClean(git) {
 
 // Render a single pass action for the human-readable monitor line. Strings pass
 // through; everything else is JSON-encoded, but JSON.stringify can throw on
-// circular refs or BigInt, so fall back to String() rather than crash the pass.
+// circular refs or BigInt, so surface the reason inline rather than crash the pass.
 function formatAction(action) {
   if (typeof action === 'string') {
     return action;
   }
   try {
     return JSON.stringify(action);
-  } catch (_err) {
-    return String(action);
+  } catch (err) {
+    return `[unprintable action: ${err.message}]`;
   }
 }
 
@@ -135,9 +135,8 @@ async function handler(args, _flags, projectRoot, deps = {}) {
   // Surface the pass outcome so the monitor is legible when run interactively or
   // tailed by a scheduler (the bounded state machine is otherwise silent).
   const passActions = Array.isArray(result.actions) ? result.actions : [];
-  process.stdout.write(
-    `Shepherd pass — PR #${pr}: ${result.state}${result.reason ? ` — ${result.reason}` : ''}\n`,
-  );
+  const reasonSuffix = result.reason ? ` — ${result.reason}` : '';
+  process.stdout.write(`Shepherd pass — PR #${pr}: ${result.state}${reasonSuffix}\n`);
   for (const action of passActions) {
     process.stdout.write(`  • ${formatAction(action)}\n`);
   }

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -76,6 +76,20 @@ function isWorkingTreeClean(git) {
   }
 }
 
+// Render a single pass action for the human-readable monitor line. Strings pass
+// through; everything else is JSON-encoded, but JSON.stringify can throw on
+// circular refs or BigInt, so fall back to String() rather than crash the pass.
+function formatAction(action) {
+  if (typeof action === 'string') {
+    return action;
+  }
+  try {
+    return JSON.stringify(action);
+  } catch (_err) {
+    return String(action);
+  }
+}
+
 /**
  * Command handler.
  *
@@ -120,12 +134,12 @@ async function handler(args, _flags, projectRoot, deps = {}) {
 
   // Surface the pass outcome so the monitor is legible when run interactively or
   // tailed by a scheduler (the bounded state machine is otherwise silent).
-  const passActions = result.actions || [];
+  const passActions = Array.isArray(result.actions) ? result.actions : [];
   process.stdout.write(
     `Shepherd pass — PR #${pr}: ${result.state}${result.reason ? ` — ${result.reason}` : ''}\n`,
   );
   for (const action of passActions) {
-    process.stdout.write(`  • ${typeof action === 'string' ? action : JSON.stringify(action)}\n`);
+    process.stdout.write(`  • ${formatAction(action)}\n`);
   }
   if (!passActions.length) {
     process.stdout.write('  • no actions this pass\n');

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -4,7 +4,7 @@ const { describe, test, expect } = require('bun:test');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { PrStateAdapter } = require('../lib/adapters/pr-state-adapter');
+const { PrStateAdapter, PR_VIEW_FIELDS } = require('../lib/adapters/pr-state-adapter');
 const { validatePrStateAdapter } = require('../lib/pr-state-validator');
 
 /**
@@ -47,6 +47,13 @@ describe('PrStateAdapter', () => {
     const adapter = new PrStateAdapter({ gh: run, git: run });
     expect(adapter.kind).toBe('pr-state');
     expect(validatePrStateAdapter(adapter)).toEqual({ valid: true, errors: [] });
+  });
+
+  test('PR_VIEW_FIELDS excludes reviewThreads (not a valid gh pr view --json field)', () => {
+    // Regression guard: requesting `reviewThreads` via `gh pr view --json` makes gh
+    // exit non-zero ("Unknown JSON field"), which crashed readState on every real PR.
+    // Review threads must be read via GraphQL (readComments), never gh pr view.
+    expect(PR_VIEW_FIELDS.split(',')).not.toContain('reviewThreads');
   });
 
   test('readState normalizes the rollup, head SHA and merge state', async () => {


### PR DESCRIPTION
Repairs the PR-shepherd monitor (#237), which was **crashing on every real PR**, and makes its pass outcome visible.

## The bug (found by dogfooding the monitor)
`forge shepherd <pr>` failed immediately with:
```
Unknown JSON field: "reviewThreads"
```
`readState` requested `reviewThreads` via `gh pr view --json` — but that is **not a valid `gh pr view` field** (the adapter's own comment at `pr-state-adapter.js` even said so; review threads are meant to come from GraphQL in `readComments`). So `readState` threw before the pass could run — the monitor never worked against a real PR.

**Why it shipped:** the shepherd acceptance tests use a *scripted mock adapter*, so they never invoked real `gh` — the mock returned canned data and hid the broken field.

## Fix
- Drop `reviewThreads` from `PR_VIEW_FIELDS` (`readState`); review threads already come from `readComments` (GraphQL). `readState().threads` is now `[]` (the shepherd uses `readComments`).
- **Regression guard:** a unit test asserts `PR_VIEW_FIELDS` excludes `reviewThreads` (the mock can't catch this, so guard the field list directly).
- **Surface the outcome:** `forge shepherd` now prints the pass result (`state — reason` + actions) instead of running silently, so it's usable interactively or tailed by a scheduler.

## Verification
- `node bin/forge.js shepherd 242` (previously crashed) now reports: `MERGE_READY — All required checks are green and the branch is up to date…` (and independently confirms #242 is mergeable).
- `pr-state-adapter` + `shepherd-acceptance` + `commands/shepherd` tests: **36 pass / 0 fail**; ESLint clean.

With this, the monitor feature actually runs — it reruns flaky checks, optionally updates branches (`--auto-rebase`), surfaces unresolved human comments, and escalates real failures (it never merges, resolves threads, or writes code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PR state loading so pull requests view reliably without failures caused by unsupported `gh` JSON fields.
  * Review thread data handling is now more robust, ensuring thread details are sourced and presented reliably.

* **New Features**
  * The shepherd command now prints a human-readable pass summary (PR number, state, reason).
  * It lists actions taken when available, shows a clear “no actions this pass” message when none exist, and safely reports any unprintable actions without failing the run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->