### PR TITLE
fix(kernel): make --priority non-decorative (persist, normalize, filter, sort)

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -12,8 +12,9 @@ const {
 	formatIssueCommandError,
 	getIssueCommandContract,
 	isValidIssuePriority,
+	normalizePriority,
 } = require('./issue-command-contract');
-const { isValidIssueStatus } = require('./taxonomy-validator');
+const { isValidIssueStatus, rankForPriorityLabel } = require('./taxonomy-validator');
 const { assertFilesystemSafeForKernel } = require('./fs-class');
 
 const LOCAL_BROKER_PRAGMAS = Object.freeze([
@@ -454,6 +455,21 @@ function parseLabelFlag(value) {
 	return value.split(',').map(label => label.trim()).filter(Boolean);
 }
 
+// Normalize the priority flags into the canonical stored form shared by create and
+// update. `--priority` is canonicalized to its P0..P4 label (the bare ranks 0..4 and
+// the P-labels map to the SAME label), and `priority_rank` is DERIVED from that label
+// so the kernel can order by priority — unless `--priority-rank` is given explicitly,
+// which still wins. A junk/out-of-range priority is left UNNORMALIZED so the validation
+// gate (assertValidIssueMutationPayload) rejects it instead of clamping it.
+function applyPriorityFlags(payload, flags) {
+	if (typeof flags.priority === 'string') payload.priority = normalizePriority(flags.priority);
+	if (flags['priority-rank'] !== undefined) {
+		payload.priority_rank = Number(flags['priority-rank']);
+	} else if (typeof payload.priority === 'string') {
+		payload.priority_rank = rankForPriorityLabel(payload.priority);
+	}
+}
+
 // Build the create payload from flags. --id is optional (minted when absent); the
 // minted/declared id becomes the event entity_id and the new issue's primary key.
 function buildCreatePayload(flags) {
@@ -467,8 +483,7 @@ function buildCreatePayload(flags) {
 	else if (typeof flags.description === 'string') payload.body = flags.description;
 	payload.type = typeof flags.type === 'string' ? flags.type : 'task';
 	payload.status = typeof flags.status === 'string' ? flags.status : 'open';
-	if (typeof flags.priority === 'string') payload.priority = flags.priority;
-	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
+	applyPriorityFlags(payload, flags);
 	if (typeof flags.parent === 'string') payload.parent_id = flags.parent;
 	if (typeof flags.label === 'string') payload.labels = parseLabelFlag(flags.label);
 	// KAP-10 (acceptance/design/notes) + KAP-11 (assignee): authored content fields
@@ -489,8 +504,7 @@ function buildUpdatePayload(flags) {
 	// body column (parity with create — beads stored the description in body).
 	if (typeof flags.body === 'string') payload.body = flags.body;
 	else if (typeof flags.description === 'string') payload.body = flags.description;
-	if (typeof flags.priority === 'string') payload.priority = flags.priority;
-	if (flags['priority-rank'] !== undefined) payload.priority_rank = Number(flags['priority-rank']);
+	applyPriorityFlags(payload, flags);
 	// KAP-4: --label reparents the full label set (last-value-wins, comma-split).
 	if (typeof flags.label === 'string') payload.labels = parseLabelFlag(flags.label);
 	// KAP-5: --parent reparents on update (create already maps --parent → parent_id).
@@ -732,6 +746,11 @@ function buildAcceptMutationData(operation, event, mutation) {
 		id: (isDep || isClaim) ? mutationIssueId(operation, event) : (mutation.id ?? event.entity_id),
 		revision: Number(mutation.revision ?? 0),
 	};
+	// Surface the canonical priority the write persisted (create/update with --priority)
+	// so the mutation response is self-describing — the bare-int and P-label inputs both
+	// echo the SAME normalized label. dep/claim payloads carry no priority, so it is omitted.
+	const payload = parseEventPayload(event);
+	if (typeof payload.priority === 'string') data.priority = payload.priority;
 	if (mutation.comment_id) data.comment_id = mutation.comment_id;
 	if (isDep) {
 		data.dependency_id = mutation.dependency_id ?? event.entity_id;

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -39,6 +39,19 @@ function isValidIssuePriority(priority) {
 	return rank >= 0 && rank <= 4;
 }
 
+// Canonicalize a priority input to its P0..P4 label. Accepts the canonical labels
+// (case-insensitive) and the bare ranks 0..4 the CLI documents (`--priority 1`), and
+// maps BOTH forms to the SAME label ('1' and 'P1' -> 'P1'). Out-of-range / non-priority
+// input is returned UNCHANGED so the create/update validation gate (isValidIssuePriority)
+// still REJECTS it rather than silently clamping (P9 must error, not become P4). The
+// stored canonical form is this label; priority_rank is its numeric rank.
+function normalizePriority(priority) {
+	if (!isValidIssuePriority(priority)) return priority;
+	const raw = typeof priority === 'number' ? String(priority) : priority.trim().toUpperCase();
+	const rank = Number(/^P?([0-9]+)$/.exec(raw)[1]);
+	return `P${rank}`;
+}
+
 function deepFreeze(value) {
 	if (!value || typeof value !== 'object') return value;
 	Object.freeze(value);
@@ -487,5 +500,6 @@ module.exports = {
 	formatIssueCommandError,
 	getIssueCommandContract,
 	isValidIssuePriority,
+	normalizePriority,
 	resolveNextCommands,
 };

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -9,10 +9,12 @@ const {
 	ISSUE_COMMAND_SCHEMA_VERSION,
 	ISSUE_COMMAND_EXIT_CODES,
 	formatIssueCommandError,
+	normalizePriority,
 	resolveNextCommands,
 } = require('./issue-command-contract');
 const { buildReadinessIndex } = require('./readiness-model');
 const { buildMemoryProjectionMigration } = require('./migrations');
+const { rankForPriorityLabel } = require('./taxonomy-validator');
 
 const BUILTIN_SQLITE_RUNTIME_ORDER = Object.freeze(['bun:sqlite', 'node:sqlite']);
 let probeCounter = 0;
@@ -296,7 +298,7 @@ function firstPositional(args = []) {
 // absent flag leaves it undefined and does not constrain that dimension. Unknown flags
 // are ignored. Values are never interpolated into SQL — filtering runs JS-side over the
 // already-built issue summaries (status/type/labels[]).
-const LIST_FILTER_FLAGS = Object.freeze(['status', 'type', 'label']);
+const LIST_FILTER_FLAGS = Object.freeze(['status', 'type', 'label', 'priority']);
 
 function parseListFilters(args = []) {
 	const filters = Object.create(null);
@@ -411,11 +413,18 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 		// the value. Multiple filters AND; an absent filter does not constrain that dimension;
 		// an unknown value simply matches nothing (exact-match → empty result, no special case).
 		const filters = parseListFilters(args);
+		// Normalize the --priority filter ONCE to its canonical label; each candidate's
+		// stored priority is normalized too before the exact-match compare. Legacy rows
+		// store a mixed bare-int / P-label form, so '1' and 'P1' rows both match
+		// --priority=1 AND --priority=P1 (the filter arg and the stored value canonicalize
+		// to the same label). An unknown value normalizes to itself and matches nothing.
+		const priorityFilter = filters.priority === undefined ? undefined : normalizePriority(filters.priority);
 		const summaries = issues
 			.map(row => rowToIssueSummary(row, index.readinessById[row.id], claimedById[row.id], dependenciesById[row.id], dependentsById[row.id]))
 			.filter(summary => (filters.status === undefined || summary.status === filters.status)
 				&& (filters.type === undefined || summary.type === filters.type)
-				&& (filters.label === undefined || summary.labels.includes(filters.label)))
+				&& (filters.label === undefined || summary.labels.includes(filters.label))
+				&& (priorityFilter === undefined || normalizePriority(summary.priority) === priorityFilter))
 			.sort((a, b) => (a.rank - b.rank) || String(a.id).localeCompare(String(b.id)));
 		return okIssueResponse('issue.list', { issues: summaries, count: summaries.length });
 	}
@@ -1018,7 +1027,13 @@ function applyAcceptedIssueEvent(runtime, db, event, context = {}) {
 
 	if (!existing) {
 		// Fresh create: seed required NOT NULL columns, then overwrite with any
-		// supplied payload values via the shared column map below.
+		// supplied payload values via the shared column map below. priority_rank is
+		// DERIVED from the (possibly defaulted) priority LABEL so a no-`--priority`
+		// create still sorts by its P2 default — seeding rank 0 would otherwise rank the
+		// common default-priority issue ABOVE an explicit P1 in `list` (priority order
+		// inverted). The CLI/broker already supplies priority_rank when --priority is
+		// given, so this fallback only fires for the defaulted/raw-event path.
+		const priorityLabel = payload.priority ?? 'P2';
 		runParams(
 			runtime,
 			db,
@@ -1029,8 +1044,8 @@ function applyAcceptedIssueEvent(runtime, db, event, context = {}) {
 				payload.title ?? issueId,
 				payload.type ?? 'task',
 				status ?? payload.status ?? 'open',
-				payload.priority ?? 'P2',
-				Number(payload.priority_rank ?? 0),
+				priorityLabel,
+				Number(payload.priority_rank ?? rankForPriorityLabel(priorityLabel)),
 				now,
 				now,
 			],

--- a/test/kernel/kernel-parity-bugs.test.js
+++ b/test/kernel/kernel-parity-bugs.test.js
@@ -217,4 +217,91 @@ describe('Kernel parity bugs', () => {
 		expect(typeof added.data.dependency_id).toBe('string');
 		expect(added.data.dependency_id).not.toBe('pd-a');
 	});
+
+	// --- BUG 4: priority is persisted, normalized, filterable and sortable -----
+	// Kernel `--priority` was decorative: the bare-int and P-label forms stored
+	// DIFFERENT verbatim values ('1' vs 'P1'), priority_rank was never derived from
+	// the label (always 0), `list --priority` ignored the filter, and list order did
+	// not reflect priority. Canonical stored form is the P0..P4 label (contract
+	// normalizePriority), with priority_rank = the numeric rank.
+
+	test('create --priority=1 and --priority=P1 both persist the canonical P1 label + rank', async () => {
+		await createIssue(['--id', 'prio-bare', '--title', 'bare', '--type', 'task', '--priority', '1']);
+		await createIssue(['--id', 'prio-label', '--title', 'label', '--type', 'task', '--priority', 'P1']);
+
+		const bare = await driver.issueOperation('show', ['prio-bare'], {}, config);
+		const label = await driver.issueOperation('show', ['prio-label'], {}, config);
+		expect(bare.data.priority).toBe('P1');
+		expect(label.data.priority).toBe('P1');
+		expect(bare.data.rank).toBe(1);
+		expect(label.data.rank).toBe(1);
+	});
+
+	test('create surfaces the normalized priority on the mutation response', async () => {
+		const bare = await createIssue(['--id', 'prio-resp-1', '--title', 'x', '--type', 'task', '--priority', '1']);
+		const label = await createIssue(['--id', 'prio-resp-2', '--title', 'y', '--type', 'task', '--priority', 'P1']);
+		expect(bare.data.priority).toBe('P1');
+		expect(label.data.priority).toBe('P1');
+	});
+
+	test('update --priority=2 normalizes the stored label + rank to P2/2', async () => {
+		await createIssue(['--id', 'prio-upd', '--title', 'x', '--type', 'task', '--priority', 'P0']);
+		const updated = await broker.runIssueOperation(
+			'update',
+			['prio-upd', '--priority', '2'],
+			{ now: '2026-06-29T01:00:00.000Z', actor: 'tester' },
+		);
+		expect(updated.ok).toBe(true);
+		expect(updated.data.priority).toBe('P2');
+
+		const shown = await driver.issueOperation('show', ['prio-upd'], {}, config);
+		expect(shown.data.priority).toBe('P2');
+		expect(shown.data.rank).toBe(2);
+	});
+
+	test('list --priority filter returns only matching issues, incl. legacy bare-int rows', async () => {
+		// Legacy row stored in the pre-normalization bare-int form ('1', rank 0),
+		// inserted directly to model data already on disk.
+		await driver.exec(
+			`INSERT INTO kernel_issues (id,title,type,status,priority,priority_rank,created_at,updated_at,entity_revision)
+				VALUES ('legacy-p1','Legacy bare int','task','open','1',0,'${now}','${now}',0)`,
+			config,
+		);
+		await createIssue(['--id', 'new-p1', '--title', 'new', '--type', 'task', '--priority', 'P1']);
+		await createIssue(['--id', 'other-p2', '--title', 'other', '--type', 'task', '--priority', '2']);
+
+		for (const arg of ['--priority=1', '--priority=P1']) {
+			const res = await driver.issueOperation('list', [arg], {}, config);
+			const ids = res.data.issues.map(issue => issue.id).sort();
+			expect(ids).toEqual(['legacy-p1', 'new-p1']);
+		}
+	});
+
+	test('a default-priority create derives rank from its P2 label (sorts after P1, not before)', async () => {
+		// No --priority: the row defaults to the P2 LABEL, so its rank must derive to 2 —
+		// not the seed 0, which would sort the common default-priority issue ABOVE an
+		// explicit P1 in `list` (priority order inverted for the typical case).
+		await createIssue(['--id', 'def-p2', '--title', 'default', '--type', 'task']);
+		const shown = await driver.issueOperation('show', ['def-p2'], {}, config);
+		expect(shown.data.priority).toBe('P2');
+		expect(shown.data.rank).toBe(2);
+
+		await createIssue(['--id', 'exp-p1', '--title', 'explicit', '--type', 'task', '--priority', 'P1']);
+		const res = await driver.issueOperation('list', [], {}, config);
+		const order = res.data.issues.map(issue => issue.id);
+		expect(order.indexOf('exp-p1')).toBeLessThan(order.indexOf('def-p2'));
+	});
+
+	test('list orders issues by priority (P0 before P1 before P3)', async () => {
+		// Ids are chosen so their alphabetical order (a < b < c) is the REVERSE of the
+		// expected priority order — proving the sort keys on derived rank, not on id.
+		await createIssue(['--id', 'ord-a', '--title', 'three', '--type', 'task', '--priority', '3']);
+		await createIssue(['--id', 'ord-b', '--title', 'one', '--type', 'task', '--priority', 'P1']);
+		await createIssue(['--id', 'ord-c', '--title', 'zero', '--type', 'task', '--priority', 'P0']);
+
+		const res = await driver.issueOperation('list', [], {}, config);
+		const order = res.data.issues.map(issue => issue.id);
+		expect(order.indexOf('ord-c')).toBeLessThan(order.indexOf('ord-b'));
+		expect(order.indexOf('ord-b')).toBeLessThan(order.indexOf('ord-a'));
+	});
 });


### PR DESCRIPTION
## Summary

Wave-2 kernel-parity fix for issue `121582e2` — `--priority` was decorative. Fixed across four aspects, each reproduced before/after against the real default-kernel CLI.

- **Persist + normalize:** create/update wrote priority verbatim (`--priority=1`→`"1"`, `--priority=P1`→`"P1"`, two forms for the same priority) and never derived `priority_rank`; the response returned no priority. A new `normalizePriority` canonicalizes valid input to the `P0..P4` label (passing invalid input **through** so `isValidIssuePriority` still rejects `P9`/junk rather than clamping); rank is derived from the label. The response now echoes the persisted priority.
- **List filter:** `priority` was missing from `LIST_FILTER_FLAGS`, so `--priority` was silently dropped. Added it; the filter normalizes both the arg and each stored value before matching, so legacy `"1"` rows and new `"P1"` rows both match `--priority=1` and `--priority=P1`.
- **Sortable:** list already orders by `priority_rank`, but the CLI write path left rank 0 on every row (so default-P2 issues even sorted above explicit P1). Rank is now derived from the canonical label on every write.

## Validation

Independently re-verified on the real CLI: `--priority=P1` and `=1` both persist as `P1`; `list --priority=1` returns only P1 rows; `P9` still rejected (not clamped). `test/kernel` + `test/commands` **939 pass, 0 fail**; `release check --target 0.1.0` **PASS**; eslint clean.

> Note: this and #257 both touch broker/contract/driver; I'll rebase whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Priority values are now shown and handled consistently across create, update, accept, and list actions.
  * Valid priority inputs are normalized to the standard `P0`–`P4` format, while invalid values remain unchanged for validation.
  * Filtering and sorting by priority now work reliably, including for older records with mixed priority formats.
  * Default-priority items now sort more consistently relative to explicit priority values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->