### PR TITLE
fix(kernel): response-contract parity — error envelope, exit codes, ok, multi-close

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -4024,7 +4024,11 @@ async function main() {
           process.stdout.write(result.output.endsWith('\n') ? result.output : `${result.output}\n`);
         }
         console.error(result.error || result.message || 'Command failed');
-        process.exit(1);
+        // Issue commands surface the issue-command-contract exit_code as
+        // `result.exitCode` (e.g. not-found=3, validation=6). Honor it so failed
+        // commands no longer collapse to exit 1; other registry commands omit
+        // `exitCode` and keep the historical exit 1.
+        process.exit(Number.isInteger(result.exitCode) ? result.exitCode : 1);
       }
       if (result && typeof result.output === 'string' && result.output.length > 0) {
         process.stdout.write(result.output.endsWith('\n') ? result.output : `${result.output}\n`);

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -16,7 +16,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 ## command
 
 - [ ] bin/forge.js (26)
-  - lines: 2234 (bd), 2236 (bd), 2382 (bd), 2784 (bd), 2793 (bd), 2806 (bd), 2819 (.beads), 2839 (bd), 2841 (bd), 2843 (bd), 2878 (bd), 2902 (bd), 2988 (bd), 3032 (bd), 3056 (bd), 3062 (bd), 3066 (bd), 3071 (bd), 3077 (bd), 3087 (bd), 3219 (bd), 3224 (bd), 3235 (bd), 3302 (bd), 3995 (bd), 4471 (bd)
+  - lines: 2234 (bd), 2236 (bd), 2382 (bd), 2784 (bd), 2793 (bd), 2806 (bd), 2819 (.beads), 2839 (bd), 2841 (bd), 2843 (bd), 2878 (bd), 2902 (bd), 2988 (bd), 3032 (bd), 3056 (bd), 3062 (bd), 3066 (bd), 3071 (bd), 3077 (bd), 3087 (bd), 3219 (bd), 3224 (bd), 3235 (bd), 3302 (bd), 3995 (bd), 4475 (bd)
 - [ ] lib/commands/_resolve-command-opts.js (2)
   - lines: 8 (bd), 10 (bd)
 - [ ] lib/commands/dev.js (1)

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -2,6 +2,12 @@
 
 const { runIssueOperation: defaultRunIssueOperation } = require('../forge-issues');
 const { resolveIssueBackend, hasExplicitBackendSignal, shouldUseKernelBroker } = require('../issue-backend');
+const {
+  ISSUE_COMMAND_SCHEMA_VERSION,
+  ISSUE_COMMAND_ERROR_SCHEMA_VERSION,
+  ISSUE_COMMAND_EXIT_CODES,
+  resolveNextCommands,
+} = require('../kernel/issue-command-contract');
 
 // The Forge issue command surface. Each subcommand routes through the shared
 // runIssueOperation, which selects the active backend (Kernel by --kernel /
@@ -225,7 +231,14 @@ function withResolvedIssueBackend(projectRoot, opts = {}) {
 // "Command failed". Normalize ONLY the contract shape (ok defined, success
 // undefined) into { success, output } here, at the command boundary — the kernel
 // contract itself stays untouched. Every other result passes through byte-identical.
-function normalizeIssueResult(result, operation) {
+//
+// Response-contract parity (the Beads behavior the Kernel replaced):
+//   * SUCCESS  → the printed envelope carries `ok:true` (consumers gate on it).
+//   * FAILURE  → the contract `exit_code` is surfaced as `result.exitCode` so the bin
+//                printer exits with the error class's code (not always 1); and on
+//                `--json` the full forge.issue.error.v1 envelope is emitted on stdout
+//                (without --json the human message alone goes to stderr, as before).
+function normalizeIssueResult(result, operation, { json = false } = {}) {
   if (!result || typeof result !== 'object') {
     return result;
   }
@@ -238,6 +251,7 @@ function normalizeIssueResult(result, operation) {
       success: true,
       operation,
       output: JSON.stringify({
+        ok: true,
         schema_version: result.schema_version,
         command: result.command,
         data: result.data ?? null,
@@ -249,7 +263,20 @@ function normalizeIssueResult(result, operation) {
   const message = result.error?.message
     || result.message
     || `Issue ${operation} failed`;
-  return { success: false, error: message };
+  const normalized = { success: false, error: message };
+  if (Number.isInteger(result.error?.exit_code)) {
+    normalized.exitCode = result.error.exit_code;
+  }
+  if (json) {
+    normalized.output = JSON.stringify({
+      ok: false,
+      schema_version: result.schema_version || ISSUE_COMMAND_ERROR_SCHEMA_VERSION,
+      command: result.command,
+      error: result.error,
+      next_commands: result.next_commands ?? [],
+    }, null, 2);
+  }
+  return normalized;
 }
 
 // Split close args into the leading run of positional ids and the trailing flag
@@ -265,29 +292,62 @@ function splitLeadingIds(args = []) {
 }
 
 // Kernel close fans out one runner call per id (the kernel close op closes a single
-// id — the first positional), then aggregates the per-id outcomes into one
-// {success,output} result. success is true only when every id closed. KERNEL PATH
-// ONLY: the Beads passthrough keeps its single `close id1 id2 ...` invocation.
+// id — the first positional), then aggregates the per-id outcomes into ONE
+// forge.issue.v1 envelope (`mutationBatch` in the contract) — NEVER a bare array,
+// which broke envelope parity for multi-id close. `ok` is true only when every id
+// closed; per-id outcomes live in `data.results` and the contract `exit_code` of the
+// first failure is surfaced as `exitCode` so the bin printer exits with the error
+// class's code. KERNEL PATH ONLY: the Beads passthrough keeps its single
+// `close id1 id2 ...` invocation.
 async function runKernelBatchClose(runner, operation, ids, flags, projectRoot, opts) {
-  const summary = [];
+  const results = [];
   let allSucceeded = true;
+  let firstFailureExit;
   for (const id of ids) {
-    const result = normalizeIssueResult(
-      await runner(operation, [id, ...flags], projectRoot, opts),
-      operation,
-    );
-    const entry = { id, success: result.success === true };
-    if (!entry.success) {
-      allSucceeded = false;
-      if (result.error) entry.error = result.error;
+    const raw = await runner(operation, [id, ...flags], projectRoot, opts);
+    const succeeded = Boolean(raw && (raw.ok === true || raw.success === true));
+    if (succeeded) {
+      const entry = { id, ok: true };
+      if (raw.data && Number.isInteger(raw.data.revision)) entry.revision = raw.data.revision;
+      if (raw.data && Array.isArray(raw.data.newly_unblocked)) entry.newly_unblocked = raw.data.newly_unblocked;
+      results.push(entry);
+      continue;
     }
-    summary.push(entry);
+    allSucceeded = false;
+    const error = (raw && raw.error && typeof raw.error === 'object')
+      ? raw.error
+      : { message: (raw && (raw.error || raw.message)) || `Issue ${operation} failed for ${id}` };
+    if (firstFailureExit === undefined && Number.isInteger(error.exit_code)) {
+      firstFailureExit = error.exit_code;
+    }
+    results.push({ id, ok: false, error });
   }
-  return {
+
+  const envelope = {
+    ok: allSucceeded,
+    schema_version: ISSUE_COMMAND_SCHEMA_VERSION,
+    command: 'issue.close',
+    data: {
+      results,
+      count: results.length,
+      closed: results.filter(entry => entry.ok).map(entry => entry.id),
+    },
+    next_commands: resolveNextCommands('issue.close'),
+  };
+
+  const normalized = {
     success: allSucceeded,
     operation,
-    output: JSON.stringify(summary, null, 2),
+    output: JSON.stringify(envelope, null, 2),
   };
+  if (!allSucceeded) {
+    const failed = results.filter(entry => !entry.ok).map(entry => entry.id);
+    normalized.error = `Failed to close ${failed.length} of ${ids.length} issue(s): ${failed.join(', ')}`;
+    normalized.exitCode = Number.isInteger(firstFailureExit)
+      ? firstFailureExit
+      : ISSUE_COMMAND_EXIT_CODES.internal;
+  }
+  return normalized;
 }
 
 async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
@@ -346,7 +406,7 @@ async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
     projectRoot,
     { ...opts, kernelBroker: opts.kernelBroker },
   );
-  return normalizeIssueResult(result, operation);
+  return normalizeIssueResult(result, operation, { json: normalizeArgs(args).includes('--json') });
 }
 
 // Build a registry command for a single issue subcommand (e.g. `forge claim`).

--- a/lib/commands/claim.js
+++ b/lib/commands/claim.js
@@ -12,9 +12,10 @@ const { normalizeArgs, normalizeIssueResult, withResolvedIssueBackend } = requir
 async function handler(args, _flags, projectRoot, opts = {}) {
   const resolved = withResolvedIssueBackend(projectRoot, opts);
   const runIssueOperation = resolved.runIssueOperation || defaultRunIssueOperation;
-  const result = await runIssueOperation('claim', normalizeArgs(args), projectRoot,
+  const normalizedArgs = normalizeArgs(args);
+  const result = await runIssueOperation('claim', normalizedArgs, projectRoot,
     { ...resolved, kernelBroker: resolved.kernelBroker });
-  return normalizeIssueResult(result, 'claim');
+  return normalizeIssueResult(result, 'claim', { json: normalizedArgs.includes('--json') });
 }
 
 module.exports = {

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -18,9 +18,10 @@ const usage = 'Usage: forge release <id>  |  forge release check --target 0.1.0 
 async function runReleaseIssue(args, projectRoot, opts = {}) {
   const resolved = withResolvedIssueBackend(projectRoot, opts);
   const runIssueOperation = resolved.runIssueOperation || defaultRunIssueOperation;
-  const result = await runIssueOperation('release', normalizeArgs(args), projectRoot,
+  const normalizedArgs = normalizeArgs(args);
+  const result = await runIssueOperation('release', normalizedArgs, projectRoot,
     { ...resolved, kernelBroker: resolved.kernelBroker });
-  return normalizeIssueResult(result, 'release');
+  return normalizeIssueResult(result, 'release', { json: normalizedArgs.includes('--json') });
 }
 
 function readOption(args, name, fallback) {

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -277,6 +277,45 @@ const ISSUE_COMMAND_RESPONSE_SCHEMAS = deepFreeze({
 			next_commands: NEXT_COMMANDS_SCHEMA,
 		},
 	},
+	// Multi-id close (`forge issue close <a> <b> ...`). The kernel close op closes a
+	// SINGLE id, so the CLI fans out one mutation per id and aggregates the outcomes
+	// into ONE envelope (never a bare array — that broke envelope parity). `ok` is a
+	// plain boolean here (true only when EVERY id closed); per-id outcomes live in
+	// `data.results`, and `data.closed` lists the ids that reached terminal state.
+	// Each result echoes the single-close mutation fields (revision/newly_unblocked)
+	// on success or the forge.issue.error.v1 `error` object on failure.
+	mutationBatch: {
+		type: 'object',
+		required: ['ok', 'schema_version', 'command', 'data', 'next_commands'],
+		properties: {
+			ok: { type: 'boolean' },
+			schema_version: { const: ISSUE_COMMAND_SCHEMA_VERSION },
+			command: { type: 'string' },
+			data: {
+				type: 'object',
+				required: ['results', 'count', 'closed'],
+				properties: {
+					results: {
+						type: 'array',
+						items: {
+							type: 'object',
+							required: ['id', 'ok'],
+							properties: {
+								id: { type: 'string' },
+								ok: { type: 'boolean' },
+								revision: { type: 'integer', minimum: 0 },
+								newly_unblocked: { type: 'array', items: { type: 'string' } },
+								error: { type: 'object' },
+							},
+						},
+					},
+					count: { type: 'integer', minimum: 0 },
+					closed: { type: 'array', items: { type: 'string' } },
+				},
+			},
+			next_commands: NEXT_COMMANDS_SCHEMA,
+		},
+	},
 });
 
 const ISSUE_COMMAND_ERROR_SCHEMA = deepFreeze({

--- a/test/commands/_issue.test.js
+++ b/test/commands/_issue.test.js
@@ -173,10 +173,12 @@ describe('issue backend resolution from env/config', () => {
 
     // The kernel contract {ok,data,...} is normalized into the {success,output}
     // shape the CLI result printer understands. output preserves the FULL contract
-    // envelope (schema_version/command/data/next_commands) — see KAP-1.
+    // envelope (ok/schema_version/command/data/next_commands) — see KAP-1. A success
+    // envelope MUST carry ok:true (response-contract parity).
     expect(result.success).toBe(true);
     expect(result.operation).toBe('create');
     expect(JSON.parse(result.output)).toEqual({
+      ok: true,
       command: 'create',
       data: { id: 'k1' },
       next_commands: [],
@@ -239,9 +241,12 @@ describe('issue backend resolution from env/config', () => {
     expect(calls[0].deps.issueBackend).toBe('kernel');
   });
 
-  test('a kernel error contract is normalized into a {success:false,error} result', async () => {
+  test('a kernel error contract is normalized into a {success:false,error,exitCode} result', async () => {
     const show = createIssueSubcommand('show');
 
+    // No --json: the human message goes to stderr, but the contract exit_code is
+    // still surfaced as result.exitCode so the bin printer exits with the error
+    // class's code instead of collapsing every failure to exit 1.
     const result = await show.handler(['nope'], {}, '/repo', {
       issueBackend: 'kernel',
       env: {},
@@ -253,7 +258,7 @@ describe('issue backend resolution from env/config', () => {
       }),
     });
 
-    expect(result).toEqual({ success: false, error: 'Issue nope not found' });
+    expect(result).toEqual({ success: false, error: 'Issue nope not found', exitCode: 4 });
   });
 
   test('a kernel ok contract preserves the FULL envelope in output (KAP-1)', async () => {
@@ -274,6 +279,7 @@ describe('issue backend resolution from env/config', () => {
     expect(result.success).toBe(true);
     expect(result.operation).toBe('create');
     const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(true);
     expect(envelope.schema_version).toBe('forge.issue.v1');
     expect(envelope.command).toBe('issue.create');
     expect(envelope.data).toEqual({ id: 'k1' });
@@ -380,12 +386,20 @@ describe('kernel batch close (KAP-9)', () => {
     expect(calls[1]).toEqual({ operation: 'close', args: ['k2'] });
     expect(result.success).toBe(true);
     expect(result.operation).toBe('close');
-    const summary = JSON.parse(result.output);
+    // Response-contract parity: a multi-id close aggregates into ONE forge.issue.v1
+    // envelope (the contract `mutationBatch` shape), never a bare array.
+    const envelope = JSON.parse(result.output);
+    expect(Array.isArray(envelope)).toBe(false);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.schema_version).toBe('forge.issue.v1');
+    expect(envelope.command).toBe('issue.close');
+    const summary = envelope.data.results;
     expect(summary).toHaveLength(2);
     expect(summary[0].id).toBe('k1');
-    expect(summary[0].success).toBe(true);
+    expect(summary[0].ok).toBe(true);
     expect(summary[1].id).toBe('k2');
-    expect(summary[1].success).toBe(true);
+    expect(summary[1].ok).toBe(true);
+    expect(envelope.data.closed).toEqual(['k1', 'k2']);
   });
 
   test('preserves trailing flags on each per-id kernel close call', async () => {
@@ -420,9 +434,15 @@ describe('kernel batch close (KAP-9)', () => {
 
     expect(result.success).toBe(false);
     expect(result.operation).toBe('close');
-    const summary = JSON.parse(result.output);
-    expect(summary[0]).toEqual({ id: 'k1', success: true });
-    expect(summary[1]).toEqual({ id: 'k2', success: false, error: 'Issue k2 not found' });
+    // One envelope (ok:false) carrying per-id outcomes; the failing id keeps the
+    // structured contract error object, not a flattened string.
+    const envelope = JSON.parse(result.output);
+    expect(Array.isArray(envelope)).toBe(false);
+    expect(envelope.ok).toBe(false);
+    const summary = envelope.data.results;
+    expect(summary[0]).toEqual({ id: 'k1', ok: true });
+    expect(summary[1]).toEqual({ id: 'k2', ok: false, error: { message: 'Issue k2 not found' } });
+    expect(envelope.data.closed).toEqual(['k1']);
   });
 
   test('a single kernel close id keeps the byte-identical envelope output', async () => {

--- a/test/commands/issue-response-contract-parity.test.js
+++ b/test/commands/issue-response-contract-parity.test.js
@@ -83,7 +83,7 @@ describe('kernel CLI response-contract parity (BUG A/B)', () => {
   // --- BUG B part 2: multi-id close is ONE envelope, not a bare array -------
   test('multi-id kernel close returns a single forge.issue.v1 envelope (not a bare array)', async () => {
     const result = await runIssueSubcommand('close', ['k1', 'k2', '--json'], '/repo', KERNEL_OPTS(
-      async (operation, args) => ({
+      async (_operation, args) => ({
         ok: true,
         schema_version: 'forge.issue.v1',
         command: 'issue.close',
@@ -102,11 +102,12 @@ describe('kernel CLI response-contract parity (BUG A/B)', () => {
     expect(envelope.data.results.map(entry => entry.id)).toEqual(['k1', 'k2']);
     expect(envelope.data.results.every(entry => entry.ok === true)).toBe(true);
     expect(envelope.data.closed).toEqual(['k1', 'k2']);
+    expect(envelope.data.count).toBe(2);
   });
 
   test('multi-id kernel close with one failure: ok:false, per-id error, exit code propagated', async () => {
     const result = await runIssueSubcommand('close', ['k1', 'k2', '--json'], '/repo', KERNEL_OPTS(
-      async (operation, args) => {
+      async (_operation, args) => {
         if (args[0] === 'k2') {
           return {
             ok: false,
@@ -137,5 +138,6 @@ describe('kernel CLI response-contract parity (BUG A/B)', () => {
     expect(k2.ok).toBe(false);
     expect(k2.error.code).toBe('FORGE_ISSUE_NOT_FOUND');
     expect(envelope.data.closed).toEqual(['k1']);
+    expect(envelope.data.count).toBe(2);
   });
 });

--- a/test/commands/issue-response-contract-parity.test.js
+++ b/test/commands/issue-response-contract-parity.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const { runIssueSubcommand } = require('../../lib/commands/_issue');
+
+// Response-contract parity regressions at the CLI seam (bin/forge.js -> _issue.js).
+// The broker already returns the canonical issue-command-contract envelopes
+// ({ ok, schema_version, command, data|error, next_commands }); these tests pin the
+// CLI normalizer that converts them into the {success,output} shape the bin printer
+// consumes. Two confirmed divergences from the Beads behavior the Kernel replaced:
+//
+//   BUG A — a failed kernel command collapsed to a plain { success:false, error }
+//           (no forge.issue.error.v1 envelope on --json, exit code always 1).
+//   BUG B — a successful envelope dropped `ok:true`, and a multi-id close returned a
+//           BARE ARRAY instead of a single forge.issue.v1 envelope.
+//
+// Each test injects a fake runIssueOperation returning the broker contract shape so
+// the assertions target the normalizer/aggregator, not the SQLite driver.
+const KERNEL_OPTS = (runIssueOperation) => ({ issueBackend: 'kernel', runIssueOperation });
+
+describe('kernel CLI response-contract parity (BUG A/B)', () => {
+  // --- BUG B part 1: success envelope carries ok:true -----------------------
+  test('a successful kernel mutation envelope sets ok:true in the printed output', async () => {
+    const result = await runIssueSubcommand('create', ['--title', 'X', '--json'], '/repo', KERNEL_OPTS(
+      async () => ({
+        ok: true,
+        schema_version: 'forge.issue.v1',
+        command: 'issue.create',
+        data: { id: 'k1', revision: 0 },
+        next_commands: [],
+      }),
+    ));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.schema_version).toBe('forge.issue.v1');
+    expect(envelope.command).toBe('issue.create');
+    expect(envelope.data).toEqual({ id: 'k1', revision: 0 });
+  });
+
+  // --- BUG A: error envelope on --json + contract exit code -----------------
+  test('a kernel error on --json emits the forge.issue.error.v1 envelope + propagates exit_code', async () => {
+    const result = await runIssueSubcommand('close', ['nope', '--json'], '/repo', KERNEL_OPTS(
+      async () => ({
+        ok: false,
+        schema_version: 'forge.issue.error.v1',
+        command: 'issue.close',
+        error: { code: 'FORGE_ISSUE_NOT_FOUND', message: 'Issue nope not found', exit_code: 3, retryable: false },
+        next_commands: [],
+      }),
+    ));
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(3);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.schema_version).toBe('forge.issue.error.v1');
+    expect(envelope.command).toBe('issue.close');
+    expect(envelope.error.code).toBe('FORGE_ISSUE_NOT_FOUND');
+    expect(envelope.error.exit_code).toBe(3);
+    expect(envelope.error.message).toBe('Issue nope not found');
+  });
+
+  test('a kernel error without --json propagates exit_code but emits no JSON envelope', async () => {
+    const result = await runIssueSubcommand('close', ['nope'], '/repo', KERNEL_OPTS(
+      async () => ({
+        ok: false,
+        schema_version: 'forge.issue.error.v1',
+        command: 'issue.close',
+        error: { code: 'FORGE_ISSUE_VALIDATION', message: 'bad input', exit_code: 6, retryable: false },
+        next_commands: [],
+      }),
+    ));
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(6);
+    expect(result.error).toBe('bad input');
+    expect(result.output).toBeUndefined();
+  });
+
+  // --- BUG B part 2: multi-id close is ONE envelope, not a bare array -------
+  test('multi-id kernel close returns a single forge.issue.v1 envelope (not a bare array)', async () => {
+    const result = await runIssueSubcommand('close', ['k1', 'k2', '--json'], '/repo', KERNEL_OPTS(
+      async (operation, args) => ({
+        ok: true,
+        schema_version: 'forge.issue.v1',
+        command: 'issue.close',
+        data: { id: args[0], revision: 1 },
+        next_commands: [],
+      }),
+    ));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(Array.isArray(envelope)).toBe(false);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.schema_version).toBe('forge.issue.v1');
+    expect(envelope.command).toBe('issue.close');
+    expect(Array.isArray(envelope.data.results)).toBe(true);
+    expect(envelope.data.results.map(entry => entry.id)).toEqual(['k1', 'k2']);
+    expect(envelope.data.results.every(entry => entry.ok === true)).toBe(true);
+    expect(envelope.data.closed).toEqual(['k1', 'k2']);
+  });
+
+  test('multi-id kernel close with one failure: ok:false, per-id error, exit code propagated', async () => {
+    const result = await runIssueSubcommand('close', ['k1', 'k2', '--json'], '/repo', KERNEL_OPTS(
+      async (operation, args) => {
+        if (args[0] === 'k2') {
+          return {
+            ok: false,
+            schema_version: 'forge.issue.error.v1',
+            command: 'issue.close',
+            error: { code: 'FORGE_ISSUE_NOT_FOUND', message: 'Issue k2 not found', exit_code: 3, retryable: false },
+            next_commands: [],
+          };
+        }
+        return {
+          ok: true,
+          schema_version: 'forge.issue.v1',
+          command: 'issue.close',
+          data: { id: args[0], revision: 1 },
+          next_commands: [],
+        };
+      },
+    ));
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(3);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.command).toBe('issue.close');
+    const k1 = envelope.data.results.find(entry => entry.id === 'k1');
+    const k2 = envelope.data.results.find(entry => entry.id === 'k2');
+    expect(k1.ok).toBe(true);
+    expect(k2.ok).toBe(false);
+    expect(k2.error.code).toBe('FORGE_ISSUE_NOT_FOUND');
+    expect(envelope.data.closed).toEqual(['k1']);
+  });
+});

--- a/test/e2e/kernel-issue-cli.test.js
+++ b/test/e2e/kernel-issue-cli.test.js
@@ -158,4 +158,30 @@ describe('kernel issue CLI — multi-id close E2E', () => {
     },
     TIMEOUT,
   );
+
+  test(
+    'a not-found close on --json prints the forge.issue.error.v1 envelope and exits 3',
+    () => {
+      // BUG A parity: a failed kernel issue command must emit the structured error
+      // envelope on stdout (under --json) and exit with the contract exit_code for
+      // the error class (not-found = 3), NOT collapse every failure to exit 1.
+      let thrown;
+      try {
+        runForge(repo, ['close', 'no-such-id', '--json', '--kernel']);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeTruthy();
+      expect(thrown.status).toBe(3);
+
+      const envelope = JSON.parse(thrown.stdout);
+      expect(envelope.ok).toBe(false);
+      expect(envelope.schema_version).toBe('forge.issue.error.v1');
+      expect(envelope.command).toBe('issue.close');
+      expect(envelope.error.code).toBe('FORGE_ISSUE_NOT_FOUND');
+      expect(envelope.error.exit_code).toBe(3);
+    },
+    TIMEOUT,
+  );
 });

--- a/test/kernel/issue-command-contract.test.js
+++ b/test/kernel/issue-command-contract.test.js
@@ -94,6 +94,24 @@ describe('Kernel issue command contract', () => {
 			.required).not.toContain('validation');
 	});
 
+	test('multi-id close declares a mutationBatch envelope (single envelope, not a bare array)', () => {
+		const { ISSUE_COMMAND_RESPONSE_SCHEMAS } = require('../../lib/kernel/issue-command-contract');
+		const batch = ISSUE_COMMAND_RESPONSE_SCHEMAS.mutationBatch;
+
+		// Existence first (clean RED — never a TypeError on undefined.required).
+		expect(batch).toBeDefined();
+		expect(batch.required).toEqual(['ok', 'schema_version', 'command', 'data', 'next_commands']);
+		// `ok` is a plain boolean here (true only when EVERY id closed), unlike the
+		// single-mutation schema whose ok is const:true.
+		expect(batch.properties.ok).toEqual({ type: 'boolean' });
+		expect(batch.properties.schema_version).toEqual({ const: 'forge.issue.v1' });
+		// Per-id outcomes live in data.results; data.closed lists the terminal ids.
+		expect(batch.properties.data.required).toEqual(['results', 'count', 'closed']);
+		const resultItem = batch.properties.data.properties.results.items;
+		expect(resultItem.required).toEqual(['id', 'ok']);
+		expect(resultItem.properties.ok).toEqual({ type: 'boolean' });
+	});
+
 	test('KAP-3: issue summary schema declares an optional comments array', () => {
 		const { ISSUE_COMMAND_RESPONSE_SCHEMAS } = require('../../lib/kernel/issue-command-contract');
 		// The show response's data is the issue summary schema; comments live there.


### PR DESCRIPTION
## Summary

Second **Wave 2 (kernel-parity)** PR. Fixes two confirmed response-contract divergences from Beads, each reproduced before/after against the real default-kernel CLI path.

## Bugs fixed

1. **Failures never emitted `forge.issue.error.v1` and always exited 1.** The broker already tags errors with contract exit codes (not-found=3, validation=6, conflict=4), but the CLI normalizer (`lib/commands/_issue.js`) collapsed them to `{success:false,error}` and `bin/forge.js` hardcoded `process.exit(1)`. Now the normalizer surfaces `error.exit_code` and, on `--json`, serializes the full `forge.issue.error.v1` envelope; `bin/forge.js` exits with the contract code when present (non-issue commands keep exit 1). `claim`/`release` forward `--json` so their failures also get the envelope.
2. **Success envelope omitted `ok:true`; multi-id close returned a bare array.** Success responses now set `ok:true` (errors `ok:false`); multi-id close returns a single `forge.issue.v1` envelope via a new minimal `mutationBatch` contract schema (`data.results[]`/`data.count`/`data.closed`).

Regenerated the D20 bd call-site kill-list (the `bin/forge.js` exit-code change shifted one audited line number); counts unchanged, **gate still PASSES**.

## Validation

Built and verified via a fix → **independent adversarial-verification** workflow, then independently re-confirmed by me on a throwaway temp repo (real broker, default kernel): not-found exits **3** with the error envelope, `create` returns `ok:true`, multi-close returns one envelope. Pre-existing tests that encoded the buggy contract (bare array, missing `ok`) were updated to the correct parity. 43 affected tests pass, eslint clean.

Part of the Wave-2 kernel-parity backlog (kernel issues efdf1561, 99e7d246).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue commands now emit kernel-style, contract-parity JSON envelopes for both success and error cases.
  * Batch `close` returns a single aggregated JSON response including per-item results and a list of closed IDs.

* **Bug Fixes**
  * CLI process exit codes now honor contract `exit_code` values for issue commands (instead of always using a generic failure status).
  * Non-`--json` output remains human-readable while preserving the correct exit status and error semantics.

* **Tests**
  * Added/updated unit and E2E coverage for response formatting, batch aggregation, and schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->