### PR TITLE
refactor(workflow): re-home premerge as an embedded gate (D13) + de-bead AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,9 @@ This project ships a **default TDD-first workflow template** with 7 named stage 
 | 3     | `/validate`    | Validate + 4-phase debug mode on failure                    | All types    |
 | 4     | `/ship`     | Create PR with documentation                             | All types    |
 | 5     | `/review`   | Address ALL PR feedback                                  | Critical, Standard |
-| 6     | `/premerge` | Complete docs on feature branch, hand off PR             | All types    |
-| 7     | `/verify`   | Post-merge health check (CI, deployments)                | All types    |
+| 6     | `/verify`   | Post-merge health check (CI, deployments)                | All types    |
+
+**Pre-merge gate (not a numbered stage)**: Completing docs on the feature branch and handing off the PR for merge is a **task-type gate and checkpoint**, not a standalone workflow stage. The gate runs for Critical, Standard, and Refactor work and is embedded in the `/ship` and `/review` stages — finish the doc updates, confirm CI is green, then hand off the PR. Simple, Hotfix, and Docs work skip the gate.
 
 **Utility**: `/status` — Context check before starting work (not a numbered stage)
 
@@ -25,12 +26,12 @@ When the user requests work, **you MUST automatically classify** the change type
 ### Critical (Full default workflow template)
 **Triggers:** Security, authentication, payments, breaking changes, new architecture, data migrations
 **Example:** "Add OAuth login", "Migrate database schema", "Implement payment gateway"
-**Workflow:** plan → dev → validate → ship → review → premerge → verify
+**Workflow:** plan → dev → validate → ship → review → verify (pre-merge gate before merge)
 
 ### Standard (default workflow without post-merge verify)
 **Triggers:** Normal features, enhancements, new components
 **Example:** "Add user profile page", "Create notification system"
-**Workflow:** plan → dev → validate → ship → review → premerge
+**Workflow:** plan → dev → validate → ship → review (pre-merge gate before merge)
 
 ### Simple (3-stage workflow, skip plan)
 **Triggers:** Bug fixes, UI tweaks, small changes, minor refactors
@@ -50,7 +51,7 @@ When the user requests work, **you MUST automatically classify** the change type
 ### Refactor (5-stage workflow for safe cleanup)
 **Triggers:** Code cleanup, performance optimization, technical debt reduction
 **Example:** "Refactor auth service", "Extract utility functions"
-**Workflow:** plan → dev → validate → ship → premerge
+**Workflow:** plan → dev → validate → ship (pre-merge gate before merge)
 
 ## Enforcement Philosophy
 
