### PR TITLE
docs: present pre-merge as an embedded doc gate, not a stage/command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This is the public documentation and positioning release.
 
 #### Migration notes
 
-- Treat `/plan -> /dev -> /validate -> /ship -> /review -> /premerge -> /verify` as an agent workflow template. Do not assume every stage is a standalone `forge <stage>` CLI command.
+- Treat `/plan -> /dev -> /validate -> /ship -> /review -> /verify` as an agent workflow template. Pre-merge is a documentation gate embedded in `/ship` and `/review`, not a numbered stage. Do not assume every stage is a standalone `forge <stage>` CLI command.
 - Use `forge init` for the `.forge/` adoption skeleton and `forge setup` for agent instructions, Beads/GitHub sync scaffolding, and harness files.
 - Use `--agents`, not the stale singular `--agent`, when documenting or invoking setup.
 - Internal roadmap labels such as `0.0.19` are future planning labels, not current public package availability.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Forge helps you:
 - Worktree helpers with `forge worktree create <slug>` and `forge worktree remove <slug>`.
 - Review adapter scaffolding and fixture replay for review adapters.
 - Validation via `bun run check`, which runs typecheck, lint, security audit, and tests through the repository validation script.
-- Documentation and stage skills for `/plan`, `/dev`, `/validate`, `/ship`, `/review`, `/premerge`, and `/verify`.
+- Documentation and stage skills for `/plan`, `/dev`, `/validate`, `/ship`, `/review`, and `/verify`. The pre-merge documentation gate is embedded in `/ship` and `/review`, not a separate stage skill.
 
 ## Experimental Or Configuration-Dependent
 
@@ -59,7 +59,7 @@ v0.0.11 is a documentation and positioning package release: canonical docs, corr
 ## Terms
 
 - Runtime control plane: local commands, files, and checks that give agents a shared operating surface.
-- Workflow template: the default stage path Forge installs for agents, such as `/plan -> /dev -> /validate -> /ship -> /review -> /premerge`.
+- Workflow template: the default stage path Forge installs for agents, such as `/plan -> /dev -> /validate -> /ship -> /review -> /verify`.
 - Harness: an agent-specific instruction surface. Forge currently supports Claude Code, Codex, and Cursor. Hermes support is planned.
 - Beads: an opt-out local issue-state backend for Forge issue wrappers; the kernel backend is used by default. Selection precedence (highest first): `--issue-backend beads`, then `FORGE_ISSUE_BACKEND=beads`, then `.forge/config.yaml` `issueBackend: beads`.
 - Adapter: an integration boundary for review or issue tools.
@@ -118,7 +118,7 @@ bun run check
 npm pack --dry-run
 ```
 
-Stage commands such as `/review`, `/premerge`, and `/verify` are agent workflow stages, not currently standalone `forge review`, `forge premerge`, or `forge verify` CLI commands.
+Stage commands such as `/review` and `/verify` are agent workflow stages, not currently standalone `forge review` or `forge verify` CLI commands. Pre-merge is neither a numbered stage nor a `/premerge` command; it is a documentation-and-handoff gate embedded in the `/ship` and `/review` stages.
 
 ## Documentation Map
 

--- a/docs/guides/WORKFLOW_TEMPLATES.md
+++ b/docs/guides/WORKFLOW_TEMPLATES.md
@@ -1,13 +1,13 @@
 # Workflow Templates
 
-Forge's workflow is a core product surface, not a side note. The default template gives agents a known path for planning, development, validation, shipping, review, premerge handoff, and post-merge verification.
+Forge's workflow is a core product surface, not a side note. The default template gives agents a known path for planning, development, validation, shipping, review, and post-merge verification, with a pre-merge documentation gate that finishes docs and hands off the PR inside the ship and review stages.
 
 ## Default Template
 
 The full default template is:
 
 ```text
