### PR TITLE
fix(workflow): pre-merge is not a numbered stage in generated workflow docs

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,6 +1,6 @@
 # Forge Workflow Rules
 
-7-stage TDD-first development workflow for any project.
+TDD-first development workflow for any project: plan → dev → validate → ship → review → verify (pre-merge gate before merge).
 
 ## Workflow Commands
 
@@ -12,8 +12,9 @@
 | 3 | `/validate` | Type check, lint, code review, security, tests — all fresh output |
 | 4 | `/ship` | Push and create PR with design doc reference |
 | 5 | `/review` | Handle ALL PR issues (GitHub Actions, Greptile, SonarCloud) |
-| 6 | `/premerge` | Complete docs on feature branch, hand off PR to user |
-| 7 | `/verify` | Post-merge health check (CI on main, close Beads) |
+| 6 | `/verify` | Post-merge health check (CI on main, close Beads) |
+
+> **Pre-merge gate (not a numbered stage)**: finish docs on the feature branch, confirm CI is green, and hand off the PR — embedded in the `/ship` and `/review` stages, not a standalone command.
 
 ## Core Principles
 
@@ -113,9 +114,11 @@ Skill("parallel-deep-research")  # Deep analysis, market reports, web research
 ## Flow Visualization
 
 ```
-/plan → /dev → /validate → /ship → /review → /premerge → /verify
-  ↓        ↓        ↓        ↓        ↓          ↓         ↓
-Design   Task-by  Validate   PR      Address    Merge    Verify
-+Research  task    +GATE    create   feedback    +docs    CI on
-+Tasks    TDD                                   GATE     master
+/plan → /dev → /validate → /ship → /review → /verify
+  ↓        ↓        ↓        ↓        ↓         ↓
+Design   Task-by  Validate   PR      Address   Verify
++Research  task    +GATE    create   feedback   CI on
++Tasks    TDD                                   master
+
+Pre-merge gate (docs done + CI green + hand off PR) runs inside /ship and /review, before merge.
 ```

--- a/bin/forge.js
+++ b/bin/forge.js
@@ -437,8 +437,9 @@ Use these default-template commands via \`/command-name\`:
 - \`/validate\` - Type check, lint, security, tests (HARD-GATE)
 - \`/ship\` - Push and create PR with design doc reference
 - \`/review\` - Handle ALL PR issues (Actions, Greptile, SonarCloud)
-- \`/premerge\` - Complete docs on feature branch, hand off PR to user
 - \`/verify\` - Post-merge health check (CI on main, close Beads)
+
+Pre-merge gate (not a numbered stage): finish docs + confirm CI green + hand off the PR — embedded in the /ship and /review stages.
 
 See AGENTS.md for full workflow details.
 `;

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -16,7 +16,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 ## command
 
 - [ ] bin/forge.js (26)
-  - lines: 2234 (bd), 2236 (bd), 2382 (bd), 2784 (bd), 2793 (bd), 2806 (bd), 2819 (.beads), 2839 (bd), 2841 (bd), 2843 (bd), 2878 (bd), 2902 (bd), 2988 (bd), 3032 (bd), 3056 (bd), 3062 (bd), 3066 (bd), 3071 (bd), 3077 (bd), 3087 (bd), 3219 (bd), 3224 (bd), 3235 (bd), 3302 (bd), 3995 (bd), 4475 (bd)
+  - lines: 2235 (bd), 2237 (bd), 2383 (bd), 2785 (bd), 2794 (bd), 2807 (bd), 2820 (.beads), 2840 (bd), 2842 (bd), 2844 (bd), 2879 (bd), 2903 (bd), 2989 (bd), 3033 (bd), 3057 (bd), 3063 (bd), 3067 (bd), 3072 (bd), 3078 (bd), 3088 (bd), 3220 (bd), 3225 (bd), 3236 (bd), 3303 (bd), 3996 (bd), 4476 (bd)
 - [ ] lib/commands/_resolve-command-opts.js (2)
   - lines: 8 (bd), 10 (bd)
 - [ ] lib/commands/dev.js (1)

--- a/test/stage-naming.test.js
+++ b/test/stage-naming.test.js
@@ -30,8 +30,13 @@ describe('Stage naming consistency', () => {
       expect(cursorRule).toContain('/validate');
     });
 
-    test('contains /premerge as stage name', () => {
-      expect(cursorRule).toContain('/premerge');
+    test('does not list /premerge as a stage command', () => {
+      // Pre-merge is a gate embedded in /ship and /review, not a numbered stage.
+      expect(cursorRule).not.toContain('/premerge');
+    });
+
+    test('mentions the pre-merge gate', () => {
+      expect(cursorRule.toLowerCase()).toContain('pre-merge gate');
     });
   });
 


### PR DESCRIPTION
## Summary

Narrow fix to the **user-facing generated workflow docs** so they match `AGENTS.md`, the single source of truth. AGENTS.md treats pre-merge as a **task-type gate embedded in `/ship` and `/review`** — *not* a standalone numbered stage:

> Pre-merge gate (not a numbered stage): finish docs on the feature branch, confirm CI green, hand off the PR — embedded in the /ship and /review stages.

Stage flow stays: `plan → dev → validate → ship → review → verify` (pre-merge gate before merge).

## Changes

- **`bin/forge.js` `CURSOR_RULE`**: removed the `` - `/premerge` - … `` stage command line; added a concise "Pre-merge gate (not a numbered stage)" note. Flow unchanged.
- **`.claude/rules/workflow.md`**: removed "7-stage" wording, dropped the numbered `/premerge` table row (renumbered `/verify` to 6), fixed the Flow Visualization diagram, and added a gate note. Beads/issue-tracking content left untouched (separate concern).
- **`test/stage-naming.test.js`**: the CURSOR_RULE test now asserts `/premerge` is **not** listed as a stage command and that the pre-merge gate is mentioned.
- Regenerated the D20 bd call-site kill-list artifact (mechanical line-number shift from the net +1 line in `bin/forge.js`).

## Deliberately out of scope (follow-up)

The **internal stage-model de-stage** is a larger refactor deferred to a later PR: `lib/agents-config.js` per-stage `/premerge` sections, `lib/plugin-catalog.js`, `lib/harness-capability-matrix.js`, `lib/commands/status.js`, `lib/commands/recommend.js`, and WORKFLOW_GATES/legacy-stage handling.

Note: after this change, `bin/forge.js` `CURSOR_RULE` and `lib/agents-config.js`'s `generateCursorConfig` **diverge** on `/premerge` (both write `.cursor/rules/forge-workflow.mdc` via different code paths). That divergence is expected and is exactly the deferred follow-up — not an oversight. `test/cursor-config-generation.test.js` and `test/agents-md-generation.test.js` still assert `/premerge` because they exercise the `lib/agents-config.js` template, which is intentionally untouched here.

## Validation

- `bun test test/stage-naming.test.js …` (+ task5-stage-count, cursor-config-generation, agents-md-generation, release-readiness, structural contracts): **all pass**.
- `npx eslint bin/forge.js test/stage-naming.test.js --max-warnings 0`: clean.
- `node bin/forge.js release check --target 0.1.0`: **PASS**, no blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the workflow guide to a 6-step sequence with a clearer final verification step.
  * Clarified where the pre-merge check fits in the process and refreshed the workflow diagram.

* **Bug Fixes**
  * Aligned the workflow template with the latest stage names and removed the outdated pre-merge step reference.

* **Tests**
  * Updated checks to match the revised workflow wording and stage expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->