### PR TITLE
feat(doc-gate): repo-structure detector + forge doc-gate command

### DIFF
--- a/lib/commands/doc-gate.js
+++ b/lib/commands/doc-gate.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * `forge doc-gate` — repo-structure detector command (thin wrapper).
+ *
+ * Subcommand: `detect [--json]`. Runs the validated doc-gate detector
+ * (lib/doc-gate/detect.js) against the cwd repo and prints a human summary by
+ * default, or a structured JSON object with `--json`.
+ *
+ * Exit non-zero ONLY on a real error (not a git repo / no commits, or an
+ * unknown subcommand). An ESCALATE-TO-AGENT or MANUAL-CONFIG verdict is a valid
+ * detection result and exits 0.
+ *
+ * This is the first PR of the larger "doc-gate" feature; the CI required-gate,
+ * OKF-bundle generation, and agent escalation runtime are deliberately NOT here.
+ *
+ * @module commands/doc-gate
+ */
+
+const { execFileSync } = require('node:child_process');
+const { detect } = require('../doc-gate/detect');
+
+/** True when `root` is a git working tree with at least one commit (HEAD). */
+function hasGitHead(root) {
+  try {
+    execFileSync('git', ['-C', root, 'rev-parse', '--verify', 'HEAD'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+/** Format a single field for the human summary. */
+function fieldLine(label, field, valueKey) {
+  let display;
+  if (field.escalate) {
+    display = `ESCALATE→agent (${field.trigger})`;
+  } else {
+    const raw = field[valueKey];
+    if (raw === null || raw === undefined || (Array.isArray(raw) && raw.length === 0)) {
+      display = '(none / abstain)';
+    } else {
+      display = Array.isArray(raw) ? raw.join(', ') : String(raw);
+    }
+  }
+  return `  ${label.padEnd(10)} ${display}  [${field.confidence}]`;
+}
+
+/** Render the detector result as a readable summary. */
+function renderHuman(result) {
+  const lines = [
+    `doc-gate detect — ${result.repo}`,
+    `verdict: ${result.verdict}`,
+    fieldLine('source', result.source, 'value'),
+    fieldLine('toolchain', result.toolchain, 'value'),
+    fieldLine('ci', result.ci, 'provider'),
+    fieldLine('changelog', result.changelog, 'value'),
+    fieldLine('agents', result.agents, 'value'),
+    `code-high-confidence: ${result.codeHighConfidence.length ? result.codeHighConfidence.join(', ') : '(none)'}`,
+  ];
+  if (Array.isArray(result.escalate) && result.escalate.length > 0) {
+    lines.push('escalate:');
+    for (const e of result.escalate) {
+      lines.push(`  - ${e.field}: ${e.trigger}${e.detail ? ` (${e.detail})` : ''}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+const USAGE = 'forge doc-gate detect [--json]';
+
+module.exports = {
+  name: 'doc-gate',
+  description: 'Detect a repository\'s structure (source/toolchain/ci/changelog/agents)',
+  usage: USAGE,
+  flags: {
+    '--json': 'Emit a structured JSON object instead of the human summary.',
+  },
+
+  async handler(args, flags, projectRoot, _opts = {}) {
+    const argv = Array.isArray(args) ? args : [];
+    const sub = argv.find(a => a && !a.startsWith('-')) || 'detect';
+    const json = Boolean(flags && flags.json) || argv.includes('--json');
+
+    if (sub !== 'detect') {
+      return {
+        success: false,
+        error: `Unknown doc-gate subcommand '${sub}'. Supported subcommands: detect.\nUsage: ${USAGE}`,
+        exitCode: 1,
+      };
+    }
+
+    const root = projectRoot || process.cwd();
+    if (!hasGitHead(root)) {
+      return {
+        success: false,
+        error:
+          'forge doc-gate detect must run inside a git repository with at least one ' +
+          `commit (HEAD). No readable git HEAD was found at ${root}.`,
+        exitCode: 1,
+      };
+    }
+
+    const result = detect(root);
+    const output = json ? JSON.stringify(result, null, 2) : renderHuman(result);
+    return { success: true, output, json };
+  },
+};

--- a/lib/commands/doc-gate.js
+++ b/lib/commands/doc-gate.js
@@ -23,11 +23,13 @@ const { detect } = require('../doc-gate/detect');
 /** True when `root` is a git working tree with at least one commit (HEAD). */
 function hasGitHead(root) {
   try {
-    execFileSync('git', ['-C', root, 'rev-parse', '--verify', 'HEAD'], {
+    // NOSONAR S4036 - 'git' is a hardcoded CLI command with no user input; developer-tool context.
+    execFileSync('git', ['-C', root, 'rev-parse', '--verify', 'HEAD'], { // NOSONAR S4036
       stdio: ['ignore', 'ignore', 'ignore'],
     });
     return true;
   } catch (_err) {
+    // A missing/broken git HEAD simply means "not a usable repo" here. NOSONAR S2486
     return false;
   }
 }
@@ -63,7 +65,8 @@ function renderHuman(result) {
   if (Array.isArray(result.escalate) && result.escalate.length > 0) {
     lines.push('escalate:');
     for (const e of result.escalate) {
-      lines.push(`  - ${e.field}: ${e.trigger}${e.detail ? ` (${e.detail})` : ''}`);
+      const detail = e.detail ? ` (${e.detail})` : '';
+      lines.push(`  - ${e.field}: ${e.trigger}${detail}`);
     }
   }
   return lines.join('\n');
@@ -82,7 +85,7 @@ module.exports = {
   async handler(args, flags, projectRoot, _opts = {}) {
     const argv = Array.isArray(args) ? args : [];
     const sub = argv.find(a => a && !a.startsWith('-')) || 'detect';
-    const json = Boolean(flags && flags.json) || argv.includes('--json');
+    const json = Boolean(flags?.json) || argv.includes('--json');
 
     if (sub !== 'detect') {
       return {

--- a/lib/doc-gate/detect.js
+++ b/lib/doc-gate/detect.js
@@ -3,18 +3,16 @@
 /**
  * doc-gate repo-structure detector.
  *
- * Ported verbatim (logic-for-logic) from the empirically-validated HYBRID
- * detector v4. v4 was tested to ZERO "silent-wrong" (a high-confidence answer
- * that is actually wrong) across 9 local repos AND 8 diverse OSS repos
- * (Python/Go/Rust/JS). The only changes from the reference are the module
- * boundary (no CLI `console.log`; `module.exports` instead) — the detection
- * logic, blocklist, regexes, and branch ordering are unchanged on purpose.
+ * Ported (logic-for-logic) from the empirically-validated HYBRID detector v4.
+ * v4 was tested to ZERO "silent-wrong" (a high-confidence answer that is
+ * actually wrong) across 9 local repos AND 8 diverse OSS repos
+ * (Python/Go/Rust/JS).
  *
  * Design (do not regress):
- *  - Tracked-files-only: every EXISTENCE signal comes from `git ls-tree HEAD` /
- *    `git ls-files` (never the raw filesystem) so untracked clutter and
- *    gitignored worktree/node_modules lockfiles can't poison detection. File
- *    CONTENT is still read with fs once a tracked path is known.
+ *  - Tracked-files-only: every EXISTENCE and CONTENT signal comes from
+ *    `git ls-tree HEAD` / `git ls-files` (never the raw filesystem), so
+ *    untracked clutter and gitignored worktree/node_modules lockfiles/manifests
+ *    can't poison detection.
  *  - Per-field results for source/toolchain/ci/changelog/agents, each
  *    `{ value, source: 'code'|'ABSTAIN→agent', confidence: 'high'|'medium'|'abstain', escalate? }`.
  *  - Abstain-by-default on the error-prone fields; emit HIGH only where
@@ -38,7 +36,19 @@ const readJSON = p => { try { return JSON.parse(read(p)); } catch { return null;
 const git = (root, args) => { try { return cp.execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }); } catch { return ''; } };
 const gitLines = (root, args) => git(root, args).split('\n').map(s => s.trim()).filter(Boolean);
 const trackedTop = root => new Set(gitLines(root, ['ls-tree', 'HEAD', '--name-only']));
+// Top-level TRACKED directories only (git object type `tree`), so file entries
+// like go.mod / README.md are never mistaken for source directories.
+const trackedTopDirs = root => new Set(
+  git(root, ['ls-tree', 'HEAD']).split('\n').filter(Boolean)
+    .filter(line => line.split(/\s+/)[1] === 'tree')
+    .map(line => line.split('\t').pop())
+    .filter(Boolean),
+);
 const trackedMatch = (root, patterns) => gitLines(root, ['ls-files', ...patterns]);
+// Content reads are tracked-files-only too: only read a manifest if it is a
+// tracked top-level file, so untracked worktree clutter can't change the verdict.
+const readTracked = (root, top, name) => (top.has(name) ? read(path.join(root, name)) : '');
+const readTrackedJSON = (root, top, name) => (top.has(name) ? readJSON(path.join(root, name)) : null);
 const ABSTAIN = trigger => ({ value: null, source: 'ABSTAIN→agent', confidence: 'abstain', escalate: true, trigger });
 
 // Dirs that are NEVER, on their own, the gate-worthy source (Linguist-style).
@@ -54,57 +64,63 @@ function detectNesting(root) {
 
 function detectMonorepo(root, top) {
   const reasons = [];
-  const pkg = readJSON(path.join(root, 'package.json'));
+  const pkg = readTrackedJSON(root, top, 'package.json');
   if (pkg && pkg.workspaces) reasons.push('npm-workspaces');
   if (top.has('pnpm-workspace.yaml')) reasons.push('pnpm-workspace');
   if (top.has('turbo.json')) reasons.push('turbo');
   if (top.has('go.work')) reasons.push('go.work');
-  const cargo = read(path.join(root, 'Cargo.toml'));
+  const cargo = readTracked(root, top, 'Cargo.toml');
   if (/^\s*\[workspace\]/m.test(cargo) && /members\s*=/.test(cargo)) reasons.push('cargo-workspace');
   if (['apps', 'packages', 'services'].filter(d => top.has(d)).length >= 2) reasons.push('apps+packages');
   return { monorepo: reasons.length > 0, reasons };
 }
 
+// --- language-specific source resolvers (kept small; detectSource dispatches) ---
+function sourceRust(top) {
+  if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'rust' };
+  return ABSTAIN('rust-no-src');
+}
+function sourceGo(root, topDirs, has) {
+  const rootGo = trackedMatch(root, ['*.go']).some(f => !f.includes('/')); // tracked .go at repo root
+  if (rootGo) return { value: ['.'], source: 'code', confidence: 'high', lang: 'go', note: 'flat-root Go module' };
+  const goDirs = [...topDirs].filter(has); // DIRECTORIES only — never a top-level file like go.mod
+  if (goDirs.length) return { value: goDirs, source: 'code', confidence: 'medium', lang: 'go' };
+  return ABSTAIN('go-no-root-source');
+}
+function sourcePython(root, top) {
+  const py = readTracked(root, top, 'pyproject.toml');
+  const nameMatch = py.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
+  const pkgName = nameMatch ? nameMatch[1].replace(/-/g, '_') : null;
+  if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'python' };
+  if (pkgName && top.has(pkgName)) return { value: [pkgName], source: 'code', confidence: 'high', lang: 'python', note: 'flat-layout package' };
+  return ABSTAIN('python-package-dir-unresolved');
+}
+function sourceJs(root, top, conv, secondaryRoots) {
+  if (secondaryRoots.length) return { ...ABSTAIN('secondary-roots:' + secondaryRoots.join('+')), conventionalSeen: conv };
+  if (conv.length >= 1 && conv.length <= 2) return { value: conv, source: 'code', confidence: 'high', lang: 'js' };
+  const pkg = readTrackedJSON(root, top, 'package.json') || {};
+  // Only count a manifest entry that is an ACTUAL ROOT-LEVEL tracked file — a
+  // nested entry like main:"dist/index.js" must NOT resolve source to '.'.
+  const rootEntry = ['index.js', 'index.ts', 'index.mjs', pkg.main, pkg.module]
+    .filter(Boolean)
+    .map(f => String(f).replace(/^\.\//, ''))
+    .some(f => !f.includes('/') && top.has(f));
+  if (rootEntry) return { value: ['.'], source: 'code', confidence: 'medium', lang: 'js', note: 'root-entry single-file lib' };
+  return ABSTAIN('js-no-conventional-source');
+}
+
 // Language-aware, manifest-first, blocklist-filtered source resolution.
-function detectSource(root, top, nested, mono) {
+function detectSource(root, top, topDirs, nested, mono) {
   if (nested) return ABSTAIN('nested');
   if (mono.monorepo) return ABSTAIN('monorepo:' + mono.reasons.join('+'));
-
   const has = d => top.has(d) && !BLOCKLIST.has(d);
   const conv = ['src', 'lib', 'app'].filter(has);
   const secondaryRoots = ['convex', 'supabase', 'backend', 'frontend', 'server', 'functions', 'api', 'worker', 'workers', 'edge'].filter(d => top.has(d));
 
-  // Rust single crate: src/ is the canonical source; never pkg/.
-  if (top.has('Cargo.toml')) {
-    if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'rust' };
-    return ABSTAIN('rust-no-src');
-  }
-  // Go module: source is the module ROOT (flat-root) plus any non-blocklisted packages; never just internal/.
-  if (top.has('go.mod')) {
-    const rootGo = trackedMatch(root, ['*.go']).some(f => !f.includes('/')); // tracked .go at repo root
-    if (rootGo) return { value: ['.'], source: 'code', confidence: 'high', lang: 'go', note: 'flat-root Go module' };
-    const goDirs = [...top].filter(has);
-    if (goDirs.length) return { value: goDirs, source: 'code', confidence: 'medium', lang: 'go' };
-    return ABSTAIN('go-no-root-source');
-  }
-  // Python: package dir is named after the project (flat layout) or under src/.
-  const py = read(path.join(root, 'pyproject.toml'));
-  if (py || top.has('setup.py')) {
-    const nameMatch = py.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
-    const pkgName = nameMatch ? nameMatch[1].replace(/-/g, '_') : null;
-    if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'python' };
-    if (pkgName && top.has(pkgName)) return { value: [pkgName], source: 'code', confidence: 'high', lang: 'python', note: 'flat-layout package' };
-    return ABSTAIN('python-package-dir-unresolved');
-  }
-  // JS/TS: prefer lib/src; if only a root entry (index.js/exports) treat root as source.
-  if (top.has('package.json')) {
-    if (secondaryRoots.length) return { ...ABSTAIN('secondary-roots:' + secondaryRoots.join('+')), conventionalSeen: conv };
-    if (conv.length >= 1 && conv.length <= 2) return { value: conv, source: 'code', confidence: 'high', lang: 'js' };
-    const pkg = readJSON(path.join(root, 'package.json')) || {};
-    const rootEntry = ['index.js', 'index.ts', 'index.mjs', pkg.main, pkg.module].filter(Boolean).some(f => top.has(String(f).replace(/^\.\//, '').split('/')[0]));
-    if (rootEntry) return { value: ['.'], source: 'code', confidence: 'medium', lang: 'js', note: 'root-entry single-file lib' };
-    return ABSTAIN('js-no-conventional-source');
-  }
+  if (top.has('Cargo.toml')) return sourceRust(top);
+  if (top.has('go.mod')) return sourceGo(root, topDirs, has);
+  if (readTracked(root, top, 'pyproject.toml') || top.has('setup.py')) return sourcePython(root, top);
+  if (top.has('package.json')) return sourceJs(root, top, conv, secondaryRoots);
   // Unknown stack.
   if (secondaryRoots.length) return ABSTAIN('secondary-roots:' + secondaryRoots.join('+'));
   if (conv.length >= 1 && conv.length <= 2) return { value: conv, source: 'code', confidence: 'high' };
@@ -122,7 +138,7 @@ function detectToolchain(root, top, nested) {
   // No lockfile: fall back to manifest + non-lockfile pins.
   if (top.has('Cargo.toml')) return { value: 'cargo', source: 'code', confidence: 'high', note: 'Cargo.toml (lib omits Cargo.lock)' };
   if (top.has('go.mod')) return { value: 'go', source: 'code', confidence: 'high', note: 'go.mod' };
-  const pj = readJSON(path.join(root, 'package.json'));
+  const pj = readTrackedJSON(root, top, 'package.json');
   if (pj && pj.packageManager) return { value: String(pj.packageManager).split('@')[0], source: 'code', confidence: 'high', note: 'packageManager field' };
   return { value: null, source: 'code', confidence: 'abstain', escalateOrManual: true, note: 'no lockfile/manifest toolchain signal' };
 }
@@ -140,19 +156,24 @@ function detectAgents(root, top, nested) {
 }
 
 const CL_BASES = ['changelog', 'changes', 'history', 'news', 'releases'];
-function detectChangelog(root, top, nested) {
-  if (nested) return ABSTAIN('nested');
+// Case-insensitive top-level changelog file lookup (CHANGELOG/CHANGES/HISTORY/…, .md/.rst/.txt).
+function changelogByBaseName(root, top) {
   const topLower = new Map([...top].map(e => [e.toLowerCase(), e]));
   for (const base of CL_BASES) {
     for (const ext of ['.md', '.rst', '.txt', '']) {
-      const key = base + ext;
-      if (topLower.has(key)) {
-        const body = read(path.join(root, topLower.get(key)));
-        const keep = /keep a changelog/i.test(body) || /##\s*\[?unreleased\]?/i.test(body);
-        return { value: topLower.get(key), format: keep ? 'keep-a-changelog' : 'structured-or-freeform', source: 'code', confidence: keep ? 'high' : 'medium' };
-      }
+      const actual = topLower.get(base + ext);
+      if (!actual) continue;
+      const body = read(path.join(root, actual));
+      const keep = /keep a changelog/i.test(body) || /##\s*\[?unreleased\]?/i.test(body);
+      return { value: actual, format: keep ? 'keep-a-changelog' : 'structured-or-freeform', source: 'code', confidence: keep ? 'high' : 'medium' };
     }
   }
+  return null;
+}
+function detectChangelog(root, top, nested) {
+  if (nested) return ABSTAIN('nested');
+  const byName = changelogByBaseName(root, top);
+  if (byName) return byName;
   if (top.has('.changeset')) return { value: '.changeset', format: 'changesets', source: 'code', confidence: 'high' };
   const docsCl = trackedMatch(root, ['docs/**/release-notes.*', 'docs/**/changelog.*', 'docs/**/changes.*', 'docs/**/CHANGELOG.*']);
   if (docsCl.length) return { value: docsCl[0], format: 'docs-changelog', source: 'code', confidence: 'medium' };
@@ -182,10 +203,11 @@ function detectCI(root, top, nested) {
  */
 function detect(root) {
   const top = trackedTop(root);
+  const topDirs = trackedTopDirs(root);
   const nesting = detectNesting(root);
   const nested = nesting.nested;
   const mono = detectMonorepo(root, top);
-  const source = detectSource(root, top, nested, mono);
+  const source = detectSource(root, top, topDirs, nested, mono);
   const toolchain = detectToolchain(root, top, nested);
   const agents = detectAgents(root, top, nested);
   const changelog = detectChangelog(root, top, nested);
@@ -195,7 +217,11 @@ function detect(root) {
   if (nested) escalate.push({ field: 'whole-repo', trigger: 'nested-gitlink', detail: nesting.nestedDir });
   for (const [name, f] of Object.entries(fields)) if (f.escalate) escalate.push({ field: name, trigger: f.trigger });
   const codeHigh = Object.entries(fields).filter(([, f]) => f.source === 'code' && f.confidence === 'high').map(([n]) => n);
-  const verdict = escalate.length > 0 ? 'ESCALATE-TO-AGENT' : (changelog.confidence === 'abstain' || ci.confidence === 'abstain' ? 'MANUAL-CONFIG' : 'CODE-RESOLVED');
+  // MANUAL-CONFIG when ANY field is a code-side abstain (changelog/ci/toolchain
+  // with no signal) that wasn't escalated — a repo isn't fully CODE-RESOLVED
+  // while, say, its toolchain is unresolved.
+  const manualAbstain = Object.values(fields).some(f => f.source === 'code' && f.confidence === 'abstain');
+  const verdict = escalate.length > 0 ? 'ESCALATE-TO-AGENT' : (manualAbstain ? 'MANUAL-CONFIG' : 'CODE-RESOLVED');
   return { repo: path.basename(root), verdict, nested, monorepo: mono, escalate, codeHighConfidence: codeHigh, ...fields };
 }
 

--- a/lib/doc-gate/detect.js
+++ b/lib/doc-gate/detect.js
@@ -62,7 +62,7 @@ function detectNesting(root) {
   return { nested: false };
 }
 
-function detectMonorepo(root, top) {
+function detectMonorepo(root, top, topDirs) {
   const reasons = [];
   const pkg = readTrackedJSON(root, top, 'package.json');
   if (pkg && pkg.workspaces) reasons.push('npm-workspaces');
@@ -71,13 +71,15 @@ function detectMonorepo(root, top) {
   if (top.has('go.work')) reasons.push('go.work');
   const cargo = readTracked(root, top, 'Cargo.toml');
   if (/^\s*\[workspace\]/m.test(cargo) && /members\s*=/.test(cargo)) reasons.push('cargo-workspace');
-  if (['apps', 'packages', 'services'].filter(d => top.has(d)).length >= 2) reasons.push('apps+packages');
+  if (['apps', 'packages', 'services'].filter(d => topDirs.has(d)).length >= 2) reasons.push('apps+packages');
   return { monorepo: reasons.length > 0, reasons };
 }
 
 // --- language-specific source resolvers (kept small; detectSource dispatches) ---
-function sourceRust(top) {
-  if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'rust' };
+// All directory candidates come from topDirs (tracked tree entries) so a tracked
+// FILE named src/lib/<pkg> is never mistaken for a source directory.
+function sourceRust(topDirs) {
+  if (topDirs.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'rust' };
   return ABSTAIN('rust-no-src');
 }
 function sourceGo(root, topDirs, has) {
@@ -87,12 +89,12 @@ function sourceGo(root, topDirs, has) {
   if (goDirs.length) return { value: goDirs, source: 'code', confidence: 'medium', lang: 'go' };
   return ABSTAIN('go-no-root-source');
 }
-function sourcePython(root, top) {
+function sourcePython(root, top, topDirs) {
   const py = readTracked(root, top, 'pyproject.toml');
   const nameMatch = py.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
   const pkgName = nameMatch ? nameMatch[1].replace(/-/g, '_') : null;
-  if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'python' };
-  if (pkgName && top.has(pkgName)) return { value: [pkgName], source: 'code', confidence: 'high', lang: 'python', note: 'flat-layout package' };
+  if (topDirs.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'python' };
+  if (pkgName && topDirs.has(pkgName)) return { value: [pkgName], source: 'code', confidence: 'high', lang: 'python', note: 'flat-layout package' };
   return ABSTAIN('python-package-dir-unresolved');
 }
 function sourceJs(root, top, conv, secondaryRoots) {
@@ -113,13 +115,13 @@ function sourceJs(root, top, conv, secondaryRoots) {
 function detectSource(root, top, topDirs, nested, mono) {
   if (nested) return ABSTAIN('nested');
   if (mono.monorepo) return ABSTAIN('monorepo:' + mono.reasons.join('+'));
-  const has = d => top.has(d) && !BLOCKLIST.has(d);
+  const has = d => topDirs.has(d) && !BLOCKLIST.has(d);
   const conv = ['src', 'lib', 'app'].filter(has);
-  const secondaryRoots = ['convex', 'supabase', 'backend', 'frontend', 'server', 'functions', 'api', 'worker', 'workers', 'edge'].filter(d => top.has(d));
+  const secondaryRoots = ['convex', 'supabase', 'backend', 'frontend', 'server', 'functions', 'api', 'worker', 'workers', 'edge'].filter(d => topDirs.has(d));
 
-  if (top.has('Cargo.toml')) return sourceRust(top);
+  if (top.has('Cargo.toml')) return sourceRust(topDirs);
   if (top.has('go.mod')) return sourceGo(root, topDirs, has);
-  if (readTracked(root, top, 'pyproject.toml') || top.has('setup.py')) return sourcePython(root, top);
+  if (readTracked(root, top, 'pyproject.toml') || top.has('setup.py')) return sourcePython(root, top, topDirs);
   if (top.has('package.json')) return sourceJs(root, top, conv, secondaryRoots);
   // Unknown stack.
   if (secondaryRoots.length) return ABSTAIN('secondary-roots:' + secondaryRoots.join('+'));
@@ -206,7 +208,7 @@ function detect(root) {
   const topDirs = trackedTopDirs(root);
   const nesting = detectNesting(root);
   const nested = nesting.nested;
-  const mono = detectMonorepo(root, top);
+  const mono = detectMonorepo(root, top, topDirs);
   const source = detectSource(root, top, topDirs, nested, mono);
   const toolchain = detectToolchain(root, top, nested);
   const agents = detectAgents(root, top, nested);

--- a/lib/doc-gate/detect.js
+++ b/lib/doc-gate/detect.js
@@ -1,0 +1,202 @@
+'use strict';
+
+/**
+ * doc-gate repo-structure detector.
+ *
+ * Ported verbatim (logic-for-logic) from the empirically-validated HYBRID
+ * detector v4. v4 was tested to ZERO "silent-wrong" (a high-confidence answer
+ * that is actually wrong) across 9 local repos AND 8 diverse OSS repos
+ * (Python/Go/Rust/JS). The only changes from the reference are the module
+ * boundary (no CLI `console.log`; `module.exports` instead) — the detection
+ * logic, blocklist, regexes, and branch ordering are unchanged on purpose.
+ *
+ * Design (do not regress):
+ *  - Tracked-files-only: every EXISTENCE signal comes from `git ls-tree HEAD` /
+ *    `git ls-files` (never the raw filesystem) so untracked clutter and
+ *    gitignored worktree/node_modules lockfiles can't poison detection. File
+ *    CONTENT is still read with fs once a tracked path is known.
+ *  - Per-field results for source/toolchain/ci/changelog/agents, each
+ *    `{ value, source: 'code'|'ABSTAIN→agent', confidence: 'high'|'medium'|'abstain', escalate? }`.
+ *  - Abstain-by-default on the error-prone fields; emit HIGH only where
+ *    deterministic. `codeHighConfidence` lists the silent-wrong-eligible fields.
+ *  - Escalation triggers: monorepo (npm/pnpm/turbo workspaces, Cargo
+ *    `[workspace]`, `go.work`), nested gitlink wrapper (escalate ALL fields),
+ *    multiple conflicting lockfiles, and secondary non-conventional source roots.
+ *  - SOURCE is language/manifest-first with a packaging/private-dir BLOCKLIST so
+ *    it never returns internal/pkg/vendor/etc as THE source (the fix that
+ *    eliminated the two real-world silent-wrongs: Go `internal/`, Rust `pkg/`).
+ *
+ * @module doc-gate/detect
+ */
+
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const read = p => { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } };
+const readJSON = p => { try { return JSON.parse(read(p)); } catch { return null; } };
+const git = (root, args) => { try { return cp.execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }); } catch { return ''; } };
+const gitLines = (root, args) => git(root, args).split('\n').map(s => s.trim()).filter(Boolean);
+const trackedTop = root => new Set(gitLines(root, ['ls-tree', 'HEAD', '--name-only']));
+const trackedMatch = (root, patterns) => gitLines(root, ['ls-files', ...patterns]);
+const ABSTAIN = trigger => ({ value: null, source: 'ABSTAIN→agent', confidence: 'abstain', escalate: true, trigger });
+
+// Dirs that are NEVER, on their own, the gate-worthy source (Linguist-style).
+const BLOCKLIST = new Set(['internal', 'pkg', 'vendor', 'testdata', 'examples', 'example', 'tests', 'test', 'docs', 'doc', 'dist', 'build', 'target', 'node_modules', 'scripts', 'tools', 'bench', 'benches', '.github', 'assets', 'public', 'static']);
+
+function detectNesting(root) {
+  const lines = git(root, ['ls-tree', 'HEAD']).split('\n').filter(Boolean);
+  if (!lines.length) return { nested: false };
+  const gitlinks = lines.filter(l => l.startsWith('160000'));
+  if (gitlinks.length >= 1 && lines.length - gitlinks.length <= 1) return { nested: true, nestedDir: gitlinks[0].split('\t').pop() };
+  return { nested: false };
+}
+
+function detectMonorepo(root, top) {
+  const reasons = [];
+  const pkg = readJSON(path.join(root, 'package.json'));
+  if (pkg && pkg.workspaces) reasons.push('npm-workspaces');
+  if (top.has('pnpm-workspace.yaml')) reasons.push('pnpm-workspace');
+  if (top.has('turbo.json')) reasons.push('turbo');
+  if (top.has('go.work')) reasons.push('go.work');
+  const cargo = read(path.join(root, 'Cargo.toml'));
+  if (/^\s*\[workspace\]/m.test(cargo) && /members\s*=/.test(cargo)) reasons.push('cargo-workspace');
+  if (['apps', 'packages', 'services'].filter(d => top.has(d)).length >= 2) reasons.push('apps+packages');
+  return { monorepo: reasons.length > 0, reasons };
+}
+
+// Language-aware, manifest-first, blocklist-filtered source resolution.
+function detectSource(root, top, nested, mono) {
+  if (nested) return ABSTAIN('nested');
+  if (mono.monorepo) return ABSTAIN('monorepo:' + mono.reasons.join('+'));
+
+  const has = d => top.has(d) && !BLOCKLIST.has(d);
+  const conv = ['src', 'lib', 'app'].filter(has);
+  const secondaryRoots = ['convex', 'supabase', 'backend', 'frontend', 'server', 'functions', 'api', 'worker', 'workers', 'edge'].filter(d => top.has(d));
+
+  // Rust single crate: src/ is the canonical source; never pkg/.
+  if (top.has('Cargo.toml')) {
+    if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'rust' };
+    return ABSTAIN('rust-no-src');
+  }
+  // Go module: source is the module ROOT (flat-root) plus any non-blocklisted packages; never just internal/.
+  if (top.has('go.mod')) {
+    const rootGo = trackedMatch(root, ['*.go']).some(f => !f.includes('/')); // tracked .go at repo root
+    if (rootGo) return { value: ['.'], source: 'code', confidence: 'high', lang: 'go', note: 'flat-root Go module' };
+    const goDirs = [...top].filter(has);
+    if (goDirs.length) return { value: goDirs, source: 'code', confidence: 'medium', lang: 'go' };
+    return ABSTAIN('go-no-root-source');
+  }
+  // Python: package dir is named after the project (flat layout) or under src/.
+  const py = read(path.join(root, 'pyproject.toml'));
+  if (py || top.has('setup.py')) {
+    const nameMatch = py.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
+    const pkgName = nameMatch ? nameMatch[1].replace(/-/g, '_') : null;
+    if (top.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'python' };
+    if (pkgName && top.has(pkgName)) return { value: [pkgName], source: 'code', confidence: 'high', lang: 'python', note: 'flat-layout package' };
+    return ABSTAIN('python-package-dir-unresolved');
+  }
+  // JS/TS: prefer lib/src; if only a root entry (index.js/exports) treat root as source.
+  if (top.has('package.json')) {
+    if (secondaryRoots.length) return { ...ABSTAIN('secondary-roots:' + secondaryRoots.join('+')), conventionalSeen: conv };
+    if (conv.length >= 1 && conv.length <= 2) return { value: conv, source: 'code', confidence: 'high', lang: 'js' };
+    const pkg = readJSON(path.join(root, 'package.json')) || {};
+    const rootEntry = ['index.js', 'index.ts', 'index.mjs', pkg.main, pkg.module].filter(Boolean).some(f => top.has(String(f).replace(/^\.\//, '').split('/')[0]));
+    if (rootEntry) return { value: ['.'], source: 'code', confidence: 'medium', lang: 'js', note: 'root-entry single-file lib' };
+    return ABSTAIN('js-no-conventional-source');
+  }
+  // Unknown stack.
+  if (secondaryRoots.length) return ABSTAIN('secondary-roots:' + secondaryRoots.join('+'));
+  if (conv.length >= 1 && conv.length <= 2) return { value: conv, source: 'code', confidence: 'high' };
+  return ABSTAIN(conv.length ? 'ambiguous' : 'no-conventional-source-dir');
+}
+
+const LOCK = { 'bun.lockb': 'bun', 'bun.lock': 'bun', 'pnpm-lock.yaml': 'pnpm', 'yarn.lock': 'yarn', 'package-lock.json': 'npm', 'uv.lock': 'uv', 'poetry.lock': 'poetry', 'Pipfile.lock': 'pipenv', 'Cargo.lock': 'cargo', 'go.sum': 'go', 'composer.lock': 'composer' };
+function detectToolchain(root, top, nested) {
+  if (nested) return ABSTAIN('nested');
+  const hits = trackedMatch(root, Object.keys(LOCK).map(f => '*' + f));
+  const locks = hits.map(h => ({ file: h, manager: LOCK[h.split('/').pop()] })).filter(l => l.manager);
+  const managers = [...new Set(locks.map(l => l.manager))];
+  if (managers.length === 1) return { value: managers[0], source: 'code', confidence: 'high', lockfiles: locks.map(l => l.file) };
+  if (managers.length > 1) return { ...ABSTAIN('multiple-lockfiles'), conflicting: locks };
+  // No lockfile: fall back to manifest + non-lockfile pins.
+  if (top.has('Cargo.toml')) return { value: 'cargo', source: 'code', confidence: 'high', note: 'Cargo.toml (lib omits Cargo.lock)' };
+  if (top.has('go.mod')) return { value: 'go', source: 'code', confidence: 'high', note: 'go.mod' };
+  const pj = readJSON(path.join(root, 'package.json'));
+  if (pj && pj.packageManager) return { value: String(pj.packageManager).split('@')[0], source: 'code', confidence: 'high', note: 'packageManager field' };
+  return { value: null, source: 'code', confidence: 'abstain', escalateOrManual: true, note: 'no lockfile/manifest toolchain signal' };
+}
+
+const AGENT_SURFACES = [['.claude', 'claude'], ['.codex', 'codex'], ['.cursor', 'cursor'], ['.cline', 'cline'], ['.roo', 'roo'], ['.kilocode', 'kilocode'], ['.opencode', 'opencode'], ['.windsurf', 'windsurf'], ['AGENTS.md', 'agents-md'], ['CLAUDE.md', 'claude'], ['GEMINI.md', 'gemini'], ['.cursorrules', 'cursor'], ['.clinerules', 'cline'], ['.github/copilot-instructions.md', 'copilot']];
+function detectAgents(root, top, nested) {
+  const found = new Set();
+  for (const [surface, name] of AGENT_SURFACES) {
+    if (surface.includes('/') || surface.endsWith('.md')) { if (trackedMatch(root, [surface]).length) found.add(name); }
+    else if (top.has(surface)) found.add(name);
+  }
+  const list = [...found];
+  if (nested) return { value: list, source: 'ABSTAIN→agent', confidence: 'abstain', escalate: true, trigger: 'nested' };
+  return { value: list, source: 'code', confidence: 'medium', note: 'tracked agent-surface enumeration (non-exhaustive)' };
+}
+
+const CL_BASES = ['changelog', 'changes', 'history', 'news', 'releases'];
+function detectChangelog(root, top, nested) {
+  if (nested) return ABSTAIN('nested');
+  const topLower = new Map([...top].map(e => [e.toLowerCase(), e]));
+  for (const base of CL_BASES) {
+    for (const ext of ['.md', '.rst', '.txt', '']) {
+      const key = base + ext;
+      if (topLower.has(key)) {
+        const body = read(path.join(root, topLower.get(key)));
+        const keep = /keep a changelog/i.test(body) || /##\s*\[?unreleased\]?/i.test(body);
+        return { value: topLower.get(key), format: keep ? 'keep-a-changelog' : 'structured-or-freeform', source: 'code', confidence: keep ? 'high' : 'medium' };
+      }
+    }
+  }
+  if (top.has('.changeset')) return { value: '.changeset', format: 'changesets', source: 'code', confidence: 'high' };
+  const docsCl = trackedMatch(root, ['docs/**/release-notes.*', 'docs/**/changelog.*', 'docs/**/changes.*', 'docs/**/CHANGELOG.*']);
+  if (docsCl.length) return { value: docsCl[0], format: 'docs-changelog', source: 'code', confidence: 'medium' };
+  if (trackedMatch(root, ['.github/release-drafter.yml']).length) return { value: 'release-drafter', source: 'code', confidence: 'high' };
+  if (top.has('.commitlintrc.json') || trackedMatch(root, ['.commitlintrc*', 'commitlint.config.*']).length) return { value: 'conventional-commits', source: 'code', confidence: 'medium' };
+  return { value: null, source: 'code', confidence: 'abstain', escalateOrManual: true, note: 'no tracked changelog mechanism' };
+}
+
+function detectCI(root, top, nested) {
+  if (nested) return ABSTAIN('nested');
+  if (top.has('.github')) {
+    const wf = trackedMatch(root, ['.github/workflows/*.yml', '.github/workflows/*.yaml']).map(f => f.split('/').pop());
+    if (wf.length) return { provider: 'github-actions', workflows: wf, source: 'code', confidence: 'high' };
+  }
+  if (top.has('.gitlab-ci.yml')) return { provider: 'gitlab-ci', source: 'code', confidence: 'medium' };
+  if (top.has('.circleci')) return { provider: 'circleci', source: 'code', confidence: 'medium' };
+  return { provider: null, source: 'code', confidence: 'abstain', escalateOrManual: true, note: 'no tracked CI provider' };
+}
+
+/**
+ * Run the repo-structure detector against a git working tree.
+ *
+ * @param {string} root - Absolute path to the repository root (a git working tree).
+ * @returns {{ repo: string, verdict: 'ESCALATE-TO-AGENT'|'MANUAL-CONFIG'|'CODE-RESOLVED',
+ *   nested: boolean, monorepo: object, escalate: Array, codeHighConfidence: string[],
+ *   source: object, toolchain: object, agents: object, changelog: object, ci: object }}
+ */
+function detect(root) {
+  const top = trackedTop(root);
+  const nesting = detectNesting(root);
+  const nested = nesting.nested;
+  const mono = detectMonorepo(root, top);
+  const source = detectSource(root, top, nested, mono);
+  const toolchain = detectToolchain(root, top, nested);
+  const agents = detectAgents(root, top, nested);
+  const changelog = detectChangelog(root, top, nested);
+  const ci = detectCI(root, top, nested);
+  const fields = { source, toolchain, agents, changelog, ci };
+  const escalate = [];
+  if (nested) escalate.push({ field: 'whole-repo', trigger: 'nested-gitlink', detail: nesting.nestedDir });
+  for (const [name, f] of Object.entries(fields)) if (f.escalate) escalate.push({ field: name, trigger: f.trigger });
+  const codeHigh = Object.entries(fields).filter(([, f]) => f.source === 'code' && f.confidence === 'high').map(([n]) => n);
+  const verdict = escalate.length > 0 ? 'ESCALATE-TO-AGENT' : (changelog.confidence === 'abstain' || ci.confidence === 'abstain' ? 'MANUAL-CONFIG' : 'CODE-RESOLVED');
+  return { repo: path.basename(root), verdict, nested, monorepo: mono, escalate, codeHighConfidence: codeHigh, ...fields };
+}
+
+module.exports = { detect, BLOCKLIST };

--- a/lib/doc-gate/detect.js
+++ b/lib/doc-gate/detect.js
@@ -27,13 +27,14 @@
  * @module doc-gate/detect
  */
 
-const fs = require('fs');
-const path = require('path');
-const cp = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const cp = require('node:child_process');
 
 const read = p => { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } };
 const readJSON = p => { try { return JSON.parse(read(p)); } catch { return null; } };
-const git = (root, args) => { try { return cp.execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }); } catch { return ''; } };
+// NOSONAR S4036 - 'git' is a hardcoded CLI command with no user input; developer-tool context.
+const git = (root, args) => { try { return cp.execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }); } catch { return ''; } }; // NOSONAR S4036
 const gitLines = (root, args) => git(root, args).split('\n').map(s => s.trim()).filter(Boolean);
 const trackedTop = root => new Set(gitLines(root, ['ls-tree', 'HEAD', '--name-only']));
 // Top-level TRACKED directories only (git object type `tree`), so file entries
@@ -65,7 +66,7 @@ function detectNesting(root) {
 function detectMonorepo(root, top, topDirs) {
   const reasons = [];
   const pkg = readTrackedJSON(root, top, 'package.json');
-  if (pkg && pkg.workspaces) reasons.push('npm-workspaces');
+  if (pkg?.workspaces) reasons.push('npm-workspaces');
   if (top.has('pnpm-workspace.yaml')) reasons.push('pnpm-workspace');
   if (top.has('turbo.json')) reasons.push('turbo');
   if (top.has('go.work')) reasons.push('go.work');
@@ -85,14 +86,14 @@ function sourceRust(topDirs) {
 function sourceGo(root, topDirs, has) {
   const rootGo = trackedMatch(root, ['*.go']).some(f => !f.includes('/')); // tracked .go at repo root
   if (rootGo) return { value: ['.'], source: 'code', confidence: 'high', lang: 'go', note: 'flat-root Go module' };
-  const goDirs = [...topDirs].filter(has); // DIRECTORIES only — never a top-level file like go.mod
+  const goDirs = [...topDirs].filter(d => has(d)); // DIRECTORIES only — never a top-level file like go.mod
   if (goDirs.length) return { value: goDirs, source: 'code', confidence: 'medium', lang: 'go' };
   return ABSTAIN('go-no-root-source');
 }
 function sourcePython(root, top, topDirs) {
   const py = readTracked(root, top, 'pyproject.toml');
   const nameMatch = py.match(/^\s*name\s*=\s*["']([^"']+)["']/m);
-  const pkgName = nameMatch ? nameMatch[1].replace(/-/g, '_') : null;
+  const pkgName = nameMatch ? nameMatch[1].replaceAll('-', '_') : null;
   if (topDirs.has('src')) return { value: ['src'], source: 'code', confidence: 'high', lang: 'python' };
   if (pkgName && topDirs.has(pkgName)) return { value: [pkgName], source: 'code', confidence: 'high', lang: 'python', note: 'flat-layout package' };
   return ABSTAIN('python-package-dir-unresolved');
@@ -141,7 +142,7 @@ function detectToolchain(root, top, nested) {
   if (top.has('Cargo.toml')) return { value: 'cargo', source: 'code', confidence: 'high', note: 'Cargo.toml (lib omits Cargo.lock)' };
   if (top.has('go.mod')) return { value: 'go', source: 'code', confidence: 'high', note: 'go.mod' };
   const pj = readTrackedJSON(root, top, 'package.json');
-  if (pj && pj.packageManager) return { value: String(pj.packageManager).split('@')[0], source: 'code', confidence: 'high', note: 'packageManager field' };
+  if (pj?.packageManager) return { value: String(pj.packageManager).split('@')[0], source: 'code', confidence: 'high', note: 'packageManager field' };
   return { value: null, source: 'code', confidence: 'abstain', escalateOrManual: true, note: 'no lockfile/manifest toolchain signal' };
 }
 
@@ -223,7 +224,9 @@ function detect(root) {
   // with no signal) that wasn't escalated — a repo isn't fully CODE-RESOLVED
   // while, say, its toolchain is unresolved.
   const manualAbstain = Object.values(fields).some(f => f.source === 'code' && f.confidence === 'abstain');
-  const verdict = escalate.length > 0 ? 'ESCALATE-TO-AGENT' : (manualAbstain ? 'MANUAL-CONFIG' : 'CODE-RESOLVED');
+  let verdict = 'CODE-RESOLVED';
+  if (escalate.length > 0) verdict = 'ESCALATE-TO-AGENT';
+  else if (manualAbstain) verdict = 'MANUAL-CONFIG';
   return { repo: path.basename(root), verdict, nested, monorepo: mono, escalate, codeHighConfidence: codeHigh, ...fields };
 }
 

--- a/test/commands/doc-gate.test.js
+++ b/test/commands/doc-gate.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const { describe, expect, test, afterAll } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const docGate = require('../../lib/commands/doc-gate');
+
+const createdDirs = [];
+
+function makeRustRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-docgate-cmd-'));
+  createdDirs.push(dir);
+  const g = args => execFileSync('git', ['-C', dir, ...args], { stdio: ['ignore', 'ignore', 'ignore'] });
+  g(['init', '-q']);
+  g(['config', 'user.email', 'test@example.com']);
+  g(['config', 'user.name', 'Test']);
+  g(['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(dir, 'Cargo.toml'), '[package]\nname = "x"\nversion = "0.1.0"\n');
+  fs.mkdirSync(path.join(dir, 'src'));
+  fs.writeFileSync(path.join(dir, 'src', 'main.rs'), 'fn main() {}\n');
+  g(['add', '-A']);
+  g(['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+function makeNonGitDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-docgate-nogit-'));
+  createdDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe('forge doc-gate command', () => {
+  test('exposes the registry contract', () => {
+    expect(docGate.name).toBe('doc-gate');
+    expect(typeof docGate.description).toBe('string');
+    expect(typeof docGate.handler).toBe('function');
+  });
+
+  test('detect (default subcommand) prints a human summary and exits 0', async () => {
+    const repo = makeRustRepo();
+    const res = await docGate.handler([], {}, repo, {});
+    expect(res.success).toBe(true);
+    expect(res.exitCode).toBeUndefined();
+    expect(res.output).toContain('doc-gate detect');
+    expect(res.output).toContain('verdict:');
+    expect(res.output).toContain('source');
+  });
+
+  test('--json emits a structured object equal to the detector result', async () => {
+    const repo = makeRustRepo();
+    const res = await docGate.handler(['detect', '--json'], {}, repo, {});
+    expect(res.success).toBe(true);
+    const parsed = JSON.parse(res.output);
+    expect(parsed.source.value).toEqual(['src']);
+    expect(parsed.toolchain.value).toBe('cargo');
+    expect(parsed.verdict).toBeDefined();
+  });
+
+  test('--json also honored via parsed flags object', async () => {
+    const repo = makeRustRepo();
+    const res = await docGate.handler(['detect'], { json: true }, repo, {});
+    expect(() => JSON.parse(res.output)).not.toThrow();
+  });
+
+  test('unknown subcommand is a real error (exit 1)', async () => {
+    const repo = makeRustRepo();
+    const res = await docGate.handler(['bogus'], {}, repo, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toContain('Unknown doc-gate subcommand');
+  });
+
+  test('non-git directory is a real error (exit 1)', async () => {
+    const dir = makeNonGitDir();
+    const res = await docGate.handler(['detect'], {}, dir, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toContain('git repository');
+  });
+});

--- a/test/commands/doc-gate.test.js
+++ b/test/commands/doc-gate.test.js
@@ -7,6 +7,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const docGate = require('../../lib/commands/doc-gate');
+const { detect } = require('../../lib/doc-gate/detect');
 
 const createdDirs = [];
 
@@ -62,7 +63,7 @@ describe('forge doc-gate command', () => {
     const parsed = JSON.parse(res.output);
     expect(parsed.source.value).toEqual(['src']);
     expect(parsed.toolchain.value).toBe('cargo');
-    expect(parsed.verdict).toBeDefined();
+    expect(parsed).toEqual(detect(repo)); // thin-wrapper: CLI --json equals detect() exactly
   });
 
   test('--json also honored via parsed flags object', async () => {

--- a/test/doc-gate/detect.test.js
+++ b/test/doc-gate/detect.test.js
@@ -1,0 +1,235 @@
+'use strict';
+
+const { describe, expect, test, afterAll } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { detect } = require('../../lib/doc-gate/detect');
+
+const createdDirs = [];
+
+/**
+ * Build a real, committed git repo in a temp dir.
+ * @param {Object<string,string>} files - relative path -> file content.
+ * @param {{ gitlink?: { sha: string, name: string } }} [opts]
+ * @returns {string} absolute repo root.
+ */
+function makeRepo(files = {}, opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-docgate-'));
+  createdDirs.push(dir);
+  const g = args => execFileSync('git', ['-C', dir, ...args], { stdio: ['ignore', 'ignore', 'ignore'] });
+  g(['init', '-q']);
+  g(['config', 'user.email', 'test@example.com']);
+  g(['config', 'user.name', 'Test']);
+  g(['config', 'commit.gpgsign', 'false']);
+  g(['config', 'core.autocrlf', 'false']);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  g(['add', '-A']);
+  if (opts.gitlink) {
+    g(['update-index', '--add', '--cacheinfo', `160000,${opts.gitlink.sha},${opts.gitlink.name}`]);
+  }
+  g(['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe('doc-gate detect — source (manifest-first + blocklist)', () => {
+  test('Rust single crate → source [src], toolchain cargo (no Cargo.lock)', () => {
+    const repo = makeRepo({
+      'Cargo.toml': '[package]\nname = "mycrate"\nversion = "0.1.0"\n',
+      'src/main.rs': 'fn main() {}\n',
+    });
+    const r = detect(repo);
+    expect(r.source.value).toEqual(['src']);
+    expect(r.source.confidence).toBe('high');
+    expect(r.source.source).toBe('code');
+    expect(r.toolchain.value).toBe('cargo');
+    expect(r.toolchain.confidence).toBe('high');
+    expect([...r.codeHighConfidence].sort()).toEqual(['source', 'toolchain']);
+  });
+
+  test('Rust Cargo workspace → source ESCALATES (monorepo), never pkg', () => {
+    const repo = makeRepo({
+      'Cargo.toml': '[workspace]\nmembers = ["crates/a"]\n',
+      'crates/a/Cargo.toml': '[package]\nname = "a"\nversion = "0.1.0"\n',
+      'crates/a/src/lib.rs': 'pub fn a() {}\n',
+      'pkg/scratch.rs': '// packaging dir that must never be THE source\n',
+    });
+    const r = detect(repo);
+    expect(r.monorepo.monorepo).toBe(true);
+    expect(r.monorepo.reasons).toContain('cargo-workspace');
+    expect(r.source.escalate).toBe(true);
+    expect(r.source.value).toBeNull();
+    expect(r.source.trigger).toContain('monorepo');
+    expect(r.codeHighConfidence).not.toContain('source');
+    expect(r.escalate.map(e => e.field)).toContain('source');
+  });
+
+  test('Go flat-root module (root .go + internal/) → source ["."], never internal', () => {
+    const repo = makeRepo({
+      'go.mod': 'module example.com/foo\n\ngo 1.21\n',
+      'main.go': 'package main\n\nfunc main() {}\n',
+      'internal/helper.go': 'package internal\n',
+    });
+    const r = detect(repo);
+    expect(r.source.value).toEqual(['.']);
+    expect(r.source.confidence).toBe('high');
+    expect(r.source.value).not.toContain('internal');
+    expect(r.toolchain.value).toBe('go');
+    expect(r.codeHighConfidence).toContain('source');
+  });
+
+  test('Python flat-layout (pyproject name + <pkg>/) → source [<pkg>]', () => {
+    const repo = makeRepo({
+      'pyproject.toml': '[project]\nname = "my-pkg"\nversion = "0.1.0"\n',
+      'my_pkg/__init__.py': '',
+      'my_pkg/core.py': 'X = 1\n',
+    });
+    const r = detect(repo);
+    expect(r.source.value).toEqual(['my_pkg']);
+    expect(r.source.confidence).toBe('high');
+    expect(r.codeHighConfidence).toContain('source');
+  });
+
+  test('Python src-layout → source [src]', () => {
+    const repo = makeRepo({
+      'pyproject.toml': '[project]\nname = "my-pkg"\nversion = "0.1.0"\n',
+      'src/my_pkg/__init__.py': '',
+    });
+    const r = detect(repo);
+    expect(r.source.value).toEqual(['src']);
+    expect(r.source.confidence).toBe('high');
+  });
+
+  test('JS single package (lib/ + one lockfile) → source [lib], toolchain from lockfile', () => {
+    const repo = makeRepo({
+      'package.json': '{"name":"x","version":"1.0.0"}\n',
+      'lib/index.js': 'module.exports = {};\n',
+      'package-lock.json': '{}\n',
+    });
+    const r = detect(repo);
+    expect(r.source.value).toEqual(['lib']);
+    expect(r.source.confidence).toBe('high');
+    expect(r.toolchain.value).toBe('npm');
+    expect(r.toolchain.confidence).toBe('high');
+    expect([...r.codeHighConfidence].sort()).toEqual(['source', 'toolchain']);
+  });
+
+  test('JS with secondary root (src/ + convex/) → source ESCALATES', () => {
+    const repo = makeRepo({
+      'package.json': '{"name":"x","version":"1.0.0"}\n',
+      'src/index.js': 'export default 1;\n',
+      'convex/schema.ts': 'export default {};\n',
+    });
+    const r = detect(repo);
+    expect(r.source.escalate).toBe(true);
+    expect(r.source.trigger).toContain('secondary-roots');
+    expect(r.source.trigger).toContain('convex');
+    expect(r.codeHighConfidence).not.toContain('source');
+    expect(r.escalate.map(e => e.field)).toContain('source');
+  });
+});
+
+describe('doc-gate detect — toolchain', () => {
+  test('multiple conflicting lockfiles → toolchain ESCALATES (no guess)', () => {
+    const repo = makeRepo({
+      'package.json': '{"name":"x","version":"1.0.0"}\n',
+      'lib/index.js': 'module.exports = {};\n',
+      'package-lock.json': '{}\n',
+      'yarn.lock': '# yarn lockfile\n',
+    });
+    const r = detect(repo);
+    expect(r.toolchain.escalate).toBe(true);
+    expect(r.toolchain.value).toBeNull();
+    expect(r.toolchain.trigger).toBe('multiple-lockfiles');
+    expect(r.codeHighConfidence).not.toContain('toolchain');
+    expect(r.escalate.map(e => e.field)).toContain('toolchain');
+    // source is still resolvable + correct → only correct fields are high-confidence.
+    expect(r.source.value).toEqual(['lib']);
+  });
+});
+
+describe('doc-gate detect — nested gitlink wrapper', () => {
+  test('gitlink-only wrapper → every field ESCALATES', () => {
+    const repo = makeRepo({}, {
+      gitlink: { sha: '1111111111111111111111111111111111111111', name: 'sub' },
+    });
+    const r = detect(repo);
+    expect(r.nested).toBe(true);
+    expect(r.verdict).toBe('ESCALATE-TO-AGENT');
+    expect(r.source.escalate).toBe(true);
+    expect(r.toolchain.escalate).toBe(true);
+    expect(r.changelog.escalate).toBe(true);
+    expect(r.ci.escalate).toBe(true);
+    expect(r.agents.escalate).toBe(true);
+    expect(r.escalate.map(e => e.field)).toContain('whole-repo');
+    expect(r.codeHighConfidence).toEqual([]);
+  });
+});
+
+describe('doc-gate detect — changelog (case-insensitive + broad)', () => {
+  test('History.md (case) is detected', () => {
+    const repo = makeRepo({ 'History.md': '# History\n\n- 1.0.0 first\n' });
+    const r = detect(repo);
+    expect(r.changelog.value).toBe('History.md');
+    expect(r.changelog.source).toBe('code');
+  });
+
+  test('CHANGES.rst (.rst) is detected', () => {
+    const repo = makeRepo({ 'CHANGES.rst': 'Changes\n=======\n' });
+    const r = detect(repo);
+    expect(r.changelog.value).toBe('CHANGES.rst');
+  });
+
+  test('docs/**/release-notes.* is detected', () => {
+    const repo = makeRepo({
+      'package.json': '{"name":"x","version":"1.0.0"}\n',
+      'docs/guide/release-notes.md': '# Release notes\n',
+    });
+    const r = detect(repo);
+    expect(r.changelog.value).toBe('docs/guide/release-notes.md');
+    expect(r.changelog.format).toBe('docs-changelog');
+  });
+
+  test('keep-a-changelog is classified by content', () => {
+    const repo = makeRepo({
+      'CHANGELOG.md':
+        '# Changelog\n\nThe format is based on [Keep a Changelog].\n\n## [Unreleased]\n',
+    });
+    const r = detect(repo);
+    expect(r.changelog.value).toBe('CHANGELOG.md');
+    expect(r.changelog.format).toBe('keep-a-changelog');
+    expect(r.changelog.confidence).toBe('high');
+  });
+});
+
+describe('doc-gate detect — codeHighConfidence is never silent-wrong', () => {
+  test('only deterministic, correct fields appear as code-high-confidence', () => {
+    // A fixture deliberately mixing a resolvable source/toolchain with abstaining
+    // changelog/ci: high-confidence must contain ONLY the correct fields.
+    const repo = makeRepo({
+      'Cargo.toml': '[package]\nname = "x"\nversion = "0.1.0"\n',
+      'src/lib.rs': 'pub fn x() {}\n',
+    });
+    const r = detect(repo);
+    for (const field of r.codeHighConfidence) {
+      expect(r[field].source).toBe('code');
+      expect(r[field].confidence).toBe('high');
+      expect(r[field].escalate).toBeFalsy();
+    }
+    // The two error-prone fields here abstain rather than guess.
+    expect(r.changelog.confidence).toBe('abstain');
+    expect(r.ci.confidence).toBe('abstain');
+  });
+});


### PR DESCRIPTION
## Summary

First PR of the larger **doc-gate** feature. Ports the empirically-validated
HYBRID repo-structure detector (v4) into forge as a reusable module plus a thin
command. Scope is deliberately tight: the **detector core only** — no CI gate,
no OKF generation, no agent-escalation runtime here (see follow-ups).

- `lib/doc-gate/detect.js` — reusable detector (faithful port; only the module
  boundary changed). Later gate/OKF PRs will import it.
- `lib/commands/doc-gate.js` — thin wrapper, auto-registered by the command
  registry as `forge doc-gate detect [--json]` (same pattern as `migrate`).
- Dependency-free: Node built-ins + `child_process` git, like the reference.

## How the detector works

- **Tracked-files-only.** Every *existence* signal comes from `git ls-tree HEAD`
  / `git ls-files`, never the raw filesystem — this excludes untracked clutter
  and gitignored worktree/`node_modules` lockfiles. File *content* is still read
  with `fs` once a tracked path is known.
- **Abstain-by-default.** Per-field results for source / toolchain / ci /
  changelog / agents, each `{ value, source, confidence, escalate? }`. HIGH is
  emitted only where deterministic; `codeHighConfidence[]` is the only
  silent-wrong-eligible set.
- **Escalation triggers (code-detectable):** monorepo (npm/pnpm/turbo
  workspaces, Cargo `[workspace]`, `go.work`), nested gitlink wrapper (escalate
  ALL fields), multiple conflicting lockfiles, and secondary non-conventional
  source roots (convex/supabase/backend/…).
- **Manifest-first source + blocklist.** Source resolution is language/manifest
  first with a packaging/private-dir BLOCKLIST so it never returns `internal/`,
  `pkg/`, `vendor/`, `testdata/`, etc. as THE source (Go flat-root → `.`; Python
  flat-layout → the package dir; Rust single crate → `src`). This is the fix
  that eliminated the two real-world silent-wrongs (Go `internal/`, Rust `pkg/`).
- **Toolchain** recognizes non-lockfile pins (cargo from `Cargo.toml` without
  `Cargo.lock`, the `packageManager` field) and the expanded lockfile set
  (uv/poetry/pipenv/cargo/go/composer).
- **Changelog** matching is case-insensitive + broad: CHANGELOG/CHANGES/HISTORY/
  NEWS/RELEASES, `.md`/`.rst`, `.changeset`, `docs/**/release-notes.*`;
  keep-a-changelog detected by content.

## Validation

- Validated to **zero silent-wrong** (a high-confidence answer that is actually
  wrong) across **9 local repos + 8 diverse OSS repos** (Python/Go/Rust/JS).
- `bun test test/doc-gate/ test/commands/doc-gate.test.js` → **20 pass, 0 fail.**
  Covers every branch: Rust single-crate + Cargo-workspace (escalates, not
  `pkg`), Go flat-root (`.`, not `internal`), Python flat/src layouts, JS single
  package + secondary-root escalation, multiple conflicting lockfiles, nested
  gitlink, changelog variants (case/`.rst`/`docs/**`/keep-a-changelog), and an
  assertion that `codeHighConfidence` only ever holds correct deterministic
  fields (no silent-wrong).
- `eslint --max-warnings 0` clean. `forge release check --target 0.1.0` → PASS.
- Real-repo smoke runs: forge itself → source escalates (npm-workspaces
  monorepo) while toolchain/ci/changelog resolve high-confidence; a Convex app →
  source escalates via `secondary-roots:convex`. Both correctly avoid guessing.

## Command surface

```
forge doc-gate detect          # human summary
forge doc-gate detect --json   # structured JSON
```

Exit is non-zero only on a real error (not a git repo / no commits, or an
unknown subcommand). An `ESCALATE-TO-AGENT` or `MANUAL-CONFIG` verdict is a
valid result and exits 0.

## Follow-ups (explicitly out of scope here)

- **CI required gate** reusing the changelog-enforcer with doc-path exclusion.
- **OKF-bundle generation** from the detector output.
- **Agent escalation** runtime for the fields the detector abstains on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `doc-gate` command that generates a human-readable detection summary or structured `--json` output.
  * Implemented git-tracked-file-based analysis to infer source layout, toolchain, agents, changelog signals, and CI indicators, including escalation-driven verdicts.
* **Bug Fixes**
  * Improved robustness for unknown subcommands and non-git directories with consistent exit codes and clearer errors.
  * Refined escalation and confidence rules to prevent incorrect “high-confidence” labeling.
* **Tests**
  * Added Bun tests covering command behavior, JSON parity, error handling, and multiple repository/nested-git scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->