### PR TITLE
feat(smart-status): de-bead the scoring engine onto the Forge Kernel

### DIFF
--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -8,7 +8,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 | Group | Call sites | Files |
 | --- | ---: | ---: |
 | command | 50 | 7 |
-| runtime | 265 | 34 |
+| runtime | 250 | 33 |
 | docs | 394 | 47 |
 | skills | 1 | 1 |
 | hooks | 0 | 0 |
@@ -96,8 +96,6 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 200 (.beads), 232 (.beads), 233 (.beads), 234 (.beads), 253 (.beads), 254 (.beads), 255 (.beads), 256 (.beads), 261 (.beads), 279 (bd), 283 (.beads), 299 (bd), 309 (.beads), 314 (bd), 318 (bd), 319 (bd), 321 (.beads), 326 (bd), 472 (dolt), 475 (.beads)
 - [ ] scripts/pr-coordinator.sh (14)
   - lines: 53 (bd), 59 (bd), 61 (bd), 78 (bd), 94 (bd), 113 (bd), 130 (bd), 152 (bd), 268 (bd), 275 (bd), 312 (bd), 375 (bd), 488 (bd), 493 (bd)
-- [ ] scripts/smart-status.sh (15)
-  - lines: 4 (bd), 14 (bd), 113 (bd), 152 (dolt), 154 (bd), 157 (bd), 158 (bd), 162 (bd), 165 (.beads), 176 (bd), 177 (.beads), 178 (bd), 183 (bd), 187 (bd), 248 (bd)
 - [ ] scripts/sync-utils.sh (23)
   - lines: 88 (.beads), 94 (.beads), 106 (.beads), 113 (.beads), 158 (.beads), 219 (.beads), 260 (bd), 262 (.beads), 273 (bd, dolt), 281 (bd), 288 (dolt), 307 (.beads), 311 (.beads), 312 (.beads), 319 (bd, dolt), 321 (bd, dolt), 371 (.beads), 372 (.beads), 408 (bd), 420 (.beads), 421 (.beads), 450 (.beads), 458 (.beads)
 