-/plan -> /dev -> /validate -> /ship -> /review -> /premerge -> /verify
+/plan -> /dev -> /validate -> /ship -> /review -> /verify
 ```
 
 Projects can use the full template or smaller profile-specific paths. The important boundary is that these are agent workflow stages, not necessarily standalone `forge <stage>` CLI commands.
@@ -21,8 +21,9 @@ The template gives AI-assisted work a repeatable operating model:
 - `/validate` gathers evidence from project checks.
 - `/ship` prepares a reviewable PR.
 - `/review` handles PR feedback and evaluator findings.
-- `/premerge` finishes documentation and handoff context.
 - `/verify` proves post-merge health when the workflow type requires it.
+
+Before merge, a pre-merge documentation gate finishes documentation and handoff context. It is not a numbered stage or a `/premerge` command; it runs inside the `/ship` and `/review` stages.
 
 The value is not the exact number of stages. The value is recoverable state, known handoff points, validation evidence, and clear ownership while agents work.
 
@@ -45,11 +46,11 @@ Current docs describe these profiles:
 | Type | Intended use | Typical path |
 | --- | --- | --- |
 | Critical | Security, auth, payments, migrations, breaking changes | Full template |
-| Standard | Normal features and enhancements | Plan through premerge |
+| Standard | Normal features and enhancements | Plan through review |
 | Simple | Small fixes and focused changes | Shorter dev, validate, ship path |
 | Hotfix | Production emergencies | Short path with urgent validation |
-| Docs | Documentation-only changes | Verify, ship, premerge where configured |
-| Refactor | Behavior-preserving cleanup | Plan, dev, validate, ship, premerge |
+| Docs | Documentation-only changes | Verify and ship |
+| Refactor | Behavior-preserving cleanup | Plan, dev, validate, ship |
 
 Profile docs must be checked against `lib/workflow-profiles.js` and `AGENTS.md` before release because command files, skills, and runtime profiles can drift.
 

--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -151,15 +151,14 @@ forge doctor --json   # machine-readable report (schemaVersion 1)
 The default agent workflow template is:
 
 ```text
-/plan -> /dev -> /validate -> /ship -> /review -> /premerge -> /verify
+/plan -> /dev -> /validate -> /ship -> /review -> /verify
 ```
 
-These are stage skills and installed agent workflows. They are intentionally documented separately from current `forge` CLI commands. The workflow is core to Forge, but it is packaged through agent harness files and skills rather than through one CLI command per stage.
+These are stage skills and installed agent workflows. They are intentionally documented separately from current `forge` CLI commands. The workflow is core to Forge, but it is packaged through agent harness files and skills rather than through one CLI command per stage. Pre-merge is not one of these numbered stages or a `/premerge` command; it is a documentation-and-handoff gate embedded in the `/ship` and `/review` stages that finishes docs and confirms CI before merge.
 
 Do not document these as current CLI commands unless the matching `lib/commands/<name>.js` file exists:
 
 ```text
 forge review
-forge premerge
 forge verify
 ```

--- a/scripts/beads-context.test.js
+++ b/scripts/beads-context.test.js
@@ -578,7 +578,9 @@ describe('/review command integration with beads-context.sh', () => {
 		expect(reviewContent).toContain('beads-context.sh stage-transition');
 	});
 
-	test('review.md should reference stage-transition from review to premerge', () => {
-		expect(reviewContent).toContain('review premerge');
+	test('review.md should reference stage-transition from review to verify', () => {
+		// Pre-merge is a doc-update gate embedded in /review, not a numbered stage,
+		// so the stage-transition advances review -> verify (the next numbered stage).
+		expect(reviewContent).toContain('review verify');
 	});
 });


### PR DESCRIPTION
## Problem

Human-facing docs presented `/premerge` as a shipped, invokable **stage skill** or **numbered pipeline stage**, but no premerge skill/command actually ships. `AGENTS.md` (the single source of truth, L16) defines pre-merge as a documentation-update **GATE** embedded in the `/ship` and `/review` stages — not a numbered stage. A 0.1.0 user could be told to run a `/premerge` command that does not exist.

## Fix

Make the human-facing docs consistent with the gate model. The 6 numbered stages are `plan -> dev -> validate -> ship -> review -> verify`; pre-merge is an embedded doc gate.

- **README.md** — dropped `/premerge` from the stage-skill list, the workflow-template path, and the CLI-boundary note; clarified pre-merge is an embedded gate in `/ship` and `/review`.
- **docs/reference/COMMANDS.md** — corrected the stage path to end at `/verify`, removed the non-existent `forge premerge` CLI example, added a gate note.
- **docs/guides/WORKFLOW_TEMPLATES.md** — corrected the path and stage bullet list; aligned the profile "Typical path" column with `lib/workflow-profiles.js` (no profile includes `/premerge`).
- **CHANGELOG.md** — corrected the released `[0.0.11]` migration-note stage path and clarified the gate model. The historical rename note (L8) and `[Unreleased]` content were left untouched.

## Test coupling kept green

`scripts/beads-context.test.js` asserted the OLD model — that `skills/review/SKILL.md` references stage-transition `review premerge`. The skill already advances `review -> verify` (pre-merge runs as an embedded gate during `/review`, not a numbered stage). The stale assertion was reconciled to `review verify`, matching the actual skill content and the corrected gate model. `skills/review/SKILL.md` itself was not modified.

## Verification

- Affected doc/structural/stage-naming tests pass: `docs-consistency`, `stage-naming`, `workflow-profiles`, `beads-context`, `agents-md-generation`, `cursor-config-generation` — 130 pass, 0 fail.
- `eslint scripts/beads-context.test.js --max-warnings 0` — clean.
- Full pre-push suite (branch-protection, lint, team-sync, tests) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)