### PR TITLE
feat(kernel): faithful beads-import write path (broker.importIssues)

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -1036,6 +1036,27 @@ function createLocalBroker(options = {}) {
 			return runGuardedEventImpl(event, context);
 		},
 
+		// Faithful-import write path (the `forge migrate` enabler PR-3 calls). Consumes
+		// the records importBeadsSnapshot(snapshot).kernel produces — `{ issues, comments,
+		// dependencies, events }` — and writes them DIRECTLY to the authority tables via
+		// the driver's import primitive, PRESERVING each issue's original
+		// created_at/updated_at, terminal status (done/cancelled), priority(+rank),
+		// labels, acceptance/content + beads-fidelity columns, plus its comments and
+		// dependency edges. Distinct from the create/update guarded path (which now-stamps
+		// + bumps CAS); the normal mutation contract is unchanged.
+		//
+		// PRECONDITION: initialize() must have run first (this does NOT auto-init) so the
+		// schema/migrations exist. The canonical input is the `.kernel` records object; the
+		// full importBeadsSnapshot result is accepted as a convenience and unwrapped.
+		// Idempotent (re-import skips existing ids) and transactional. Returns
+		// { issues, comments, dependencies } each { inserted, skipped }.
+		async importIssues(records = {}, options = {}) {
+			requireDriverMethod(driver, 'importIssues');
+			const config = getConfig();
+			const kernel = records && records.kernel ? records.kernel : records;
+			return driver.importIssues(kernel, options, {}, config);
+		},
+
 		// --- Projection-outbox read/update surface (D16) -----------------------
 		// Additive read/update methods for projection consumers. These never touch
 		// the append/CAS path above (runGuardedEvent / enqueueKernelProjection);

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -1243,6 +1243,168 @@ function applyAcceptedMutation(runtime, db, event, context = {}) {
 	return null;
 }
 
