### PR TITLE
fix(kernel): issue-command parity bugs (description, validation, claim id)

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -11,7 +11,9 @@ const {
 	ISSUE_COMMAND_SCHEMA_VERSION,
 	formatIssueCommandError,
 	getIssueCommandContract,
+	isValidIssuePriority,
 } = require('./issue-command-contract');
+const { isValidIssueStatus } = require('./taxonomy-validator');
 const { assertFilesystemSafeForKernel } = require('./fs-class');
 
 const LOCAL_BROKER_PRAGMAS = Object.freeze([
@@ -458,7 +460,11 @@ function buildCreatePayload(flags) {
 	const id = typeof flags.id === 'string' ? flags.id : randomUUID();
 	const payload = { id };
 	if (typeof flags.title === 'string') payload.title = flags.title;
+	// Beads stored the long-form description in `body` (beads-kernel-compat maps
+	// description ?? body ?? notes -> body). --body wins when both are supplied;
+	// otherwise --description populates the same body column so it is never dropped.
 	if (typeof flags.body === 'string') payload.body = flags.body;
+	else if (typeof flags.description === 'string') payload.body = flags.description;
 	payload.type = typeof flags.type === 'string' ? flags.type : 'task';
 	payload.status = typeof flags.status === 'string' ? flags.status : 'open';
 	if (typeof flags.priority === 'string') payload.priority = flags.priority;
@@ -479,7 +485,10 @@ function buildUpdatePayload(flags) {
 	const payload = {};
 	if (typeof flags.status === 'string') payload.status = flags.status;
 	if (typeof flags.title === 'string') payload.title = flags.title;
+	// --body wins when both are supplied; otherwise --description rewrites the same
+	// body column (parity with create — beads stored the description in body).
 	if (typeof flags.body === 'string') payload.body = flags.body;
+	else if (typeof flags.description === 'string') payload.body = flags.description;
 	if (typeof flags.priority === 'string') payload.priority = flags.priority;
 	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
 	// KAP-4: --label reparents the full label set (last-value-wins, comma-split).
@@ -582,6 +591,36 @@ function buildClaimMutationEvent(operation, flags, actor, origin, context, args 
 	};
 }
 
+// Reject an out-of-contract create/update payload before it reaches the CAS path,
+// throwing a tagged error runIssueMutation maps to the contract validation error
+// (exit 6). Beads refused these too: an empty/whitespace (or, on create, missing)
+// title, and any status/type/priority outside the canonical vocabulary, are rejected
+// rather than silently stored. On UPDATE only the fields actually supplied are
+// checked; on CREATE a title is mandatory.
+function assertValidIssueMutationPayload(payload, isCreate) {
+	const reject = (message, field) => {
+		const error = new Error(message);
+		error.isIssueValidation = true;
+		error.validationField = field;
+		throw error;
+	};
+	const hasTitle = typeof payload.title === 'string';
+	if ((isCreate || hasTitle) && (!hasTitle || payload.title.trim() === '')) {
+		reject('Issue title must be a non-empty string', 'title');
+	}
+	// NOTE: issue `type` is intentionally NOT validated here. `feature`/`story`/etc.
+	// are labels, not canonical types (D18), but forge-internal callers (e.g.
+	// lib/commands/plan.js) and the documented CLI still create with --type=feature,
+	// which the kernel stores verbatim. Rejecting it would be an out-of-scope regression;
+	// this gate matches Beads on title/status/priority only.
+	if (payload.status !== undefined && !isValidIssueStatus(payload.status)) {
+		reject(`Unknown issue status: ${payload.status}`, 'status');
+	}
+	if (payload.priority !== undefined && !isValidIssuePriority(payload.priority)) {
+		reject(`Invalid issue priority: ${payload.priority}`, 'priority');
+	}
+}
+
 // Construct the kernel event for a mutation op. For update/close/comment, the
 // expected_revision is the FRESHLY READ stored revision (so runIssueOperation can
 // never manufacture a stale CAS — a behind revision only arrives via a raw
@@ -593,6 +632,7 @@ async function buildIssueMutationEvent(driver, operation, args, context, config)
 
 	if (operation === 'create') {
 		const payload = buildCreatePayload(flags);
+		assertValidIssueMutationPayload(payload, true);
 		return {
 			entity_type: 'issue',
 			entity_id: payload.id,
@@ -632,6 +672,11 @@ async function buildIssueMutationEvent(driver, operation, args, context, config)
 	const payload = operation === 'comment'
 		? buildCommentPayload(issueId, args)
 		: buildUpdatePayload(flags);
+	// update/close validate only the supplied taxonomy fields (no mandatory title);
+	// comment carries no taxonomy fields, so it is exempt.
+	if (operation !== 'comment') {
+		assertValidIssueMutationPayload(payload, false);
+	}
 	// Comments never bump entity_revision, so a revision-based key would collide for
 	// every comment on the same issue (second → false duplicate → silently dropped).
 	// Key on the minted comment_id instead. For update/close the synthesized key uses
@@ -678,15 +723,20 @@ function mutationIssueId(operation, event) {
 // stays low as op-specific fields accrue (comment_id / dependency_id / claim_id /
 // KAP-8 newly_unblocked).
 function buildAcceptMutationData(operation, event, mutation) {
+	const isDep = DEPENDENCY_OPERATIONS.has(operation);
+	const isClaim = CLAIM_OPERATIONS.has(operation);
+	// data.id is the ISSUE id consumers key on. For dep/claim ops the event entity_id
+	// is the dependency/claim ROW id, so resolve the issue id from the payload; the row
+	// id is echoed separately via dependency_id / claim_id.
 	const data = {
-		id: mutation.id ?? event.entity_id,
+		id: (isDep || isClaim) ? mutationIssueId(operation, event) : (mutation.id ?? event.entity_id),
 		revision: Number(mutation.revision ?? 0),
 	};
 	if (mutation.comment_id) data.comment_id = mutation.comment_id;
-	if (DEPENDENCY_OPERATIONS.has(operation)) {
+	if (isDep) {
 		data.dependency_id = mutation.dependency_id ?? event.entity_id;
 	}
-	if (CLAIM_OPERATIONS.has(operation)) {
+	if (isClaim) {
 		data.claim_id = mutation.claim_id ?? event.entity_id;
 	}
 	// KAP-8: a close surfaces the ids that became ready now that this issue is done.
@@ -712,11 +762,12 @@ async function mapMutationResult(driver, operation, event, result, context, conf
 	if (result.decision === 'duplicate' || result.decision === 'dedupe' || result.decision === 'projection_echo') {
 		// Idempotent replay / equivalent write: no double-write. Report the host
 		// issue's current persisted revision so the caller sees a stable result. For
-		// dep/claim ops the issue id comes from the payload, not the entity_id.
+		// dep/claim ops the issue id comes from the payload, not the entity_id — and
+		// data.id is that issue id (the dep/claim ROW id is echoed via *_id below).
 		const issueId = mutationIssueId(operation, event);
 		const entity = await driver.loadKernelEntity('issue', issueId, context, config);
 		const data = {
-			id: event.entity_id,
+			id: issueId,
 			revision: Number(entity?.entity_revision || 0),
 		};
 		if (DEPENDENCY_OPERATIONS.has(operation)) data.dependency_id = event.entity_id;
@@ -866,6 +917,17 @@ function createLocalBroker(options = {}) {
 					code: 'FORGE_ISSUE_NOT_FOUND',
 					message: err.message,
 					exitCode: ISSUE_COMMAND_EXIT_CODES.notFound,
+				});
+			}
+			if (err && err.isIssueValidation) {
+				// Out-of-contract input (empty title / invalid status/type/priority):
+				// return the contract validation error (exit 6) without writing a row.
+				return formatIssueCommandError({
+					command: ISSUE_MUTATION_COMMAND_IDS[operation],
+					code: 'FORGE_ISSUE_VALIDATION',
+					message: err.message,
+					exitCode: ISSUE_COMMAND_EXIT_CODES.validation,
+					details: err.validationField ? { field: err.validationField } : undefined,
 				});
 			}
 			throw err;

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -18,6 +18,26 @@ const ISSUE_COMMAND_EXIT_CODES = Object.freeze({
 // derived readiness (ready/blocked) stay outside the stored status set.
 const ISSUE_TYPES = Object.freeze(['epic', 'task', 'bug', 'decision']);
 const ISSUE_STATUSES = Object.freeze(['open', 'in_progress', 'review', 'done', 'cancelled']);
+// Canonical priority labels P0..P4. The bare integers 0..4 are also accepted on input
+// (the CLI documents `--priority 1`; normalizePriority maps ranks 0..4) — see
+// isValidIssuePriority. P5+ / non-numeric labels are rejected at the validation layer,
+// matching MAX_DISPLAY_PRIORITY_RANK in taxonomy-validator.
+const ISSUE_PRIORITIES = Object.freeze(['P0', 'P1', 'P2', 'P3', 'P4']);
+
+// True when `priority` is a canonical P0..P4 label (case-insensitive) or a bare
+// integer 0..4. Used by the create/update validation gate to reject junk priorities
+// (P9, BOGUS, -1) instead of persisting them verbatim — Beads rejected them too.
+function isValidIssuePriority(priority) {
+	if (typeof priority === 'number') {
+		return Number.isInteger(priority) && priority >= 0 && priority <= 4;
+	}
+	if (typeof priority !== 'string') return false;
+	const raw = priority.trim().toUpperCase();
+	const match = /^P?([0-9]+)$/.exec(raw);
+	if (!match) return false;
+	const rank = Number(match[1]);
+	return rank >= 0 && rank <= 4;
+}
 
 function deepFreeze(value) {
 	if (!value || typeof value !== 'object') return value;
@@ -422,9 +442,11 @@ module.exports = {
 	ISSUE_COMMAND_EXIT_CODES,
 	ISSUE_COMMAND_RESPONSE_SCHEMAS,
 	ISSUE_COMMAND_SCHEMA_VERSION,
+	ISSUE_PRIORITIES,
 	ISSUE_STATUSES,
 	ISSUE_TYPES,
 	formatIssueCommandError,
 	getIssueCommandContract,
+	isValidIssuePriority,
 	resolveNextCommands,
 };

--- a/test/kernel/kernel-parity-bugs.test.js
+++ b/test/kernel/kernel-parity-bugs.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Kernel-parity regression suite. Three confirmed divergences from the Beads
+// behavior the Kernel replaced:
+//   BUG 1 — `create --description` was silently dropped (data loss).
+//   BUG 2 — no input validation: empty title accepted, invalid status/priority/type
+//           persisted verbatim.
+//   BUG 3 — claim/release/dep returned the lease/dep row id as data.id instead of
+//           the issue id consumers key on.
+// Each test drives the real SQLite driver through broker.runIssueOperation, matching
+// the CLI path (bin/forge.js -> _issue.js -> adapter -> broker).
+describe('Kernel parity bugs', () => {
+	let tmpDir;
+	let driver;
+	let broker;
+	let config;
+	const now = '2026-06-29T00:00:00.000Z';
+
+	async function createIssue(args, context = {}) {
+		return broker.runIssueOperation('create', args, { now, actor: 'tester', ...context });
+	}
+
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kparity-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// --- BUG 1: --description persists ----------------------------------------
+
+	test('create --description persists to body and show surfaces it', async () => {
+		const created = await createIssue(
+			['--id', 'desc-1', '--title', 'Has description', '--type', 'task', '--description', 'HELLO'],
+		);
+		expect(created.ok).toBe(true);
+
+		const shown = await driver.issueOperation('show', ['desc-1'], {}, config);
+		expect(shown.ok).toBe(true);
+		expect(shown.data.body).toBe('HELLO');
+	});
+
+	test('explicit --body wins over --description when both are given', async () => {
+		await createIssue(
+			['--id', 'desc-2', '--title', 'Both', '--type', 'task', '--body', 'BODYWINS', '--description', 'ignored'],
+		);
+		const shown = await driver.issueOperation('show', ['desc-2'], {}, config);
+		expect(shown.data.body).toBe('BODYWINS');
+	});
+
+	test('update --description rewrites the body', async () => {
+		await createIssue(['--id', 'desc-3', '--title', 'Initial', '--type', 'task']);
+		const updated = await broker.runIssueOperation(
+			'update',
+			['desc-3', '--description', 'UPDATED'],
+			{ now: '2026-06-29T00:01:00.000Z', actor: 'tester' },
+		);
+		expect(updated.ok).toBe(true);
+
+		const shown = await driver.issueOperation('show', ['desc-3'], {}, config);
+		expect(shown.data.body).toBe('UPDATED');
+	});
+
+	// --- BUG 2: input validation ----------------------------------------------
+
+	test('create rejects an empty title', async () => {
+		const result = await createIssue(['--id', 'empty-1', '--title', '', '--type', 'task']);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+		expect(result.error.code).toContain('VALIDATION');
+		// Nothing was written.
+		const rows = await driver.queryAll('SELECT * FROM kernel_issues', config);
+		expect(rows).toHaveLength(0);
+	});
+
+	test('create rejects a whitespace-only title', async () => {
+		const result = await createIssue(['--id', 'empty-2', '--title', '   ', '--type', 'task']);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+	});
+
+	test('create rejects a missing title', async () => {
+		const result = await createIssue(['--id', 'empty-3', '--type', 'task']);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+	});
+
+	test('create rejects an invalid status', async () => {
+		const result = await createIssue(
+			['--id', 'bad-status-1', '--title', 'x', '--type', 'task', '--status', 'BOGUSSTATUS'],
+		);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+	});
+
+	test('create accepts a non-canonical type verbatim (type is NOT validated)', async () => {
+		// `feature` is a label, not a canonical D18 type, but forge-internal callers
+		// (lib/commands/plan.js) and the documented CLI create with --type=feature.
+		// The kernel stores it verbatim; rejecting it would be an out-of-scope regression.
+		const result = await createIssue(['--id', 'feat-type-1', '--title', 'x', '--type', 'feature']);
+		expect(result.ok).toBe(true);
+		const shown = await driver.issueOperation('show', ['feat-type-1'], {}, config);
+		expect(shown.data.type).toBe('feature');
+	});
+
+	test('create rejects an invalid priority', async () => {
+		const result = await createIssue(
+			['--id', 'bad-prio-1', '--title', 'x', '--type', 'task', '--priority', 'P9'],
+		);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+	});
+
+	test('create accepts a canonical priority (P1) and a bare-int priority (1)', async () => {
+		const labelled = await createIssue(
+			['--id', 'ok-prio-1', '--title', 'x', '--type', 'task', '--priority', 'P1'],
+		);
+		expect(labelled.ok).toBe(true);
+		const numeric = await createIssue(
+			['--id', 'ok-prio-2', '--title', 'y', '--type', 'task', '--priority', '1'],
+		);
+		expect(numeric.ok).toBe(true);
+	});
+
+	test('update rejects an invalid status and does not persist it', async () => {
+		await createIssue(['--id', 'upd-1', '--title', 'Updatable', '--type', 'task']);
+		const result = await broker.runIssueOperation(
+			'update',
+			['upd-1', '--status', 'BOGUSSTATUS'],
+			{ now: '2026-06-29T00:02:00.000Z', actor: 'tester' },
+		);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+
+		const shown = await driver.issueOperation('show', ['upd-1'], {}, config);
+		expect(shown.data.status).toBe('open');
+	});
+
+	test('update rejects an invalid priority', async () => {
+		await createIssue(['--id', 'upd-2', '--title', 'Updatable', '--type', 'task']);
+		const result = await broker.runIssueOperation(
+			'update',
+			['upd-2', '--priority', 'BOGUS'],
+			{ now: '2026-06-29T00:03:00.000Z', actor: 'tester' },
+		);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+	});
+
+	test('update rejects an empty title', async () => {
+		await createIssue(['--id', 'upd-3', '--title', 'Updatable', '--type', 'task']);
+		const result = await broker.runIssueOperation(
+			'update',
+			['upd-3', '--title', ''],
+			{ now: '2026-06-29T00:04:00.000Z', actor: 'tester' },
+		);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+	});
+
+	// --- BUG 3: data.id is the issue id for claim/release/dep -----------------
+
+	test('claim returns the issue id as data.id (claim_id carries the lease id)', async () => {
+		await createIssue(['--id', 'claim-1', '--title', 'Claimable', '--type', 'task']);
+		const claimed = await broker.runIssueOperation('claim', ['claim-1'], { now, actor: 'alice' });
+
+		expect(claimed.ok).toBe(true);
+		expect(claimed.data.id).toBe('claim-1');
+		expect(typeof claimed.data.claim_id).toBe('string');
+		expect(claimed.data.claim_id).not.toBe('claim-1');
+	});
+
+	test('release returns the issue id as data.id', async () => {
+		await createIssue(['--id', 'rel-1', '--title', 'Releasable', '--type', 'task']);
+		await broker.runIssueOperation('claim', ['rel-1'], { now, actor: 'alice' });
+		const released = await broker.runIssueOperation(
+			'release',
+			['rel-1'],
+			{ now: '2026-06-29T00:05:00.000Z', actor: 'alice' },
+		);
+
+		expect(released.ok).toBe(true);
+		expect(released.data.id).toBe('rel-1');
+	});
+
+	test('dep.add returns the dependent issue id as data.id (dependency_id carries the row id)', async () => {
+		await createIssue(['--id', 'pd-a', '--title', 'Dependent', '--type', 'task']);
+		await createIssue(['--id', 'pd-b', '--title', 'Blocker', '--type', 'task']);
+		const added = await broker.runIssueOperation(
+			'dep.add',
+			['pd-a', 'pd-b'],
+			{ now, actor: 'tester' },
+		);
+
+		expect(added.ok).toBe(true);
+		expect(added.data.id).toBe('pd-a');
+		expect(typeof added.data.dependency_id).toBe('string');
+		expect(added.data.dependency_id).not.toBe('pd-a');
+	});
+});


### PR DESCRIPTION
## Summary

First **Wave 2 (kernel-parity)** PR. Fixes three confirmed divergences from Beads behavior in the Forge Kernel, each reproduced empirically (beads behaved correctly; the kernel diverged) and covered by new TDD tests.

## Bugs fixed

1. **`create`/`update --description` was silently dropped** (data loss). `buildCreatePayload`/`buildUpdatePayload` read `flags.body` but never `flags.description`. Now `--description` maps to `payload.body` (`--body` wins if both given); `show` already surfaces `body`.
2. **No input validation** — empty/whitespace titles were accepted and invalid status/priority persisted verbatim. New `assertValidIssueMutationPayload` rejects them on create + update with a `FORGE_ISSUE_VALIDATION` contract error. Added `ISSUE_PRIORITIES` + `isValidIssuePriority` (P0–P4 and bare 0–4) to the issue command contract.
3. **`claim`/`release`/`dep` returned the lease/dep ROW uuid as `data.id`** instead of the issue id. For claim/dependency ops, `data.id` is now the issue id; `claim_id`/`dependency_id` still carry the row id.

## Intentional non-change

`type` is **not** validated: `--type=feature` is a documented, in-use form (`lib/commands/plan.js`), so validating it would be a live regression. The kernel stores type verbatim as before; a test locks this in.

## Validation

- New `test/kernel/kernel-parity-bugs.test.js` (16 tests, RED→GREEN).
- `test/kernel/` 410 pass; eslint clean.
- Independently re-verified against real `node bin/forge.js`: descriptions persist, empty title + invalid status/priority rejected, `claim` returns the issue id, valid creates still succeed.

Part of the Wave-2 kernel-parity backlog (kernel issues abda7898, a91ca025, 40a41dbb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `--description` when creating or updating issues, with `--body` still taking priority.
  * Expanded accepted priority values to include both numeric and `P0`–`P4` formats.

* **Bug Fixes**
  * Added clearer validation for issue title, status, and priority inputs.
  * Fixed returned IDs for dependency and claim operations so the main issue ID is shown consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->