### PR TITLE
fix: scope forge reset to Forge-managed skill dirs (preserve user skills)

### DIFF
--- a/lib/reset.js
+++ b/lib/reset.js
@@ -1,5 +1,13 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { listCanonicalSkills } = require('./skills-sync');
+
+/**
+ * Package root that ships the canonical `skills/` source. Used to determine
+ * which skill directories Forge itself installed (so user/third-party skills
+ * sharing a skills dir are not removed during reset).
+ */
+const FORGE_PACKAGE_ROOT = path.resolve(__dirname, '..');
 
 /**
  * Known forge-created file patterns.
@@ -174,7 +182,7 @@ function resetSoft(projectRoot, { force = false } = {}) {
  * @param {{ force?: boolean }} options
  * @returns {{ removed: string[], preserved: string[] }}
  */
-function resetHard(projectRoot, { force = false } = {}) {
+function resetHard(projectRoot, { force = false, sourceRoot = FORGE_PACKAGE_ROOT } = {}) {
   if (!force) {
     throw new Error('Hard reset requires --force flag. This will remove ALL forge files.');
   }
@@ -230,12 +238,32 @@ function resetHard(projectRoot, { force = false } = {}) {
     }
   }
 
-  // Remove skill directories
+  // Remove Forge-managed skill directories ONLY.
+  // Shared skills dirs (e.g. .claude/skills) can also hold user/third-party
+  // skills. Scope removal to the canonical Forge skill set so user work is
+  // preserved; the surrounding dir is removed only if nothing else remains.
+  const forgeSkillNames = new Set(
+    listCanonicalSkills(sourceRoot).map((s) => s.name)
+  );
   for (const dir of inventory.skillDirs) {
-    const fullPath = path.join(projectRoot, dir);
-    if (fs.existsSync(fullPath)) {
-      fs.rmSync(fullPath, { recursive: true, force: true });
-      removed.push(dir);
+    const skillsRoot = path.join(projectRoot, dir);
+    if (!fs.existsSync(skillsRoot)) continue;
+
+    for (const entry of fs.readdirSync(skillsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (!forgeSkillNames.has(entry.name)) continue;
+      fs.rmSync(path.join(skillsRoot, entry.name), { recursive: true, force: true });
+      removed.push([dir, entry.name].join('/'));
+    }
+
+    // Drop the now-empty skills dir, but keep it if user/third-party skills remain.
+    try {
+      if (fs.readdirSync(skillsRoot).length === 0) {
+        fs.rmSync(skillsRoot, { recursive: true, force: true });
+        removed.push(dir);
+      }
+    } catch (_error) {
+      // Directory read failed, skip
     }
   }
 

--- a/test/reset-hard.test.js
+++ b/test/reset-hard.test.js
@@ -93,6 +93,40 @@ describe('resetHard', () => {
     expect(result.removed).toEqual([]);
   });
 
+  test('preserves user/third-party skills while removing Forge-managed skills', () => {
+    // Fixture canonical source: Forge "owns" only the 'plan' skill here.
+    const sourceRoot = path.join(tmpDir, '_forge-src');
+    scaffold(sourceRoot, ['skills/plan/SKILL.md']);
+
+    // Project skills dir mixes a Forge-managed skill and a user-authored one.
+    scaffold(tmpDir, [
+      '.claude/skills/plan/SKILL.md',
+      '.claude/skills/my-custom-skill/SKILL.md',
+    ]);
+
+    resetHard(tmpDir, { force: true, sourceRoot });
+
+    // Forge-managed skill removed
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'skills', 'plan'))).toBe(false);
+    // User/third-party skill preserved
+    expect(
+      fs.existsSync(path.join(tmpDir, '.claude', 'skills', 'my-custom-skill', 'SKILL.md'))
+    ).toBe(true);
+    // Surrounding skills dir intact (not wiped) because a user skill remains
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'skills'))).toBe(true);
+  });
+
+  test('removes Forge skill dir entirely when no user skills remain', () => {
+    const sourceRoot = path.join(tmpDir, '_forge-src');
+    scaffold(sourceRoot, ['skills/plan/SKILL.md']);
+    scaffold(tmpDir, ['.claude/skills/plan/SKILL.md']);
+
+    resetHard(tmpDir, { force: true, sourceRoot });
+
+    // Empty Forge skills dir is cleaned up
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'skills'))).toBe(false);
+  });
+
   test('removes multiple agent directories', () => {
     scaffold(tmpDir, [
       '.cursor/rules/forge-workflow.mdc',


### PR DESCRIPTION
## Summary
`forge reset --hard` (the teardown/uninstall path) destroyed user- and third-party-authored skills that live alongside Forge's own skills in shared dirs such as `.claude/skills`.

## The bug
`resetHard()` in `lib/reset.js` removed each entry of `inventory.skillDirs` with `fs.rmSync(fullPath, { recursive: true, force: true })`, where the entry is the whole shared dir (e.g. `.claude/skills`). Because `.claude` is not a Forge-owned agent dir, that wholesale `rmSync` wiped any user/third-party skill subdirectories too — destroying user work.

## The fix
Scope skill removal to the canonical Forge skill set:
- Enumerate Forge-installed skills via `listCanonicalSkills(sourceRoot)` (same mechanism Forge uses to install them).
- Remove only skill subdirectories whose names are in that set; user/third-party skill dirs are preserved.
- Drop the surrounding skills dir only when it becomes empty (keeps existing all-Forge reset behavior).

This mirrors the canonical-name scoping already used by `skills-sync.populateAgentSkills`'s `clean` path. A `sourceRoot` option (defaulting to the package root) is added for deterministic testing.

## Validation
- New RED→GREEN tests in `test/reset-hard.test.js`: a user/third-party skill is preserved while a Forge-managed skill is removed; empty Forge skills dir is still cleaned up.
- Full reset suite (reset-hard, reset-inventory, reset-soft, reset, reinstall, cli-lifecycle): 31 pass / 0 fail.
- `npx eslint lib/reset.js test/reset-hard.test.js --max-warnings 0`: clean.
- `node bin/forge.js release check --target 0.1.0`: Result: PASS, no blockers.
- No changes under `lib/kernel/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)