+// --- Faithful import write path (beads → kernel) ------------------------------
+// Direct authority-table writes that PRESERVE an imported issue's ORIGINAL
+// created_at/updated_at, terminal status (done/cancelled), priority(+rank), labels,
+// acceptance/content and beads-fidelity columns — BYPASSING applyAcceptedIssueEvent's
+// now-stamping create/CAS path. This is the ONLY path that writes an issue's original
+// timestamps; the normal create/update flow is unchanged. Consumed exclusively by the
+// broker's importIssues entry point (the `forge migrate` write path). Each call is
+// idempotent (ON CONFLICT(id) DO NOTHING — an existing id is skipped, never duplicated
+// or thrown) and transactional (one BEGIN IMMEDIATE per call; all-or-nothing).
+
+// The full kernel_issues column set the importer writes. Every NOT NULL column is
+// seeded with a default in buildImportIssueRow, so a sparse record (only id/title)
+// still inserts a valid row, while a full-fidelity record round-trips verbatim.
+const IMPORT_ISSUE_COLUMNS = Object.freeze([
+	'id', 'title', 'body', 'type', 'status', 'priority', 'priority_rank',
+	'created_at', 'updated_at', 'entity_revision',
+	'parent_id', 'sprint_id', 'release_id', 'stage_state', 'labels',
+	'acceptance_criteria', 'estimate', 'design', 'notes', 'assignee',
+	'created_by', 'closed_at', 'close_reason', 'metadata',
+]);
+
+const IMPORT_COMMENT_COLUMNS = Object.freeze(['id', 'issue_id', 'body', 'actor', 'visibility', 'created_at']);
+const IMPORT_DEPENDENCY_COLUMNS = Object.freeze(['id', 'issue_id', 'blocks_issue_id', 'dependency_type', 'created_at']);
+
+// The mapper carries an issue's terminal close metadata on a SEPARATE
+// `beads.issue.closed` event (kernel.events), not on the issue record — mirror the
+// adapter's getCloseMetadataByIssue so closed_at/close_reason land on the issue row.
+function buildImportCloseMetadata(events = []) {
+	const byIssue = new Map();
+	for (const event of Array.isArray(events) ? events : []) {
+		if (!event || event.event_type !== 'beads.issue.closed') continue;
+		let payload;
+		try {
+			payload = event.payload_json ? JSON.parse(event.payload_json) : (event.payload || {});
+		} catch {
+			payload = {};
+		}
+		byIssue.set(event.entity_id, {
+			closed_at: payload.closed_at ?? event.created_at ?? null,
+			close_reason: payload.close_reason ?? null,
+		});
+	}
+	return byIssue;
+}
+
+// Build the full insert row for one imported issue record. NOT NULL columns default so a
+// sparse record stays valid; created_at/updated_at fall back to the original created_at
+// (then `now`) rather than always-now, so the imported issue's history is preserved.
+// labels are stored verbatim (the mapper already JSON-encodes them) — an accidental array
+// is re-encoded defensively. Close metadata prefers a record-level column, else the
+// close-event sidecar.
+function buildImportIssueRow(record, closeMeta, now) {
+	const priority = record.priority ?? 'P2';
+	const createdAt = record.created_at ?? now;
+	const close = closeMeta || {};
+	const labels = Array.isArray(record.labels) ? JSON.stringify(record.labels) : (record.labels ?? null);
+	return {
+		id: record.id,
+		title: record.title ?? record.id,
+		body: record.body ?? null,
+		type: record.type ?? 'task',
+		status: record.status ?? 'open',
+		priority,
+		priority_rank: Number(record.priority_rank ?? rankForPriorityLabel(priority)),
+		created_at: createdAt,
+		updated_at: record.updated_at ?? createdAt,
+		entity_revision: Number(record.entity_revision ?? 0),
+		parent_id: record.parent_id ?? null,
+		sprint_id: record.sprint_id ?? null,
+		release_id: record.release_id ?? null,
+		stage_state: record.stage_state ?? null,
+		labels,
+		acceptance_criteria: record.acceptance_criteria ?? null,
+		estimate: record.estimate ?? null,
+		design: record.design ?? null,
+		notes: record.notes ?? null,
+		assignee: record.assignee ?? null,
+		created_by: record.created_by ?? null,
+		closed_at: record.closed_at ?? close.closed_at ?? null,
+		close_reason: record.close_reason ?? close.close_reason ?? null,
+		metadata: record.metadata ?? null,
+	};
+}
+
+// Insert a kernel records bundle ({ issues, comments, dependencies, events }) into the
+// authority tables inside ONE transaction. Order is issues → comments → dependencies so
+// every child FK resolves; children whose endpoint id is absent (a dangling edge) are
+// filtered out rather than aborting the whole batch on the live FK. Returns per-table
+// {inserted, skipped} counts (skipped = an id that already existed or a filtered child).
+function importIssueRecords(runtime, db, records = {}, options = {}) {
+	const now = options.now || new Date().toISOString();
+	const issues = Array.isArray(records.issues) ? records.issues : [];
+	const comments = Array.isArray(records.comments) ? records.comments : [];
+	const dependencies = Array.isArray(records.dependencies) ? records.dependencies : [];
+	const closeByIssue = buildImportCloseMetadata(records.events);
+	const summary = {
+		issues: { inserted: 0, skipped: 0 },
+		comments: { inserted: 0, skipped: 0 },
+		dependencies: { inserted: 0, skipped: 0 },
+	};
+	const wasInserted = result => Number(result?.changes || 0) > 0;
+
+	execSql(runtime, db, 'BEGIN IMMEDIATE;');
+	try {
+		const issueSql = `INSERT INTO kernel_issues (${IMPORT_ISSUE_COLUMNS.join(', ')})`
+			+ ` VALUES (${IMPORT_ISSUE_COLUMNS.map(() => '?').join(', ')}) ON CONFLICT(id) DO NOTHING`;
+		for (const record of issues) {
+			if (!record || record.id == null) { summary.issues.skipped += 1; continue; }
+			const row = buildImportIssueRow(record, closeByIssue.get(record.id), now);
+			const result = runParams(runtime, db, issueSql, IMPORT_ISSUE_COLUMNS.map(column => row[column]));
+			summary.issues[wasInserted(result) ? 'inserted' : 'skipped'] += 1;
+		}
+
+		// FK-safe child filtering: an id present after the issue inserts (imported OR
+		// pre-existing) is a valid endpoint; anything else would trip the live FK.
+		const existingIds = new Set(allParams(runtime, db, 'SELECT id FROM kernel_issues').map(issue => issue.id));
+
+		const commentSql = `INSERT INTO kernel_comments (${IMPORT_COMMENT_COLUMNS.join(', ')})`
+			+ ` VALUES (${IMPORT_COMMENT_COLUMNS.map(() => '?').join(', ')}) ON CONFLICT(id) DO NOTHING`;
+		for (const comment of comments) {
+			if (!comment || comment.id == null || !existingIds.has(comment.issue_id)) { summary.comments.skipped += 1; continue; }
+			const result = runParams(runtime, db, commentSql, [
+				comment.id,
+				comment.issue_id,
+				comment.body ?? '',
+				comment.actor ?? 'beads',
+				comment.visibility ?? 'local',
+				comment.created_at ?? now,
+			]);
+			summary.comments[wasInserted(result) ? 'inserted' : 'skipped'] += 1;
+		}
+
+		const dependencySql = `INSERT INTO kernel_dependencies (${IMPORT_DEPENDENCY_COLUMNS.join(', ')})`
+			+ ` VALUES (${IMPORT_DEPENDENCY_COLUMNS.map(() => '?').join(', ')}) ON CONFLICT(id) DO NOTHING`;
+		for (const dependency of dependencies) {
+			if (!dependency || dependency.id == null
+				|| !existingIds.has(dependency.issue_id) || !existingIds.has(dependency.blocks_issue_id)) {
+				summary.dependencies.skipped += 1;
+				continue;
+			}
+			const result = runParams(runtime, db, dependencySql, [
+				dependency.id,
+				dependency.issue_id,
+				dependency.blocks_issue_id,
+				dependency.dependency_type ?? 'blocks',
+				dependency.created_at ?? now,
+			]);
+			summary.dependencies[wasInserted(result) ? 'inserted' : 'skipped'] += 1;
+		}
+
+		execSql(runtime, db, 'COMMIT;');
+	} catch (error) {
+		try {
+			execSql(runtime, db, 'ROLLBACK;');
+		} catch {
+			// A rollback failure must not mask the original import error.
+		}
+		throw error;
+	}
+	return summary;
+}
+
 // --- Project-memory read-model primitives -------------------------------------
 // kernel_memories is a Forge read model written DIRECTLY (NOT through the guarded-event
 // path), so these are plain synchronous SQL helpers. project-memory.js owns the memory
