### PR TITLE
feat: carry beads created_by and metadata through the kernel mapper

### DIFF
--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -37,7 +37,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] lib/adapters/beads-issue-adapter.js (1)
   - lines: 78 (bd)
 - [ ] lib/adapters/beads-kernel-compat.js (1)
-  - lines: 670 (.beads)
+  - lines: 686 (.beads)
 - [ ] lib/audit-evidence.js (3)
   - lines: 148 (bd), 214 (bd), 240 (bd)
 - [ ] lib/beads-bootstrap.js (6)

--- a/lib/adapters/beads-kernel-compat.js
+++ b/lib/adapters/beads-kernel-compat.js
@@ -350,6 +350,33 @@ function parseMetadataObject(value) {
   }
 }
 
+// Carry a Beads issue's metadata onto the Kernel `metadata` TEXT column for full-fidelity import.
+// The forge_projection key is an internal Forge -> Beads projection marker (written on export and
+// consumed as close-event provenance via getForgeProjectionOrigin), NOT user data, so it is
+// stripped here; the remaining object keys are preserved verbatim as a JSON string. Non-object
+// metadata is kept as its raw value. Returns null when nothing user-authored remains.
+function serializeBeadsMetadata(value) {
+  if (!hasBeadsFieldValue(value)) return null;
+  let metadata = null;
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    metadata = { ...value };
+  } else if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        metadata = parsed;
+      }
+    } catch (_error) { // NOSONAR S2486 — non-JSON metadata is preserved verbatim below
+      metadata = null;
+    }
+  }
+  if (metadata === null) {
+    return typeof value === 'string' ? value : JSON.stringify(value);
+  }
+  delete metadata[FORGE_PROJECTION_METADATA_KEY];
+  return Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null;
+}
+
 function hasFiniteRevisionValue(value) {
   if (typeof value === 'number') return Number.isFinite(value);
   if (typeof value !== 'string') return false;
@@ -384,15 +411,6 @@ function getForgeProjectionOrigin(issue = {}, currentPayload = {}) {
     payload_hash: projection.payload_hash,
     imported_payload_hash: importedPayloadHash,
   };
-}
-
-function hasUnsupportedBeadsMetadata(value, issueId) {
-  if (!hasBeadsFieldValue(value)) return false;
-  if (typeof value !== 'string' && (typeof value !== 'object' || Array.isArray(value))) return true;
-  const metadata = parseMetadataObject(value);
-  const keys = Object.keys(metadata);
-  if (keys.length !== 1 || keys[0] !== FORGE_PROJECTION_METADATA_KEY) return true;
-  return !isValidForgeProjection(metadata[FORGE_PROJECTION_METADATA_KEY], issueId);
 }
 
 function buildCloseProjectionPayload(closeMetadata = {}) {
@@ -444,12 +462,6 @@ function mapBeadsIssueToKernel(issue, importedAt, gaps, seenGaps) {
   if (issue.owner) {
     addGap(gaps, seenGaps, 'issues.owner', 'no Kernel issue owner column in schema v1');
   }
-  if (issue.created_by) {
-    addGap(gaps, seenGaps, 'issues.created_by', 'no Kernel issue creator column in schema v1');
-  }
-  if (hasUnsupportedBeadsMetadata(issue.metadata, issue.id)) {
-    addGap(gaps, seenGaps, 'issues.metadata', 'no Kernel issue metadata column in schema v1');
-  }
   for (const [field, reason] of UNSUPPORTED_ISSUE_FIELDS) {
     if (hasBeadsFieldValue(issue[field])) {
       addGap(gaps, seenGaps, `issues.${field}`, reason);
@@ -466,6 +478,10 @@ function mapBeadsIssueToKernel(issue, importedAt, gaps, seenGaps) {
     priority_rank: priority.rank,
     labels: serializeLabels(labels),
     acceptance_criteria: serializeAcceptanceCriteria(issue.acceptance_criteria),
+    // Full-fidelity import: the Beads author (or owner, when no explicit author is recorded) and
+    // the verbatim metadata blob land on the dedicated Kernel issue columns added in migration 006.
+    created_by: issue.created_by || issue.owner || null,
+    metadata: serializeBeadsMetadata(issue.metadata),
     created_at: issue.created_at || importedAt,
     updated_at: issue.updated_at || issue.created_at || importedAt,
     entity_revision: 0,

--- a/test/adapters/beads-kernel-compat.test.js
+++ b/test/adapters/beads-kernel-compat.test.js
@@ -84,6 +84,10 @@ describe('Beads Kernel compatibility adapter', () => {
 		const importedChild = result.kernel.issues.find(issue => issue.id === 'forge-child');
 		expect(JSON.parse(importedChild.labels)).toEqual(['0.0.20', 'adapter']);
 		expect(importedChild.acceptance_criteria).toBeNull();
+		// Full-fidelity import: the beads author is carried onto the Kernel created_by column.
+		expect(importedChild.created_by).toBe('Harsha Nanda');
+		// forge-child carries no issue-level metadata, so the Kernel metadata column stays null.
+		expect(importedChild.metadata).toBeNull();
 		expect(result.kernel.dependencies).toEqual(expect.arrayContaining([
 			expect.objectContaining({
 				issue_id: 'forge-child',
@@ -134,7 +138,7 @@ describe('Beads Kernel compatibility adapter', () => {
 			dependencies: 2,
 			comments: 2,
 			closeEvents: 1,
-			unsupportedFields: 4,
+			unsupportedFields: 3,
 		});
 		expect(result.report.preservedFields).toEqual(expect.arrayContaining([
 			'issues.id',
@@ -147,7 +151,6 @@ describe('Beads Kernel compatibility adapter', () => {
 			'events.close_reason',
 		]));
 		expect(result.report.gaps).toEqual(expect.arrayContaining([
-			expect.objectContaining({ field: 'issues.created_by', reason: 'no Kernel issue creator column in schema v1' }),
 			expect.objectContaining({ field: 'issues.owner', reason: 'no Kernel issue owner column in schema v1' }),
 			expect.objectContaining({ field: 'dependencies.created_by', reason: 'no Kernel dependency creator column in schema v1' }),
 			expect.objectContaining({ field: 'dependencies.metadata', reason: 'no Kernel dependency metadata column in schema v1' }),
@@ -155,11 +158,73 @@ describe('Beads Kernel compatibility adapter', () => {
 		const gapFields = result.report.gaps.map(gap => gap.field);
 		expect(gapFields).not.toContain('issues.labels');
 		expect(gapFields).not.toContain('issues.acceptance_criteria');
+		// created_by and issue metadata are now carried onto the Kernel record, not dropped.
+		expect(gapFields).not.toContain('issues.created_by');
+		expect(gapFields).not.toContain('issues.metadata');
 		expect(result.rollback).toMatchObject({
 			available: true,
 			mode: 'import-only',
 			reason: 'Import did not mutate Beads files; discard imported Kernel records to roll back.',
 		});
+	});
+
+	test('carries beads issue created_by and metadata onto the Kernel record', () => {
+		const snapshot = {
+			issues: [{
+				id: 'forge-md',
+				title: 'Issue with author and metadata',
+				status: 'open',
+				priority: 2,
+				issue_type: 'task',
+				owner: 'harsha@example.com',
+				created_by: 'Harsha Nanda',
+				metadata: JSON.stringify({ team: 'kernel', sprint: 3 }),
+				created_at: IMPORTED_AT,
+				updated_at: IMPORTED_AT,
+			}],
+		};
+
+		const result = importBeadsSnapshot(snapshot, { importedAt: IMPORTED_AT });
+		const [imported] = result.kernel.issues;
+
+		expect(imported.created_by).toBe('Harsha Nanda');
+		expect(JSON.parse(imported.metadata)).toEqual({ team: 'kernel', sprint: 3 });
+
+		const gapFields = result.report.gaps.map(gap => gap.field);
+		expect(gapFields).not.toContain('issues.created_by');
+		expect(gapFields).not.toContain('issues.metadata');
+	});
+
+	test('falls back to the beads owner for Kernel created_by when no author is recorded', () => {
+		const result = importBeadsSnapshot({
+			issues: [{ id: 'forge-owned', title: 'Owner only', status: 'open', owner: 'owner@example.com' }],
+		}, { importedAt: IMPORTED_AT });
+
+		expect(result.kernel.issues[0].created_by).toBe('owner@example.com');
+	});
+
+	test('strips the internal forge_projection marker from carried Kernel metadata', () => {
+		const snapshot = {
+			issues: [{
+				id: 'forge-proj',
+				title: 'Projection marker only',
+				status: 'open',
+				priority: 2,
+				issue_type: 'task',
+				metadata: JSON.stringify({
+					forge_projection: { source: 'forge-kernel', target: 'beads' },
+				}),
+				created_at: IMPORTED_AT,
+				updated_at: IMPORTED_AT,
+			}],
+		};
+
+		const result = importBeadsSnapshot(snapshot, { importedAt: IMPORTED_AT });
+		const [imported] = result.kernel.issues;
+
+		// forge_projection is an internal Forge->Beads marker, not user metadata, so it is stripped.
+		expect(imported.metadata).toBeNull();
+		expect(result.report.gaps.map(gap => gap.field)).not.toContain('issues.metadata');
 	});
 
 	test('falls back to revision zero for malformed Beads close-event revisions', () => {
@@ -288,7 +353,7 @@ describe('Beads Kernel compatibility adapter', () => {
 		});
 	});
 
-	test('reports malformed Forge projection metadata as unsupported', () => {
+	test('ignores malformed Forge projection provenance without dropping issue metadata', () => {
 		const exportResult = exportClosedKernelIssue();
 
 		const [exportedIssue] = parseJsonl(exportResult.files['issues.jsonl']);
@@ -313,9 +378,12 @@ describe('Beads Kernel compatibility adapter', () => {
 		}, { importedAt: IMPORTED_AT });
 		const [closeEvent] = importResult.kernel.events;
 
-		expect(importResult.report.gaps).toEqual(expect.arrayContaining([
-			expect.objectContaining({ field: 'issues.metadata' }),
-		]));
+		// Metadata is now carried (not reported as an unsupported gap); the forge_projection marker
+		// is stripped, so the only key here leaves an empty Kernel metadata column.
+		const gapFields = importResult.report.gaps.map(gap => gap.field);
+		expect(gapFields).not.toContain('issues.metadata');
+		expect(importResult.kernel.issues[0].metadata).toBeNull();
+		// A malformed projection still grants no provenance to the close event.
 		expect(JSON.parse(closeEvent.payload_json).projection_origin).toBeUndefined();
 	});
 
@@ -427,14 +495,18 @@ describe('Beads Kernel compatibility adapter', () => {
 		expect(importedIssue.type).toBe('task');
 		expect(JSON.parse(importedIssue.labels)).toEqual(expect.arrayContaining(['migration', 'feature']));
 		expect(importedIssue.acceptance_criteria).toBe(JSON.stringify(['Imported issue keeps migration context visible.']));
+		// The beads author is carried; "{}" metadata holds no user data, so the column stays null.
+		expect(importedIssue.created_by).toBe('Harsha Nanda');
+		expect(importedIssue.metadata).toBeNull();
 		expect(result.report.gaps).toEqual(expect.arrayContaining([
 			expect.objectContaining({ field: 'issues.assignee' }),
-			expect.objectContaining({ field: 'issues.created_by' }),
 			expect.objectContaining({ field: 'issues.design' }),
 		]));
 		const aa1GapFields = result.report.gaps.map(gap => gap.field);
 		expect(aa1GapFields).not.toContain('issues.labels');
 		expect(aa1GapFields).not.toContain('issues.acceptance_criteria');
+		// created_by is now carried onto the Kernel record, no longer a fidelity gap.
+		expect(aa1GapFields).not.toContain('issues.created_by');
 	});
 
 	test('imports dependency rows with non-lossy generated ids', () => {

--- a/test/kernel/sqlite-driver-import.test.js
+++ b/test/kernel/sqlite-driver-import.test.js
@@ -152,9 +152,10 @@ describe('Kernel SQLite driver — faithful beads import write path', () => {
 		// Legacy `feature` issue_type collapses to `task` with a `feature` alias label.
 		expect(aa1.data.type).toBe('task');
 		expect(aa1.data.labels).toContain('feature');
-		// created_by is a known mapper GAP (no issue record field) — it does NOT survive
-		// the current mapper, proving the write path persists only what it is given.
-		expect(aa1.data.created_by).toBeNull();
+		// created_by now survives the mapper (PR #261): the beads `created_by` (falling
+		// back to `owner`) is carried onto the kernel created_by column, so the legacy
+		// fixture's author lands on the imported issue.
+		expect(aa1.data.created_by).toBe('Harsha Nanda');
 		// Real comment + synthetic note comment (collectComments turns distinct notes into
 		// a beads-note-* comment) → 2 comments on forge-aa1.
 		expect(aa1.data.comments.length).toBe(2);


### PR DESCRIPTION
## Summary

Completes faithful beads -> kernel import for the `created_by` and `metadata` issue columns.

## The gap

A prior PR added kernel issue columns `created_by` + `metadata` (migration 006) and a faithful-import write path (`broker.importIssues`) that persists them when a record carries them. But the beads -> kernel **mapper** (`mapBeadsIssueToKernel` in `lib/adapters/beads-kernel-compat.js`) dropped both fields, reporting them as fidelity "gaps". End-to-end through `importBeadsSnapshot`, both columns therefore came back `null` — full fidelity was incomplete.

## The fix

- `mapBeadsIssueToKernel` now sets `created_by` (`issue.created_by || issue.owner || null`) and `metadata` onto the kernel record.
- New `serializeBeadsMetadata` carries the beads metadata as a JSON string.
- Removed the obsolete `issues.created_by` / `issues.metadata` `addGap` entries and the now-dead `hasUnsupportedBeadsMetadata` helper. The `issues.owner` gap and the dependency-sidecar gaps (`dependencies.created_by`, `dependencies.metadata`) and the events/interactions sidecar gaps are unchanged.

## Metadata / projection caution

This module also uses `issue.metadata` for the Forge **projection marker** (`forge_projection` key) on the export/round-trip side. On import, `serializeBeadsMetadata` **strips only the internal `forge_projection` key** and preserves the remaining user metadata verbatim; non-object metadata is kept as its raw value. The projection key is re-synthesized on export (`buildForgeProjectionMetadata`) and consumed as close-event provenance (`getForgeProjectionOrigin`) — both read the **raw beads issue**, not the kernel record, so export/projection behavior is untouched.

## Encoded-contract updates

Updated the gap assertions in `test/adapters/beads-kernel-compat.test.js` that encoded the old limitation: `unsupportedFields` 4 -> 3, dropped the `issues.created_by` / `issues.metadata` gap expectations, and the malformed-projection test now asserts metadata is carried (not a gap) while malformed provenance still grants no close-event origin. Added dedicated tests for carrying `created_by` + `metadata`, the owner fallback, and `forge_projection` stripping.

## Validation

- `bun test test/adapters/ test/kernel/`: 449 pass, 0 fail
- `npx eslint <changed files> --max-warnings 0`: clean
- `node bin/forge.js release check --target 0.1.0`: Result: PASS (regenerated the D20 bd call-site kill-list; audited line 670 -> 686)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Beads-to-Kernel imports so author information is preserved more consistently, with a fallback to the issue owner when needed.
  * Issue metadata is now carried over more faithfully, while internal projection markers are stripped out before storage.
  * Unsupported-field warnings are reduced by treating preserved author and metadata data as part of the imported record.

* **Documentation**
  * Updated the compatibility documentation to reflect the latest call-site line reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->