@@ -120,7 +121,7 @@ Task 2: Validation logic
 
 ```json
 {
-  "id": "bd-x7y2",
+  "id": "forge-x7y2",
   "type": "critical",
   "currentStage": "dev",
   "completedStages": ["plan"],
@@ -162,7 +163,6 @@ Task 2: Validation logic
 - [skills/ship/SKILL.md](skills/ship/SKILL.md) - How to create PRs
 - [skills/review/SKILL.md](skills/review/SKILL.md) - How to address PR feedback (with HARD-GATE exit)
 - [skills/shepherd/SKILL.md](skills/shepherd/SKILL.md) - How to run a bounded PR monitor pass (utility; never merges, never resolves threads)
-- [skills/premerge/SKILL.md](skills/premerge/SKILL.md) - How to complete docs and hand off PR for merge
 - [skills/verify/SKILL.md](skills/verify/SKILL.md) - How to verify post-merge health
 
 **Planning documents** (created by `/plan`, consumed by `/dev`):
@@ -178,7 +178,7 @@ Task 2: Validation logic
 **Forge v3 / Kernel Plan (active design):**
 - [docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md](docs/work/2026-04-28-skeleton-pivot/forge-kernel-authority-control-plane.md) — canonical Forge Kernel authority reset plan for issue authority, local broker, team authority, adapters, storage, and gates
 - [docs/work/2026-04-28-skeleton-pivot/locked-decisions.md](docs/work/2026-04-28-skeleton-pivot/locked-decisions.md) — D1–D44 decisions ledger with rationale + tradeoffs + anti-decisions; D44 supersedes Beads-only authority portions of earlier decisions
-- [docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md](docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md) — historical v3 strategy and background; do not use its Beads/Dolt default-substrate language over D44
+- [docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md](docs/work/2026-04-28-skeleton-pivot/v3-redesign-strategy.md) — historical v3 strategy and background; do not use its legacy default-substrate language over D44
 - See [docs/INDEX.md](docs/INDEX.md) for the full reading order across the v3 design folder
 
 **Load these files when you need detailed instructions for a specific stage.**
@@ -196,7 +196,7 @@ Every stage transition should carry structured context so the next stage (or a n
 | /validate  | All checks pass/fail summary | Failures diagnosed | Scripts/commands run | Ship readiness |
 | /ship      | PR created, checks pending | Template sections filled | PR URL, branch name | Review focus areas |
 | /review    | All feedback addressed | Comment resolutions | Fixed files, commit SHAs | Doc update needs |
-| /premerge  | Docs updated, CI green | N/A | Updated doc files | Merge instructions |
+| pre-merge gate | Docs updated, CI green | N/A | Updated doc files | Merge instructions |
 
 ### Validation Command
 
@@ -233,10 +233,9 @@ bash scripts/beads-context.sh stage-transition <id> dev validate \
 
 This convention is **advisory only**. The `validate` subcommand prints warnings but always exits 0. It does not block any stage transition. The goal is to build good habits, not to create friction.
 
-<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
-## Beads Issue Tracker
+## Forge Issue Tracker
 
-This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+This project uses the **Forge Kernel** for issue tracking. Run `forge prime` to see full workflow context and commands.
 
 ### Quick Reference
 
@@ -249,9 +248,9 @@ forge close <id>      # Complete work
 
 ### Rules
 
-- Use `forge` as the routine command surface for current bd-backed issue tracking and sync workflows until Forge Kernel replaces it — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/work/YYYY-MM-DD-<slug>/tasks.md` — these are approved artifacts consumed by `/dev`. Beads (`bd`) remains the current operational tracker for existing issues, but not the target architecture. New issue-authority work must route through the Forge Kernel design. Use `bd` directly only for operations Forge does not wrap yet, such as `bd init`, `bd comments`, `bd dep`, and `bd dolt *`. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to Beads (see `docs/guides/BEADS_GITHUB_SYNC.md`).
-- Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- Use `forge` as the routine command surface for issue tracking and sync workflows — do NOT use TodoWrite, TaskCreate, or markdown TODO lists. Exception: `/plan` Phase 3 generates task lists at `docs/work/YYYY-MM-DD-<slug>/tasks.md` — these are approved artifacts consumed by `/dev`. New issue-authority work routes through the Forge Kernel design. Use `forge issue` subcommands (e.g. `forge issue dep`, `forge issue comment`) for operations beyond the shortcuts above. GitHub issues may be used for external/public tracking; CI may sync GitHub issue lifecycle to the issue store.
+- Run `forge prime` for detailed command reference and session close protocol
+- Use `forge remember` for persistent knowledge — do NOT use MEMORY.md files
 
 ## Session Completion
 
@@ -265,7 +264,7 @@ forge close <id>      # Complete work
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
     git pull --rebase
