### PR TITLE
feat(doc-gate): .docgate.json declaration override

### DIFF
--- a/lib/commands/doc-gate.js
+++ b/lib/commands/doc-gate.js
@@ -174,7 +174,19 @@ function runInit(argv, flags, root) {
   const json = Boolean(flags?.json) || argv.includes('--json');
   const force = Boolean(flags?.force) || argv.includes('--force');
   const target = path.join(root, DECLARATION_FILE);
-  const exists = fs.existsSync(target);
+  // lstat (does NOT follow symlinks) detects both existence and a symlink target.
+  let stat = null;
+  try { stat = fs.lstatSync(target); } catch { /* absent: stat stays null */ }
+  // Refuse to write THROUGH a symlink — a checked-in symlink could clobber a file
+  // outside the repo. This holds even with --force.
+  if (stat?.isSymbolicLink()) {
+    return {
+      success: false,
+      error: `${DECLARATION_FILE} at ${root} is a symlink; refusing to write through it.`,
+      exitCode: 1,
+    };
+  }
+  const exists = stat !== null;
   if (exists && !force) {
     return {
       success: false,

--- a/lib/commands/doc-gate.js
+++ b/lib/commands/doc-gate.js
@@ -17,9 +17,12 @@
  * @module commands/doc-gate
  */
 
+const fs = require('node:fs');
+const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const { detect } = require('../doc-gate/detect');
 const { evaluateGate } = require('../doc-gate/gate');
+const { scaffoldDeclaration, DECLARATION_FILE } = require('../doc-gate/declaration');
 
 /** True when `root` is a git working tree with at least one commit (HEAD). */
 function hasGitHead(root) {
@@ -74,7 +77,8 @@ function renderHuman(result) {
 }
 
 const CHECK_USAGE = 'forge doc-gate check --base <ref> --head <ref> [--skip] [--json]';
-const USAGE = `forge doc-gate detect [--json]\n       ${CHECK_USAGE}`;
+const INIT_USAGE = 'forge doc-gate init [--force] [--json]';
+const USAGE = `forge doc-gate detect [--json]\n       ${CHECK_USAGE}\n       ${INIT_USAGE}`;
 
 /** Standard "not a usable git repo" error result (exit 1). */
 function notAGitRepo(root, sub) {
@@ -152,6 +156,46 @@ function runCheck(argv, flags, root) {
   return { success: true, output, json };
 }
 
+/** Render an init result as a readable summary. */
+function renderInit(payload) {
+  const decl = payload.declaration;
+  const lines = [
+    `doc-gate init — wrote ${payload.path}${payload.overwritten ? ' (overwritten)' : ''}`,
+    `source: ${decl.source.join(', ')}`,
+    `toolchain: ${decl.toolchain ?? '(none)'}`,
+    `Edit ${payload.path} to declare your repo structure, then commit it (tracked-files-only).`,
+  ];
+  return lines.join('\n');
+}
+
+/** `init` subcommand — scaffold a `.docgate.json` from the current detect() result. */
+function runInit(argv, flags, root) {
+  if (!hasGitHead(root)) return notAGitRepo(root, 'init');
+  const json = Boolean(flags?.json) || argv.includes('--json');
+  const force = Boolean(flags?.force) || argv.includes('--force');
+  const target = path.join(root, DECLARATION_FILE);
+  const exists = fs.existsSync(target);
+  if (exists && !force) {
+    return {
+      success: false,
+      error: `${DECLARATION_FILE} already exists at ${root}. Re-run with --force to overwrite.\nUsage: ${INIT_USAGE}`,
+      exitCode: 1,
+    };
+  }
+
+  const declaration = scaffoldDeclaration(detect(root));
+  try {
+    fs.writeFileSync(target, `${JSON.stringify(declaration, null, 2)}\n`);
+  } catch (err) {
+    // A write failure (permissions / read-only tree) is a real error — surface it.
+    return { success: false, error: `could not write ${DECLARATION_FILE}: ${err.message}`, exitCode: 1 };
+  }
+
+  const payload = { path: DECLARATION_FILE, overwritten: exists, declaration };
+  const output = json ? JSON.stringify(payload, null, 2) : renderInit(payload);
+  return { success: true, output, json };
+}
+
 module.exports = {
   name: 'doc-gate',
   description: 'Detect a repository\'s structure, or enforce the doc-update gate on a PR',
@@ -161,6 +205,7 @@ module.exports = {
     '--base': 'check: base ref/SHA of the pull request.',
     '--head': 'check: head ref/SHA of the pull request.',
     '--skip': 'check: force a pass (e.g. a no-docs-needed label).',
+    '--force': 'init: overwrite an existing .docgate.json.',
   },
 
   async handler(args, flags, projectRoot, _opts = {}) {
@@ -170,9 +215,10 @@ module.exports = {
 
     if (sub === 'detect') return runDetect(argv, flags, root);
     if (sub === 'check') return runCheck(argv, flags, root);
+    if (sub === 'init') return runInit(argv, flags, root);
     return {
       success: false,
-      error: `Unknown doc-gate subcommand '${sub}'. Supported subcommands: detect, check.\nUsage: ${USAGE}`,
+      error: `Unknown doc-gate subcommand '${sub}'. Supported subcommands: detect, check, init.\nUsage: ${USAGE}`,
       exitCode: 1,
     };
   },

--- a/lib/doc-gate/declaration.js
+++ b/lib/doc-gate/declaration.js
@@ -1,0 +1,171 @@
+'use strict';
+
+/**
+ * doc-gate `.docgate.json` declaration loader + validator.
+ *
+ * The detector (lib/doc-gate/detect.js) abstains / escalates on repos it cannot
+ * confidently resolve. This module implements the research-validated
+ * "declaration beats inference" escape hatch (cf. corepack `packageManager`,
+ * knip.json): a repo may commit a `.docgate.json` that AUTHORITATIVELY declares
+ * its structure, so the detector resolves it and the gate enforces precisely.
+ *
+ * Design (consistent with the detector + gate):
+ *  - Tracked-files-only: the declaration is read ONLY when `git ls-files` lists
+ *    it, so untracked worktree clutter can never change a verdict.
+ *  - Fail-closed: the git wrapper THROWS on failure; a git error, unreadable
+ *    file, invalid JSON, or a schema violation is SURFACED as a non-empty
+ *    `errors` array — an invalid declaration is never silently ignored.
+ *  - Strict schema: unknown top-level keys are rejected and every field's type
+ *    is validated; `version` must be 1.
+ *
+ * @module doc-gate/declaration
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const DECLARATION_FILE = '.docgate.json';
+const ALLOWED_KEYS = new Set(['version', 'source', 'toolchain', 'excludeFromGate', 'rules']);
+const RULE_KEYS = new Set(['when', 'requires']);
+
+/**
+ * Strict git wrapper: THROWS on any failure (fail-closed). The declaration
+ * loader must never treat a git error as "no declaration" — that would let a
+ * broken repo silently skip enforcement. Callers turn the throw into an explicit
+ * `errors` entry.
+ *
+ * @param {string} root - Repository root.
+ * @param {string[]} args - git arguments.
+ * @returns {string} stdout.
+ */
+function gitStrict(root, args) {
+  // NOSONAR S4036 - hardcoded CLI command, no user input.
+  const res = cp.spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' }); // NOSONAR S4036
+  if (res.error) throw new Error(`git ${args.join(' ')}: ${res.error.message}`);
+  if (res.status !== 0) throw new Error(`git ${args.join(' ')} exited ${res.status}: ${String(res.stderr || '').trim()}`);
+  return res.stdout;
+}
+
+/** True when `file` is a tracked path in the repo at `root`. */
+function isTracked(root, file) {
+  const out = gitStrict(root, ['ls-files', '--', file]);
+  return out.split('\n').map(s => s.trim()).filter(Boolean).length > 0;
+}
+
+/** True when `v` is an array whose every element is a string. */
+function isStringArray(v) {
+  return Array.isArray(v) && v.every(x => typeof x === 'string');
+}
+
+/** Validate a single `rules[]` entry, pushing precise messages into `errors`. */
+function validateRule(rule, index, errors) {
+  if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
+    errors.push(`"rules[${index}]" must be an object with "when" and "requires"`);
+    return;
+  }
+  if (typeof rule.when !== 'string' || !rule.when) errors.push(`"rules[${index}].when" must be a non-empty string`);
+  if (typeof rule.requires !== 'string' || !rule.requires) errors.push(`"rules[${index}].requires" must be a non-empty string`);
+  for (const key of Object.keys(rule)) {
+    if (!RULE_KEYS.has(key)) errors.push(`"rules[${index}]" has unknown key "${key}"`);
+  }
+}
+
+/**
+ * Validate a parsed `.docgate.json` object against the strict schema.
+ *
+ * Schema: `{ version: 1, source?: string[], toolchain?: string,
+ * excludeFromGate?: string[], rules?: [{ when: string, requires: string }] }`.
+ *
+ * @param {*} parsed - The JSON.parse result.
+ * @returns {{ declaration: object|null, errors: string[] }} A valid object is
+ *   returned as `declaration`; ANY problem yields a non-empty `errors` array and
+ *   a null `declaration` (invalid declarations are never applied).
+ */
+function validateDeclaration(parsed) {
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { declaration: null, errors: [`${DECLARATION_FILE} must be a JSON object`] };
+  }
+  const errors = [];
+  for (const key of Object.keys(parsed)) {
+    if (!ALLOWED_KEYS.has(key)) errors.push(`unknown top-level key "${key}"`);
+  }
+  if (parsed.version !== 1) errors.push('"version" must be 1');
+  if (parsed.source !== undefined && !(isStringArray(parsed.source) && parsed.source.length > 0)) {
+    errors.push('"source" must be a non-empty array of strings');
+  }
+  if (parsed.toolchain !== undefined && (typeof parsed.toolchain !== 'string' || !parsed.toolchain)) {
+    errors.push('"toolchain" must be a non-empty string');
+  }
+  if (parsed.excludeFromGate !== undefined && !isStringArray(parsed.excludeFromGate)) {
+    errors.push('"excludeFromGate" must be an array of strings');
+  }
+  if (parsed.rules !== undefined) {
+    if (!Array.isArray(parsed.rules)) {
+      errors.push('"rules" must be an array');
+    } else {
+      parsed.rules.forEach((rule, i) => validateRule(rule, i, errors));
+    }
+  }
+  if (errors.length > 0) return { declaration: null, errors };
+  return { declaration: parsed, errors: [] };
+}
+
+/**
+ * Load + validate a repo's committed `.docgate.json` declaration.
+ *
+ * Tracked-files-only: the file is read only when `git ls-files` lists it. A
+ * missing / untracked file is a normal "no declaration" (`{ declaration: null,
+ * errors: [] }`). A git error, unreadable file, invalid JSON, or a schema
+ * violation is surfaced as a non-empty `errors` array (fail-closed).
+ *
+ * @param {string} root - Absolute repository root (a git working tree).
+ * @returns {{ declaration: object|null, errors: string[] }}
+ */
+function loadDeclaration(root) {
+  let tracked;
+  try {
+    tracked = isTracked(root, DECLARATION_FILE);
+  } catch (err) {
+    // FAIL-CLOSED: a git failure must surface, never be treated as "no file".
+    return { declaration: null, errors: [`could not determine tracked status of ${DECLARATION_FILE}: ${err.message}`] };
+  }
+  if (!tracked) return { declaration: null, errors: [] };
+
+  let raw;
+  try {
+    raw = fs.readFileSync(path.join(root, DECLARATION_FILE), 'utf8');
+  } catch (err) {
+    return { declaration: null, errors: [`could not read ${DECLARATION_FILE}: ${err.message}`] };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { declaration: null, errors: [`invalid JSON in ${DECLARATION_FILE}: ${err.message}`] };
+  }
+
+  return validateDeclaration(parsed);
+}
+
+/**
+ * Build a starter `.docgate.json` object from a detector result, so a human or
+ * agent can commit + edit it. Uses the auto-detected source/toolchain as the
+ * starting point; falls back to a `src` placeholder when detection abstained.
+ *
+ * @param {object} detectResult - The result of `detect(root)`.
+ * @returns {object} A schema-valid declaration object.
+ */
+function scaffoldDeclaration(detectResult) {
+  const declaration = { version: 1 };
+  const src = detectResult?.source?.value;
+  declaration.source = Array.isArray(src) && src.length > 0 ? [...src] : ['src'];
+  const toolchain = detectResult?.toolchain?.value;
+  if (typeof toolchain === 'string' && toolchain) declaration.toolchain = toolchain;
+  declaration.excludeFromGate = [];
+  declaration.rules = [];
+  return declaration;
+}
+
+module.exports = { loadDeclaration, validateDeclaration, scaffoldDeclaration, DECLARATION_FILE };

--- a/lib/doc-gate/declaration.js
+++ b/lib/doc-gate/declaration.js
@@ -53,9 +53,11 @@ function isTracked(root, file) {
   return out.split('\n').map(s => s.trim()).filter(Boolean).length > 0;
 }
 
-/** True when `v` is an array whose every element is a string. */
-function isStringArray(v) {
-  return Array.isArray(v) && v.every(x => typeof x === 'string');
+/** True when `v` is an array of NON-BLANK strings (an empty array is allowed).
+ * Blank/whitespace entries are rejected so `source: [""]` can't promote a repo to
+ * DECLARED while matching no files. */
+function isNonBlankStringArray(v) {
+  return Array.isArray(v) && v.every(x => typeof x === 'string' && x.trim() !== '');
 }
 
 /** Validate a single `rules[]` entry, pushing precise messages into `errors`. */
@@ -82,6 +84,25 @@ function validateRule(rule, index, errors) {
  *   returned as `declaration`; ANY problem yields a non-empty `errors` array and
  *   a null `declaration` (invalid declarations are never applied).
  */
+/** Validate the optional schema fields (source/toolchain/excludeFromGate/rules),
+ * pushing precise messages into `errors`. Extracted to keep validateDeclaration
+ * under the SonarCloud cognitive-complexity threshold. */
+function validateOptionalFields(parsed, errors) {
+  if (parsed.source !== undefined && !(isNonBlankStringArray(parsed.source) && parsed.source.length > 0)) {
+    errors.push('"source" must be a non-empty array of non-empty strings');
+  }
+  if (parsed.toolchain !== undefined && (typeof parsed.toolchain !== 'string' || !parsed.toolchain.trim())) {
+    errors.push('"toolchain" must be a non-empty string');
+  }
+  if (parsed.excludeFromGate !== undefined && !isNonBlankStringArray(parsed.excludeFromGate)) {
+    errors.push('"excludeFromGate" must be an array of non-empty strings');
+  }
+  if (parsed.rules !== undefined) {
+    if (!Array.isArray(parsed.rules)) errors.push('"rules" must be an array');
+    else parsed.rules.forEach((rule, i) => validateRule(rule, i, errors));
+  }
+}
+
 function validateDeclaration(parsed) {
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return { declaration: null, errors: [`${DECLARATION_FILE} must be a JSON object`] };
@@ -91,22 +112,7 @@ function validateDeclaration(parsed) {
     if (!ALLOWED_KEYS.has(key)) errors.push(`unknown top-level key "${key}"`);
   }
   if (parsed.version !== 1) errors.push('"version" must be 1');
-  if (parsed.source !== undefined && !(isStringArray(parsed.source) && parsed.source.length > 0)) {
-    errors.push('"source" must be a non-empty array of strings');
-  }
-  if (parsed.toolchain !== undefined && (typeof parsed.toolchain !== 'string' || !parsed.toolchain)) {
-    errors.push('"toolchain" must be a non-empty string');
-  }
-  if (parsed.excludeFromGate !== undefined && !isStringArray(parsed.excludeFromGate)) {
-    errors.push('"excludeFromGate" must be an array of strings');
-  }
-  if (parsed.rules !== undefined) {
-    if (!Array.isArray(parsed.rules)) {
-      errors.push('"rules" must be an array');
-    } else {
-      parsed.rules.forEach((rule, i) => validateRule(rule, i, errors));
-    }
-  }
+  validateOptionalFields(parsed, errors);
   if (errors.length > 0) return { declaration: null, errors };
   return { declaration: parsed, errors: [] };
 }

--- a/lib/doc-gate/detect.js
+++ b/lib/doc-gate/detect.js
@@ -228,6 +228,12 @@ function applyDeclaration(root, result) {
     overridden.add('toolchain');
   }
 
+  // An overridden field is 'declared', not code-derived, so it must not remain in
+  // codeHighConfidence (which lists only code-derived, silent-wrong-eligible fields).
+  if (overridden.size > 0) {
+    applied.codeHighConfidence = result.codeHighConfidence.filter(f => !overridden.has(f));
+  }
+
   // Promote to DECLARED only when an enforceable source surface exists.
   const surface = applied.source?.value;
   if (Array.isArray(surface) && surface.length > 0) {

--- a/lib/doc-gate/detect.js
+++ b/lib/doc-gate/detect.js
@@ -30,6 +30,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const cp = require('node:child_process');
+const { loadDeclaration } = require('./declaration');
 
 const read = p => { try { return fs.readFileSync(p, 'utf8'); } catch { return ''; } };
 const readJSON = p => { try { return JSON.parse(read(p)); } catch { return null; } };
@@ -197,12 +198,60 @@ function detectCI(root, top, nested) {
 }
 
 /**
+ * Apply a committed `.docgate.json` declaration on top of a detection result.
+ *
+ * "Declaration beats inference": a VALID declaration OVERRIDES the inferred
+ * source (and, if declared, toolchain) and promotes the verdict to DECLARED —
+ * but ONLY when it yields a concrete source surface (a declared `source`, or a
+ * source detection already resolved). This is fail-closed: a DECLARED verdict is
+ * enforced by the gate, so it must never rest on a null/empty surface. An
+ * INVALID declaration never applies; its `errors` are attached as
+ * `declarationErrors` so callers can surface them (the gate fails closed on them).
+ *
+ * @param {string} root - Repository root.
+ * @param {object} result - The plain detection result to augment.
+ * @returns {object} The (possibly) augmented result.
+ */
+function applyDeclaration(root, result) {
+  const { declaration, errors } = loadDeclaration(root);
+  if (errors.length > 0) return { ...result, declarationErrors: errors };
+  if (!declaration) return result;
+
+  const applied = { ...result, declaration };
+  const overridden = new Set();
+  if (Array.isArray(declaration.source) && declaration.source.length > 0) {
+    applied.source = { value: [...declaration.source], source: 'declared', confidence: 'high' };
+    overridden.add('source');
+  }
+  if (typeof declaration.toolchain === 'string' && declaration.toolchain) {
+    applied.toolchain = { value: declaration.toolchain, source: 'declared', confidence: 'high' };
+    overridden.add('toolchain');
+  }
+
+  // Promote to DECLARED only when an enforceable source surface exists.
+  const surface = applied.source?.value;
+  if (Array.isArray(surface) && surface.length > 0) {
+    applied.declared = true;
+    applied.verdict = 'DECLARED';
+    applied.escalate = result.escalate.filter(e => !overridden.has(e.field));
+  }
+  return applied;
+}
+
+/**
  * Run the repo-structure detector against a git working tree.
  *
+ * When a VALID `.docgate.json` is committed at the root it OVERRIDES inference:
+ * the verdict becomes DECLARED (enforced by the gate exactly like CODE-RESOLVED)
+ * and `declaration` is attached. An INVALID declaration attaches
+ * `declarationErrors` and leaves normal detection untouched.
+ *
  * @param {string} root - Absolute path to the repository root (a git working tree).
- * @returns {{ repo: string, verdict: 'ESCALATE-TO-AGENT'|'MANUAL-CONFIG'|'CODE-RESOLVED',
+ * @returns {{ repo: string,
+ *   verdict: 'ESCALATE-TO-AGENT'|'MANUAL-CONFIG'|'CODE-RESOLVED'|'DECLARED',
  *   nested: boolean, monorepo: object, escalate: Array, codeHighConfidence: string[],
- *   source: object, toolchain: object, agents: object, changelog: object, ci: object }}
+ *   source: object, toolchain: object, agents: object, changelog: object, ci: object,
+ *   declared?: boolean, declaration?: object, declarationErrors?: string[] }}
  */
 function detect(root) {
   const top = trackedTop(root);
@@ -227,7 +276,8 @@ function detect(root) {
   let verdict = 'CODE-RESOLVED';
   if (escalate.length > 0) verdict = 'ESCALATE-TO-AGENT';
   else if (manualAbstain) verdict = 'MANUAL-CONFIG';
-  return { repo: path.basename(root), verdict, nested, monorepo: mono, escalate, codeHighConfidence: codeHigh, ...fields };
+  const result = { repo: path.basename(root), verdict, nested, monorepo: mono, escalate, codeHighConfidence: codeHigh, ...fields };
+  return applyDeclaration(root, result);
 }
 
 module.exports = { detect, BLOCKLIST };

--- a/lib/doc-gate/gate.js
+++ b/lib/doc-gate/gate.js
@@ -213,7 +213,8 @@ function normalizeChangedFiles(changedFiles) {
  * @returns {string[]} repo-relative code paths
  */
 function codeChangesUnderSource(changes, sourceDirs, excludeGlobs = []) {
-  const dirs = Array.isArray(sourceDirs) ? sourceDirs.map(p => toPosix(p)) : [];
+  // Strip trailing slashes so a declared `packages/a/` matches `packages/a/index.js`.
+  const dirs = Array.isArray(sourceDirs) ? sourceDirs.map(p => toPosix(p).replace(/\/+$/, '')) : [];
   const flatRoot = dirs.includes('.');
   const code = [];
   for (const change of changes) {

--- a/lib/doc-gate/gate.js
+++ b/lib/doc-gate/gate.js
@@ -47,6 +47,51 @@ const extOf = p => {
   return i > 0 ? b.slice(i).toLowerCase() : '';
 };
 
+// --- declaration glob matching (excludeFromGate / rules) ---------------------
+// Deterministic, ReDoS-safe glob → RegExp. Only linear tokens are emitted
+// (`[^/]*`, `[^/]`, `.*`, `(?:.*/)?`), anchored ^…$ — no nested/overlapping
+// quantifiers, so committed (trusted) globs cannot cause catastrophic backtracking.
+const GLOB_SPECIALS = new Set(['.', '+', '^', '$', '{', '}', '(', ')', '|', '[', ']', '\\']);
+function globToRegExp(glob) {
+  const g = toPosix(glob);
+  let re = '^';
+  let i = 0;
+  while (i < g.length) {
+    const c = g[i];
+    if (c === '*' && g[i + 1] === '*') {
+      if (g[i + 2] === '/') { re += '(?:.*/)?'; i += 3; } // '**/' — zero or more dirs
+      else { re += '.*'; i += 2; } // trailing '**' — anything, including '/'
+    } else if (c === '*') {
+      re += '[^/]*'; i += 1; // single-segment wildcard
+    } else if (c === '?') {
+      re += '[^/]'; i += 1;
+    } else if (GLOB_SPECIALS.has(c)) {
+      re += `\\${c}`; i += 1;
+    } else {
+      re += c; i += 1;
+    }
+  }
+  return new RegExp(`${re}$`);
+}
+
+/**
+ * True when repo-relative path `rel` matches ANY of `globs`. A bare directory
+ * glob (no wildcard) also matches everything beneath it (prefix semantics).
+ *
+ * @param {string} rel - Repo-relative POSIX path.
+ * @param {string[]} globs - Declaration globs.
+ * @returns {boolean}
+ */
+function matchesAnyGlob(rel, globs) {
+  for (const raw of globs) {
+    const glob = toPosix(raw).replace(/\/+$/, '');
+    if (!glob) continue;
+    if (rel === glob || rel.startsWith(`${glob}/`)) return true; // exact or dir prefix
+    if (globToRegExp(glob).test(rel)) return true;
+  }
+  return false;
+}
+
 // --- doc-path classification (mandatory exclusion) ---------------------------
 const DOC_EXTS = new Set(['.md', '.mdx', '.rst']);
 // Anchored so NEWSLETTER.js / LICENSEMANAGER.go (real code) are NOT treated as
@@ -158,28 +203,56 @@ function normalizeChangedFiles(changedFiles) {
 
 /**
  * From the Added/Modified changes, return the ones that count as CODE under the
- * resolved source surface. Docs are always excluded; for a flat-root `["."]`
- * surface only top-level, non-config files count.
+ * resolved source surface. Docs are always excluded; paths matching a declared
+ * `excludeFromGate` glob are excluded; for a flat-root `["."]` surface only
+ * top-level, non-config files count.
  *
  * @param {Array<{status:string, path:string}>} changes
  * @param {string[]|null} sourceDirs
+ * @param {string[]} [excludeGlobs] - Declared `excludeFromGate` globs.
  * @returns {string[]} repo-relative code paths
  */
-function codeChangesUnderSource(changes, sourceDirs) {
-  const dirs = Array.isArray(sourceDirs) ? sourceDirs.map(toPosix) : [];
+function codeChangesUnderSource(changes, sourceDirs, excludeGlobs = []) {
+  const dirs = Array.isArray(sourceDirs) ? sourceDirs.map(p => toPosix(p)) : [];
   const flatRoot = dirs.includes('.');
   const code = [];
   for (const change of changes) {
     if (change.status === 'DELETED') continue;
     const rel = toPosix(change.path);
     if (isDocPath(rel)) continue;
+    if (excludeGlobs.length > 0 && matchesAnyGlob(rel, excludeGlobs)) continue; // declared exclusion
     if (flatRoot) {
       if (!rel.includes('/') && !isConfigPath(rel)) code.push(rel);
       continue;
     }
-    if (dirs.some(d => rel === d || rel.startsWith(d + '/'))) code.push(rel);
+    if (dirs.some(d => rel === d || rel.startsWith(`${d}/`))) code.push(rel);
   }
   return code;
+}
+
+/**
+ * Apply declared `rules`: a changed non-doc file matching `rule.when` REQUIRES
+ * the `rule.requires` path to be Added/Modified in the same change set. Returns
+ * a precise message for each violated rule (empty when all satisfied).
+ *
+ * @param {Array<{status:string, path:string}>} changes
+ * @param {Array<{when:string, requires:string}>} rules
+ * @returns {string[]} violation messages
+ */
+function checkDeclaredRules(changes, rules) {
+  if (!Array.isArray(rules) || rules.length === 0) return [];
+  const touched = changes.filter(c => c.status !== 'DELETED').map(c => toPosix(c.path));
+  const violations = [];
+  for (const rule of rules) {
+    const triggered = touched.filter(p => !isDocPath(p) && matchesAnyGlob(p, [rule.when]));
+    if (triggered.length === 0) continue;
+    const requires = toPosix(rule.requires);
+    const satisfied = touched.some(p => p === requires || matchesAnyGlob(p, [rule.requires]));
+    if (!satisfied) {
+      violations.push(`change to ${triggered[0]} requires an update to "${rule.requires}" (rule when="${rule.when}")`);
+    }
+  }
+  return violations;
 }
 
 /**
@@ -220,6 +293,19 @@ function evaluateGate({ root, base, head, changedFiles, skip } = {}) {
   const verdict = result.verdict;
   const summary = { sourceSurface, verdict };
 
+  // FAIL-CLOSED on an INVALID committed `.docgate.json`: a malformed declaration
+  // is a config error that must block a required check, never silently pass —
+  // checked BEFORE `skip` so a broken declaration can't be waved through.
+  if (Array.isArray(result.declarationErrors) && result.declarationErrors.length > 0) {
+    return {
+      decision: 'fail',
+      reason: `invalid .docgate.json declaration: ${result.declarationErrors.join('; ')}`,
+      offendingCodeFiles: [],
+      docChangesSeen: [],
+      ...summary,
+    };
+  }
+
   if (skip) {
     return { decision: 'pass', reason: 'skipped', offendingCodeFiles: [], docChangesSeen: [], ...summary };
   }
@@ -234,7 +320,8 @@ function evaluateGate({ root, base, head, changedFiles, skip } = {}) {
     };
   }
 
-  // CODE-RESOLVED: the source surface is a concrete set of dirs (or ".").
+  // CODE-RESOLVED or DECLARED (a committed declaration is enforced exactly like
+  // CODE-RESOLVED): the source surface is a concrete set of dirs (or ".").
   let changes;
   try {
     changes = resolveChanges({ root, base, head, changedFiles });
@@ -249,15 +336,29 @@ function evaluateGate({ root, base, head, changedFiles, skip } = {}) {
       ...summary,
     };
   }
+  const excludeGlobs = result.declaration?.excludeFromGate ?? [];
   const docChangesSeen = changes
     .filter(c => c.status !== 'DELETED' && isDocPath(c.path))
     .map(c => toPosix(c.path));
-  const offending = codeChangesUnderSource(changes, sourceSurface);
+  const offending = codeChangesUnderSource(changes, sourceSurface, excludeGlobs);
 
   if (offending.length > 0 && docChangesSeen.length === 0) {
     return {
       decision: 'fail',
       reason: `${offending.length} code change(s) under source surface [${(sourceSurface || []).join(', ')}] with no accompanying doc update`,
+      offendingCodeFiles: offending,
+      docChangesSeen,
+      ...summary,
+    };
+  }
+
+  // Declared `rules` are enforced independently of the doc-companion check: a
+  // triggered rule fails even when a doc update accompanied the code change.
+  const ruleViolations = checkDeclaredRules(changes, result.declaration?.rules ?? []);
+  if (ruleViolations.length > 0) {
+    return {
+      decision: 'fail',
+      reason: ruleViolations.join('; '),
       offendingCodeFiles: offending,
       docChangesSeen,
       ...summary,

--- a/test/commands/doc-gate-init.test.js
+++ b/test/commands/doc-gate-init.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const { describe, expect, test, afterAll, setDefaultTimeout } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const docGate = require('../../lib/commands/doc-gate');
+const { detect } = require('../../lib/doc-gate/detect');
+const { scaffoldDeclaration, loadDeclaration } = require('../../lib/doc-gate/declaration');
+
+// Real git fixtures + parallel disk I/O can exceed the 5s default on Windows CI.
+setDefaultTimeout(30000);
+
+const createdDirs = [];
+
+function makeJsRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-docgate-init-'));
+  createdDirs.push(dir);
+  const g = args => execFileSync('git', ['-C', dir, ...args], { stdio: ['ignore', 'ignore', 'ignore'] });
+  g(['init', '-q']);
+  g(['config', 'user.email', 'test@example.com']);
+  g(['config', 'user.name', 'Test']);
+  g(['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"x","version":"1.0.0"}\n');
+  fs.writeFileSync(path.join(dir, 'package-lock.json'), '{}\n');
+  fs.mkdirSync(path.join(dir, 'lib'));
+  fs.writeFileSync(path.join(dir, 'lib', 'index.js'), 'module.exports = 1;\n');
+  g(['add', '-A']);
+  g(['commit', '-q', '-m', 'init']);
+  return dir;
+}
+function makeNonGitDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-docgate-init-nogit-'));
+  createdDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe('forge doc-gate init', () => {
+  test('scaffolds a .docgate.json from the current detect() result', async () => {
+    const dir = makeJsRepo();
+    const res = await docGate.handler(['init'], {}, dir, {});
+    expect(res.success).toBe(true);
+    expect(res.exitCode).toBeUndefined();
+    const written = path.join(dir, '.docgate.json');
+    expect(fs.existsSync(written)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(written, 'utf8'));
+    expect(parsed).toEqual(scaffoldDeclaration(detect(dir)));
+    expect(parsed.source).toEqual(['lib']);
+  });
+
+  test('--json output equals the scaffold written to disk (thin-wrapper contract)', async () => {
+    const dir = makeJsRepo();
+    // The scaffold is written UNTRACKED, so detect(dir) is unaffected by it.
+    const expectedDecl = scaffoldDeclaration(detect(dir));
+    const res = await docGate.handler(['init', '--json'], {}, dir, {});
+    expect(res.success).toBe(true);
+    const payload = JSON.parse(res.output);
+    expect(payload.path).toBe('.docgate.json');
+    expect(payload.overwritten).toBe(false);
+    expect(payload.declaration).toEqual(expectedDecl);
+    // And the file on disk matches the reported declaration exactly.
+    expect(JSON.parse(fs.readFileSync(path.join(dir, '.docgate.json'), 'utf8'))).toEqual(payload.declaration);
+  });
+
+  test('refuses to overwrite an existing .docgate.json without --force (exit 1)', async () => {
+    const dir = makeJsRepo();
+    fs.writeFileSync(path.join(dir, '.docgate.json'), '{"version":1,"source":["custom"]}\n');
+    const res = await docGate.handler(['init'], {}, dir, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toMatch(/already exists/i);
+    // The existing file must be untouched.
+    expect(JSON.parse(fs.readFileSync(path.join(dir, '.docgate.json'), 'utf8')).source).toEqual(['custom']);
+  });
+
+  test('--force overwrites and reports overwritten: true', async () => {
+    const dir = makeJsRepo();
+    fs.writeFileSync(path.join(dir, '.docgate.json'), '{"version":1,"source":["custom"]}\n');
+    const res = await docGate.handler(['init', '--force', '--json'], {}, dir, {});
+    expect(res.success).toBe(true);
+    const payload = JSON.parse(res.output);
+    expect(payload.overwritten).toBe(true);
+    expect(payload.declaration.source).toEqual(['lib']);
+  });
+
+  test('--force also honored via parsed flags object', async () => {
+    const dir = makeJsRepo();
+    fs.writeFileSync(path.join(dir, '.docgate.json'), '{"version":1,"source":["custom"]}\n');
+    const res = await docGate.handler(['init'], { force: true }, dir, {});
+    expect(res.success).toBe(true);
+  });
+
+  test('a committed init scaffold is loadable as a valid declaration (round-trip)', async () => {
+    const dir = makeJsRepo();
+    await docGate.handler(['init'], {}, dir, {});
+    execFileSync('git', ['-C', dir, 'add', '.docgate.json'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    execFileSync('git', ['-C', dir, 'commit', '-q', '-m', 'add declaration'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    const { declaration, errors } = loadDeclaration(dir);
+    expect(errors).toEqual([]);
+    expect(declaration.source).toEqual(['lib']);
+    // Once committed + tracked, the declaration flips the verdict to DECLARED.
+    expect(detect(dir).verdict).toBe('DECLARED');
+  });
+
+  test('non-git directory is a real error (exit 1)', async () => {
+    const dir = makeNonGitDir();
+    const res = await docGate.handler(['init'], {}, dir, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toContain('git repository');
+  });
+});

--- a/test/doc-gate/declaration.test.js
+++ b/test/doc-gate/declaration.test.js
@@ -161,6 +161,28 @@ describe('detect() honors a committed declaration', () => {
     expect(r.toolchain.source).toBe('declared');
   });
 
+  test('overriding an already CODE-RESOLVED field drops it from codeHighConfidence', () => {
+    // A single JS package resolves source+toolchain as code/high; a declaration
+    // overriding them makes them 'declared', so they must leave codeHighConfidence
+    // (which lists only code-derived, silent-wrong-eligible fields).
+    const decl = `${JSON.stringify({ version: 1, source: ['app'], toolchain: 'pnpm' }, null, 2)}\n`;
+    const dir = makeRepo({
+      'package.json': '{"name":"x","version":"1.0.0"}\n',
+      'package-lock.json': '{}\n',
+      'lib/index.js': 'module.exports = 1;\n',
+      '.docgate.json': decl,
+    });
+    const r = detect(dir);
+    expect(r.verdict).toBe('DECLARED');
+    expect(r.codeHighConfidence).not.toContain('source');
+    expect(r.codeHighConfidence).not.toContain('toolchain');
+    // Invariant preserved: every remaining field is genuinely code-derived + high.
+    for (const field of r.codeHighConfidence) {
+      expect(r[field].source).toBe('code');
+      expect(r[field].confidence).toBe('high');
+    }
+  });
+
   test('INVALID declaration → declarationErrors set, detection still runs', () => {
     const dir = makeRepo({ ...MONOREPO_BASE, '.docgate.json': `${JSON.stringify({ version: 9, source: ['packages/a'] })}\n` });
     const r = detect(dir);

--- a/test/doc-gate/declaration.test.js
+++ b/test/doc-gate/declaration.test.js
@@ -1,0 +1,284 @@
+'use strict';
+
+const { describe, expect, test, afterAll, setDefaultTimeout } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadDeclaration, validateDeclaration, scaffoldDeclaration } = require('../../lib/doc-gate/declaration');
+const { detect } = require('../../lib/doc-gate/detect');
+const { evaluateGate } = require('../../lib/doc-gate/gate');
+
+// Real git fixtures + parallel disk I/O can exceed the 5s default on Windows CI.
+setDefaultTimeout(30000);
+
+const createdDirs = [];
+
+function gitq(dir, args) {
+  return execFileSync('git', ['-C', dir, ...args], { stdio: ['ignore', 'ignore', 'ignore'] });
+}
+function writeFiles(dir, files) {
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+}
+function initRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-docgate-decl-'));
+  createdDirs.push(dir);
+  gitq(dir, ['init', '-q']);
+  gitq(dir, ['config', 'user.email', 'test@example.com']);
+  gitq(dir, ['config', 'user.name', 'Test']);
+  gitq(dir, ['config', 'commit.gpgsign', 'false']);
+  gitq(dir, ['config', 'core.autocrlf', 'false']);
+  return dir;
+}
+/** Commit a files map; returns the repo dir. */
+function makeRepo(files = {}) {
+  const dir = initRepo();
+  writeFiles(dir, files);
+  gitq(dir, ['add', '-A']);
+  gitq(dir, ['commit', '-q', '-m', 'init']);
+  return dir;
+}
+function headSha(dir) {
+  return execFileSync('git', ['-C', dir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+}
+
+// A monorepo the detector ESCALATES on (npm workspaces) — the perfect subject to
+// show a committed declaration flips it to an enforceable DECLARED verdict.
+const MONOREPO_BASE = {
+  'package.json': '{"name":"root","private":true,"workspaces":["packages/*"]}\n',
+  'packages/a/package.json': '{"name":"a","version":"1.0.0"}\n',
+  'packages/a/index.js': 'module.exports = 1;\n',
+  'CHANGELOG.md': '# Changelog\n\n## [Unreleased]\n',
+};
+const DECL = source => `${JSON.stringify({ version: 1, source }, null, 2)}\n`;
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe('loadDeclaration — tracked-files-only + strict schema', () => {
+  test('valid TRACKED .docgate.json → parsed declaration, no errors', () => {
+    const dir = makeRepo({ '.docgate.json': DECL(['packages/a']), 'packages/a/index.js': 'module.exports = 1;\n' });
+    const { declaration, errors } = loadDeclaration(dir);
+    expect(errors).toEqual([]);
+    expect(declaration).toEqual({ version: 1, source: ['packages/a'] });
+  });
+
+  test('UNTRACKED .docgate.json → ignored (tracked-files-only)', () => {
+    const dir = makeRepo({ 'packages/a/index.js': 'module.exports = 1;\n' });
+    // Present on disk but never `git add`ed → must be ignored.
+    fs.writeFileSync(path.join(dir, '.docgate.json'), DECL(['packages/a']));
+    const { declaration, errors } = loadDeclaration(dir);
+    expect(declaration).toBeNull();
+    expect(errors).toEqual([]);
+  });
+
+  test('missing .docgate.json → { declaration: null, errors: [] }', () => {
+    const dir = makeRepo({ 'packages/a/index.js': 'module.exports = 1;\n' });
+    expect(loadDeclaration(dir)).toEqual({ declaration: null, errors: [] });
+  });
+
+  test('invalid JSON → errors non-empty, declaration null', () => {
+    const dir = makeRepo({ '.docgate.json': '{ not json ]\n' });
+    const { declaration, errors } = loadDeclaration(dir);
+    expect(declaration).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toMatch(/invalid JSON/i);
+  });
+
+  test('wrong types → errors non-empty', () => {
+    const dir = makeRepo({ '.docgate.json': `${JSON.stringify({ version: 1, source: 'lib', toolchain: 5 })}\n` });
+    const { declaration, errors } = loadDeclaration(dir);
+    expect(declaration).toBeNull();
+    expect(errors.some(e => /"source"/.test(e))).toBe(true);
+    expect(errors.some(e => /"toolchain"/.test(e))).toBe(true);
+  });
+
+  test('unknown top-level key → error', () => {
+    const dir = makeRepo({ '.docgate.json': `${JSON.stringify({ version: 1, source: ['lib'], bogus: true })}\n` });
+    const { errors } = loadDeclaration(dir);
+    expect(errors.some(e => /unknown top-level key "bogus"/.test(e))).toBe(true);
+  });
+
+  test('version !== 1 → error', () => {
+    const dir = makeRepo({ '.docgate.json': `${JSON.stringify({ version: 2, source: ['lib'] })}\n` });
+    const { errors } = loadDeclaration(dir);
+    expect(errors.some(e => /"version" must be 1/.test(e))).toBe(true);
+  });
+});
+
+describe('validateDeclaration — pure schema checks', () => {
+  test('a well-formed declaration with all fields validates', () => {
+    const decl = {
+      version: 1,
+      source: ['packages/a'],
+      toolchain: 'npm',
+      excludeFromGate: ['packages/a/generated/**'],
+      rules: [{ when: 'packages/a/api/**', requires: 'openapi.yaml' }],
+    };
+    expect(validateDeclaration(decl)).toEqual({ declaration: decl, errors: [] });
+  });
+
+  test('a malformed rule entry is rejected with a precise message', () => {
+    const { errors } = validateDeclaration({ version: 1, source: ['lib'], rules: [{ when: 'a/**' }] });
+    expect(errors.some(e => /rules\[0\]\.requires/.test(e))).toBe(true);
+  });
+
+  test('non-object → error', () => {
+    expect(validateDeclaration(['nope']).errors.length).toBeGreaterThan(0);
+    expect(validateDeclaration(null).errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('detect() honors a committed declaration', () => {
+  test('a monorepo (would ESCALATE) with a tracked declaration → verdict DECLARED', () => {
+    const dir = makeRepo({ ...MONOREPO_BASE, '.docgate.json': DECL(['packages/a']) });
+    // Sanity: without the declaration this layout escalates.
+    const bare = makeRepo(MONOREPO_BASE);
+    expect(detect(bare).verdict).toBe('ESCALATE-TO-AGENT');
+
+    const r = detect(dir);
+    expect(r.verdict).toBe('DECLARED');
+    expect(r.declared).toBe(true);
+    expect(r.source.value).toEqual(['packages/a']);
+    expect(r.source.source).toBe('declared');
+    expect(r.source.confidence).toBe('high');
+    expect(r.escalate.map(e => e.field)).not.toContain('source');
+  });
+
+  test('declared toolchain overrides inference too', () => {
+    const decl = `${JSON.stringify({ version: 1, source: ['packages/a'], toolchain: 'pnpm' }, null, 2)}\n`;
+    const dir = makeRepo({ ...MONOREPO_BASE, '.docgate.json': decl });
+    const r = detect(dir);
+    expect(r.toolchain.value).toBe('pnpm');
+    expect(r.toolchain.source).toBe('declared');
+  });
+
+  test('INVALID declaration → declarationErrors set, detection still runs', () => {
+    const dir = makeRepo({ ...MONOREPO_BASE, '.docgate.json': `${JSON.stringify({ version: 9, source: ['packages/a'] })}\n` });
+    const r = detect(dir);
+    expect(Array.isArray(r.declarationErrors)).toBe(true);
+    expect(r.declarationErrors.length).toBeGreaterThan(0);
+    // Detection is untouched: the monorepo still escalates, declaration NOT applied.
+    expect(r.verdict).toBe('ESCALATE-TO-AGENT');
+    expect(r.declared).toBeUndefined();
+  });
+});
+
+describe('evaluateGate() honors the declaration', () => {
+  /** Base commit (with tracked .docgate.json), then a head commit applying mutations. */
+  function twoCommit(baseFiles, mutations) {
+    const dir = makeRepo(baseFiles);
+    const base = headSha(dir);
+    writeFiles(dir, mutations);
+    gitq(dir, ['add', '-A']);
+    gitq(dir, ['commit', '-q', '-m', 'head']);
+    return { dir, base, head: headSha(dir) };
+  }
+
+  test('DECLARED enforces: code change with NO doc → fail', () => {
+    const { dir, base, head } = twoCommit(
+      { ...MONOREPO_BASE, '.docgate.json': DECL(['packages/a']) },
+      { 'packages/a/index.js': 'module.exports = 2;\n' },
+    );
+    const r = evaluateGate({ root: dir, base, head });
+    expect(r.verdict).toBe('DECLARED');
+    expect(r.decision).toBe('fail');
+    expect(r.offendingCodeFiles).toContain('packages/a/index.js');
+  });
+
+  test('DECLARED enforces: code change + doc update → pass', () => {
+    const { dir, base, head } = twoCommit(
+      { ...MONOREPO_BASE, '.docgate.json': DECL(['packages/a']) },
+      { 'packages/a/index.js': 'module.exports = 2;\n', 'CHANGELOG.md': '# Changelog\n\n## [Unreleased]\n- change\n' },
+    );
+    const r = evaluateGate({ root: dir, base, head });
+    expect(r.decision).toBe('pass');
+    expect(r.docChangesSeen).toContain('CHANGELOG.md');
+  });
+
+  test('excludeFromGate: a change confined to an excluded path is not code → pass', () => {
+    const decl = `${JSON.stringify({ version: 1, source: ['packages/a'], excludeFromGate: ['packages/a/generated/**'] }, null, 2)}\n`;
+    const { dir, base, head } = twoCommit(
+      { ...MONOREPO_BASE, '.docgate.json': decl, 'packages/a/generated/schema.js': 'module.exports = 0;\n' },
+      { 'packages/a/generated/schema.js': 'module.exports = 1;\n' },
+    );
+    const r = evaluateGate({ root: dir, base, head });
+    expect(r.decision).toBe('pass');
+    expect(r.offendingCodeFiles).toEqual([]);
+  });
+
+  test('excludeFromGate: a normal source change still fails', () => {
+    const decl = `${JSON.stringify({ version: 1, source: ['packages/a'], excludeFromGate: ['packages/a/generated/**'] }, null, 2)}\n`;
+    const { dir, base, head } = twoCommit(
+      { ...MONOREPO_BASE, '.docgate.json': decl },
+      { 'packages/a/index.js': 'module.exports = 2;\n' },
+    );
+    const r = evaluateGate({ root: dir, base, head });
+    expect(r.decision).toBe('fail');
+    expect(r.offendingCodeFiles).toContain('packages/a/index.js');
+  });
+
+  test('rules: a triggered rule fails even when a doc update accompanies the change', () => {
+    const decl = `${JSON.stringify({ version: 1, source: ['packages/a'], rules: [{ when: 'packages/a/api/**', requires: 'openapi.yaml' }] }, null, 2)}\n`;
+    const { dir, base, head } = twoCommit(
+      { ...MONOREPO_BASE, '.docgate.json': decl, 'packages/a/api/users.js': 'module.exports = 0;\n', 'openapi.yaml': 'openapi: 3.0.0\n' },
+      { 'packages/a/api/users.js': 'module.exports = 1;\n', 'CHANGELOG.md': '# Changelog\n\n## [Unreleased]\n- api\n' },
+    );
+    const r = evaluateGate({ root: dir, base, head });
+    expect(r.decision).toBe('fail');
+    expect(r.reason).toMatch(/openapi\.yaml/);
+  });
+
+  test('rules: satisfying the required path passes', () => {
+    const decl = `${JSON.stringify({ version: 1, source: ['packages/a'], rules: [{ when: 'packages/a/api/**', requires: 'openapi.yaml' }] }, null, 2)}\n`;
+    const { dir, base, head } = twoCommit(
+      { ...MONOREPO_BASE, '.docgate.json': decl, 'packages/a/api/users.js': 'module.exports = 0;\n', 'openapi.yaml': 'openapi: 3.0.0\n' },
+      {
+        'packages/a/api/users.js': 'module.exports = 1;\n',
+        'openapi.yaml': 'openapi: 3.0.1\n',
+        'CHANGELOG.md': '# Changelog\n\n## [Unreleased]\n- api\n',
+      },
+    );
+    const r = evaluateGate({ root: dir, base, head });
+    expect(r.decision).toBe('pass');
+  });
+
+  test('INVALID declaration → gate FAILS closed (never a silent pass)', () => {
+    const { dir, base, head } = twoCommit(
+      { ...MONOREPO_BASE, '.docgate.json': `${JSON.stringify({ version: 1, unknownKey: true })}\n` },
+      { 'CHANGELOG.md': '# Changelog\n\n## [Unreleased]\n- docs only\n' },
+    );
+    const r = evaluateGate({ root: dir, base, head });
+    expect(r.decision).toBe('fail');
+    expect(r.reason).toMatch(/invalid \.docgate\.json/i);
+  });
+});
+
+describe('scaffoldDeclaration — starter object from a detect() result', () => {
+  test('uses detected source/toolchain and is itself schema-valid', () => {
+    const dir = makeRepo({
+      'package.json': '{"name":"x","version":"1.0.0"}\n',
+      'package-lock.json': '{}\n',
+      'lib/index.js': 'module.exports = 1;\n',
+    });
+    const scaffold = scaffoldDeclaration(detect(dir));
+    expect(scaffold.version).toBe(1);
+    expect(scaffold.source).toEqual(['lib']);
+    expect(scaffold.toolchain).toBe('npm');
+    expect(validateDeclaration(scaffold).errors).toEqual([]);
+  });
+
+  test('falls back to a src placeholder when detection abstained', () => {
+    const scaffold = scaffoldDeclaration({ source: { value: null }, toolchain: { value: null } });
+    expect(scaffold.source).toEqual(['src']);
+    expect(scaffold.toolchain).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a checked-in **`.docgate.json`** declaration that authoritatively declares a repo's structure and **overrides the detector's inference** — the research-validated "declaration beats inference" escape hatch (cf. corepack `packageManager`, knip.json). The detector abstains/escalates on repos it can't confidently resolve (e.g. monorepos); a committed declaration lets such a repo resolve precisely so the gate enforces. This is also the **persistence seam** a future agent will write into.

Scope is JUST the declaration — schema + loader + detect/gate honoring it + a scaffold command. OKF-bundle generation and the agent runtime are deliberately out of scope (follow-ups below).

## The declaration

Schema (strict): `{ "version": 1, "source"?: string[], "toolchain"?: string, "excludeFromGate"?: string[], "rules"?: [{ "when": string, "requires": string }] }`

- **Tracked-files-only** — read only when `git ls-files .docgate.json` lists it (consistent with the detector); untracked clutter can never change a verdict.
- **Overrides inference** — a valid declaration sets `source` (`source:'declared'`, `confidence:'high'`) and, if declared, `toolchain`, and promotes the verdict to **`DECLARED`**.
- **`DECLARED` = `CODE-RESOLVED`** to the gate (it enforces, never abstains) — but only when the declaration yields a concrete source surface, so a required check never enforces against a null surface (fail-closed).
- **`excludeFromGate`** globs are merged into the exclusion set (matching paths are never "code"), via a small ReDoS-safe glob matcher.
- **`rules`** (`when` → `requires`): a changed non-doc file matching `when` requires the `requires` path to be Added/Modified in the same change set, else fail with a precise message.
- **Fail-closed** — an INVALID declaration is surfaced (`declarationErrors`), never silently applied; `detect()` keeps normal detection and `evaluateGate()` fails closed (checked before `--skip`).
- **`forge doc-gate init [--force] [--json]`** — scaffolds a `.docgate.json` from the current `detect()` result so a human/agent can commit + edit it; refuses to overwrite without `--force`.

## Files

- `lib/doc-gate/declaration.js` (new) — `loadDeclaration(root)`, `validateDeclaration`, `scaffoldDeclaration`, strict fail-closed git wrapper.
- `lib/doc-gate/detect.js` — apply a valid declaration (verdict `DECLARED`); attach `declarationErrors` on invalid.
- `lib/doc-gate/gate.js` — enforce `DECLARED`; merge `excludeFromGate`; enforce `rules`; fail-closed on `declarationErrors`.
- `lib/commands/doc-gate.js` — `init` subcommand (`detect`/`check` unchanged).
- `test/doc-gate/declaration.test.js`, `test/commands/doc-gate-init.test.js` (new).

## Validation

- `bun test` (5 doc-gate files): **87 pass / 0 fail**.
- `npx eslint <changed> --max-warnings 0`: clean.
- `node bin/forge.js release check --target 0.1.0`: **PASS** (no blockers).
- Manual demo — a monorepo the detector `ESCALATE`s on, plus a tracked `.docgate.json` declaring `source: ["packages/a"]`: `doc-gate detect` now reports **verdict DECLARED** (`source.source: declared`); `doc-gate check` **enforces** (code w/o doc → FAIL exit 1; code + doc → PASS exit 0).

## Follow-ups (out of scope)

- OKF-bundle generation from the declaration.
- Agent escalation runtime that writes `.docgate.json` autonomously (this PR is its persistence seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `forge doc-gate init` command to generate a starter `.docgate.json` file for the current repository.
  * The command supports `--force` to overwrite an existing declaration file and `--json` output.
* **Bug Fixes**
  * Git-based declaration handling is now stricter, ignoring untracked declaration files and failing safely when a committed declaration is invalid.
  * Gate checks now apply declared exclusions and required companion-file rules more consistently, with improved glob matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->