### PR TITLE
feat(doc-gate): opt-in OKF knowledge-base bundle generation

### DIFF
--- a/lib/commands/doc-gate.js
+++ b/lib/commands/doc-gate.js
@@ -23,6 +23,8 @@ const { execFileSync } = require('node:child_process');
 const { detect } = require('../doc-gate/detect');
 const { evaluateGate } = require('../doc-gate/gate');
 const { scaffoldDeclaration, DECLARATION_FILE } = require('../doc-gate/declaration');
+const { loadOkfConfig, setOkfEnabled, isOkfEnabled } = require('../doc-gate/okf-config');
+const { generateBundle, linkAgentsMd } = require('../doc-gate/okf');
 
 /** True when `root` is a git working tree with at least one commit (HEAD). */
 function hasGitHead(root) {
@@ -78,7 +80,11 @@ function renderHuman(result) {
 
 const CHECK_USAGE = 'forge doc-gate check --base <ref> --head <ref> [--skip] [--json]';
 const INIT_USAGE = 'forge doc-gate init [--force] [--json]';
-const USAGE = `forge doc-gate detect [--json]\n       ${CHECK_USAGE}\n       ${INIT_USAGE}`;
+const OKF_USAGE =
+  'forge doc-gate okf <status|enable|disable> [--json]\n' +
+  '       forge doc-gate okf generate [--source <dir>] [--out <dir>] [--json]\n' +
+  '       forge doc-gate okf link [--out <dir>] [--json]';
+const USAGE = `forge doc-gate detect [--json]\n       ${CHECK_USAGE}\n       ${INIT_USAGE}\n       ${OKF_USAGE}`;
 
 /** Standard "not a usable git repo" error result (exit 1). */
 function notAGitRepo(root, sub) {
@@ -208,6 +214,96 @@ function runInit(argv, flags, root) {
   return { success: true, output, json };
 }
 
+/** True when JSON output was requested (parsed flag OR raw `--json`). */
+function wantsJson(argv, flags) {
+  return Boolean(flags?.json) || argv.includes('--json');
+}
+
+const OKF_DISABLED_HINT = 'OKF is disabled. Run `forge doc-gate okf enable` to turn it on.';
+
+/** `okf status` — report whether OKF generation is enabled. */
+function okfStatus(argv, flags, root) {
+  const payload = { enabled: loadOkfConfig(root).okf.enabled };
+  const json = wantsJson(argv, flags);
+  const output = json ? JSON.stringify(payload, null, 2) : `doc-gate okf: ${payload.enabled ? 'ENABLED' : 'disabled'}`;
+  return { success: true, output, json };
+}
+
+/** `okf enable|disable` — flip the toggle in `.forge/doc-gate.json`. */
+function okfSetEnabled(argv, flags, root, enabled) {
+  let cfg;
+  try {
+    cfg = setOkfEnabled(root, enabled);
+  } catch (err) {
+    return { success: false, error: `could not update OKF toggle: ${err.message}`, exitCode: 1 };
+  }
+  const payload = { enabled: cfg.okf.enabled };
+  const json = wantsJson(argv, flags);
+  const output = json ? JSON.stringify(payload, null, 2) : `doc-gate okf ${enabled ? 'enabled' : 'disabled'}.`;
+  return { success: true, output, json };
+}
+
+/** Render a bundle-generation result as a readable summary. */
+function renderOkfGenerate(result) {
+  return [
+    `doc-gate okf generate — wrote ${result.count} concept${result.count === 1 ? '' : 's'} to ${result.out}/`,
+    `source: ${result.source}`,
+    `okf_version: ${result.okfVersion}`,
+    `root index: ${result.out}/index.md`,
+  ].join('\n');
+}
+
+/** `okf generate` — build the OKF bundle (refuses unless enabled). */
+function okfGenerate(argv, flags, root) {
+  if (!hasGitHead(root)) return notAGitRepo(root, 'okf generate');
+  if (!isOkfEnabled(root)) return { success: false, error: OKF_DISABLED_HINT, exitCode: 1 };
+  const source = flags?.source ?? readArgValue(argv, '--source');
+  const out = flags?.out ?? readArgValue(argv, '--out');
+  let result;
+  try {
+    result = generateBundle({ root, source: source ?? undefined, out: out ?? undefined });
+  } catch (err) {
+    return { success: false, error: `okf generate failed: ${err.message}`, exitCode: 1 };
+  }
+  if (!result.ok) return { success: false, error: result.error, exitCode: 1 };
+  const json = wantsJson(argv, flags);
+  const output = json ? JSON.stringify(result, null, 2) : renderOkfGenerate(result);
+  return { success: true, output, json };
+}
+
+/** `okf link` — write the thin AGENTS.md nav overlay (refuses unless enabled). */
+function okfLink(argv, flags, root) {
+  if (!isOkfEnabled(root)) return { success: false, error: OKF_DISABLED_HINT, exitCode: 1 };
+  const out = flags?.out ?? readArgValue(argv, '--out');
+  let result;
+  try {
+    result = linkAgentsMd({ root, out: out ?? undefined });
+  } catch (err) {
+    return { success: false, error: `okf link failed: ${err.message}`, exitCode: 1 };
+  }
+  const json = wantsJson(argv, flags);
+  const output = json
+    ? JSON.stringify(result, null, 2)
+    : `doc-gate okf link — ${result.created ? 'created' : 'updated'} ${result.path} nav → ${result.target}`;
+  return { success: true, output, json };
+}
+
+/** `okf` subcommand router. */
+function runOkf(argv, flags, root) {
+  const nonFlags = argv.filter(a => a && !a.startsWith('-'));
+  const action = nonFlags[1] ?? 'status';
+  if (action === 'status') return okfStatus(argv, flags, root);
+  if (action === 'enable') return okfSetEnabled(argv, flags, root, true);
+  if (action === 'disable') return okfSetEnabled(argv, flags, root, false);
+  if (action === 'generate') return okfGenerate(argv, flags, root);
+  if (action === 'link') return okfLink(argv, flags, root);
+  return {
+    success: false,
+    error: `Unknown doc-gate okf action '${action}'. Supported: status, enable, disable, generate, link.\nUsage: ${OKF_USAGE}`,
+    exitCode: 1,
+  };
+}
+
 module.exports = {
   name: 'doc-gate',
   description: 'Detect a repository\'s structure, or enforce the doc-update gate on a PR',
@@ -218,6 +314,8 @@ module.exports = {
     '--head': 'check: head ref/SHA of the pull request.',
     '--skip': 'check: force a pass (e.g. a no-docs-needed label).',
     '--force': 'init: overwrite an existing .docgate.json.',
+    '--source': 'okf generate: source docs dir (default: auto — docs/ or tracked markdown).',
+    '--out': 'okf generate/link: bundle output dir (default: .okf).',
   },
 
   async handler(args, flags, projectRoot, _opts = {}) {
@@ -228,9 +326,10 @@ module.exports = {
     if (sub === 'detect') return runDetect(argv, flags, root);
     if (sub === 'check') return runCheck(argv, flags, root);
     if (sub === 'init') return runInit(argv, flags, root);
+    if (sub === 'okf') return runOkf(argv, flags, root);
     return {
       success: false,
-      error: `Unknown doc-gate subcommand '${sub}'. Supported subcommands: detect, check, init.\nUsage: ${USAGE}`,
+      error: `Unknown doc-gate subcommand '${sub}'. Supported subcommands: detect, check, init, okf.\nUsage: ${USAGE}`,
       exitCode: 1,
     };
   },

--- a/lib/doc-gate/okf-config.js
+++ b/lib/doc-gate/okf-config.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * doc-gate OKF feature toggle — `.forge/doc-gate.json`.
+ *
+ * OKF (Google's Open Knowledge Format) support is an OPT-IN, user-toggleable
+ * knowledge-base feature. It is DISABLED by default: OKF v0.1 is a DRAFT and
+ * explicitly "not an official Google product", so nothing generates a bundle or
+ * touches AGENTS.md until a user turns it on.
+ *
+ * This module is the toggle store. It mirrors the `.forge/*.json` config pattern
+ * used by `lib/adapter-cli.js` (see `setAdapterEnabled`) but writes a dedicated
+ * `.forge/doc-gate.json` shaped `{ okf: { enabled: boolean } }`.
+ *
+ * IMPORTANT: this file is NOT the repo-root `.docgate.json` declaration
+ * (lib/doc-gate/declaration.js). Those two are deliberately separate — the
+ * declaration authoritatively describes repo structure and flips the detector
+ * verdict to DECLARED; this toggle ONLY gates OKF bundle generation. Neither
+ * reads or writes the other's file.
+ *
+ * Fail-safe: a missing OR malformed config resolves to DISABLED, never an error.
+ *
+ * @module doc-gate/okf-config
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CONFIG_DIR = '.forge';
+const CONFIG_FILE = 'doc-gate.json';
+
+/** Absolute path to a repo's `.forge/doc-gate.json`. */
+function configPath(root) {
+  return path.join(root, CONFIG_DIR, CONFIG_FILE);
+}
+
+/** True only for a plain (non-array) object. */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Normalize any parsed value into a well-formed `{ okf: { enabled: boolean } }`,
+ * preserving unrelated top-level keys. `enabled` is `true` ONLY when it is
+ * strictly the boolean `true`, so any junk (missing, string, number, null) is a
+ * safe `false`.
+ */
+function normalizeConfig(parsed) {
+  const base = isPlainObject(parsed) ? parsed : {};
+  const okf = isPlainObject(base.okf) ? base.okf : {};
+  return { ...base, okf: { ...okf, enabled: okf.enabled === true } };
+}
+
+/**
+ * Load + normalize a repo's `.forge/doc-gate.json`.
+ *
+ * A missing file, an unreadable file, or invalid JSON all resolve to the DISABLED
+ * default — this must never throw, so the toggle can be queried anywhere.
+ *
+ * @param {string} root - Repository root.
+ * @returns {{ okf: { enabled: boolean } }}
+ */
+function loadOkfConfig(root) {
+  let raw;
+  try {
+    raw = fs.readFileSync(configPath(root), 'utf8');
+  } catch (_err) {
+    // Missing / unreadable config => disabled (fail-safe). NOSONAR S2486
+    return normalizeConfig(null);
+  }
+  try {
+    return normalizeConfig(JSON.parse(raw));
+  } catch (_err) {
+    // Malformed JSON => disabled (fail-safe), never surfaced as an error. NOSONAR S2486
+    return normalizeConfig(null);
+  }
+}
+
+/** True when OKF generation is enabled for `root`. */
+function isOkfEnabled(root) {
+  return loadOkfConfig(root).okf.enabled === true;
+}
+
+/**
+ * Symlink-safe config write: refuse to write THROUGH a symlink (a checked-in
+ * symlink could clobber a file outside the repo), matching `doc-gate init`.
+ */
+function writeConfig(root, config) {
+  fs.mkdirSync(path.join(root, CONFIG_DIR), { recursive: true });
+  const file = configPath(root);
+  let stat = null;
+  try { stat = fs.lstatSync(file); } catch { /* absent: stat stays null */ }
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`${CONFIG_DIR}/${CONFIG_FILE} is a symlink; refusing to write through it.`);
+  }
+  fs.writeFileSync(file, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+/**
+ * Set the OKF `enabled` flag, preserving any unrelated config keys.
+ *
+ * @param {string} root - Repository root.
+ * @param {boolean} enabled - Desired state.
+ * @returns {{ okf: { enabled: boolean } }} The written config.
+ */
+function setOkfEnabled(root, enabled) {
+  const current = loadOkfConfig(root);
+  const next = { ...current, okf: { ...current.okf, enabled: enabled === true } };
+  writeConfig(root, next);
+  return next;
+}
+
+module.exports = {
+  loadOkfConfig,
+  isOkfEnabled,
+  setOkfEnabled,
+  configPath,
+  CONFIG_DIR,
+  CONFIG_FILE,
+};

--- a/lib/doc-gate/okf-config.js
+++ b/lib/doc-gate/okf-config.js
@@ -86,7 +86,15 @@ function isOkfEnabled(root) {
  * symlink could clobber a file outside the repo), matching `doc-gate init`.
  */
 function writeConfig(root, config) {
-  fs.mkdirSync(path.join(root, CONFIG_DIR), { recursive: true });
+  const dir = path.join(root, CONFIG_DIR);
+  // Refuse a symlinked CONFIG_DIR (.forge) BEFORE mkdir/write — a checked-in
+  // symlink there could redirect the write to a file OUTSIDE the repo.
+  let dirStat = null;
+  try { dirStat = fs.lstatSync(dir); } catch { /* absent: will be created */ }
+  if (dirStat?.isSymbolicLink()) {
+    throw new Error(`${CONFIG_DIR} is a symlink; refusing to write through it.`);
+  }
+  fs.mkdirSync(dir, { recursive: true });
   const file = configPath(root);
   let stat = null;
   try { stat = fs.lstatSync(file); } catch { /* absent: stat stays null */ }

--- a/lib/doc-gate/okf.js
+++ b/lib/doc-gate/okf.js
@@ -231,7 +231,9 @@ function buildTree(conceptRels) {
   return folders;
 }
 
-const byLocale = (a, b) => a.localeCompare(b);
+// Deterministic code-point order — localeCompare() varies by runtime/locale and
+// would make the bundle ordering (indexes + concept list) non-reproducible.
+const byCodePoint = (a, b) => (a < b ? -1 : Number(a > b));
 
 /**
  * Render a folder's `index.md`. The bundle-root index (dir === '') is the ONLY
@@ -242,11 +244,11 @@ function renderIndex(dir, node, titles) {
   const lines = [];
   if (isRoot) lines.push('---', `okf_version: ${JSON.stringify(OKF_VERSION)}`, '---', '');
   lines.push(`# ${isRoot ? 'Knowledge Base' : path.posix.basename(dir)}`, '');
-  for (const sub of [...node.subdirs].sort(byLocale)) {
+  for (const sub of [...node.subdirs].sort(byCodePoint)) {
     const rel = path.posix.relative(dir, sub);
     lines.push(`- [${path.posix.basename(sub)}/](${rel}/index.md)`);
   }
-  for (const file of [...node.files].sort(byLocale)) {
+  for (const file of [...node.files].sort(byCodePoint)) {
     const rel = path.posix.relative(dir, file);
     lines.push(`- [${titles.get(file)}](${rel})`);
   }
@@ -342,7 +344,15 @@ function generateBundle({ root, source, out } = {}) {
   const titles = new Map();
   for (const file of files) {
     const rel = conceptRel(file, base);
-    const content = fs.readFileSync(path.join(root, file), 'utf8');
+    const abs = path.join(root, file);
+    // `git ls-files` can list tracked .md SYMLINKS; readFileSync would follow them
+    // outside the repo. Refuse a symlinked source before reading (fail-closed).
+    let srcStat = null;
+    try { srcStat = fs.lstatSync(abs); } catch { /* a real read error surfaces below */ }
+    if (srcStat?.isSymbolicLink()) {
+      throw new Error(`refusing to read a symlinked source file (could escape the repo): ${file}`);
+    }
+    const content = fs.readFileSync(abs, 'utf8');
     const title = conceptTitle(content, rel);
     titles.set(rel, title);
     writeFileSafe(outAbs, rel, buildConcept(content, rel, title));
@@ -358,7 +368,7 @@ function generateBundle({ root, source, out } = {}) {
     ok: true,
     out: outRel,
     source: base === '' ? '(tracked markdown)' : base,
-    concepts: concepts.sort(byLocale),
+    concepts: concepts.sort(byCodePoint),
     count: concepts.length,
     okfVersion: OKF_VERSION,
   };

--- a/lib/doc-gate/okf.js
+++ b/lib/doc-gate/okf.js
@@ -107,7 +107,10 @@ function resolveSources(root, sourceRel, outRel) {
   if (sourceRel !== null) {
     const base = sourceRel;
     const prefix = base === '' ? '' : `${base}/`;
-    const files = all.filter(f => isMarkdown(f) && f.startsWith(prefix) && f !== base);
+    // Exclude the output dir even with an explicit --source, so re-generating
+    // never folds a previous bundle back into itself.
+    const inOut = f => outRel !== '' && (f === outRel || f.startsWith(`${outRel}/`));
+    const files = all.filter(f => isMarkdown(f) && f.startsWith(prefix) && f !== base && !inOut(f));
     return { base, files };
   }
   const docs = all.filter(f => isMarkdown(f) && f.startsWith('docs/'));
@@ -191,7 +194,9 @@ function buildConcept(content, rel, title) {
   const { inner, body } = splitFrontMatter(content);
   if (inner === null) {
     const fm = `---\ntype: ${JSON.stringify(inferType(rel))}\ntitle: ${JSON.stringify(title)}\n---\n`;
-    return `${fm}\n${content}`;
+    // No injected blank line — preserve the body verbatim, matching the
+    // existing-front-matter branch below.
+    return `${fm}${content}`;
   }
   const keys = frontMatterKeys(inner);
   const additions = [];
@@ -250,13 +255,28 @@ function renderIndex(dir, node, titles) {
 
 // --- symlink-safe writing -----------------------------------------------------
 
-/** Prepare the out dir: refuse a symlink, create it if missing, require a dir. */
-function prepareOutRoot(outAbs) {
+/** Refuse if ANY existing path segment from `rootAbs` down to `targetAbs` is a
+ * symlink — otherwise a symlinked ANCESTOR could redirect writes outside the repo
+ * even though the final component isn't itself a link. */
+function assertNoSymlinkedAncestor(targetAbs, rootAbs) {
+  const rel = path.relative(rootAbs, targetAbs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(`path escapes the repo root: ${targetAbs}`);
+  }
+  let cur = rootAbs;
+  for (const part of rel.split(path.sep).filter(seg => seg !== '')) {
+    cur = path.join(cur, part);
+    let seg = null;
+    try { seg = fs.lstatSync(cur); } catch { /* absent yet */ }
+    if (seg?.isSymbolicLink()) throw new Error(`refusing to write through a symlinked path segment: ${cur}`);
+  }
+}
+
+/** Prepare the out dir: refuse a symlinked ancestor OR target, create if missing, require a dir. */
+function prepareOutRoot(outAbs, rootAbs) {
+  assertNoSymlinkedAncestor(outAbs, rootAbs);
   let stat = null;
   try { stat = fs.lstatSync(outAbs); } catch { /* absent: stat stays null */ }
-  if (stat?.isSymbolicLink()) {
-    throw new Error(`out dir is a symlink; refusing to write through it: ${outAbs}`);
-  }
   if (stat === null) { fs.mkdirSync(outAbs, { recursive: true }); return; }
   if (!stat.isDirectory()) throw new Error(`out path exists and is not a directory: ${outAbs}`);
 }
@@ -316,7 +336,7 @@ function generateBundle({ root, source, out } = {}) {
   }
 
   const outAbs = path.resolve(root, outRel);
-  prepareOutRoot(outAbs);
+  prepareOutRoot(outAbs, path.resolve(root));
 
   const concepts = [];
   const titles = new Map();

--- a/lib/doc-gate/okf.js
+++ b/lib/doc-gate/okf.js
@@ -1,0 +1,399 @@
+'use strict';
+
+/**
+ * doc-gate OKF (Open Knowledge Format) bundle generator.
+ *
+ * Deterministic, script-first "markdown -> OKF bundle" core. A "bundle" is a
+ * directory tree of concept docs (the unit of distribution). Each source `.md`
+ * becomes a concept doc whose Concept ID is its path minus `.md`.
+ *
+ * Spec facts implemented (OKF v0.1 DRAFT — "not an official Google product"):
+ *  - Concept front matter: the ONLY required key is `type`. `title` is the
+ *    optional display name (there is NO `name` key). We inject `type` + `title`
+ *    and preserve the body verbatim.
+ *  - Per-folder `index.md` lists that folder's contents and carries NO front
+ *    matter. The BUNDLE-ROOT `index.md` is the ONLY index that may carry front
+ *    matter, for exactly one key: `okf_version: "0.1"`.
+ *
+ * OKF is a SERIALIZATION / interop format only — it has no enforcement or query
+ * semantics. Generation NEVER touches detect()/gate() verdicts; resolution
+ * correctness stays doc-gate's own concern.
+ *
+ * Conventions shared with the rest of doc-gate:
+ *  - Tracked-files-only reads: source markdown comes from `git ls-files`, never a
+ *    raw filesystem walk, so untracked clutter can't leak into a bundle.
+ *  - Fail-closed git wrapper that THROWS.
+ *  - Symlink-safe writes: every write target is `lstat`-checked and refused if it
+ *    (or a parent component) is a symlink, and nothing is ever written outside the
+ *    out dir.
+ *
+ * @module doc-gate/okf
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const OKF_VERSION = '0.1';
+const ROOT_INDEX = 'index.md';
+const NAV_BEGIN = '<!-- BEGIN FORGE OKF NAV -->';
+const NAV_END = '<!-- END FORGE OKF NAV -->';
+
+// Top-level markdown that is boilerplate, not knowledge-base content. Only used
+// by the auto-source fallback (when there is no docs/ dir and no --source).
+const AGENT_OR_META_MD = new Set([
+  'agents.md', 'claude.md', 'gemini.md', 'readme.md', 'contributing.md',
+  'license.md', 'changelog.md', 'code_of_conduct.md', 'security.md',
+]);
+
+// --- git (fail-closed) --------------------------------------------------------
+
+/** Strict git wrapper — THROWS on any failure (fail-closed), like declaration.js. */
+function gitStrict(root, args) {
+  // NOSONAR S4036 - hardcoded CLI command, no user input; developer-tool context.
+  const res = cp.spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' }); // NOSONAR S4036
+  if (res.error) throw new Error(`git ${args.join(' ')}: ${res.error.message}`);
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(' ')} exited ${res.status}: ${String(res.stderr || '').trim()}`);
+  }
+  return res.stdout;
+}
+
+/** Tracked files (repo-relative, forward-slashed) at `root`. */
+function trackedFiles(root) {
+  return gitStrict(root, ['ls-files'])
+    .split('\n')
+    .map(s => s.trim())
+    .filter(line => line !== '');
+}
+
+// --- path hygiene -------------------------------------------------------------
+
+/**
+ * Normalize + validate a user-supplied relative path. Rejects blank/whitespace
+ * input and any `..` segment; returns a forward-slashed, trimmed path. A lone
+ * `.` normalizes to '' (meaning "repo root").
+ */
+function cleanRel(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${label} must be a non-empty path`);
+  }
+  const norm = value.replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  const stripped = norm === '.' ? '' : norm;
+  if (stripped.split('/').some(seg => seg === '..')) {
+    throw new Error(`${label} must not contain '..': ${value}`);
+  }
+  return stripped;
+}
+
+// --- source resolution --------------------------------------------------------
+
+const isMarkdown = file => file.toLowerCase().endsWith('.md');
+
+/** True when a fallback markdown file should be skipped (out dir / boilerplate). */
+function isExcludedFallback(file, outRel) {
+  if (outRel !== '' && (file === outRel || file.startsWith(`${outRel}/`))) return true;
+  if (!file.includes('/') && AGENT_OR_META_MD.has(file.toLowerCase())) return true;
+  return false;
+}
+
+/**
+ * Resolve the source markdown set + the base dir concept paths are relative to.
+ * With `--source`: tracked markdown UNDER that dir. Auto: prefer `docs/`; else
+ * fall back to all tracked markdown minus the out dir and top-level boilerplate.
+ */
+function resolveSources(root, sourceRel, outRel) {
+  const all = trackedFiles(root);
+  if (sourceRel !== null) {
+    const base = sourceRel;
+    const prefix = base === '' ? '' : `${base}/`;
+    const files = all.filter(f => isMarkdown(f) && f.startsWith(prefix) && f !== base);
+    return { base, files };
+  }
+  const docs = all.filter(f => isMarkdown(f) && f.startsWith('docs/'));
+  if (docs.length > 0) return { base: 'docs', files: docs };
+  const files = all.filter(f => isMarkdown(f) && !isExcludedFallback(f, outRel));
+  return { base: '', files };
+}
+
+/** Concept path relative to the source base dir. */
+function conceptRel(file, base) {
+  return base === '' ? file : file.slice(base.length + 1);
+}
+
+// --- concept construction -----------------------------------------------------
+
+/** Infer a sensible OKF `type` from the concept path (default `document`). */
+function inferType(rel) {
+  const p = rel.toLowerCase();
+  if (p.includes('guide') || p.includes('tutorial') || p.includes('how-to') || p.includes('howto')) {
+    return 'guide';
+  }
+  if (p.includes('reference') || p.includes('/api/') || p.startsWith('api/')) {
+    return 'reference';
+  }
+  return 'document';
+}
+
+/** First ATX H1 (`# Title`) in `body`, or null. */
+function firstHeading(body) {
+  const m = body.match(/^#\s+(.+?)\s*$/m);
+  return m ? m[1].trim() : null;
+}
+
+/** Strip surrounding single/double quotes from a YAML scalar. */
+function stripYamlScalar(value) {
+  const t = value.trim();
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+/**
+ * Split a leading YAML front-matter block. Returns `{ inner, body }` where
+ * `inner` is the raw block content (no `---` fences) or null when absent.
+ */
+function splitFrontMatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) return { inner: null, body: content };
+  return { inner: m[1], body: content.slice(m[0].length) };
+}
+
+/** Set of top-level keys present in a raw front-matter block (lower-cased). */
+function frontMatterKeys(inner) {
+  const keys = new Set();
+  for (const line of inner.split('\n')) {
+    const m = line.match(/^([A-Za-z0-9_-]+)\s*:/);
+    if (m) keys.add(m[1].toLowerCase());
+  }
+  return keys;
+}
+
+/** Display title for a concept: H1, else existing front-matter title, else filename. */
+function conceptTitle(content, rel) {
+  const { inner, body } = splitFrontMatter(content);
+  const heading = firstHeading(body);
+  if (heading) return heading;
+  if (inner) {
+    const m = inner.match(/^title\s*:\s*(.+?)\s*$/m);
+    if (m) return stripYamlScalar(m[1]);
+  }
+  return path.posix.basename(rel).replace(/\.md$/i, '');
+}
+
+/**
+ * Build the concept doc content: ensure a single front-matter block that carries
+ * at least `type` (+ `title`), preserving the original body and any pre-existing
+ * front matter (only MISSING required keys are appended — never duplicated).
+ */
+function buildConcept(content, rel, title) {
+  const { inner, body } = splitFrontMatter(content);
+  if (inner === null) {
+    const fm = `---\ntype: ${JSON.stringify(inferType(rel))}\ntitle: ${JSON.stringify(title)}\n---\n`;
+    return `${fm}\n${content}`;
+  }
+  const keys = frontMatterKeys(inner);
+  const additions = [];
+  if (!keys.has('type')) additions.push(`type: ${JSON.stringify(inferType(rel))}`);
+  if (!keys.has('title')) additions.push(`title: ${JSON.stringify(title)}`);
+  const mergedInner = additions.length > 0 ? `${inner}\n${additions.join('\n')}` : inner;
+  return `---\n${mergedInner}\n---\n${body}`;
+}
+
+// --- index construction -------------------------------------------------------
+
+/** Build a folder tree: `Map<dir, { files: string[], subdirs: Set<string> }>`. */
+function buildTree(conceptRels) {
+  const folders = new Map();
+  const ensure = dir => {
+    if (!folders.has(dir)) folders.set(dir, { files: [], subdirs: new Set() });
+    return folders.get(dir);
+  };
+  ensure('');
+  for (const rel of conceptRels) {
+    const dirName = path.posix.dirname(rel);
+    const dir = dirName === '.' ? '' : dirName;
+    ensure(dir).files.push(rel);
+    let child = dir;
+    while (child !== '') {
+      const parentName = path.posix.dirname(child);
+      const parent = parentName === '.' ? '' : parentName;
+      ensure(parent).subdirs.add(child);
+      child = parent;
+    }
+  }
+  return folders;
+}
+
+const byLocale = (a, b) => a.localeCompare(b);
+
+/**
+ * Render a folder's `index.md`. The bundle-root index (dir === '') is the ONLY
+ * one that carries front matter, for the single key `okf_version`.
+ */
+function renderIndex(dir, node, titles) {
+  const isRoot = dir === '';
+  const lines = [];
+  if (isRoot) lines.push('---', `okf_version: ${JSON.stringify(OKF_VERSION)}`, '---', '');
+  lines.push(`# ${isRoot ? 'Knowledge Base' : path.posix.basename(dir)}`, '');
+  for (const sub of [...node.subdirs].sort(byLocale)) {
+    const rel = path.posix.relative(dir, sub);
+    lines.push(`- [${path.posix.basename(sub)}/](${rel}/index.md)`);
+  }
+  for (const file of [...node.files].sort(byLocale)) {
+    const rel = path.posix.relative(dir, file);
+    lines.push(`- [${titles.get(file)}](${rel})`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+// --- symlink-safe writing -----------------------------------------------------
+
+/** Prepare the out dir: refuse a symlink, create it if missing, require a dir. */
+function prepareOutRoot(outAbs) {
+  let stat = null;
+  try { stat = fs.lstatSync(outAbs); } catch { /* absent: stat stays null */ }
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`out dir is a symlink; refusing to write through it: ${outAbs}`);
+  }
+  if (stat === null) { fs.mkdirSync(outAbs, { recursive: true }); return; }
+  if (!stat.isDirectory()) throw new Error(`out path exists and is not a directory: ${outAbs}`);
+}
+
+/** Create the dir chain under `outAbs`, refusing to traverse a symlinked component. */
+function ensureDirSafe(outAbs, dirAbs) {
+  const relParts = path.relative(outAbs, dirAbs).split(path.sep).filter(seg => seg !== '');
+  let cur = outAbs;
+  for (const part of relParts) {
+    cur = path.join(cur, part);
+    let stat = null;
+    try { stat = fs.lstatSync(cur); } catch { /* absent: stat stays null */ }
+    if (stat?.isSymbolicLink()) {
+      throw new Error(`refusing to write through a symlinked directory: ${cur}`);
+    }
+    if (stat === null) fs.mkdirSync(cur);
+  }
+}
+
+/** Write `content` to `outAbs/relPath`, symlink-safe and contained within `outAbs`. */
+function writeFileSafe(outAbs, relPath, content) {
+  const targetAbs = path.resolve(outAbs, relPath);
+  const within = path.relative(outAbs, targetAbs);
+  if (within.startsWith('..') || path.isAbsolute(within)) {
+    throw new Error(`refusing to write outside the out dir: ${relPath}`);
+  }
+  ensureDirSafe(outAbs, path.dirname(targetAbs));
+  let stat = null;
+  try { stat = fs.lstatSync(targetAbs); } catch { /* absent: stat stays null */ }
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`${relPath} is a symlink; refusing to write through it.`);
+  }
+  fs.writeFileSync(targetAbs, content);
+}
+
+// --- public API ---------------------------------------------------------------
+
+/**
+ * Generate an OKF bundle from a repo's tracked markdown.
+ *
+ * @param {object} opts
+ * @param {string} opts.root - Repository root (a git working tree).
+ * @param {string} [opts.source] - Source docs dir; auto-detected when omitted.
+ * @param {string} [opts.out='.okf'] - Bundle output dir (must not be the repo root).
+ * @returns {{ ok: boolean, error?: string, out?: string, source?: string,
+ *   concepts?: string[], count?: number, okfVersion?: string }}
+ */
+function generateBundle({ root, source, out } = {}) {
+  if (typeof root !== 'string' || root.trim() === '') throw new Error('root must be a non-empty path');
+  const outRel = cleanRel(out ?? '.okf', 'out');
+  if (outRel === '') throw new Error('out dir must not be the repo root');
+  const sourceRel = source === undefined || source === null ? null : cleanRel(source, 'source');
+
+  const { base, files } = resolveSources(root, sourceRel, outRel);
+  if (files.length === 0) {
+    return { ok: false, error: 'No tracked markdown found to generate an OKF bundle from.' };
+  }
+
+  const outAbs = path.resolve(root, outRel);
+  prepareOutRoot(outAbs);
+
+  const concepts = [];
+  const titles = new Map();
+  for (const file of files) {
+    const rel = conceptRel(file, base);
+    const content = fs.readFileSync(path.join(root, file), 'utf8');
+    const title = conceptTitle(content, rel);
+    titles.set(rel, title);
+    writeFileSafe(outAbs, rel, buildConcept(content, rel, title));
+    concepts.push(rel);
+  }
+
+  for (const [dir, node] of buildTree(concepts)) {
+    const indexRel = dir === '' ? ROOT_INDEX : `${dir}/${ROOT_INDEX}`;
+    writeFileSafe(outAbs, indexRel, renderIndex(dir, node, titles));
+  }
+
+  return {
+    ok: true,
+    out: outRel,
+    source: base === '' ? '(tracked markdown)' : base,
+    concepts: concepts.sort(byLocale),
+    count: concepts.length,
+    okfVersion: OKF_VERSION,
+  };
+}
+
+/** Build the delimited AGENTS.md managed nav block pointing at the bundle root. */
+function buildNavBlock(outRel) {
+  const indexRel = `${outRel}/${ROOT_INDEX}`;
+  return [
+    NAV_BEGIN,
+    '## Knowledge Base (OKF)',
+    '',
+    'This repository maintains an Open Knowledge Format (OKF v0.1 draft) bundle.',
+    `Start at the bundle index: [\`${indexRel}\`](${indexRel}).`,
+    '',
+    'This is a thin navigation overlay; the bundle itself is the source of truth.',
+    NAV_END,
+  ].join('\n');
+}
+
+/** Insert or replace the managed nav block, preserving surrounding content. */
+function upsertNavBlock(existing, block) {
+  const start = existing.indexOf(NAV_BEGIN);
+  const end = existing.indexOf(NAV_END);
+  if (start !== -1 && end !== -1 && end > start) {
+    return `${existing.slice(0, start)}${block}${existing.slice(end + NAV_END.length)}`;
+  }
+  if (existing === '') return `${block}\n`;
+  const sep = existing.endsWith('\n') ? '\n' : '\n\n';
+  return `${existing}${sep}${block}\n`;
+}
+
+/**
+ * Write/update a thin OKF navigation section in AGENTS.md (NOT CLAUDE.md) that
+ * POINTS AT the bundle root index. Idempotent via a delimited managed block.
+ *
+ * @param {object} opts
+ * @param {string} opts.root - Repository root.
+ * @param {string} [opts.out='.okf'] - Bundle dir the nav should point at.
+ * @returns {{ ok: boolean, path: string, target: string, created: boolean }}
+ */
+function linkAgentsMd({ root, out } = {}) {
+  if (typeof root !== 'string' || root.trim() === '') throw new Error('root must be a non-empty path');
+  const outRel = cleanRel(out ?? '.okf', 'out');
+  if (outRel === '') throw new Error('out dir must not be the repo root');
+
+  const agentsAbs = path.join(root, 'AGENTS.md');
+  let stat = null;
+  try { stat = fs.lstatSync(agentsAbs); } catch { /* absent: stat stays null */ }
+  if (stat?.isSymbolicLink()) {
+    throw new Error('AGENTS.md is a symlink; refusing to write through it.');
+  }
+  const existing = stat === null ? '' : fs.readFileSync(agentsAbs, 'utf8');
+  fs.writeFileSync(agentsAbs, upsertNavBlock(existing, buildNavBlock(outRel)));
+  return { ok: true, path: 'AGENTS.md', target: `${outRel}/${ROOT_INDEX}`, created: stat === null };
+}
+
+module.exports = { generateBundle, linkAgentsMd, OKF_VERSION };

--- a/test/commands/doc-gate-okf.test.js
+++ b/test/commands/doc-gate-okf.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const { describe, expect, test, afterAll, setDefaultTimeout } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const docGate = require('../../lib/commands/doc-gate');
+const { generateBundle } = require('../../lib/doc-gate/okf');
+const { isOkfEnabled } = require('../../lib/doc-gate/okf-config');
+
+// Real git fixtures + parallel disk I/O can exceed the 5s default on Windows CI.
+setDefaultTimeout(30000);
+
+const createdDirs = [];
+function git(dir, args) {
+  execFileSync('git', ['-C', dir, ...args], { stdio: ['ignore', 'ignore', 'ignore'] });
+}
+function makeDocsRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-okf-cmd-'));
+  createdDirs.push(dir);
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.mkdirSync(path.join(dir, 'docs', 'guides'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'docs', 'intro.md'), '# Introduction\n\nWelcome.\n');
+  fs.writeFileSync(path.join(dir, 'docs', 'guides', 'setup.md'), '# Setup Guide\n\nSteps.\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe('forge doc-gate okf (command wrapper)', () => {
+  test('status defaults to disabled', async () => {
+    const dir = makeDocsRepo();
+    const res = await docGate.handler(['okf', 'status', '--json'], {}, dir, {});
+    expect(res.success).toBe(true);
+    expect(JSON.parse(res.output)).toEqual({ enabled: false });
+  });
+
+  test('generate refuses when disabled (exit 1, no bundle written)', async () => {
+    const dir = makeDocsRepo();
+    const res = await docGate.handler(['okf', 'generate', '--source', 'docs'], {}, dir, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toMatch(/disabled/i);
+    expect(fs.existsSync(path.join(dir, '.okf'))).toBe(false);
+  });
+
+  test('enable then status reports enabled; disable reverts', async () => {
+    const dir = makeDocsRepo();
+    const en = await docGate.handler(['okf', 'enable'], {}, dir, {});
+    expect(en.success).toBe(true);
+    expect(isOkfEnabled(dir)).toBe(true);
+
+    const status = await docGate.handler(['okf', 'status', '--json'], {}, dir, {});
+    expect(JSON.parse(status.output)).toEqual({ enabled: true });
+
+    const dis = await docGate.handler(['okf', 'disable'], {}, dir, {});
+    expect(dis.success).toBe(true);
+    expect(isOkfEnabled(dir)).toBe(false);
+  });
+
+  test('generate --json equals the underlying generateBundle result (thin wrapper)', async () => {
+    const dir = makeDocsRepo();
+    await docGate.handler(['okf', 'enable'], {}, dir, {});
+    // Deterministic core: calling the function directly writes the same bundle.
+    const direct = generateBundle({ root: dir, source: 'docs', out: '.okf' });
+    const res = await docGate.handler(['okf', 'generate', '--source', 'docs', '--out', '.okf', '--json'], {}, dir, {});
+    expect(res.success).toBe(true);
+    expect(JSON.parse(res.output)).toEqual(direct);
+  });
+
+  test('unknown okf action is an error (exit 1)', async () => {
+    const dir = makeDocsRepo();
+    const res = await docGate.handler(['okf', 'bogus'], {}, dir, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+  });
+
+  test('link writes AGENTS.md nav (exit 0) when enabled', async () => {
+    const dir = makeDocsRepo();
+    await docGate.handler(['okf', 'enable'], {}, dir, {});
+    await docGate.handler(['okf', 'generate', '--source', 'docs', '--out', '.okf'], {}, dir, {});
+    const res = await docGate.handler(['okf', 'link', '--out', '.okf', '--json'], {}, dir, {});
+    expect(res.success).toBe(true);
+    expect(fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf8')).toContain('.okf/index.md');
+  });
+
+  test('link refuses when disabled (exit 1)', async () => {
+    const dir = makeDocsRepo();
+    const res = await docGate.handler(['okf', 'link', '--out', '.okf'], {}, dir, {});
+    expect(res.success).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toMatch(/disabled/i);
+  });
+});

--- a/test/doc-gate/okf-config.test.js
+++ b/test/doc-gate/okf-config.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { describe, expect, test, afterAll, setDefaultTimeout } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadOkfConfig, isOkfEnabled, setOkfEnabled } = require('../../lib/doc-gate/okf-config');
+
+// Disk I/O on Windows CI can exceed the 5s default.
+setDefaultTimeout(30000);
+
+const createdDirs = [];
+function tmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-okf-config-'));
+  createdDirs.push(dir);
+  return dir;
+}
+const cfgFile = dir => path.join(dir, '.forge', 'doc-gate.json');
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe('doc-gate okf toggle (.forge/doc-gate.json)', () => {
+  test('status defaults to disabled when no config exists', () => {
+    const dir = tmpDir();
+    expect(isOkfEnabled(dir)).toBe(false);
+    expect(loadOkfConfig(dir).okf.enabled).toBe(false);
+    // Reading must not create the file.
+    expect(fs.existsSync(cfgFile(dir))).toBe(false);
+  });
+
+  test('enable writes .forge/doc-gate.json {okf:{enabled:true}}', () => {
+    const dir = tmpDir();
+    setOkfEnabled(dir, true);
+    expect(fs.existsSync(cfgFile(dir))).toBe(true);
+    expect(JSON.parse(fs.readFileSync(cfgFile(dir), 'utf8'))).toEqual({ okf: { enabled: true } });
+    expect(isOkfEnabled(dir)).toBe(true);
+  });
+
+  test('disable reverts enabled to false', () => {
+    const dir = tmpDir();
+    setOkfEnabled(dir, true);
+    setOkfEnabled(dir, false);
+    expect(isOkfEnabled(dir)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(cfgFile(dir), 'utf8'))).toEqual({ okf: { enabled: false } });
+  });
+
+  test('malformed config is treated as disabled (fail-safe), never throws', () => {
+    const dir = tmpDir();
+    fs.mkdirSync(path.join(dir, '.forge'));
+    fs.writeFileSync(cfgFile(dir), '{ this is not json');
+    expect(isOkfEnabled(dir)).toBe(false);
+    expect(loadOkfConfig(dir).okf.enabled).toBe(false);
+  });
+
+  test('a non-object okf key is coerced to disabled', () => {
+    const dir = tmpDir();
+    fs.mkdirSync(path.join(dir, '.forge'));
+    fs.writeFileSync(cfgFile(dir), JSON.stringify({ okf: 'yes' }));
+    expect(isOkfEnabled(dir)).toBe(false);
+  });
+
+  test('toggling preserves unrelated top-level keys', () => {
+    const dir = tmpDir();
+    fs.mkdirSync(path.join(dir, '.forge'));
+    fs.writeFileSync(cfgFile(dir), JSON.stringify({ other: 1, okf: { enabled: false } }));
+    setOkfEnabled(dir, true);
+    const cfg = JSON.parse(fs.readFileSync(cfgFile(dir), 'utf8'));
+    expect(cfg.other).toBe(1);
+    expect(cfg.okf.enabled).toBe(true);
+  });
+
+  test('refuses to write the config through a symlink', () => {
+    const dir = tmpDir();
+    fs.mkdirSync(path.join(dir, '.forge'));
+    let linked = true;
+    try {
+      fs.symlinkSync(path.join(os.tmpdir(), 'forge-okf-evil-config'), cfgFile(dir));
+    } catch { linked = false; }
+    if (!linked) return; // platform without symlink perms
+    expect(() => setOkfEnabled(dir, true)).toThrow(/symlink/i);
+  });
+});

--- a/test/doc-gate/okf.test.js
+++ b/test/doc-gate/okf.test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const { describe, expect, test, afterAll, setDefaultTimeout } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { generateBundle, linkAgentsMd } = require('../../lib/doc-gate/okf');
+
+// Real git fixtures + parallel disk I/O can exceed the 5s default on Windows CI.
+setDefaultTimeout(30000);
+
+const createdDirs = [];
+function git(dir, args) {
+  execFileSync('git', ['-C', dir, ...args], { stdio: ['ignore', 'ignore', 'ignore'] });
+}
+
+function makeDocsRepo(extra = () => {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-okf-'));
+  createdDirs.push(dir);
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.mkdirSync(path.join(dir, 'docs', 'guides'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'docs', 'intro.md'), '# Introduction\n\nWelcome to the project.\n');
+  fs.writeFileSync(path.join(dir, 'docs', 'guides', 'setup.md'), '# Setup Guide\n\nInstall steps here.\n');
+  fs.writeFileSync(path.join(dir, 'README.md'), '# Repo\n\nRoot readme.\n');
+  extra(dir);
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'init']);
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+const read = (dir, rel) => fs.readFileSync(path.join(dir, rel), 'utf8');
+const hasFrontMatter = text => /^---\r?\n/.test(text);
+function frontMatterInner(text) {
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return m ? m[1] : null;
+}
+function walkFiles(root, base = '') {
+  const out = [];
+  for (const entry of fs.readdirSync(path.join(root, base), { withFileTypes: true })) {
+    const rel = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...walkFiles(root, rel));
+    else out.push(rel);
+  }
+  return out;
+}
+
+describe('okf generateBundle', () => {
+  test('every concept carries a type front-matter key and preserves the body', () => {
+    const dir = makeDocsRepo();
+    const res = generateBundle({ root: dir, source: 'docs', out: '.okf' });
+    expect(res.ok).toBe(true);
+    expect(res.okfVersion).toBe('0.1');
+
+    const intro = read(dir, '.okf/intro.md');
+    expect(frontMatterInner(intro)).toMatch(/^type:/m);
+    expect(intro).toContain('# Introduction');
+    expect(intro).toContain('Welcome to the project.');
+
+    const setup = read(dir, '.okf/guides/setup.md');
+    expect(frontMatterInner(setup)).toMatch(/type:/);
+    expect(setup).toContain('Install steps here.');
+  });
+
+  test('README.md at repo root is NOT swept in when source is docs/', () => {
+    const dir = makeDocsRepo();
+    generateBundle({ root: dir, source: 'docs', out: '.okf' });
+    expect(fs.existsSync(path.join(dir, '.okf', 'README.md'))).toBe(false);
+  });
+
+  test('root index.md is the ONLY index.md with frontmatter and carries okf_version "0.1"', () => {
+    const dir = makeDocsRepo();
+    generateBundle({ root: dir, source: 'docs', out: '.okf' });
+
+    const rootIdx = read(dir, '.okf/index.md');
+    expect(hasFrontMatter(rootIdx)).toBe(true);
+    expect(rootIdx).toMatch(/okf_version:\s*"0\.1"/);
+    expect(rootIdx).not.toMatch(/okf_version:\s*0\.1\s*$/m); // must be the STRING "0.1"
+
+    const subIdx = read(dir, '.okf/guides/index.md');
+    expect(hasFrontMatter(subIdx)).toBe(false);
+
+    // Assert globally: exactly one index.md in the whole bundle has frontmatter.
+    const indexes = walkFiles(path.join(dir, '.okf')).filter(f => f.endsWith('index.md'));
+    const withFm = indexes.filter(f => hasFrontMatter(read(dir, path.posix.join('.okf', f))));
+    expect(withFm).toEqual(['index.md']);
+  });
+
+  test('infers "guide" from path and defaults to "document"', () => {
+    const dir = makeDocsRepo();
+    generateBundle({ root: dir, source: 'docs', out: '.okf' });
+    expect(frontMatterInner(read(dir, '.okf/guides/setup.md'))).toMatch(/type:\s*"guide"/);
+    expect(frontMatterInner(read(dir, '.okf/intro.md'))).toMatch(/type:\s*"document"/);
+  });
+
+  test('merges into existing YAML frontmatter without duplicating the fence', () => {
+    const dir = makeDocsRepo(d => {
+      fs.writeFileSync(
+        path.join(d, 'docs', 'faq.md'),
+        '---\ndescription: Common questions\n---\n\n# FAQ\n\nQ and A here.\n',
+      );
+    });
+    generateBundle({ root: dir, source: 'docs', out: '.okf' });
+    const faq = read(dir, '.okf/faq.md');
+    const fences = (faq.match(/^---\s*$/gm) || []).length;
+    expect(fences).toBe(2); // exactly ONE frontmatter block
+    expect(faq).toContain('description: Common questions'); // original key preserved
+    expect(frontMatterInner(faq)).toMatch(/type:/); // required key injected
+    expect(faq).toContain('Q and A here.'); // body preserved
+  });
+
+  test('auto source prefers docs/ when present', () => {
+    const dir = makeDocsRepo();
+    const res = generateBundle({ root: dir, out: '.okf' });
+    expect(res.ok).toBe(true);
+    expect(fs.existsSync(path.join(dir, '.okf', 'intro.md'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, '.okf', 'README.md'))).toBe(false);
+  });
+
+  test('refuses to write a concept through a symlink target', () => {
+    const dir = makeDocsRepo();
+    fs.mkdirSync(path.join(dir, '.okf'));
+    let linked = true;
+    try {
+      fs.symlinkSync(path.join(os.tmpdir(), 'forge-okf-evil-concept'), path.join(dir, '.okf', 'intro.md'));
+    } catch { linked = false; }
+    if (!linked) return; // platform without symlink perms
+    expect(() => generateBundle({ root: dir, source: 'docs', out: '.okf' })).toThrow(/symlink/i);
+  });
+
+  test('refuses a symlinked out dir', () => {
+    const dir = makeDocsRepo();
+    let linked = true;
+    try { fs.symlinkSync(os.tmpdir(), path.join(dir, '.okf')); } catch { linked = false; }
+    if (!linked) return;
+    expect(() => generateBundle({ root: dir, source: 'docs', out: '.okf' })).toThrow(/symlink/i);
+  });
+
+  test('rejects blank source/out paths and a repo-root out dir', () => {
+    const dir = makeDocsRepo();
+    expect(() => generateBundle({ root: dir, source: '   ', out: '.okf' })).toThrow();
+    expect(() => generateBundle({ root: dir, source: 'docs', out: '   ' })).toThrow();
+    expect(() => generateBundle({ root: dir, source: 'docs', out: '.' })).toThrow(/root/i);
+  });
+});
+
+describe('okf AGENTS.md overlay (linkAgentsMd)', () => {
+  test('writes an idempotent managed nav block pointing at the bundle index', () => {
+    const dir = makeDocsRepo();
+    generateBundle({ root: dir, source: 'docs', out: '.okf' });
+
+    linkAgentsMd({ root: dir, out: '.okf' });
+    const first = read(dir, 'AGENTS.md');
+    expect(first).toContain('.okf/index.md');
+    expect((first.match(/BEGIN FORGE OKF NAV/g) || []).length).toBe(1);
+
+    // Second run must not duplicate the block.
+    linkAgentsMd({ root: dir, out: '.okf' });
+    const second = read(dir, 'AGENTS.md');
+    expect((second.match(/BEGIN FORGE OKF NAV/g) || []).length).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test('preserves existing AGENTS.md content around the managed block', () => {
+    const dir = makeDocsRepo();
+    fs.writeFileSync(path.join(dir, 'AGENTS.md'), '# Agents\n\nHand-written guidance.\n');
+    generateBundle({ root: dir, source: 'docs', out: '.okf' });
+    linkAgentsMd({ root: dir, out: '.okf' });
+    const text = read(dir, 'AGENTS.md');
+    expect(text).toContain('Hand-written guidance.');
+    expect(text).toContain('.okf/index.md');
+  });
+
+  test('refuses to write AGENTS.md through a symlink', () => {
+    const dir = makeDocsRepo();
+    let linked = true;
+    try {
+      fs.symlinkSync(path.join(os.tmpdir(), 'forge-okf-evil-agents'), path.join(dir, 'AGENTS.md'));
+    } catch { linked = false; }
+    if (!linked) return;
+    expect(() => linkAgentsMd({ root: dir, out: '.okf' })).toThrow(/symlink/i);
+  });
+});


### PR DESCRIPTION
## What

Adds Google's **Open Knowledge Format (OKF)** as an **OPT-IN, user-toggleable** knowledge-base feature for the doc-gate. It is **disabled by default** — OKF is a **v0.1 DRAFT** and explicitly "not an official Google product," so nothing generates a bundle or touches `AGENTS.md` until a user turns it on.

Scope of this PR: the toggle + deterministic markdown→OKF bundle generation + a thin `AGENTS.md` overlay. The auto agent-resolution runtime is a future follow-up (see below).

## The toggle (opt-in, default OFF)

- Config lives in **`.forge/doc-gate.json`** shaped `{ "okf": { "enabled": false } }` (mirrors the `.forge/*.json` config pattern in `lib/adapter-cli.js`).
- New `lib/doc-gate/okf-config.js` loads/saves it. **Fail-safe:** a missing OR malformed config resolves to **disabled**, never an error.
- This is kept **fully separate** from the repo-root **`.docgate.json`** declaration (`lib/doc-gate/declaration.js`). Those two never read or write each other's file — the declaration authoritatively describes repo structure and flips the detector verdict to `DECLARED`; this toggle ONLY gates OKF generation.
- When disabled, OKF generation is a no-op and everything behaves as today (detect/check run; unresolved repos abstain; no bundle, no `AGENTS.md` nav).

## Command surface

```
forge doc-gate okf status | enable | disable            [--json]
forge doc-gate okf generate [--source <dir>] [--out <dir>] [--json]
forge doc-gate okf link     [--out <dir>]                [--json]
```

- `generate` and `link` **refuse to run unless OKF is enabled**, with a clear hint: `Run `forge doc-gate okf enable``.
- Thin-wrapper contract: `okf generate --json` output equals the underlying `generateBundle()` result exactly (asserted in tests).

## Correct OKF spec facts implemented (verified against a primary-source cross-check)

- A **concept** = one markdown doc; Concept ID = its path minus `.md`.
- Concept front matter: the **only required key is `type`** (inferred `guide`/`reference`/`document`, default `document`). `title` is the optional display name derived from the H1/filename — there is **no `name` key**. The body is preserved verbatim; a pre-existing YAML front-matter block is **merged, never duplicated**.
- **Per-folder `index.md`** lists that folder's contents and carries **NO** front matter.
- The **bundle-root `index.md`** is the **ONLY** index that carries front matter, for exactly one key: **`okf_version: "0.1"`** (the string).
- A **bundle** = a directory tree of concept files (the unit of distribution).
- **OKF is a SERIALIZATION / interop format only** — it has no enforcement or query semantics. Generation **never** touches `detect()` / `evaluateGate()` verdicts; resolution-correctness stays doc-gate's own concern.

## Thin AGENTS.md overlay

`okf link` writes/updates a small navigation section in **`AGENTS.md`** (not `CLAUDE.md`) that **points at** the bundle root `index.md`. It is a thin overlay, not a duplicate of the bundle, wrapped in a delimited managed block (`<!-- BEGIN/END FORGE OKF NAV -->`) so re-running is idempotent.

## Review-preempt hygiene

- **Tracked-files-only** reads of the repo (`git ls-files`), never a raw filesystem walk.
- **Fail-closed** strict git wrapper that THROWS on failure.
- **Symlink-safe writes:** every target (and every parent directory component) is `lstat`-checked and refused if it is a symlink; nothing is ever written outside the out dir (even with a would-be traversal). The out dir must not be the repo root.
- Input validation: blank/whitespace `--source`/`--out` and `..` segments are rejected; config shape is validated/coerced.
- `require('node:...')`; `// NOSONAR S4036` on git spawns; optional chaining; no nested ternaries; no bare function to `.filter()`; `String#replaceAll`; helpers kept under the SonarCloud cognitive-complexity threshold.

## Tests (TDD)

- `test/doc-gate/okf-config.test.js` — status defaults disabled; enable writes `{okf:{enabled:true}}`; disable reverts; malformed→disabled; preserves unrelated keys; symlink config write refused.
- `test/doc-gate/okf.test.js` — every concept has a `type` key + body preserved; root `index.md` is the only index with front matter and carries `okf_version:"0.1"`; per-folder indexes have none; `guide`/`document` type inference; existing front matter merged (single fence); auto-source prefers `docs/`; symlinked concept/out-dir refused; blank/root-out rejected; idempotent `AGENTS.md` overlay preserving surrounding content; symlinked `AGENTS.md` refused.
- `test/commands/doc-gate-okf.test.js` — status/enable/disable; generate refuses when disabled (no bundle written); `--json` equals the function result; unknown action → exit 1; link writes nav; link refuses when disabled.

**Results:** 26 new tests pass; full doc-gate suite `114 pass / 0 fail`. `eslint --max-warnings 0` clean on all changed files. `forge release check --target 0.1.0` → **PASS** (no blockers; D20 artifact not stale).

## Known limitations (intended for follow-up — not fixed here to keep scope tight)

- **Re-generate does not prune:** generation overwrites but does not remove orphaned concepts left by a since-deleted source doc.
- The toggle's `--json` returns a flattened `{ enabled }` view (CLI convenience), whereas `generate --json` is a strict pass-through of the function result.

## Follow-ups (out of scope for this PR)

- The **auto agent-resolution runtime** (using the bundle to resolve/answer at runtime).
- A **format-conformance validator** integration (okf-skills / the Rust `okf` tooling) to lint bundles against the spec.
- **Deliverable 4 — OKF-bundle recognition** helper (detect an existing bundle via root `index.md` `okf_version` + typed concepts so the KB layer can treat it as first-class). Deliberately deferred to avoid scope creep.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `forge doc-gate okf` commands to check status, enable/disable the feature, generate the bundle, and update navigation links.
  * Added support for generating an OKF bundle from markdown content with configurable source and output locations.
* **Bug Fixes**
  * Improved handling of invalid or missing configuration so the feature safely defaults to disabled.
  * Added safeguards to prevent unsafe writes and keep existing content intact when updating generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->