--- a/lib/smart-status/scoring.js
+++ b/lib/smart-status/scoring.js
@@ -139,13 +139,22 @@ function scoreIssues(issues, options = {}) {
 	return [...issues]
 		.map((issue) => {
 			const priorityWeight = getPriorityWeight(issue.priority);
-			const directDependents = issue.dependent_count ?? dependentsMap.get(issue.id)?.length ?? 0;
+			// Prefer an explicit count, then the Kernel's authoritative `dependents`
+			// reverse-graph array, then the locally-reconstructed map (legacy shape).
+			const directDependents = issue.dependent_count
+				?? (Array.isArray(issue.dependents) ? issue.dependents.length : undefined)
+				?? dependentsMap.get(issue.id)?.length
+				?? 0;
 			const unblockChain = Math.max(directDependents + 1, 1);
 			const typeWeight = getTypeWeight(issue.type);
 			const statusBoost = getStatusBoost(issue.status);
 			const epicProximity = getEpicProximity(issue, epicStats);
 			const stalenessBoost = getStalenessBoost(issue.updated_at, now);
-			const dependents = dependentsMap.get(issue.id) ?? [];
+			// The Kernel supplies `dependents` directly (reverse graph); fall back to
+			// the reconstructed map only for the legacy { depends_on_id } shape.
+			const dependents = Array.isArray(issue.dependents)
+				? issue.dependents
+				: (dependentsMap.get(issue.id) ?? []);
 			const score = priorityWeight
 				* unblockChain
 				* typeWeight

--- a/lib/smart-status/scoring.js
+++ b/lib/smart-status/scoring.js
@@ -104,7 +104,12 @@ function buildDependentsMap(issues) {
 
 	for (const issue of issues) {
 		for (const dependency of issue.dependencies ?? []) {
-			const dependencyId = dependency?.depends_on_id;
+			// The Kernel emits `dependencies` as bare id strings; the legacy shape
+			// used `{ depends_on_id }` objects. Accept both so the reverse-graph is
+			// reconstructable even when an issue arrives without a `dependents` array.
+			const dependencyId = typeof dependency === 'string'
+				? dependency
+				: dependency?.depends_on_id;
 			if (!dependencyId) {
 				continue;
 			}

--- a/scripts/smart-status.sh
+++ b/scripts/smart-status.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # smart-status.sh Ã¢â‚¬â€ Workflow intelligence scoring engine
 #
-# Reads issues via `bd list --json --limit 0`, computes a composite score
-# for each issue, and outputs them sorted by score descending.
+# Reads issues via `forge issue list --json` (Forge Kernel), computes a composite
+# score for each issue, and outputs them sorted by score descending.
 #
 # Composite score:
 #   priority_weight * unblock_chain * type_weight * status_boost * epic_proximity * staleness_boost
@@ -11,7 +11,7 @@
 #   smart-status.sh [--json]
 #
 # Environment:
-#   BD_CMD  Ã¢â‚¬â€ override the bd command (for testing with mocks)
+#   FORGE_CMDÃ¢â‚¬â€ override the forge command (for testing with mocks)
 #   GIT_CMD Ã¢â‚¬â€ override the git command (for testing with mocks)
 #   DEFAULT_BRANCH Ã¢â‚¬â€ override the default branch name (default: auto-detect)
 #
@@ -110,7 +110,6 @@ jq() {
 
 # Ã¢â€â‚¬Ã¢â€â‚¬ Configuration Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
-BD="${BD_CMD:-bd}"
 FORGE="${FORGE_CMD:-forge}"
 GIT="${GIT_CMD:-git}"
 JSON_MODE=0
@@ -149,42 +148,16 @@ done
 
 # Ã¢â€â‚¬Ã¢â€â‚¬ Fetch issues Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬Ã¢â€â‚¬
 
-# Auto-recover beads database if Dolt server lost the database (e.g. branch
-# switch, fresh clone, server restart).  Checks for the specific "database
-# not found" error, runs bd init --force + bd backup restore, then retries.
-# Capture stderr into variable (2>&1 redirects stderr to stdout for capture,
-# then >/dev/null discards original stdout so only errors remain).
-if ! command -v "$BD" >/dev/null 2>&1; then
-  echo "Error: bd is required but not found." >&2
-  exit 1
-fi
-
-_bd_list_err="$("$BD" list --json --limit 0 2>&1 >/dev/null || true)"
-if printf '%s' "$_bd_list_err" | grep -qi "database.*not found"; then
-  _repo_root="$("$GIT" rev-parse --show-toplevel 2>/dev/null || pwd)"
-  _metadata_path="$_repo_root/.beads/metadata.json"
-  _bd_prefix=""
-  if [ -f "$_metadata_path" ]; then
-    if _metadata_prefix="$(cat "$_metadata_path" 2>/dev/null | jq -r '(.dolt_database // "") | strings')"; then
-      _bd_prefix="$(printf '%s' "$_metadata_prefix" | tr -d '\r')"
-    fi
-  fi
-  if [ -z "$_bd_prefix" ]; then
-    _bd_prefix="$(basename "$_repo_root" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]-' '-' | sed 's/^-//;s/-$//')"
-  fi
-  echo "Beads database not found - attempting auto-recovery..." >&2
-  if "$BD" init --force --prefix "$_bd_prefix" >/dev/null 2>&1; then
-    if [ -d "$_repo_root/.beads/backup" ] && ls "$_repo_root/.beads/backup"/*.jsonl >/dev/null 2>&1; then
-      "$BD" backup restore >/dev/null 2>&1 && echo "Beads: restored from backup." >&2 || echo "Beads: backup restore failed." >&2
-    else
-      echo "Beads: initialized fresh (no backup found)." >&2
-    fi
-  else
-    echo "Beads: auto-recovery failed - run 'bd doctor' manually." >&2
-  fi
-fi
-
-ISSUES_JSON="$("$BD" list --json --limit 0 2>/dev/null || echo '[]')"
+# Fetch issues from the Forge Kernel and normalize the envelope into the bare
+# array the scorer + grouping expect: extract .data.issues and drop terminal
+# (done/cancelled) issues so completed work never pollutes the work queue. The
+# kernel already supplies each issue's `dependents` (reverse-graph) and
+# `dependencies` arrays, so no per-issue reshaping is needed. The kernel
+# auto-migrates its single-machine SQLite store on read — nothing to recover.
+ISSUES_JSON="$("$FORGE" issue list --json 2>/dev/null | jq '[
+  .data.issues[]
+  | select(.status != "done" and .status != "cancelled")
+]' 2>/dev/null || echo '[]')"
 
 # Bail early on empty
 if [ "$(printf '%s' "$ISSUES_JSON" | jq 'length')" = "0" ]; then
@@ -245,10 +218,9 @@ WORKTREE_PORCELAIN="$("$GIT" worktree list --porcelain 2>/dev/null || echo '')"
 # only performs command execution and rendering.
 IN_PROGRESS_JSON="[]"
 if [ -n "$WORKTREE_PORCELAIN" ]; then
-  IN_PROGRESS_JSON="$("$BD" list --status in_progress --json --limit 0 2>/dev/null || echo '')"
-  if [ -z "$IN_PROGRESS_JSON" ] || ! printf '%s' "$IN_PROGRESS_JSON" | jq empty 2>/dev/null; then
-    IN_PROGRESS_JSON="$(printf '%s' "$ISSUES_JSON" | jq '[.[] | select(.status == "in_progress")]')"
-  fi
+  # In-progress issues come straight from the already-fetched kernel list (it
+  # includes in_progress; only done/cancelled were dropped during the fetch).
+  IN_PROGRESS_JSON="$(printf '%s' "$ISSUES_JSON" | jq '[.[] | select(.status == "in_progress")]')"
 fi
 
 SESSIONS_JSON="$(printf '{"baseBranch":%s,"worktreePorcelain":%s,"inProgressIssues":%s}' \
@@ -505,14 +477,18 @@ else
       # Group assignment (priority order: RESUME > UNBLOCK_CHAINS > BLOCKED > BACKLOG > READY_WORK)
       # Note: in_progress issues with active blockers still show in RESUME (you started
       # the work, you need to see it) but get a "BLOCKED" annotation in the output.
+      # Counts come from the scorer output: dependents is the reverse-graph
+      # array it computes, dependencies is the normalized { depends_on_id }
+      # list. done/cancelled were dropped at fetch; the status guards below stay
+      # as defense-in-depth so a terminal issue can never land in BLOCKED.
       (if .status == "in_progress" then "RESUME"
-       elif (.dependent_count // 0) >= 2 then "UNBLOCK_CHAINS"
-       elif (.dependency_count // 0) > 0 and .status != "closed" then "BLOCKED"
+       elif ((.dependents // []) | length) >= 2 then "UNBLOCK_CHAINS"
+       elif ((.dependencies // []) | length) > 0 and .status != "done" and .status != "cancelled" then "BLOCKED"
        elif (.priority == "P4" or .priority == 4) then "BACKLOG"
        else "READY_WORK"
        end) as $group |
       # Flag in_progress issues that have active blockers
-      (if .status == "in_progress" and (.dependency_count // 0) > 0 then true else false end) as $blocked_resume |
+      (if .status == "in_progress" and ((.dependencies // []) | length) > 0 then true else false end) as $blocked_resume |
       $item + { group: $group, days_ago: $days_ago, blocked_resume: $blocked_resume }
     ] |
 

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -32,17 +32,16 @@ describe('forge release check command', () => {
     expect(result.error).toContain('Forge release readiness check: 0.1.0');
 
     const blockerIds = result.report.blockers.map(blocker => blocker.id);
-    // kernel-backed-forge-issue cleared once _issue.js was de-beaded, the kernel
-    // adapter exposed `dep`, and claim/release became kernel-backed static commands.
-    // premerge-embedded-gate cleared once pre-merge was re-homed as a task-type
-    // gate (WORKFLOW_GATES) and the premerge token left stages.js, workflow-profiles.js,
-    // and AGENTS.md.
+    // bd-hot-path-issue-commands cleared once scripts/smart-status.sh — the last
+    // hot-path surface — was de-beaded (it now reads `forge issue list --json`),
+    // so the only remaining 0.1.0 blocker is the fresh-clone acceptance test.
+    // (kernel-backed-forge-issue + premerge-embedded-gate cleared in earlier lanes.)
     expect(blockerIds).toEqual([
-      'bd-hot-path-issue-commands',
       'fresh-clone-no-beads-acceptance',
     ]);
 
     expect(result.report.blockers.some(blocker => blocker.id === 'kernel-backed-forge-issue')).toBe(false);
+    expect(result.report.blockers.some(blocker => blocker.id === 'bd-hot-path-issue-commands')).toBe(false);
   }, FULL_REPO_READINESS_TIMEOUT_MS);
 
   test('rejects unsupported targets explicitly', async () => {
@@ -69,7 +68,7 @@ describe('forge release check command', () => {
     const report = JSON.parse(result.stdout);
     expect(report.success).toBe(false);
     expect(report.target).toBe('0.1.0');
-    expect(report.blockers.map(blocker => blocker.id)).toContain('bd-hot-path-issue-commands');
+    expect(report.blockers.map(blocker => blocker.id)).toContain('fresh-clone-no-beads-acceptance');
     expect(result.stderr).toContain('Forge release readiness check failed for 0.1.0');
   }, FULL_REPO_READINESS_TIMEOUT_MS);
 });
@@ -85,29 +84,14 @@ describe('0.1.0 readiness report', () => {
     expect(report.audit.groups.skills.count).toBeGreaterThan(0);
     expect(report.audit.groups.hooks).toBeDefined();
 
+    // The bd-hot-path blocker is fully CLEARED: every D20 hot-path surface
+    // (issue/sync/worktree/setup/preflight/forge-team and finally
+    // scripts/smart-status.sh in this lane) was de-beaded, so hotPathBlocker
+    // returns null and the blocker drops out of the report. The audit groups
+    // above still count non-hot-path bd references (docs/runtime), which are
+    // tracked but never block the gate.
     const hotPathBlocker = report.blockers.find(blocker => blocker.id === 'bd-hot-path-issue-commands');
-    expect(hotPathBlocker).toBeDefined();
-    // lib/commands/_issue.js is no longer hot-path evidence: it was de-beaded (all bd
-    // translation moved into the beads backend), so it carries no bd/.beads/dolt token.
-    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/_issue.js')).toBe(false);
-    // The sync-cluster (sync/worktree/setup) + preflight were de-beaded: forge sync routes
-    // through the SyncBackend seam (local-noop), worktree/clean are pure git, setup ensures the
-    // kernel instead of installing beads, and preflight validates the kernel. They carry no token.
-    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/sync.js')).toBe(false);
-    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/worktree.js')).toBe(false);
-    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/clean.js')).toBe(false);
-    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/commands/setup.js')).toBe(false);
-    // lib/workflow/state-manager.js is no longer hot-path evidence: its issue reads
-    // route through `forge issue show --json` (the comment-list fallback collapsed into
-    // that single read), so it carries no bd/.beads/dolt token.
-    expect(hotPathBlocker.evidence.some(item => item.path === 'lib/workflow/state-manager.js')).toBe(false);
-    expect(hotPathBlocker.evidence.some(item => item.path === 'scripts/preflight.sh')).toBe(false);
-    // scripts/forge-team/ (epic.sh) was de-beaded in THIS lane: epic rendering now
-    // consumes `forge issue children`'s kernel envelope, so it carries no bd token.
-    expect(hotPathBlocker.evidence.some(item => item.path.startsWith('scripts/forge-team/'))).toBe(false);
-    // scripts/smart-status.sh is the last remaining hot-path surface — its full
-    // bd-list de-bead + scorer reshape is deferred to a dedicated follow-up.
-    expect(hotPathBlocker.evidence.some(item => item.path === 'scripts/smart-status.sh')).toBe(true);
+    expect(hotPathBlocker).toBeUndefined();
   }, FULL_REPO_READINESS_TIMEOUT_MS);
 
   test('renders human-readable blocker output and the checked-in D20 audit artifact', () => {
@@ -123,7 +107,7 @@ describe('0.1.0 readiness report', () => {
     );
 
     expect(output).toContain('Result: FAIL');
-    expect(output).toContain('bd in D20 hot-path surfaces');
+    expect(output).toContain('fresh-clone-no-beads-acceptance');
     expect(auditMarkdown).toContain('# D20 bd Call-Site Kill List');
     expect(auditMarkdown).toContain('## command');
     expect(auditMarkdown).toContain('## runtime');

--- a/test/scripts/smart-status.basics.test.js
+++ b/test/scripts/smart-status.basics.test.js
@@ -5,12 +5,10 @@ const { describe, test, expect, setDefaultTimeout } = require('bun:test');
 
 const {
   BASH_PATH_ENV,
-  PROJECT_ROOT,
   SCRIPT,
   cleanupTmpDir,
   createCrLfJqWrapper,
-  createMetadataRecoveryMocks,
-  createMockBd,
+  createMockForge,
   daysAgo,
   runSmartStatus,
   toBashPath,
@@ -38,25 +36,17 @@ describe('smart-status.sh', () => {
     expect(result.stderr).not.toContain(';');
   });
 
-  test('hard-stops with a repair hint when bd is unavailable', () => {
-    const missingBd = path.join(os.tmpdir(), 'definitely-missing-bd-command');
-    const result = runSmartStatus(['--json'], { BD_CMD: missingBd });
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toMatch(/bd is required/i);
-  });
-
   test('strips CRLF from jq output so arithmetic comparisons do not warn', () => {
     const mockData = {
       issues: [
         { id: 'crlf', title: 'CRLF-safe issue', priority: 2, type: 'feature', status: 'open', dependent_count: 0, updated_at: daysAgo(1) },
       ],
     };
-    const { tmpDir: bdTmpDir, mockScript: bdScript } = createMockBd(mockData);
+    const { tmpDir: bdTmpDir, forgeScript: bdScript } = createMockForge(mockData);
     const { tmpDir: jqTmpDir } = createCrLfJqWrapper();
     try {
       const result = runSmartStatus([], {
-        BD_CMD: toBashPath(bdScript),
+        FORGE_CMD: toBashPath(bdScript),
         PATH: `${toBashPath(jqTmpDir)}:${BASH_PATH_ENV}`,
         NO_COLOR: '1',
       });
@@ -66,83 +56,6 @@ describe('smart-status.sh', () => {
     } finally {
       cleanupTmpDir(bdTmpDir);
       cleanupTmpDir(jqTmpDir);
-    }
-  });
-
-  test('uses .beads/metadata.json dolt_database for auto-recovery instead of the repo basename', () => {
-    const repoRoot = fs.mkdtempSync(path.join(PROJECT_ROOT, '.tmp-basename-mismatch-'));
-    const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
-      repoRoot,
-      databaseName: 'forge-shared-db',
-    });
-
-    try {
-      const result = runSmartStatus(['--json'], {
-        BD_CMD: bdScript,
-        GIT_CMD: gitScript,
-      });
-
-      expect(result.status).toBe(0);
-      expect(fs.readFileSync(capturePath, 'utf8')).toContain('--prefix forge-shared-db');
-      expect(fs.readFileSync(capturePath, 'utf8')).not.toContain(path.basename(repoRoot));
-    } finally {
-      cleanupTmpDir(tmpDir);
-      cleanupTmpDir(repoRoot);
-    }
-  });
-
-  test('falls back to the repo basename when .beads/metadata.json is malformed', () => {
-    const repoRoot = fs.mkdtempSync(path.join(PROJECT_ROOT, '.tmp-malformed-metadata-'));
-    const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
-      repoRoot,
-      databaseName: 'forge-shared-db',
-    });
-
-    try {
-      fs.writeFileSync(path.join(repoRoot, '.beads', 'metadata.json'), '{"dolt_database":');
-      const fallbackPrefix = path.basename(repoRoot)
-        .toLowerCase()
-        .replace(/[^a-z0-9-]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-
-      const result = runSmartStatus(['--json'], {
-        BD_CMD: bdScript,
-        GIT_CMD: gitScript,
-      });
-
-      expect(result.status).toBe(0);
-      expect(fs.readFileSync(capturePath, 'utf8')).toContain(`--prefix ${fallbackPrefix}`);
-      expect(fs.readFileSync(capturePath, 'utf8')).not.toContain('forge-shared-db');
-    } finally {
-      cleanupTmpDir(tmpDir);
-      cleanupTmpDir(repoRoot);
-    }
-  });
-
-  test('falls back to the repo basename when metadata only has the backend database field', () => {
-    const repoRoot = fs.mkdtempSync(path.join(PROJECT_ROOT, '.tmp-backend-only-metadata-'));
-    const { tmpDir, bdScript, gitScript, capturePath } = createMetadataRecoveryMocks({
-      repoRoot,
-      metadata: { database: 'dolt' },
-    });
-
-    try {
-      const fallbackPrefix = path.basename(repoRoot)
-        .toLowerCase()
-        .replace(/[^a-z0-9-]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-
-      const result = runSmartStatus(['--json'], {
-        BD_CMD: bdScript,
-        GIT_CMD: gitScript,
-      });
-
-      expect(result.status).toBe(0);
-      expect(fs.readFileSync(capturePath, 'utf8')).toContain(`--prefix ${fallbackPrefix}`);
-      expect(fs.readFileSync(capturePath, 'utf8')).not.toContain('--prefix dolt');
-    } finally {
-      cleanupTmpDir(tmpDir);
-      cleanupTmpDir(repoRoot);
     }
   });
 });

--- a/test/scripts/smart-status.conflicts.files.test.js
+++ b/test/scripts/smart-status.conflicts.files.test.js
@@ -1,16 +1,16 @@
 const { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } = require('bun:test');
 
-const { cleanupTmpDir, createMockBd, daysAgo, runSmartStatus } = require('./smart-status.helpers');
+const { cleanupTmpDir, createMockForge, daysAgo, runSmartStatus } = require('./smart-status.helpers');
 const { createMockGitWithDiff } = require('./smart-status.conflicts.helpers');
 
 setDefaultTimeout(30000);
 
 describe('smart-status.sh > file-level conflict detection smoke', () => {
-	let mockBd;
+	let mockForge;
 	let scenarios;
 
 	beforeAll(() => {
-		mockBd = createMockBd({
+		mockForge = createMockForge({
 			issues: [
 				{ id: 'i1', title: 'Work', priority: 'P2', type: 'feature', status: 'open', dependent_count: 0, updated_at: daysAgo(1) },
 			],
@@ -36,7 +36,7 @@ describe('smart-status.sh > file-level conflict detection smoke', () => {
 	});
 
 	afterAll(() => {
-		cleanupTmpDir(mockBd?.tmpDir);
+		cleanupTmpDir(mockForge?.tmpDir);
 		for (const scenario of Object.values(scenarios || {})) {
 			cleanupTmpDir(scenario?.tmpDir);
 		}
@@ -44,7 +44,7 @@ describe('smart-status.sh > file-level conflict detection smoke', () => {
 
 	test('truncates long changed-file lists in the shell output', () => {
 		const result = runSmartStatus([], {
-			BD_CMD: mockBd.mockScript,
+			FORGE_CMD: mockForge.forgeScript,
 			GIT_CMD: scenarios.truncatedNoConflict.mockScript,
 			REAL_GIT: scenarios.truncatedNoConflict.realGit,
 			NO_COLOR: '1',
@@ -61,7 +61,7 @@ describe('smart-status.sh > file-level conflict detection smoke', () => {
 
 	test('renders conflict risk for overlapping files', () => {
 		const result = runSmartStatus([], {
-			BD_CMD: mockBd.mockScript,
+			FORGE_CMD: mockForge.forgeScript,
 			GIT_CMD: scenarios.overlap.mockScript,
 			REAL_GIT: scenarios.overlap.realGit,
 			NO_COLOR: '1',

--- a/test/scripts/smart-status.conflicts.merge-tree.test.js
+++ b/test/scripts/smart-status.conflicts.merge-tree.test.js
@@ -1,6 +1,6 @@
 const { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } = require('bun:test');
 
-const { cleanupTmpDir, createMockBd, daysAgo, runSmartStatus } = require('./smart-status.helpers');
+const { cleanupTmpDir, createMockForge, daysAgo, runSmartStatus } = require('./smart-status.helpers');
 const { createMockGitTier2, twoBranchPorcelain } = require('./smart-status.conflicts.helpers');
 
 setDefaultTimeout(20000);
@@ -10,7 +10,7 @@ describe('smart-status.sh > merge-tree conflict detection smoke', () => {
 	let scenarios;
 
 	beforeAll(() => {
-		mockBd = createMockBd({
+		mockBd = createMockForge({
 			issues: [
 				{ id: 'i1', title: 'Work', priority: 'P2', type: 'feature', status: 'open', dependent_count: 0, updated_at: daysAgo(1) },
 			],
@@ -40,7 +40,7 @@ describe('smart-status.sh > merge-tree conflict detection smoke', () => {
 
 	test('shows merge conflict annotations when merge-tree reports a real conflict', () => {
 		const result = runSmartStatus([], {
-			BD_CMD: mockBd.mockScript,
+			FORGE_CMD: mockBd.forgeScript,
 			GIT_CMD: scenarios.realConflict.mockScript,
 			REAL_GIT: scenarios.realConflict.realGit,
 			NO_COLOR: '1',
@@ -53,7 +53,7 @@ describe('smart-status.sh > merge-tree conflict detection smoke', () => {
 
 	test('omits merge_conflicts from JSON output when merge-tree finds no real conflict', () => {
 		const result = runSmartStatus(['--json'], {
-			BD_CMD: mockBd.mockScript,
+			FORGE_CMD: mockBd.forgeScript,
 			GIT_CMD: scenarios.jsonNoConflict.mockScript,
 			REAL_GIT: scenarios.jsonNoConflict.realGit,
 			NO_COLOR: '1',

--- a/test/scripts/smart-status.helpers.js
+++ b/test/scripts/smart-status.helpers.js
@@ -168,11 +168,15 @@ function createMockForge(jsonData) {
   }).join('\n');
   const emptyEnvelope = '{"schema_version":"forge.issue.v1","command":"issue.children","data":{"epic":null,"children":[],"rollup":{"total":0,"done":0,"in_progress":0,"open":0,"review":0,"cancelled":0,"blocked":0,"percentage":0,"by_status":{}},"count":0},"next_commands":[]}';
   const forgeContent = `#!/usr/bin/env bash
-if [[ "$1" == "issue" && "$2" == "list" ]]; then
+if [[ "$1" == "issue" && "$2" == "list" && "$3" == "--json" ]]; then
   cat <<'JSONEOF'
 ${JSON.stringify(listEnvelope)}
 JSONEOF
   exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  echo "mock forge: expected 'issue list --json', got: $*" >&2
+  exit 2
 fi
 if [[ "$1" == "issue" && "$2" == "children" ]]; then
   EPIC_ID="$3"

--- a/test/scripts/smart-status.helpers.js
+++ b/test/scripts/smart-status.helpers.js
@@ -45,7 +45,6 @@ const BASH_PATH_ENV = resolveBashPathEnv();
 function normalizeBashEnv(env = {}) {
   return {
     ...env,
-    ...(env.BD_CMD ? { BD_CMD: toBashPath(env.BD_CMD) } : {}),
     ...(env.FORGE_CMD ? { FORGE_CMD: toBashPath(env.FORGE_CMD) } : {}),
     ...(env.GIT_CMD ? { GIT_CMD: toBashPath(env.GIT_CMD) } : {}),
     ...(env.JQ_CMD ? { JQ_CMD: toBashPath(env.JQ_CMD) } : {}),
@@ -89,23 +88,48 @@ function parseIssues(stdout) {
   return parsed.issues;
 }
 
-function createMockBd(jsonData) {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smart-status-test-'));
-  const mockScript = path.join(tmpDir, 'bd');
-  const scriptContent = `#!/usr/bin/env bash
-if [[ "$1" == "list" ]]; then
-  cat <<'JSONEOF'
-${JSON.stringify(jsonData.issues || [])}
-JSONEOF
-fi
-`;
-  fs.writeFileSync(mockScript, scriptContent, { mode: 0o755 });
+// Convert a bd-shaped fixture issue into the Forge Kernel `issue.list` shape:
+// `closed` -> `done`; dependency/dependent COUNTS -> id ARRAYS (the kernel
+// supplies dependents/dependencies as arrays, not counts). Synthetic ids are
+// fine — the scorer + grouping read only array lengths, and the "Unblocks"
+// display asserts presence, not specific ids. An explicit `dependencies` array
+// of `{ depends_on_id }` objects is flattened to the kernel id-string form.
+function toKernelIssue(issue) {
+  const out = { ...issue };
+  if (out.status === 'closed') {
+    out.status = 'done';
+  }
+  if (Array.isArray(out.dependencies)) {
+    out.dependencies = out.dependencies.map((d) => (typeof d === 'string' ? d : d.depends_on_id));
+  } else if (typeof out.dependency_count === 'number') {
+    out.dependencies = Array.from({ length: out.dependency_count }, (_, i) => `__dep_${out.id}_${i}`);
+  } else {
+    out.dependencies = [];
+  }
+  if (!Array.isArray(out.dependents) && typeof out.dependent_count === 'number') {
+    out.dependents = Array.from({ length: out.dependent_count }, (_, i) => `__dependent_${out.id}_${i}`);
+  } else if (!Array.isArray(out.dependents)) {
+    out.dependents = [];
+  }
+  delete out.dependent_count;
+  delete out.dependency_count;
+  return out;
+}
 
-  // The de-beaded smart-status.sh sources epic child rollups from
-  // `forge issue children <id> --json` (the kernel issue-command-contract envelope),
-  // not from `bd children`. Build a matching forge mock from the same epicChildren
-  // fixtures — smart-status reads only .data.rollup.total + .data.rollup.done, and the
-  // kernel `done` status replaces the legacy beads `closed`.
+// Build a `forge` mock that answers both the issue-list fetch and the epic-child
+// rollup the de-beaded smart-status.sh relies on:
+//   - `forge issue list --json`        -> the kernel issue.list envelope
+//   - `forge issue children <id> --json` -> the kernel issue.children envelope
+// smart-status reads only .data.rollup.total + .data.rollup.done from children,
+// and the kernel `done` status replaces the legacy beads `closed`.
+function createMockForge(jsonData) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smart-status-test-'));
+  const listEnvelope = {
+    schema_version: 'forge.issue.v1',
+    command: 'issue.list',
+    data: { issues: (jsonData.issues || []).map(toKernelIssue) },
+  };
+
   const forgeScript = path.join(tmpDir, 'forge');
   const forgeCases = (jsonData.epicChildren || []).map((ec) => {
     const kids = ec.children || [];
@@ -144,6 +168,12 @@ fi
   }).join('\n');
   const emptyEnvelope = '{"schema_version":"forge.issue.v1","command":"issue.children","data":{"epic":null,"children":[],"rollup":{"total":0,"done":0,"in_progress":0,"open":0,"review":0,"cancelled":0,"blocked":0,"percentage":0,"by_status":{}},"count":0},"next_commands":[]}';
   const forgeContent = `#!/usr/bin/env bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  cat <<'JSONEOF'
+${JSON.stringify(listEnvelope)}
+JSONEOF
+  exit 0
+fi
 if [[ "$1" == "issue" && "$2" == "children" ]]; then
   EPIC_ID="$3"
   case "$EPIC_ID" in
@@ -154,7 +184,7 @@ fi
 `;
   fs.writeFileSync(forgeScript, forgeContent, { mode: 0o755 });
 
-  return { tmpDir, mockScript, forgeScript };
+  return { tmpDir, forgeScript };
 }
 
 function cleanupTmpDir(tmpDir) {
@@ -184,58 +214,6 @@ REAL_JQ="${cachedRealJq}"
   return { tmpDir, wrapperPath };
 }
 
-function createMetadataRecoveryMocks({ repoRoot, databaseName, metadata }) {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smart-status-recovery-'));
-  const bdScript = path.join(tmpDir, 'bd');
-  const gitScript = path.join(tmpDir, 'git');
-  const capturePath = path.join(tmpDir, 'init-args.txt');
-  const restoredFlag = path.join(tmpDir, 'restored.flag');
-
-  fs.mkdirSync(path.join(repoRoot, '.beads', 'backup'), { recursive: true });
-  fs.writeFileSync(
-    path.join(repoRoot, '.beads', 'metadata.json'),
-    JSON.stringify(metadata || { database: 'dolt', dolt_database: databaseName }, null, 2),
-  );
-  fs.writeFileSync(path.join(repoRoot, '.beads', 'backup', 'issues.jsonl'), '{"id":"forge-1"}\n');
-
-  fs.writeFileSync(bdScript, `#!/usr/bin/env bash
-set -euo pipefail
-if [[ "$1" == "list" ]]; then
-  if [[ -f ${JSON.stringify(toBashPath(restoredFlag))} ]]; then
-    echo "[]"
-    exit 0
-  fi
-  echo "database repo-root not found" >&2
-  exit 1
-fi
-if [[ "$1" == "init" ]]; then
-  printf '%s' "$*" > ${JSON.stringify(toBashPath(capturePath))}
-  exit 0
-fi
-if [[ "$1" == "backup" && "$2" == "restore" ]]; then
-  touch ${JSON.stringify(toBashPath(restoredFlag))}
-  exit 0
-fi
-if [[ "$1" == "children" ]]; then
-  echo "[]"
-  exit 0
-fi
-echo "[]" 
-`, { mode: 0o755 });
-
-  fs.writeFileSync(gitScript, `#!/usr/bin/env bash
-set -euo pipefail
-if [[ "$1" == "rev-parse" && "$2" == "--show-toplevel" ]]; then
-  printf '%s\\n' ${JSON.stringify(toBashPath(repoRoot))}
-  exit 0
-fi
-echo "unexpected git args: $*" >&2
-exit 1
-`, { mode: 0o755 });
-
-  return { tmpDir, bdScript, gitScript, capturePath };
-}
-
 function daysAgo(n) {
   const d = new Date();
   d.setDate(d.getDate() - n);
@@ -248,8 +226,7 @@ module.exports = {
   SCRIPT,
   cleanupTmpDir,
   createCrLfJqWrapper,
-  createMetadataRecoveryMocks,
-  createMockBd,
+  createMockForge,
   daysAgo,
   normalizeBashEnv,
   parseIssues,

--- a/test/scripts/smart-status.scoring.helpers.js
+++ b/test/scripts/smart-status.scoring.helpers.js
@@ -1,22 +1,22 @@
 const {
   cleanupTmpDir,
-  createMockBd,
+  createMockForge,
   parseIssues,
   runSmartStatus,
 } = require('./smart-status.helpers');
 
-function withMockBd(mockData, callback) {
-  const { tmpDir, mockScript } = createMockBd(mockData);
+function withMockForge(mockData, callback) {
+  const { tmpDir, forgeScript } = createMockForge(mockData);
   try {
-    return callback(mockScript);
+    return callback(forgeScript);
   } finally {
     cleanupTmpDir(tmpDir);
   }
 }
 
 function runScoringJson(mockData, env = {}) {
-  return withMockBd(mockData, (mockScript) => {
-    const result = runSmartStatus(['--json'], { BD_CMD: mockScript, ...env });
+  return withMockForge(mockData, (forgeScript) => {
+    const result = runSmartStatus(['--json'], { FORGE_CMD: forgeScript, ...env });
     return {
       result,
       scored: result.status === 0 ? parseIssues(result.stdout) : [],
@@ -25,8 +25,8 @@ function runScoringJson(mockData, env = {}) {
 }
 
 function runScoringText(mockData, env = {}) {
-  return withMockBd(mockData, (mockScript) => runSmartStatus([], {
-    BD_CMD: mockScript,
+  return withMockForge(mockData, (forgeScript) => runSmartStatus([], {
+    FORGE_CMD: forgeScript,
     ...env,
   }));
 }
@@ -34,5 +34,5 @@ function runScoringText(mockData, env = {}) {
 module.exports = {
   runScoringJson,
   runScoringText,
-  withMockBd,
+  withMockForge,
 };

--- a/test/scripts/smart-status.scoring.output.test.js
+++ b/test/scripts/smart-status.scoring.output.test.js
@@ -5,7 +5,7 @@ const {
   PROJECT_ROOT,
   SCRIPT,
   cleanupTmpDir,
-  createMockBd,
+  createMockForge,
   daysAgo,
   parseIssues,
   resolveBashCommand,
@@ -29,7 +29,7 @@ describe('smart-status.sh', () => {
     let epicIssues;
 
     beforeAll(() => {
-      groupedMock = createMockBd({
+      groupedMock = createMockForge({
         issues: [
           { id: 'wip1', title: 'Active work', priority: 'P1', type: 'feature', status: 'in_progress', dependent_count: 0, dependency_count: 0, updated_at: daysAgo(1) },
           { id: 'chain1', title: 'Unblock chain item', priority: 'P2', type: 'feature', status: 'open', dependent_count: 3, dependency_count: 0, updated_at: daysAgo(1) },
@@ -43,19 +43,19 @@ describe('smart-status.sh', () => {
         ],
       });
 
-      freshMock = createMockBd({
+      freshMock = createMockForge({
         issues: [
           { id: 'fresh1', title: 'Fresh item', priority: 'P2', type: 'feature', status: 'open', dependent_count: 0, dependency_count: 0, updated_at: daysAgo(3) },
         ],
       });
 
-      colorMock = createMockBd({
+      colorMock = createMockForge({
         issues: [
           { id: 'c1', title: 'Color test', priority: 'P1', type: 'feature', status: 'in_progress', dependent_count: 0, dependency_count: 0, updated_at: daysAgo(1) },
         ],
       });
 
-      epicMock = createMockBd({
+      epicMock = createMockForge({
         issues: [
           { id: 'epic1', title: 'Epic 1', priority: 'P2', type: 'epic', status: 'open', dependent_count: 0, updated_at: daysAgo(1) },
           { id: 'child1', title: 'Child 1', priority: 'P2', type: 'feature', status: 'open', dependent_count: 0, updated_at: daysAgo(1), parent_id: 'epic1' },
@@ -74,10 +74,10 @@ describe('smart-status.sh', () => {
         ],
       });
 
-      groupedResult = runSmartStatus([], { BD_CMD: groupedMock.mockScript, NO_COLOR: '1' });
-      freshResult = runSmartStatus([], { BD_CMD: freshMock.mockScript, NO_COLOR: '1' });
+      groupedResult = runSmartStatus([], { FORGE_CMD: groupedMock.forgeScript, NO_COLOR: '1' });
+      freshResult = runSmartStatus([], { FORGE_CMD: freshMock.forgeScript, NO_COLOR: '1' });
 
-      const env = { ...process.env, BD_CMD: colorMock.mockScript, GIT_CMD: 'true' };
+      const env = { ...process.env, FORGE_CMD: colorMock.forgeScript, GIT_CMD: 'true' };
       delete env.NO_COLOR;
       colorStdout = (spawnSync(resolveBashCommand(), [toBashPath(SCRIPT)], {
         cwd: PROJECT_ROOT,
@@ -87,7 +87,6 @@ describe('smart-status.sh', () => {
       }).stdout || '').trim();
 
       epicIssues = parseIssues(runSmartStatus(['--json'], {
-        BD_CMD: epicMock.mockScript,
         FORGE_CMD: epicMock.forgeScript,
       }).stdout);
     });

--- a/test/scripts/smart-status.sessions.test.js
+++ b/test/scripts/smart-status.sessions.test.js
@@ -3,7 +3,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } = require('bun:test');
 
-const { cleanupTmpDir, createMockBd, daysAgo, runSmartStatus } = require('./smart-status.helpers');
+const { cleanupTmpDir, createMockForge, daysAgo, runSmartStatus } = require('./smart-status.helpers');
 
 setDefaultTimeout(20000);
 
@@ -46,7 +46,7 @@ describe('smart-status.sh > session detection smoke', () => {
 			'branch refs/heads/feat/workflow-intelligence',
 			'',
 		].join('\n'));
-		trackedBd = createMockBd({
+		trackedBd = createMockForge({
 			issues: [
 				{ id: 'forge-68oj', title: 'Workflow intelligence', priority: 'P1', type: 'feature', status: 'in_progress', dependent_count: 0, updated_at: daysAgo(1) },
 			],
@@ -61,7 +61,7 @@ describe('smart-status.sh > session detection smoke', () => {
 			'branch refs/heads/feat/orphan-branch',
 			'',
 		].join('\n'));
-		orphanBd = createMockBd({
+		orphanBd = createMockForge({
 			issues: [
 				{ id: 'forge-abc', title: 'Some issue', priority: 'P2', type: 'feature', status: 'open', dependent_count: 0, updated_at: daysAgo(1) },
 			],
@@ -76,7 +76,7 @@ describe('smart-status.sh > session detection smoke', () => {
 
 	test('shows ACTIVE SESSIONS before grouped output and matches the branch to an in-progress issue', () => {
 		const result = runSmartStatus([], {
-			BD_CMD: trackedBd.mockScript,
+			FORGE_CMD: trackedBd.forgeScript,
 			GIT_CMD: trackedGit.mockScript,
 			NO_COLOR: '1',
 		});
@@ -90,7 +90,7 @@ describe('smart-status.sh > session detection smoke', () => {
 
 	test('shows unmatched branches as untracked', () => {
 		const result = runSmartStatus([], {
-			BD_CMD: orphanBd.mockScript,
+			FORGE_CMD: orphanBd.forgeScript,
 			GIT_CMD: orphanGit.mockScript,
 			NO_COLOR: '1',
 		});


### PR DESCRIPTION
## Summary

Clears the **final** `bd-hot-path-issue-commands` blocker for the 0.1.0 readiness gate. `scripts/smart-status.sh` was the last D20 hot-path surface still calling `bd`; it now sources issues from the Forge Kernel. After this lands, the only remaining 0.1.0 blocker is `fresh-clone-no-beads-acceptance`.

## Changes

- **smart-status.sh**: fetch via `forge issue list --json` and normalize the envelope to the scorer's array (`.data.issues`, dropping terminal `done`/`cancelled` so completed work never pollutes the queue). Removed the beads/Dolt auto-recovery block (the kernel auto-migrates its single-machine SQLite store on read) and the in-progress `bd list` call (now a filter over the fetched list). Grouping reads the scorer's `dependents`/`dependencies` arrays instead of bd's `dependent_count`/`dependency_count`.
- **lib/smart-status/scoring.js**: prefer the kernel's authoritative `dependents` reverse-graph array, falling back to `dependent_count` then the reconstructed map (legacy shape). Backward-compatible — direct-scorer tests unchanged.
- **tests**: `createMockBd` → `createMockForge` (emits the kernel `issue.list` + `issue.children` envelopes, converting fixture counts to id arrays); removed the obsolete auto-recovery + bd-required tests.
- **release.test.js**: `bd-hot-path-issue-commands` is now fully cleared; regenerated the D20 bd call-site kill-list for the de-beaded tree.

## Behavior note (intentional)

A missing/failing `forge` now yields an empty queue rather than the old hard-fail-with-hint that `bd` had. This is acceptable for a read-only status tool — the kernel ships with Forge — and matches the `forge`-on-PATH convention already used by the de-beaded `epic.sh`.

## Validation

Validated end-to-end against **real** `forge issue list` output (not just the mock): the fetch normalization and the scorer both return 44 issues, matching the raw kernel count — confirming no truncation/default-cap and no shape mismatch. All smart-status tests pass; `release.test.js` passes (6/0) with `bd-hot-path` cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smart Status now uses Forge-based issue data for its output and scoring, keeping results aligned with the current issue graph.

* **Bug Fixes**
  * Improved blocker and dependency reporting so status categories and summaries reflect up-to-date issue relationships.
  * Removed outdated recovery behavior and updated handling of completed/cancelled issues for more consistent results.
  * Refreshed release readiness checks to match the latest blocker set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->