-    forge sync     # wraps the supported Beads sync flow when Beads is configured
+    forge sync     # wraps the supported issue-store sync flow when the issue store is configured
     git push
     git status  # MUST show "up to date with origin"
    ```
@@ -279,4 +278,3 @@ forge close <id>      # Complete work
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 - After fixing review feedback, always push the changes and resolve the related GitHub review threads via the GraphQL API before considering the work complete
-<!-- END BEADS INTEGRATION -->

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -9,7 +9,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 | --- | ---: | ---: |
 | command | 108 | 11 |
 | runtime | 282 | 36 |
-| docs | 400 | 48 |
+| docs | 394 | 47 |
 | skills | 1 | 1 |
 | hooks | 0 | 0 |
 
@@ -115,8 +115,6 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 
 ## docs
 
-- [ ] AGENTS.md (6)
-  - lines: 123 (bd), 181 (dolt), 239 (bd), 252 (bd, dolt), 253 (bd), 254 (bd)
 - [ ] docs/guides/BEADS_GITHUB_SYNC.md (3)
   - lines: 7 (.beads), 10 (dolt), 32 (.beads)
 - [ ] docs/guides/SETUP.md (5)

--- a/lib/workflow-profiles.js
+++ b/lib/workflow-profiles.js
@@ -12,7 +12,7 @@
 const PROFILES = {
   critical: {
     name: 'Critical (Maximum Rigor)',
-    stages: ['/status', '/plan', '/dev', '/validate', '/ship', '/review', '/premerge', '/verify'],
+    stages: ['/status', '/plan', '/dev', '/validate', '/ship', '/review', '/verify'],
     tdd: 'strict',
     research: 'required',
     description: 'Security, auth, payments, data integrity, breaking changes',
@@ -21,7 +21,7 @@ const PROFILES = {
 
   standard: {
     name: 'Standard (Full Workflow)',
-    stages: ['/status', '/plan', '/dev', '/validate', '/ship', '/review', '/premerge'],
+    stages: ['/status', '/plan', '/dev', '/validate', '/ship', '/review'],
     tdd: 'required',
     research: 'optional',
     description: 'Most features and non-critical enhancements'
@@ -29,7 +29,7 @@ const PROFILES = {
 
   simple: {
     name: 'Simple (Streamlined)',
-    stages: ['/dev', '/validate', '/ship', '/premerge'],
+    stages: ['/dev', '/validate', '/ship'],
     tdd: 'recommended',
     research: 'skip',
     description: 'UI tweaks, small improvements, minor fixes'
@@ -46,7 +46,7 @@ const PROFILES = {
 
   docs: {
     name: 'Docs (Documentation Only)',
-    stages: ['/verify', '/ship', '/premerge'],
+    stages: ['/verify', '/ship'],
     tdd: 'no',
     research: 'no',
     description: 'Documentation updates, README changes'
@@ -54,7 +54,7 @@ const PROFILES = {
 
   refactor: {
     name: 'Refactor (Behavior-Preserving)',
-    stages: ['/plan', '/dev', '/validate', '/ship', '/premerge'],
+    stages: ['/plan', '/dev', '/validate', '/ship'],
     tdd: 'strict',  // Must preserve behavior
     research: 'optional',
     description: 'Code cleanup, optimization, behavior-preserving improvements'

--- a/lib/workflow/stages.js
+++ b/lib/workflow/stages.js
@@ -15,7 +15,6 @@ const STAGE_IDS = Object.freeze([
 	'validate',
 	'ship',
 	'review',
-	'premerge',
 	'verify',
 ]);
 
@@ -25,7 +24,6 @@ const STAGE_LABELS = Object.freeze({
 	validate: 'Validate',
 	ship: 'Ship',
 	review: 'Review',
-	premerge: 'Premerge',
 	verify: 'Verify',
 });
 
@@ -35,20 +33,31 @@ const STAGE_COMMANDS = Object.freeze({
 	validate: '/validate',
 	ship: '/ship',
 	review: '/review',
-	premerge: '/premerge',
 	verify: '/verify',
 });
 
 const WORKFLOW_STAGE_MATRIX = Object.freeze({
-	critical: Object.freeze(['plan', 'dev', 'validate', 'ship', 'review', 'premerge', 'verify']),
-	standard: Object.freeze(['plan', 'dev', 'validate', 'ship', 'review', 'premerge']),
-	refactor: Object.freeze(['plan', 'dev', 'validate', 'ship', 'premerge']),
+	critical: Object.freeze(['plan', 'dev', 'validate', 'ship', 'review', 'verify']),
+	standard: Object.freeze(['plan', 'dev', 'validate', 'ship', 'review']),
+	refactor: Object.freeze(['plan', 'dev', 'validate', 'ship']),
 	simple: Object.freeze(['dev', 'validate', 'ship']),
 	hotfix: Object.freeze(['dev', 'validate', 'ship']),
 	// Docs-only work intentionally reuses /verify as a pre-ship content check to
 	// keep the existing lightweight docs path, even though /verify is post-merge
 	// everywhere else in the full workflow.
 	docs: Object.freeze(['verify', 'ship']),
+});
+
+// Pre-merge is a task-type gate/checkpoint embedded inside existing stages
+// (the doc-completion + PR-handoff checks that run before merge), not a
+// standalone universal workflow stage. It is keyed with a hyphen ('pre-merge')
+// so it never re-enters the stage model. `enabledFor` lists the classifications
+// that run the gate; `embeddedIn` names the stages where it fires.
+const WORKFLOW_GATES = Object.freeze({
+	'pre-merge': Object.freeze({
+		embeddedIn: Object.freeze(['ship', 'review']),
+		enabledFor: Object.freeze(['critical', 'standard', 'refactor']),
+	}),
 });
 
 const WORKFLOW_TERMINAL_STAGES = Object.freeze(Object.entries(WORKFLOW_STAGE_MATRIX).reduce((accumulator, [classification, path]) => {
@@ -75,6 +84,19 @@ function isCanonicalStageId(stageId) {
 function getWorkflowPath(classification) {
 	const normalized = normalizeClassification(classification);
 	return normalized ? WORKFLOW_STAGE_MATRIX[normalized] : Object.freeze([]);
+}
+
+function getGatesForClassification(classification) {
+	const normalized = normalizeClassification(classification);
+	if (!normalized) {
+		return Object.freeze([]);
+	}
+
+	return Object.freeze(
+		Object.entries(WORKFLOW_GATES)
+			.filter(([, gate]) => gate.enabledFor.includes(normalized))
+			.map(([gateId]) => gateId),
+	);
 }
 
 function getStageWorkflow(stageId, classification) {
@@ -186,6 +208,7 @@ module.exports = {
 	STAGE_LABELS,
 	STAGE_COMMANDS,
 	WORKFLOW_STAGE_MATRIX,
+	WORKFLOW_GATES,
 	WORKFLOW_TERMINAL_STAGES,
 	STAGE_TRANSITIONS,
 	STAGE_MODEL,
@@ -193,6 +216,7 @@ module.exports = {
 	normalizeStageId,
 	isCanonicalStageId,
 	getWorkflowPath,
+	getGatesForClassification,
 	getStageWorkflow,
 	getAllowedTransitions,
 	canTransition,

--- a/lib/workflow/state.js
+++ b/lib/workflow/state.js
@@ -5,7 +5,7 @@ const {
   STAGE_IDS,
   STAGE_MODEL,
   getWorkflowPath,
-  normalizeStageId,
+  normalizeStageId: normalizeCanonicalStageId,
 } = require('./stages.js');
 
 const WORKFLOW_STATE_SCHEMA_VERSION = 2;
@@ -19,6 +19,28 @@ const LEGACY_STANDARD_WORKFLOW_PATH = Object.freeze([
   'premerge',
   'verify',
 ]);
+
+// Stages that the canonical model no longer recognizes but that legacy
+// schemaVersion 1 standard workflows persisted (e.g. pre-merge, retired as a
+// standalone stage and re-homed as a task-type gate). We still accept these ids
+// when normalizing legacy state so historical .forge-state.json files survive a
+// read/write round-trip. The workflow-path membership checks below remain the
+// real guard: a non-legacy classification whose path omits the stage still
+// rejects it, so accepting the id here never leaks retired stages into current
+// flows.
+const LEGACY_STAGE_IDS = Object.freeze(
+  LEGACY_STANDARD_WORKFLOW_PATH.filter(stage => !normalizeCanonicalStageId(stage))
+);
+
+function normalizeStageId(stage) {
+  const canonical = normalizeCanonicalStageId(stage);
+  if (canonical) {
+    return canonical;
+  }
+
+  const value = typeof stage === 'string' ? stage.trim() : '';
+  return LEGACY_STAGE_IDS.includes(value) ? value : null;
+}
 const LEGACY_WORKFLOW_STATE_OPTIONS = Object.freeze({
   allowLegacyDefaultClassification: true,
   allowLegacyStandardVerify: true,

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -34,9 +34,11 @@ describe('forge release check command', () => {
     const blockerIds = result.report.blockers.map(blocker => blocker.id);
     // kernel-backed-forge-issue cleared once _issue.js was de-beaded, the kernel
     // adapter exposed `dep`, and claim/release became kernel-backed static commands.
+    // premerge-embedded-gate cleared once pre-merge was re-homed as a task-type
+    // gate (WORKFLOW_GATES) and the premerge token left stages.js, workflow-profiles.js,
+    // and AGENTS.md.
     expect(blockerIds).toEqual([
       'bd-hot-path-issue-commands',
-      'premerge-embedded-gate',
       'fresh-clone-no-beads-acceptance',
     ]);
 

--- a/test/workflow-profiles.test.js
+++ b/test/workflow-profiles.test.js
@@ -1,4 +1,4 @@
-const { describe, test, expect } = require('bun:test');
+const { describe, test, expect } = require('bun:test');
 
 // Module under test
 const {
@@ -21,24 +21,24 @@ describe('workflow-profiles', () => {
       expect(PROFILES.refactor).toBeTruthy();
     });
 
-    test('critical profile should have 8 stages', () => {
-      expect(PROFILES.critical.stages.length).toBe(8);
+    test('critical profile should have 7 stages', () => {
+      expect(PROFILES.critical.stages.length).toBe(7);
       expect(PROFILES.critical.stages.includes('/status')).toBeTruthy();
-      expect(PROFILES.critical.stages.includes('/premerge')).toBeTruthy();
+      expect(PROFILES.critical.stages.includes('/premerge')).toBeFalsy();
       expect(PROFILES.critical.stages.includes('/verify')).toBeTruthy();
       expect(PROFILES.critical.tdd).toBe('strict');
     });
 
     test('standard profile should include the default command template', () => {
-      expect(PROFILES.standard.stages.length).toBe(7);
+      expect(PROFILES.standard.stages.length).toBe(6);
       expect(PROFILES.standard.stages.includes('/status')).toBeTruthy();
       expect(PROFILES.standard.stages.includes('/plan')).toBeTruthy();
-      expect(PROFILES.standard.stages.includes('/premerge')).toBeTruthy();
+      expect(PROFILES.standard.stages.includes('/premerge')).toBeFalsy();
       expect(PROFILES.standard.tdd).toBe('required');
     });
 
-    test('simple profile should have 4 stages', () => {
-      expect(PROFILES.simple.stages.length).toBe(4);
+    test('simple profile should have 3 stages', () => {
+      expect(PROFILES.simple.stages.length).toBe(3);
       expect(PROFILES.simple.stages.includes('/dev')).toBeTruthy();
       expect(!PROFILES.simple.stages.includes('/research')).toBeTruthy();
       expect(PROFILES.simple.tdd).toBe('recommended');
@@ -51,14 +51,14 @@ describe('workflow-profiles', () => {
       expect(PROFILES.hotfix.tdd).toBe('required');
     });
 
-    test('docs profile should have 3 stages', () => {
-      expect(PROFILES.docs.stages.length).toBe(3);
+    test('docs profile should have 2 stages', () => {
+      expect(PROFILES.docs.stages.length).toBe(2);
       expect(PROFILES.docs.stages.includes('/verify')).toBeTruthy();
       expect(PROFILES.docs.tdd).toBe('no');
     });
 
-    test('refactor profile should have 5 stages', () => {
-      expect(PROFILES.refactor.stages.length).toBe(5);
+    test('refactor profile should have 4 stages', () => {
+      expect(PROFILES.refactor.stages.length).toBe(4);
       expect(PROFILES.refactor.stages.includes('/plan')).toBeTruthy();
       expect(PROFILES.refactor.tdd).toBe('strict');
     });

--- a/test/workflow/stages.test.js
+++ b/test/workflow/stages.test.js
@@ -1,8 +1,11 @@
 const { describe, test, expect } = require('bun:test');
 
 const {
+  STAGE_IDS,
+  WORKFLOW_GATES,
   getWorkflowPath,
   getStageWorkflow,
+  getGatesForClassification,
   assertTransitionAllowed,
 } = require('../../lib/workflow/stages');
 
@@ -21,5 +24,27 @@ describe('workflow stages', () => {
 
   test('assertTransitionAllowed rejects docs transitions outside the documented path', () => {
     expect(() => assertTransitionAllowed('verify', 'review', 'docs')).toThrow(/Invalid workflow transition/i);
+  });
+});
+
+describe('workflow gates', () => {
+  test('pre-merge is modeled as a task-type gate, not a workflow stage', () => {
+    // The gate id is hyphenated so it never re-enters the canonical stage model.
+    expect(STAGE_IDS).not.toContain('premerge');
+    expect(STAGE_IDS).not.toContain('pre-merge');
+    expect(WORKFLOW_GATES['pre-merge']).toEqual({
+      embeddedIn: ['ship', 'review'],
+      enabledFor: ['critical', 'standard', 'refactor'],
+    });
+  });
+
+  test('getGatesForClassification reports the pre-merge gate only where it is enabled', () => {
+    expect(getGatesForClassification('critical')).toEqual(['pre-merge']);
+    expect(getGatesForClassification('standard')).toEqual(['pre-merge']);
+    expect(getGatesForClassification('refactor')).toEqual(['pre-merge']);
+    expect(getGatesForClassification('simple')).toEqual([]);
+    expect(getGatesForClassification('hotfix')).toEqual([]);
+    expect(getGatesForClassification('docs')).toEqual([]);
+    expect(getGatesForClassification('bogus')).toEqual([]);
   });
 });

--- a/test/workflow/state.test.js
+++ b/test/workflow/state.test.js
@@ -23,22 +23,21 @@ describe('workflow state layer', () => {
 			'validate',
 			'ship',
 			'review',
-			'premerge',
 			'verify',
 		]);
 
 		expect(Object.keys(STAGE_MODEL)).toEqual(STAGE_IDS);
-		expect(getWorkflowPath('standard')).toEqual(['plan', 'dev', 'validate', 'ship', 'review', 'premerge']);
-		expect(getWorkflowPath('critical')).toEqual(['plan', 'dev', 'validate', 'ship', 'review', 'premerge', 'verify']);
-		expect(getWorkflowPath('refactor')).toEqual(['plan', 'dev', 'validate', 'ship', 'premerge']);
+		expect(getWorkflowPath('standard')).toEqual(['plan', 'dev', 'validate', 'ship', 'review']);
+		expect(getWorkflowPath('critical')).toEqual(['plan', 'dev', 'validate', 'ship', 'review', 'verify']);
+		expect(getWorkflowPath('refactor')).toEqual(['plan', 'dev', 'validate', 'ship']);
 		expect(getWorkflowPath('simple')).toEqual(['dev', 'validate', 'ship']);
 		expect(getWorkflowPath('hotfix')).toEqual(['dev', 'validate', 'ship']);
 		expect(getWorkflowPath('docs')).toEqual(['verify', 'ship']);
-		expect(WORKFLOW_STAGE_MATRIX.standard).toEqual(['plan', 'dev', 'validate', 'ship', 'review', 'premerge']);
+		expect(WORKFLOW_STAGE_MATRIX.standard).toEqual(['plan', 'dev', 'validate', 'ship', 'review']);
 		expect(WORKFLOW_TERMINAL_STAGES).toEqual({
 			critical: 'verify',
-			standard: 'premerge',
-			refactor: 'premerge',
+			standard: 'review',
+			refactor: 'ship',
 			simple: 'ship',
 			hotfix: 'ship',
 			docs: 'ship',


### PR DESCRIPTION
Clears the **premerge-embedded-gate** blocker and the **AGENTS.md** bd-hot-path file (0.1.0 gate). Part of retiring Beads.

## What
- **`lib/workflow/stages.js`** — `WORKFLOW_GATES` construct (hyphenated `pre-merge`, `embeddedIn: [ship, review]`) + `getGatesForClassification()`; `premerge` removed from `STAGE_IDS/LABELS/COMMANDS/MATRIX`. Implements **D13** (pre-merge = task-type gate, not a universal stage).
- **`lib/workflow-profiles.js`** — `premerge` out of the current matrix/profiles.
- **`lib/workflow/state.js`** — legacy `premerge → verify` migration kept (back-compat; migration tests preserved).
- **`AGENTS.md`** — beads-integration block replaced with a forge equivalent (bd markers dropped); `bd-x7y2`→`forge-x7y2`; Beads/Dolt reworded; pre-merge framed as a gate; the `skills/premerge` index link dropped (skill dir kept — proper rename tracked in `c5deccc1`).

## Gate impact
Clears `premerge-embedded-gate` entirely + removes `AGENTS.md` from `bd-hot-path`. The `bd-hot-path` blocker stays RED until the sibling PRs land (epic #248, sync #249) — it's all-or-nothing across the files. After all three, the only remainder is `smart-status.sh`'s `bd list` (deferred scorer-reshape follow-up).

## Verification
Affected suites green: workflow/stages, workflow-profiles, workflow/state, structural, status-command, release, release-readiness (301 pass / 0 fail). eslint clean. D20 artifact regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible pre-merge checkpoint within the workflow for selected paths, with updated stage guidance and completion checks.
  * Expanded workflow tracking to recognize an additional verification step in relevant flows.

* **Bug Fixes**
  * Updated workflow routing so standard, critical, refactor, and docs paths reflect the latest stage order.
  * Preserved compatibility with older saved workflow states while keeping current workflows consistent.

* **Documentation**
  * Refreshed workflow guidance and issue-tracking instructions to match the new process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->