### PR TITLE
feat(kernel): add issue fidelity columns for full beads import (migration 006)

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -477,6 +477,13 @@ function buildCreatePayload(flags) {
 	if (typeof flags.design === 'string') payload.design = flags.design;
 	if (typeof flags.notes === 'string') payload.notes = flags.notes;
 	if (typeof flags.assignee === 'string') payload.assignee = flags.assignee;
+	// Beads full-fidelity import: author, close timestamp + raw close reason, and a
+	// verbatim metadata JSON blob (stored as-is). --close-reason is distinct from the
+	// --reason close-event flag; the importer sets these so no beads field is dropped.
+	if (typeof flags['created-by'] === 'string') payload.created_by = flags['created-by'];
+	if (typeof flags['closed-at'] === 'string') payload.closed_at = flags['closed-at'];
+	if (typeof flags['close-reason'] === 'string') payload.close_reason = flags['close-reason'];
+	if (typeof flags.metadata === 'string') payload.metadata = flags.metadata;
 	return payload;
 }
 
@@ -504,6 +511,13 @@ function buildUpdatePayload(flags) {
 	if (typeof flags.design === 'string') payload.design = flags.design;
 	if (typeof flags.notes === 'string') payload.notes = flags.notes;
 	if (typeof flags.assignee === 'string') payload.assignee = flags.assignee;
+	// Beads full-fidelity import: overwrite author/close timestamp/raw close reason/
+	// metadata when supplied. --close-reason is a distinct COLUMN from the --reason
+	// close-event payload, and metadata is stored verbatim.
+	if (typeof flags['created-by'] === 'string') payload.created_by = flags['created-by'];
+	if (typeof flags['closed-at'] === 'string') payload.closed_at = flags['closed-at'];
+	if (typeof flags['close-reason'] === 'string') payload.close_reason = flags['close-reason'];
+	if (typeof flags.metadata === 'string') payload.metadata = flags.metadata;
 	return payload;
 }
 

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -81,6 +81,13 @@ const ISSUE_SUMMARY_SCHEMA = {
 		design: { type: ['string', 'null'] },
 		notes: { type: ['string', 'null'] },
 		assignee: { type: ['string', 'null'] },
+		// Beads full-fidelity import: author, close timestamp, raw close reason and a
+		// verbatim metadata JSON blob. Optional (NOT required) and nullable so summaries
+		// that omit them still validate.
+		created_by: { type: ['string', 'null'] },
+		closed_at: { type: ['string', 'null'] },
+		close_reason: { type: ['string', 'null'] },
+		metadata: { type: ['string', 'null'] },
 		// KAP-3: `show` attaches the issue's comments; other reads (list/ready/search/
 		// stats) omit the key. Optional (NOT in required) so comment-less summaries still
 		// validate. Each item carries id/body/actor/created_at (body may be null).

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -66,12 +66,13 @@ function getInitialKernelSchema() {
 	// CREATE TABLE, so a fresh DB doesn't create them before the ALTER … ADD COLUMN
 	// migration runs (else "duplicate column name"). schema.js stays the full current
 	// schema; this map mirrors which columns each later migration backfills.
-	//   events.expected_revision → 002 ; issues.design/notes/assignee → 004
+	//   events.expected_revision → 002 ; issues.design/notes/assignee → 004 ;
+	//   issues.created_by/closed_at/close_reason/metadata → 006
 	// KEEP IN SYNC: every new `ALTER TABLE … ADD COLUMN` migration MUST add its
 	// column(s) here, or a fresh DB will hit "duplicate column name" on setup.
 	const MIGRATION_ADDED_COLUMNS = {
 		events: ['expected_revision'],
-		issues: ['design', 'notes', 'assignee'],
+		issues: ['design', 'notes', 'assignee', 'created_by', 'closed_at', 'close_reason', 'metadata'],
 	};
 	return {
 		...schema,
@@ -191,6 +192,30 @@ function buildMemoryProjectionMigration() {
 	};
 }
 
+// 006: full-fidelity beads import. Four additive ADD COLUMNs on kernel_issues so no
+// beads issue data is dropped — the author (created_by), the close timestamp
+// (closed_at) and raw close reason (close_reason, distinct from the mapped terminal
+// status), plus a verbatim JSON metadata blob (metadata). Plain ADD COLUMNs — the 001
+// initial schema omits these columns (getInitialKernelSchema/MIGRATION_ADDED_COLUMNS)
+// and the broker's per-migration ledger + guarded ADD COLUMN apply them exactly once.
+function buildIssueFidelityColumnsMigration() {
+	return {
+		id: '006_kernel_issue_fidelity_columns',
+		apply: [
+			'ALTER TABLE kernel_issues ADD COLUMN created_by TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN closed_at TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN close_reason TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN metadata TEXT;',
+		],
+		rollback: [
+			'ALTER TABLE kernel_issues DROP COLUMN metadata;',
+			'ALTER TABLE kernel_issues DROP COLUMN close_reason;',
+			'ALTER TABLE kernel_issues DROP COLUMN closed_at;',
+			'ALTER TABLE kernel_issues DROP COLUMN created_by;',
+		],
+	};
+}
+
 function validateKernelMigrations(migrations) {
 	const ids = new Set();
 	for (const migration of migrations) {
@@ -218,6 +243,7 @@ function buildKernelMigrationPlan(migrations = [
 	buildClaimActiveLeaseMigration(),
 	buildIssueContentFieldsMigration(),
 	buildMemoryProjectionMigration(),
+	buildIssueFidelityColumnsMigration(),
 ]) {
 	validateKernelMigrations(migrations);
 
@@ -232,6 +258,7 @@ module.exports = {
 	buildClaimActiveLeaseMigration,
 	buildEventExpectedRevisionMigration,
 	buildIssueContentFieldsMigration,
+	buildIssueFidelityColumnsMigration,
 	buildKernelMigrationPlan,
 	buildMemoryProjectionMigration,
 	buildSchemaMigration,

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -85,6 +85,14 @@ const TABLE_LIST = deepFreeze([
 		field('design', 'TEXT'),
 		field('notes', 'TEXT'),
 		field('assignee', 'TEXT'),
+		// Beads full-fidelity import: the issue author, the close timestamp + raw close
+		// reason (distinct from the mapped terminal status), and a verbatim JSON blob for
+		// any other beads metadata. Migration 006 backfills existing DBs; fresh DBs get
+		// them here.
+		field('created_by', 'TEXT'),
+		field('closed_at', 'TEXT'),
+		field('close_reason', 'TEXT'),
+		field('metadata', 'TEXT'),
 	], [
 		index('idx_kernel_issues_status_priority', ['status', 'priority_rank']),
 		index('idx_kernel_issues_updated_at', ['updated_at']),

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -214,6 +214,12 @@ function rowToIssueSummary(row, readinessEntry, claimedBy = null, dependencyIds 
 		design: row.design ?? null,
 		notes: row.notes ?? null,
 		assignee: row.assignee ?? null,
+		// Beads full-fidelity import: author, close timestamp, raw close reason and the
+		// verbatim metadata JSON blob, each null when the column is unset.
+		created_by: row.created_by ?? null,
+		closed_at: row.closed_at ?? null,
+		close_reason: row.close_reason ?? null,
+		metadata: row.metadata ?? null,
 	};
 }
 
@@ -974,6 +980,13 @@ const ISSUE_MUTABLE_COLUMNS = Object.freeze([
 	'design',
 	'notes',
 	'assignee',
+	// Beads full-fidelity import: the author, close timestamp + raw close reason, and a
+	// verbatim metadata JSON blob. The importer sets these on an issue event payload and
+	// the upsert persists each to its own column (no native CLI close auto-fills them).
+	'created_by',
+	'closed_at',
+	'close_reason',
+	'metadata',
 ]);
 
 // close drives the issue to a terminal status; an explicit payload.status (rework

--- a/test/kernel/broker-migration-ledger.test.js
+++ b/test/kernel/broker-migration-ledger.test.js
@@ -95,6 +95,44 @@ describe('Kernel broker — migration ledger', () => {
 		expect(await ledgerIds()).toEqual([...planIds].sort());
 	});
 
+	test('migration 006 backfills the beads fidelity columns on a DB created at the prior schema version', async () => {
+		const {
+			buildSchemaMigration,
+			buildEventExpectedRevisionMigration,
+			buildClaimActiveLeaseMigration,
+			buildIssueContentFieldsMigration,
+			buildMemoryProjectionMigration,
+		} = require('../../lib/kernel/migrations');
+		const fidelityColumns = ['created_by', 'closed_at', 'close_reason', 'metadata'];
+
+		// A DB migrated only through 005 — the schema version BEFORE the fidelity columns.
+		const priorPlan = buildKernelMigrationPlan([
+			buildSchemaMigration(),
+			buildEventExpectedRevisionMigration(),
+			buildClaimActiveLeaseMigration(),
+			buildIssueContentFieldsMigration(),
+			buildMemoryProjectionMigration(),
+		]);
+		await makeBroker(priorPlan).initialize();
+
+		const before = await driver.queryAll('PRAGMA table_info(kernel_issues);', config);
+		const beforeCols = before.map(col => col.name);
+		for (const column of fidelityColumns) {
+			expect(beforeCols).not.toContain(column);
+		}
+
+		// The full plan adds migration 006, which ALTERs the four columns in without error.
+		const result = await makeBroker(buildKernelMigrationPlan()).initialize();
+		expect(result.success).toBe(true);
+		expect(result.migrationsNewlyApplied).toEqual(['006_kernel_issue_fidelity_columns']);
+
+		const after = await driver.queryAll('PRAGMA table_info(kernel_issues);', config);
+		const afterCols = after.map(col => col.name);
+		for (const column of fidelityColumns) {
+			expect(afterCols).toContain(column);
+		}
+	});
+
 	test('a newly added ADD COLUMN migration applies once on an up-to-date DB', async () => {
 		await makeBroker().initialize();
 

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -21,9 +21,10 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.apply).toContain('ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
-		// Rollback runs migrations in reverse, so 005 (the latest migration) rolls back
-		// first: its search index drop precedes the kernel_memories table drop.
-		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_kernel_memories_source_agent;');
+		// Rollback runs migrations in reverse, so 006 (the latest migration) rolls back
+		// first: its last-added fidelity column (metadata) drops before everything else.
+		expect(plan.rollback[0]).toBe('ALTER TABLE kernel_issues DROP COLUMN metadata;');
+		expect(plan.rollback).toContain('DROP INDEX IF EXISTS idx_kernel_memories_source_agent;');
 		expect(plan.rollback).toContain('DROP TABLE IF EXISTS kernel_memories;');
 		expect(plan.rollback).toContain('ALTER TABLE kernel_issues DROP COLUMN assignee;');
 		expect(plan.rollback).toContain('DROP INDEX IF EXISTS idx_kernel_claims_active_lease;');
@@ -37,6 +38,7 @@ describe('kernel migration plans', () => {
 			'003_kernel_claims_active_lease',
 			'004_kernel_issues_content_fields',
 			'005_kernel_memories',
+			'006_kernel_issue_fidelity_columns',
 		]);
 	});
 
@@ -96,6 +98,43 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN notes TEXT;');
 		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN assignee TEXT;');
 		expect(plan.rollback).toContain('ALTER TABLE kernel_issues DROP COLUMN assignee;');
+	});
+
+	test('beads fidelity: migration 006 adds created_by/closed_at/close_reason/metadata and drops them on rollback', () => {
+		const { buildIssueFidelityColumnsMigration } = require('../../lib/kernel/migrations');
+		const migration = buildIssueFidelityColumnsMigration();
+
+		expect(migration.id).toBe('006_kernel_issue_fidelity_columns');
+		// The four additive full-fidelity beads-import columns, in declaration order.
+		expect(migration.apply).toEqual([
+			'ALTER TABLE kernel_issues ADD COLUMN created_by TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN closed_at TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN close_reason TEXT;',
+			'ALTER TABLE kernel_issues ADD COLUMN metadata TEXT;',
+		]);
+		// Rollback drops them in reverse so dependent ordering is symmetric.
+		expect(migration.rollback).toEqual([
+			'ALTER TABLE kernel_issues DROP COLUMN metadata;',
+			'ALTER TABLE kernel_issues DROP COLUMN close_reason;',
+			'ALTER TABLE kernel_issues DROP COLUMN closed_at;',
+			'ALTER TABLE kernel_issues DROP COLUMN created_by;',
+		]);
+
+		// Registered in the default plan so fresh and existing DBs both migrate.
+		const plan = buildKernelMigrationPlan();
+		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN created_by TEXT;');
+		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN closed_at TEXT;');
+		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN close_reason TEXT;');
+		expect(plan.apply).toContain('ALTER TABLE kernel_issues ADD COLUMN metadata TEXT;');
+		expect(plan.rollback).toContain('ALTER TABLE kernel_issues DROP COLUMN metadata;');
+
+		// The initial (001) schema must EXCLUDE the four columns — they are owned by 006,
+		// so a fresh DB does not create them before the ALTER … ADD COLUMN runs.
+		const schemaMigration = plan.migrations.find(entry => entry.id === '001_kernel_schema');
+		const createIssues = schemaMigration.apply.find(statement => statement.includes('CREATE TABLE IF NOT EXISTS kernel_issues'));
+		for (const column of ['created_by', 'closed_at', 'close_reason', 'metadata']) {
+			expect(createIssues.includes(`${column} TEXT`)).toBe(false);
+		}
 	});
 
 	test('enforces a single active claim lease per issue via a partial unique index (9.5.10)', () => {

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -55,6 +55,13 @@ describe('kernel schema registry', () => {
 		expect(issueFieldNames).toContain('design');
 		expect(issueFieldNames).toContain('notes');
 		expect(issueFieldNames).toContain('assignee');
+
+		// Beads full-fidelity import: author, close timestamp, raw close reason and a
+		// verbatim metadata JSON blob (migration 006 backfills existing DBs).
+		expect(issueFieldNames).toContain('created_by');
+		expect(issueFieldNames).toContain('closed_at');
+		expect(issueFieldNames).toContain('close_reason');
+		expect(issueFieldNames).toContain('metadata');
 	});
 
 	test('registers the project-memory read-model table (kernel_memories)', () => {

--- a/test/kernel/sqlite-driver-mutations.test.js
+++ b/test/kernel/sqlite-driver-mutations.test.js
@@ -267,6 +267,58 @@ describe('Kernel SQLite driver — issue mutations via guarded path (Wave 3)', (
 		expect(shown.data.assignee).toBe('bob');
 	});
 
+	// Beads full-fidelity import (migration 006): created_by/closed_at/close_reason/
+	// metadata persist on create via the issue-upsert write allow-list and surface on
+	// show. close_reason is a distinct COLUMN from the --reason close-event payload.
+	test('create persists created_by/closed_at/close_reason/metadata (beads fidelity)', async () => {
+		await broker.runIssueOperation(
+			'create',
+			[
+				'--id', 'fid-1', '--title', 'Imported issue', '--type', 'task',
+				'--created-by', 'importer', '--closed-at', '2026-06-01T00:00:00.000Z',
+				'--close-reason', 'completed upstream', '--metadata', '{"beads_id":"bd-7"}',
+			],
+			{ now, actor: 'tester' },
+		);
+
+		const shown = await driver.issueOperation('show', ['fid-1'], {}, config);
+		expect(shown.data.created_by).toBe('importer');
+		expect(shown.data.closed_at).toBe('2026-06-01T00:00:00.000Z');
+		expect(shown.data.close_reason).toBe('completed upstream');
+		expect(shown.data.metadata).toBe('{"beads_id":"bd-7"}');
+
+		// Persisted directly to their columns (not just the event payload). metadata is
+		// stored verbatim — the JSON blob is not re-encoded.
+		const rows = await driver.queryAll(
+			'SELECT created_by, closed_at, close_reason, metadata FROM kernel_issues WHERE id = \'fid-1\'',
+			config,
+		);
+		expect(rows[0]).toEqual({
+			created_by: 'importer',
+			closed_at: '2026-06-01T00:00:00.000Z',
+			close_reason: 'completed upstream',
+			metadata: '{"beads_id":"bd-7"}',
+		});
+	});
+
+	// Update reassigns the fidelity columns the same way the content fields do.
+	test('update overwrites the beads fidelity columns', async () => {
+		await broker.runIssueOperation(
+			'create', ['--id', 'fid-2', '--title', 'Reimport', '--type', 'task', '--created-by', 'old'],
+			{ now, actor: 'tester' },
+		);
+
+		await broker.runIssueOperation(
+			'update',
+			['fid-2', '--created-by', 'new', '--metadata', '{"v":2}'],
+			{ now: '2026-06-19T00:13:00.000Z', actor: 'tester' },
+		);
+
+		const shown = await driver.issueOperation('show', ['fid-2'], {}, config);
+		expect(shown.data.created_by).toBe('new');
+		expect(shown.data.metadata).toBe('{"v":2}');
+	});
+
 	// KAP-5: close --reason is captured in the close EVENT payload (no column/migration).
 	test('close --reason succeeds and records the reason in the close event payload', async () => {
 		await broker.runIssueOperation(


### PR DESCRIPTION
## Summary

Foundational PR for the **full-fidelity beads→Forge-Kernel migration**. Extends the issues schema with the columns beads carries that the kernel currently drops, so no historical issue data is lost on import.

The issues table already had `design`/`notes`/`acceptance_criteria`/`assignee` (KAP-10/11). This adds the remaining four (all nullable `TEXT`) via **migration 006**, mirroring migration 004:

| column | purpose |
|--------|---------|
| `created_by` | beads issue author/owner |
| `closed_at` | ISO timestamp the issue was closed |
| `close_reason` | raw beads close reason (distinct from the mapped terminal status) |
| `metadata` | verbatim JSON blob for any other beads metadata |

Wired through the write gate (`ISSUE_MUTABLE_COLUMNS`), read projection (`rowToIssueSummary`), the issue-command contract (`ISSUE_SUMMARY_SCHEMA`), and the broker create/update payload builders (`--created-by`/`--closed-at`/`--close-reason`/`--metadata`). The KEEP-IN-SYNC backfill map is updated so `001` excludes these on a fresh DB.

## Validation

- Columns round-trip via the **real CLI** (`create … --created-by/--closed-at/--close-reason/--metadata` → `show` surfaces all four).
- Migration 006 applies to a DB built at the **prior** schema (001–005) without error.
- `test/kernel/` **415 pass, 0 fail**; `release check --target 0.1.0` still **PASS**; eslint clean.

Part of the Wave-2 memory/data migration track (kernel issue `f18448ff`). Next: the broker faithful-import write path, then the `forge migrate --from beads` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)