@@ -1506,6 +1668,14 @@ function createDriver(runtime, configuredDatabasePath) {
 		// runGuardedEvent's result so runIssueOperation can shape the mutation response.
 		async applyAcceptedIssueMutation(event, context = {}, config = {}) {
 			return applyAcceptedMutation(runtime, getDatabase(config), event, context);
+		},
+		// Faithful-import write path: insert a kernel records bundle ({ issues, comments,
+		// dependencies, events }) DIRECTLY into the authority tables, preserving each
+		// issue's original created_at/updated_at + terminal status (bypassing the
+		// now-stamping create/CAS path). Idempotent + transactional. `context` is part of
+		// the driver contract but unused by this direct write (prefixed `_`).
+		async importIssues(records = {}, options = {}, _context = {}, config = {}) {
+			return importIssueRecords(runtime, getDatabase(config), records, options);
 		},
 		// --- Project-memory read model (written directly, not via the guarded path).
 		// Synchronous by design: the project-memory facade is synchronous, and these

--- a/test/kernel/sqlite-driver-import.test.js
+++ b/test/kernel/sqlite-driver-import.test.js
@@ -1,0 +1,249 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+const {
+	importBeadsSnapshot,
+	loadBeadsSnapshotFromDirectory,
+} = require('../../lib/adapters/beads-kernel-compat');
+
+// Faithful-import WRITE PATH (the forge migrate enabler). broker.importIssues consumes
+// the records importBeadsSnapshot(snapshot).kernel produces and writes them DIRECTLY to
+// the authority tables, PRESERVING the original created_at/updated_at, terminal status,
+// priority, labels, acceptance/fidelity columns, plus the issue's comments and
+// dependencies. Distinct from the normal create/update path (which now-stamps + CAS).
+describe('Kernel SQLite driver — faithful beads import write path', () => {
+	let tmpDir;
+	let driver;
+	let broker;
+	let config;
+	const now = '2026-06-30T00:00:00.000Z';
+	const fixtureDir = path.join(__dirname, '..', 'fixtures', 'beads-migrate', 'legacy-backup');
+
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-import-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// GAP 1 + GAP 2 (done) + close-event merge: a beads `closed` issue imported through
+	// importBeadsSnapshot keeps its ORIGINAL timestamps and lands at terminal status
+	// `done` with closed_at/close_reason merged from the close-event sidecar — NOT
+	// now-stamped like the normal create path.
+	test('imports a done issue preserving original timestamps + terminal status + close metadata', async () => {
+		const { kernel } = importBeadsSnapshot({
+			issues: [{
+				id: 'imp-done-1',
+				title: 'Imported done',
+				description: 'Body text from beads description',
+				issue_type: 'task',
+				status: 'closed',
+				priority: 1,
+				labels: ['alpha'],
+				acceptance_criteria: 'Original acceptance criteria',
+				created_at: '2025-01-01T00:00:00Z',
+				updated_at: '2025-02-02T00:00:00Z',
+				closed_at: '2025-02-02T00:00:00Z',
+				close_reason: 'Shipped and verified',
+			}],
+		}, { importedAt: now });
+
+		const summary = await broker.importIssues(kernel, { now });
+		expect(summary.issues.inserted).toBe(1);
+
+		const shown = await driver.issueOperation('show', ['imp-done-1'], {}, config);
+		expect(shown.ok).toBe(true);
+		expect(shown.data.status).toBe('done');
+		// Original timestamps preserved — the auto-stamp would have written `now`.
+		expect(shown.data.created_at).toBe('2025-01-01T00:00:00Z');
+		expect(shown.data.updated_at).toBe('2025-02-02T00:00:00Z');
+		expect(shown.data.created_at).not.toBe(now);
+		// Close metadata merged from the kernel.events sidecar.
+		expect(shown.data.closed_at).toBe('2025-02-02T00:00:00Z');
+		expect(shown.data.close_reason).toBe('Shipped and verified');
+		expect(shown.data.priority).toBe('P1');
+		expect(shown.data.rank).toBe(1);
+		expect(shown.data.labels).toEqual(['alpha']);
+		expect(shown.data.acceptance_criteria).toBe('Original acceptance criteria');
+		expect(shown.data.body).toBe('Body text from beads description');
+		// Imported issues start at revision 0.
+		expect(shown.data.revision).toBe(0);
+	});
+
+	// GAP 2 (cancelled) + column-completeness: a hand-built record carrying EVERY
+	// fidelity column (created_by + metadata, which the mapper currently drops as gaps,
+	// plus record-level closed_at/close_reason) persists verbatim at a terminal
+	// `cancelled` status with preserved timestamps.
+	test('persists a cancelled issue with all fidelity columns (created_by/metadata) verbatim', async () => {
+		const summary = await broker.importIssues({
+			issues: [{
+				id: 'cc-1',
+				title: 'Column complete',
+				body: 'b',
+				type: 'task',
+				status: 'cancelled',
+				priority: 'P2',
+				priority_rank: 2,
+				created_at: '2024-06-06T00:00:00.000Z',
+				updated_at: '2024-06-06T00:00:00.000Z',
+				entity_revision: 0,
+				created_by: 'Harsha Nanda',
+				metadata: '{"beads_id":"bd-1"}',
+				design: 'Design notes',
+				notes: 'Working notes',
+				assignee: 'bob',
+				closed_at: '2024-07-07T00:00:00.000Z',
+				close_reason: 'Cancelled — superseded',
+			}],
+			comments: [],
+			dependencies: [],
+			events: [],
+		}, { now });
+		expect(summary.issues.inserted).toBe(1);
+
+		const shown = await driver.issueOperation('show', ['cc-1'], {}, config);
+		expect(shown.data.status).toBe('cancelled');
+		expect(shown.data.created_at).toBe('2024-06-06T00:00:00.000Z');
+		expect(shown.data.updated_at).toBe('2024-06-06T00:00:00.000Z');
+		expect(shown.data.created_by).toBe('Harsha Nanda');
+		expect(shown.data.metadata).toBe('{"beads_id":"bd-1"}');
+		expect(shown.data.design).toBe('Design notes');
+		expect(shown.data.notes).toBe('Working notes');
+		expect(shown.data.assignee).toBe('bob');
+		expect(shown.data.closed_at).toBe('2024-07-07T00:00:00.000Z');
+		expect(shown.data.close_reason).toBe('Cancelled — superseded');
+	});
+
+	// GAP 1 + GAP 3 end-to-end: the legacy-backup fixtures flow through
+	// loadBeadsSnapshotFromDirectory → importBeadsSnapshot → broker.importIssues, and
+	// every issue keeps its original timestamps/status while its comments and the
+	// dependency edge land in the authority tables.
+	test('imports the legacy-backup fixtures end-to-end with comments + dependency', async () => {
+		const snapshot = loadBeadsSnapshotFromDirectory(fixtureDir);
+		const { kernel } = importBeadsSnapshot(snapshot, { importedAt: now });
+
+		const summary = await broker.importIssues(kernel, { now });
+		expect(summary.issues.inserted).toBe(2);
+		expect(summary.comments.inserted).toBe(kernel.comments.length);
+		expect(summary.dependencies.inserted).toBe(1);
+
+		const aa1 = await driver.issueOperation('show', ['forge-aa1'], {}, config);
+		expect(aa1.data.status).toBe('open');
+		expect(aa1.data.created_at).toBe('2026-04-01T09:00:00Z');
+		expect(aa1.data.updated_at).toBe('2026-04-01T09:00:00Z');
+		// Legacy `feature` issue_type collapses to `task` with a `feature` alias label.
+		expect(aa1.data.type).toBe('task');
+		expect(aa1.data.labels).toContain('feature');
+		// created_by is a known mapper GAP (no issue record field) — it does NOT survive
+		// the current mapper, proving the write path persists only what it is given.
+		expect(aa1.data.created_by).toBeNull();
+		// Real comment + synthetic note comment (collectComments turns distinct notes into
+		// a beads-note-* comment) → 2 comments on forge-aa1.
+		expect(aa1.data.comments.length).toBe(2);
+		expect(aa1.data.comments.map(comment => comment.body))
+			.toContain('Stage: plan complete → ready for dev');
+
+		const bb2 = await driver.issueOperation('show', ['forge-bb2'], {}, config);
+		expect(bb2.data.status).toBe('in_progress');
+		expect(bb2.data.created_at).toBe('2026-04-01T10:00:00Z');
+		expect(bb2.data.updated_at).toBe('2026-04-01T10:30:00Z');
+		// The dependency edge forge-bb2 → forge-aa1 is present.
+		expect(bb2.data.dependencies).toContain('forge-aa1');
+	});
+
+	// GAP 4: a second import of the same snapshot mints NO duplicate rows — every record
+	// is skipped on its id conflict and the authority-table counts stay stable.
+	test('re-import is idempotent (no duplicate issues/comments/dependencies)', async () => {
+		const snapshot = loadBeadsSnapshotFromDirectory(fixtureDir);
+		const { kernel } = importBeadsSnapshot(snapshot, { importedAt: now });
+
+		await broker.importIssues(kernel, { now });
+		const second = await broker.importIssues(kernel, { now });
+
+		expect(second.issues.inserted).toBe(0);
+		expect(second.issues.skipped).toBe(2);
+		expect(second.comments.inserted).toBe(0);
+		expect(second.comments.skipped).toBe(kernel.comments.length);
+		expect(second.dependencies.inserted).toBe(0);
+		expect(second.dependencies.skipped).toBe(1);
+
+		const issueRows = await driver.queryAll('SELECT id FROM kernel_issues', config);
+		expect(issueRows).toHaveLength(2);
+		const commentRows = await driver.queryAll('SELECT id FROM kernel_comments', config);
+		expect(commentRows).toHaveLength(kernel.comments.length);
+		const depRows = await driver.queryAll('SELECT id FROM kernel_dependencies', config);
+		expect(depRows).toHaveLength(1);
+	});
+
+	// Robustness: a dangling dependency edge (endpoint missing from the import set and the
+	// DB) is filtered out rather than aborting the whole batch on the live FK.
+	test('filters a dangling dependency edge without aborting the issue insert', async () => {
+		const summary = await broker.importIssues({
+			issues: [{
+				id: 'fk-1',
+				title: 'Has a dangling dep',
+				type: 'task',
+				status: 'open',
+				priority: 'P2',
+				priority_rank: 2,
+				created_at: '2024-01-01T00:00:00.000Z',
+				updated_at: '2024-01-01T00:00:00.000Z',
+			}],
+			comments: [],
+			dependencies: [{
+				id: 'dep-dangling',
+				issue_id: 'fk-1',
+				blocks_issue_id: 'does-not-exist',
+				dependency_type: 'blocks',
+				created_at: '2024-01-01T00:00:00.000Z',
+			}],
+			events: [],
+		}, { now });
+
+		expect(summary.issues.inserted).toBe(1);
+		expect(summary.dependencies.inserted).toBe(0);
+		expect(summary.dependencies.skipped).toBe(1);
+
+		const shown = await driver.issueOperation('show', ['fk-1'], {}, config);
+		expect(shown.ok).toBe(true);
+		expect(shown.data.dependencies).toEqual([]);
+	});
+
+	// Accepts the full importBeadsSnapshot result (unwraps `.kernel`) as a convenience.
+	test('accepts the full importBeadsSnapshot result via its .kernel records', async () => {
+		const result = importBeadsSnapshot({
+			issues: [{
+				id: 'wrap-1',
+				title: 'Wrapped',
+				issue_type: 'task',
+				status: 'open',
+				priority: 2,
+				created_at: '2024-03-03T00:00:00Z',
+				updated_at: '2024-03-03T00:00:00Z',
+			}],
+		}, { importedAt: now });
+
+		const summary = await broker.importIssues(result, { now });
+		expect(summary.issues.inserted).toBe(1);
+		const shown = await driver.issueOperation('show', ['wrap-1'], {}, config);
+		expect(shown.data.created_at).toBe('2024-03-03T00:00:00Z');
+	});
+});


### PR DESCRIPTION
## Summary

**Migration PR-②.** Adds the kernel write path needed to import beads issues without losing history: `broker.importIssues(records, options)` (+ `driver.importIssues`) writes directly to the authority tables, bypassing the auto-stamping create/CAS path. The normal create/update path is **unchanged** — this is a distinct internal entry point, which neutralizes regression risk.

Per record (from `importBeadsSnapshot(snapshot).kernel`):
- preserves **original `created_at`/`updated_at`** (no auto-stamp to now);
- sets status directly at insert (incl. terminal `done`/`cancelled`), merging `closed_at`/`close_reason` from the `beads.issue.closed` event sidecar;
- persists all fidelity/content columns (`created_by`, `metadata`, `design`, `notes`, `assignee`, priority+rank, `parent_id`, `labels`) when present;
- inserts comments + dependencies in the **same transaction** (issues → comments → deps so FKs resolve);
- **idempotent** (`ON CONFLICT(id) DO NOTHING`) + transactional (`BEGIN IMMEDIATE`/`COMMIT`, rollback on error); dangling child edges are filtered, not fatal.

## API for PR-③ (`forge migrate`)

```js
await broker.importIssues(importBeadsSnapshot(snapshot).kernel, { now })
// -> { issues, comments, dependencies: { inserted, skipped } }
```
`broker.initialize()` must run first.

## Known boundary (separate adapter PR)

The mapper (`mapBeadsIssueToKernel`) still **drops `created_by`/`metadata`** (a documented gap the beads-compat test encodes), so end-to-end those two come back null today — even though this write path persists them when present. Enriching the mapper is a clean follow-up I'll do next, to complete full fidelity.

## Validation

New `test/kernel/sqlite-driver-import.test.js` (6 tests): done issue keeps original timestamps + status; cancelled persists all columns; legacy-backup fixtures end-to-end with comments + a dependency; idempotent re-import (zero duplicates). `test/kernel` + `test/commands` green (one pre-existing migration-ledger **load-flake** timeout, 10/0 in isolation); `release check --target 0.1.0` **PASS**. Independently re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing issue snapshots into the app while preserving original issue details, timestamps, and close status.
  * Related comments and dependency links are included when they can be safely matched.

* **Bug Fixes**
  * Re-importing the same snapshot now avoids creating duplicates.
  * Imports now handle incomplete dependency links more gracefully, keeping valid data instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->