### PR TITLE
test(e2e): fresh-clone no-Beads acceptance (D22) — clears the 0.1.0 gate

### DIFF
--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -24,24 +24,16 @@ describe('forge release command', () => {
 });
 
 describe('forge release check command', () => {
-  test('fails the 0.1.0 readiness gate with all current Beads retirement blockers', async () => {
+  test('passes the 0.1.0 readiness gate — all Beads retirement blockers cleared', async () => {
     const result = await releaseCommand.handler(['check', '--target', '0.1.0'], {}, repoRoot);
 
-    expect(result.success).toBe(false);
+    // The final blocker (fresh-clone-no-beads-acceptance) cleared once the D22
+    // fresh-clone acceptance test landed. With bd-hot-path-issue-commands,
+    // kernel-backed-forge-issue, and premerge-embedded-gate cleared in earlier
+    // lanes, the 0.1.0 Beads-retirement gate now PASSES with zero blockers.
+    expect(result.success).toBe(true);
     expect(result.report.target).toBe('0.1.0');
-    expect(result.error).toContain('Forge release readiness check: 0.1.0');
-
-    const blockerIds = result.report.blockers.map(blocker => blocker.id);
-    // bd-hot-path-issue-commands cleared once scripts/smart-status.sh — the last
-    // hot-path surface — was de-beaded (it now reads `forge issue list --json`),
-    // so the only remaining 0.1.0 blocker is the fresh-clone acceptance test.
-    // (kernel-backed-forge-issue + premerge-embedded-gate cleared in earlier lanes.)
-    expect(blockerIds).toEqual([
-      'fresh-clone-no-beads-acceptance',
-    ]);
-
-    expect(result.report.blockers.some(blocker => blocker.id === 'kernel-backed-forge-issue')).toBe(false);
-    expect(result.report.blockers.some(blocker => blocker.id === 'bd-hot-path-issue-commands')).toBe(false);
+    expect(result.report.blockers).toEqual([]);
   }, FULL_REPO_READINESS_TIMEOUT_MS);
 
   test('rejects unsupported targets explicitly', async () => {
@@ -51,7 +43,7 @@ describe('forge release check command', () => {
     expect(result.error).toContain('Unsupported release readiness target');
   }, FULL_REPO_READINESS_TIMEOUT_MS);
 
-  test('writes JSON reports to stdout while failing the CLI gate', () => {
+  test('writes JSON reports to stdout and passes the CLI gate', () => {
     const result = spawnSync(process.execPath, [
       'bin/forge.js',
       'release',
@@ -64,12 +56,11 @@ describe('forge release check command', () => {
       encoding: 'utf8',
     });
 
-    expect(result.status).toBe(1);
+    expect(result.status).toBe(0);
     const report = JSON.parse(result.stdout);
-    expect(report.success).toBe(false);
+    expect(report.success).toBe(true);
     expect(report.target).toBe('0.1.0');
-    expect(report.blockers.map(blocker => blocker.id)).toContain('fresh-clone-no-beads-acceptance');
-    expect(result.stderr).toContain('Forge release readiness check failed for 0.1.0');
+    expect(report.blockers).toEqual([]);
   }, FULL_REPO_READINESS_TIMEOUT_MS);
 });
 
@@ -77,7 +68,10 @@ describe('0.1.0 readiness report', () => {
   test('tracks bd call sites by migration group', () => {
     const report = buildReadinessReport(repoRoot, { target: '0.1.0' });
 
-    expect(report.success).toBe(false);
+    // The gate now PASSES (zero blockers), but the bd call-site audit still
+    // tracks non-hot-path references in docs/runtime so retirement progress
+    // stays observable.
+    expect(report.success).toBe(true);
     expect(report.audit.groups.command.count).toBeGreaterThan(0);
     expect(report.audit.groups.runtime.count).toBeGreaterThan(0);
     expect(report.audit.groups.docs.count).toBeGreaterThan(0);
@@ -106,8 +100,8 @@ describe('0.1.0 readiness report', () => {
       'bd-call-site-kill-list.md'
     );
 
-    expect(output).toContain('Result: FAIL');
-    expect(output).toContain('fresh-clone-no-beads-acceptance');
+    expect(output).toContain('Result: PASS');
+    expect(output).toContain('No blockers found.');
     expect(auditMarkdown).toContain('# D20 bd Call-Site Kill List');
     expect(auditMarkdown).toContain('## command');
     expect(auditMarkdown).toContain('## runtime');

--- a/test/e2e/fresh-clone-no-beads.test.js
+++ b/test/e2e/fresh-clone-no-beads.test.js
@@ -86,14 +86,14 @@ describe('fresh clone, no Beads — full Forge issue lifecycle on the builtin ke
         const repoNodeModules = path.join(REPO_ROOT, 'node_modules');
         const cloneNodeModules = path.join(freshCloneDir, 'node_modules');
         if (fs.existsSync(repoNodeModules) && !fs.existsSync(cloneNodeModules)) {
-          if (IS_WINDOWS) {
-            execFileSync('cmd', ['/c', 'mklink', '/J', cloneNodeModules, repoNodeModules], { stdio: 'pipe' });
-          } else {
-            try {
-              fs.symlinkSync(repoNodeModules, cloneNodeModules, 'junction');
-            } catch {
-              fs.symlinkSync(repoNodeModules, cloneNodeModules, 'dir');
-            }
+          // `fs.symlinkSync(..., 'junction')` makes a Windows junction (no admin,
+          // no shell-out) and a normal dir symlink elsewhere. Using the Node API
+          // instead of `cmd /c mklink` avoids building a shell command from path
+          // values (CodeQL js/shell-command-injection-from-environment).
+          try {
+            fs.symlinkSync(repoNodeModules, cloneNodeModules, 'junction');
+          } catch {
+            fs.symlinkSync(repoNodeModules, cloneNodeModules, 'dir');
           }
         }
         expect(fs.existsSync(cloneNodeModules)).toBe(true);

--- a/test/e2e/fresh-clone-no-beads.test.js
+++ b/test/e2e/fresh-clone-no-beads.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+// E2E acceptance (Forge 0.1.0 readiness gate: `fresh-clone-no-beads-acceptance`).
+//
+// Proves the Beads-retirement promise end to end: a FRESH CLONE of this repo, run
+// with NO Beads/Dolt available on PATH, can drive the entire Forge issue lifecycle
+// (prime -> ready -> create -> claim -> comment -> close -> recap) purely on the
+// builtin `node:sqlite` kernel, never shelling out to `bd` or `dolt`.
+//
+// The harness is real, not mocked:
+//   1. `git clone` makes a genuine fresh checkout (no node_modules of its own).
+//   2. The repo's node_modules is junction/symlinked in so the cloned CLI runs.
+//   3. `bd`/`dolt` are shimmed to a temp bin placed FIRST on PATH; each shim
+//      appends its argv to a log and exits non-zero. If forge ever invoked them
+//      the log would be non-empty (and the failing shim would likely break the
+//      command), so an empty `bdInvocations` is hard proof forge stayed off Beads.
+
+const { describe, test, expect, setDefaultTimeout } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const IS_WINDOWS = process.platform === 'win32';
+
+// A real clone + lifecycle is slow; keep the per-test budget generous.
+setDefaultTimeout(120000);
+
+// Write a fake `bd`/`dolt` executable into `binDir` that records every call to
+// `logPath` and fails, so any accidental shell-out is both logged and surfaced.
+function installToolShim(binDir, name, logPath) {
+  const posixShim = path.join(binDir, name);
+  const posixLog = logPath.replace(/\\/g, '/');
+  fs.writeFileSync(posixShim, `#!/bin/sh\nprintf '%s\\n' "${name} $*" >> "${posixLog}"\nexit 1\n`);
+  if (!IS_WINDOWS) {
+    fs.chmodSync(posixShim, 0o755);
+  }
+  if (IS_WINDOWS) {
+    const cmdShim = path.join(binDir, `${name}.cmd`);
+    fs.writeFileSync(cmdShim, `@echo off\r\necho ${name} %* >> "${logPath}"\r\nexit /b 1\r\n`);
+  }
+}
+
+// Windows can hold a transient WAL/junction lock right after the kernel DB
+// closes; retry the rm so cleanup never flakes the suite.
+function rmrfWithRetry(dir) {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      // `recursive` rm treats the node_modules junction as a symlink and unlinks
+      // it instead of descending, so the repo's real node_modules is untouched.
+      fs.rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (attempt === 4 || (error.code !== 'EBUSY' && error.code !== 'EPERM' && error.code !== 'ENOTEMPTY')) {
+        return; // best-effort cleanup; never fail the test on a temp-dir lock
+      }
+      const until = Date.now() + 100;
+      while (Date.now() < until) { /* brief spin before retry */ }
+    }
+  }
+}
+
+describe('fresh clone, no Beads — full Forge issue lifecycle on the builtin kernel', () => {
+  test(
+    'prime -> ready -> create -> claim -> comment -> close -> recap with zero bd invocations',
+    () => {
+      const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-fresh-clone-'));
+      try {
+        // 1) FRESH CLONE of this repo. `--local` is fast; fall back to `--no-local`
+        //    for environments (e.g. linked worktrees on older git) where the local
+        //    object copy is unavailable. The clone has no node_modules of its own.
+        const freshCloneDir = path.join(workspace, 'clone');
+        try {
+          execFileSync('git', ['clone', '--local', '--no-hardlinks', REPO_ROOT, freshCloneDir], { stdio: 'pipe' });
+        } catch {
+          rmrfWithRetry(freshCloneDir);
+          execFileSync('git', ['clone', '--no-local', REPO_ROOT, freshCloneDir], { stdio: 'pipe' });
+        }
+        expect(fs.existsSync(path.join(freshCloneDir, 'bin', 'forge.js'))).toBe(true);
+        expect(fs.existsSync(path.join(freshCloneDir, '.git'))).toBe(true);
+
+        // Make the clone runnable. The kernel uses node:sqlite (no install needed),
+        // but the CLI still resolves npm deps from <clone>/node_modules, so link the
+        // repo's node_modules in rather than running a slow reinstall.
+        const repoNodeModules = path.join(REPO_ROOT, 'node_modules');
+        const cloneNodeModules = path.join(freshCloneDir, 'node_modules');
+        if (fs.existsSync(repoNodeModules) && !fs.existsSync(cloneNodeModules)) {
+          if (IS_WINDOWS) {
+            execFileSync('cmd', ['/c', 'mklink', '/J', cloneNodeModules, repoNodeModules], { stdio: 'pipe' });
+          } else {
+            try {
+              fs.symlinkSync(repoNodeModules, cloneNodeModules, 'junction');
+            } catch {
+              fs.symlinkSync(repoNodeModules, cloneNodeModules, 'dir');
+            }
+          }
+        }
+        expect(fs.existsSync(cloneNodeModules)).toBe(true);
+
+        // AGENTS.md bypasses the first-run setup gate in the fresh clone.
+        fs.writeFileSync(path.join(freshCloneDir, 'AGENTS.md'), '# fresh clone acceptance\n');
+
+        // 2) NO Beads/Dolt environment: shim `bd`/`dolt` so any shell-out is
+        //    recorded and fails, then put the shim dir FIRST on PATH.
+        const noBeadsBinDir = path.join(workspace, 'no-beads-bin');
+        fs.mkdirSync(noBeadsBinDir, { recursive: true });
+        const bdInvocationsLog = path.join(workspace, 'bd-invocations.log');
+        installToolShim(noBeadsBinDir, 'bd', bdInvocationsLog);
+        installToolShim(noBeadsBinDir, 'dolt', bdInvocationsLog);
+
+        const env = { ...process.env };
+        // Windows env is case-insensitive; overwrite the existing PATH key in place
+        // so the shim dir wins regardless of the original casing (`Path` vs `PATH`).
+        const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path') || 'PATH';
+        env[pathKey] = noBeadsBinDir + path.delimiter + (env[pathKey] || '');
+
+        // forge runner bound to the cloned CLI, the clone cwd, and the no-beads PATH.
+        const cloneForgeBin = path.join(freshCloneDir, 'bin', 'forge.js');
+        const forge = (args) => {
+          try {
+            return execFileSync('node', [cloneForgeBin, ...args], {
+              cwd: freshCloneDir,
+              env,
+              encoding: 'utf8',
+              stdio: ['ignore', 'pipe', 'pipe'],
+            });
+          } catch (error) {
+            const stdout = error.stdout ? error.stdout.toString() : '';
+            const stderr = error.stderr ? error.stderr.toString() : '';
+            throw new Error(`forge ${args.join(' ')} failed (exit ${error.status}):\n${stdout}\n${stderr}`);
+          }
+        };
+
+        // 3) Drive the full lifecycle in the fresh clone (each must exit 0 —
+        //    execFileSync throws on non-zero, which `forge` rethrows with stderr).
+        forge(['prime']); // initialize/prime the kernel-backed session orientation
+
+        const ready = JSON.parse(forge(['issue', 'ready', '--json']));
+        expect(Array.isArray(ready.data.issues)).toBe(true); // empty on a fresh clone is fine
+
+        const created = JSON.parse(forge(['create', 'Fresh clone acceptance issue', '--type=task', '--json']));
+        const issueId = created.data.id;
+        expect(typeof issueId).toBe('string');
+        expect(issueId.length).toBeGreaterThan(0);
+
+        forge(['claim', issueId, '--json']);
+        forge(['comment', issueId, 'Acceptance run: fresh-clone lifecycle in progress', '--json']);
+        forge(['close', issueId, '--reason=fresh-clone acceptance complete', '--json']);
+        forge(['recap', issueId]); // issue-scoped recap; exits 0 even on the D21 V1 projection
+
+        // 4) Prove forge never shelled out to bd/dolt: the recorder log is empty.
+        const bdInvocations = fs.existsSync(bdInvocationsLog)
+          ? fs.readFileSync(bdInvocationsLog, 'utf8').split('\n').filter(line => line.trim().length > 0)
+          : [];
+        expect(bdInvocations).toEqual([]);
+      } finally {
+        rmrfWithRetry(workspace);
+      }
+    },
+    120000,
+  );
+});


### PR DESCRIPTION
## Summary

Adds `test/e2e/fresh-clone-no-beads.test.js` — the **last** 0.1.0 readiness-gate blocker (`fresh-clone-no-beads-acceptance`). With it landed, **`forge release check --target 0.1.0` PASSES with zero blockers** — Beads retirement is complete by the gate.

## What it proves (real harness, not mocked)

- **Fresh clone**: `git clone --local --no-hardlinks` of the repo (with a `--no-local` fallback); the clone's `node_modules` is junction/symlinked from the repo so the cloned CLI runs (the kernel itself uses Node's builtin `node:sqlite`).
- **No Beads/Dolt**: `bd`/`dolt` are shimmed onto a temp bin placed **first** on PATH; each shim records its argv to a log and exits non-zero.
- **Full lifecycle in the clone**: `forge prime` → `forge issue ready --json` → `forge create` → `forge claim` → `forge comment` → `forge close` → `forge recap`, each exiting 0.
- **Hard proof**: asserts `bdInvocations` is empty — forge never shelled out to `bd`/`dolt`.

## Validation

- `bun test test/e2e/fresh-clone-no-beads.test.js` → 1 pass, 0 fail (~30s, real clone).
- `forge release check --target 0.1.0` → **Result: PASS**, `blockers: []`.
- eslint clean.

Closes the D22 acceptance requirement. After this merges, the 0.1.0 gate is green; remaining work is all beyond-the-gate roadmap (monitor increment 2, Wave 2, small cleanups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated release-check expectations so the 0.1.0 readiness flow now passes and reports no blockers.
  * Added an end-to-end acceptance test covering a fresh-clone issue lifecycle, including create, claim, comment, close, and recap flows.
  * Verified the command output and success status in both JSON and human-readable formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->