### PR TITLE
fix(kernel): make `forge export` actually project issues to git-tracked JSONL

### DIFF
--- a/lib/commands/_resolve-command-opts.js
+++ b/lib/commands/_resolve-command-opts.js
@@ -17,7 +17,9 @@
  *   3. When kernel, assembles the kernel deps (driver + flag) via the CLI broker
  *      factory so createKernelIssueBackend has a real driver (B1).
  *
- * Non-issue commands get an empty opts object and untouched args.
+ * Kernel-native tool commands (KERNEL_TOOL_COMMANDS, e.g. `export`) instead get a
+ * migrated Kernel broker injected as `_broker` (independent of the selector), and
+ * all other non-issue commands get an empty opts object and untouched args.
  *
  * @module commands/resolve-command-opts
  */
@@ -51,6 +53,15 @@ const ISSUE_COMMANDS = new Set([
   'dep',
   'issue',
   'issues',
+]);
+
+// Kernel-native tool commands that operate directly on the Kernel regardless of the
+// issue-backend selector, so they need a real (migrated) Kernel broker injected as
+// the handler's `_broker`. `export` drains the Kernel projection outbox to
+// git-tracked JSONL (D16); without an injected broker its handler always reports
+// "No Kernel broker available" and writes nothing.
+const KERNEL_TOOL_COMMANDS = new Set([
+  'export',
 ]);
 
 const ISSUE_BACKEND_FLAG = '--issue-backend';
@@ -142,12 +153,32 @@ function resolveFlagBackend(flags = {}) {
  * @throws {Error} on conflicting flags (surfaced to user).
  */
 async function resolveCommandOpts(command, rawArgs = [], deps = {}) {
+  const buildKernelIssueDeps = deps.buildKernelIssueDeps || defaultBuildKernelIssueDeps;
+
+  if (KERNEL_TOOL_COMMANDS.has(command)) {
+    // Kernel-native tools (e.g. `export`) always get a migrated Kernel broker the
+    // same way issue commands do (the CLI broker factory builds the driver, builds
+    // the broker, and runs initialize()). The handler consumes it as `_broker`.
+    // If no broker can be built (e.g. no SQLite runtime) we fall through with no
+    // broker so the handler skips gracefully rather than hard-failing — these tools
+    // are explicitly non-fatal when the Kernel is unavailable.
+    try {
+      const kernelDeps = await buildKernelIssueDeps({
+        projectRoot: deps.projectRoot,
+        databasePath: deps.databasePath,
+        gitCommonDir: deps.gitCommonDir,
+      });
+      return { commandOpts: { _broker: kernelDeps.kernelBroker }, args: rawArgs };
+    } catch {
+      return { commandOpts: {}, args: rawArgs };
+    }
+  }
+
   if (!ISSUE_COMMANDS.has(command)) {
     return { commandOpts: {}, args: rawArgs };
   }
 
   const env = deps.env || process.env;
-  const buildKernelIssueDeps = deps.buildKernelIssueDeps || defaultBuildKernelIssueDeps;
 
   const { args, flags } = stripSelectorTokens(rawArgs);
   const flagBackend = resolveFlagBackend(flags);
@@ -189,4 +220,5 @@ module.exports = {
   stripSelectorTokens,
   resolveFlagBackend,
   ISSUE_COMMANDS,
+  KERNEL_TOOL_COMMANDS,
 };

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -479,6 +479,13 @@ async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
   const result = await service.run(operation, rawArgs, {
     projectRoot,
     deps,
+    // Kernel mutations enqueue a projection-outbox "dirty marker" that `forge export`
+    // (the D16 git-JSONL portability projection) drains under target 'jsonl'. The
+    // broker's legacy primitive default is 'beads', so without steering the target
+    // here every Kernel-created issue is enqueued as 'beads' and `forge export` — which
+    // drains 'jsonl' — finds nothing, silently never emitting git-tracked JSONL. Only
+    // the Kernel path uses this seam (`context.projectionTarget`); Beads ignores it.
+    ...(shouldUseKernelBroker(deps) ? { projectionTarget: 'jsonl' } : {}),
   });
 
   const queueGitHubProjection = deps.enqueueGitHubProjection || deps.queueGitHubProjection;

--- a/test/commands/export-real-dispatch.test.js
+++ b/test/commands/export-real-dispatch.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// End-to-end proof that `forge export` actually moves a Kernel-created issue into
+// git-tracked JSONL — the beads-signature portability capability (D16). Unlike
+// export.test.js (which unit-tests the handler with a hand-rolled mock broker that
+// seeds 'jsonl' rows and ignores the target filter), this drives the REAL dispatch:
+//
+//   1. `runIssueOperation('create', …)` — the real CLI Kernel mutation path, which
+//      must enqueue the projection-outbox row under the target the export consumer
+//      drains ('jsonl'), not the broker's legacy primitive default ('beads').
+//   2. `resolveCommandOpts('export', …)` — the real command dispatcher, which must
+//      inject a Kernel broker as the handler's `_broker` (it previously injected one
+//      only for ISSUE_COMMANDS, so `export` silently ran with no broker).
+//   3. `exportCommand.handler(…)` — the real handler draining the outbox to disk.
+//
+// Both fixes are load-bearing: with either missing this test is RED (no `_broker` →
+// skip, or 'beads' rows → 0 drained → nothing written).
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { runIssueOperation } = require('../../lib/forge-issues');
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+const { resolveCommandOpts } = require('../../lib/commands/_resolve-command-opts');
+const exportCommand = require('../../lib/commands/export');
+
+const NOW = '2026-06-20T00:00:00.000Z';
+
+// Deterministic local-ok classifier: keeps this DB-acceptance test independent of
+// the host filesystem class and avoids the real Windows drive probe the D19 gate
+// runs in the broker getConfig() chokepoint (mirrors driver-smoke.test.js).
+const LOCAL_OK_CLASSIFIER = () => ({
+	class: 'local-ok', riskTier: 'safe', signal: 'test-stub', remediationKey: 'local-ok',
+});
+
+// Windows releases the SQLite WAL/SHM sidecars asynchronously after close, so a
+// teardown rmSync can race the unmap and throw EBUSY/EPERM. Retry with a real timer
+// yield, then tolerate a final lock error only (the OS reclaims temp dirs).
+async function removeDirWithRetry(dir, attempts = 10) {
+	for (let attempt = 0; attempt < attempts; attempt += 1) {
+		try {
+			fs.rmSync(dir, { recursive: true, force: true });
+			return;
+		} catch (error) {
+			const locked = ['EBUSY', 'EPERM', 'ENOTEMPTY'].includes(error.code);
+			if (!locked || attempt === attempts - 1) {
+				if (locked) return;
+				throw error;
+			}
+			await new Promise(resolve => setTimeout(resolve, 100));
+		}
+	}
+}
+
+describe('forge export — real dispatch (Kernel create → git-tracked JSONL)', () => {
+	test('a Kernel-created issue is drained to .forge/kernel/issues.jsonl with fidelity', async () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-export-real-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		const projectRoot = tmpDir;
+		// Share ONE driver across the setup / create / export brokers: it caches the
+		// open connection keyed on config.databasePath, so every broker sees the same
+		// migrated DB (the create's outbox + issue rows are visible to the exporter).
+		const driver = createBuiltinSQLiteDriver({});
+		const execFileSync = () => path.join(tmpDir, '.git');
+
+		try {
+			// Migrate once — the public entry point never initializes the broker.
+			const setup = createLocalBroker({
+				projectRoot, execFileSync, databasePath: dbPath, driver, classifyFilesystem: LOCAL_OK_CLASSIFIER,
+			});
+			await setup.initialize();
+
+			const deps = {
+				issueBackend: 'kernel',
+				kernelDatabasePath: dbPath,
+				kernelDriver: driver,
+				execFileSync,
+				classifyFilesystem: LOCAL_OK_CLASSIFIER,
+			};
+
+			// 1) Create through the REAL CLI Kernel mutation path.
+			const created = await runIssueOperation(
+				'create',
+				['--id', 'portable-1', '--title', 'Portable', '--type', 'task'],
+				projectRoot,
+				{ ...deps, now: NOW, actor: 'tester' },
+			);
+			expect(created.ok).toBe(true);
+			expect(created.data.id).toBe('portable-1');
+
+			// 2) Export through the REAL dispatcher broker injection. The injected
+			// factory is the same DI seam production uses; it reuses the shared driver
+			// + fs-gate stub so the exporter reads the same DB the create wrote to.
+			const { commandOpts } = await resolveCommandOpts('export', [], {
+				projectRoot,
+				databasePath: dbPath,
+				buildKernelIssueDeps: async () => {
+					const broker = createLocalBroker({
+						projectRoot, execFileSync, databasePath: dbPath, driver, classifyFilesystem: LOCAL_OK_CLASSIFIER,
+					});
+					await broker.initialize();
+					return { kernelBroker: broker };
+				},
+			});
+			// Root cause #1: the dispatcher must hand the export handler a broker.
+			expect(commandOpts._broker).toBeDefined();
+
+			const result = await exportCommand.handler([], {}, projectRoot, { ...commandOpts, _now: NOW });
+
+			// Root cause #2: the enqueued 'jsonl' marker is actually drained + written.
+			expect(result.success).toBe(true);
+			expect(result.exported).toBe(true);
+			expect(result.drained).toBeGreaterThanOrEqual(1);
+
+			// The issue reaches deterministic git-tracked JSONL with id + status fidelity.
+			const issuesJsonl = path.join(projectRoot, '.forge', 'kernel', 'issues.jsonl');
+			expect(fs.existsSync(issuesJsonl)).toBe(true);
+			const lines = fs.readFileSync(issuesJsonl, 'utf8').trim().split('\n').filter(Boolean);
+			const record = JSON.parse(lines[0]);
+			expect(record.id).toBe('portable-1');
+			expect(record.status).toBe('open');
+		} finally {
+			if (driver) driver.close();
+			await removeDirWithRetry(tmpDir);
+		}
+	}, 15000);
+});

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -295,6 +295,9 @@ describe('forge issue service contract', () => {
       operationContext: {
         projectRoot: '/repo',
         deps: expect.objectContaining({ useKernelBroker: true }),
+        // Kernel mutations steer the projection-outbox marker to the 'jsonl' target
+        // that `forge export` (D16) drains; the broker primitive default is 'beads'.
+        projectionTarget: 'jsonl',
       },
     }]);
   });

--- a/test/kernel/driver-smoke.test.js
+++ b/test/kernel/driver-smoke.test.js
@@ -220,7 +220,7 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 			projectionDir,
 			projectRoot,
 			now: '2026-06-20T00:10:00.000Z',
-			target: 'beads', // commitGuardedAccept defaults the outbox target to 'beads'
+			target: 'jsonl', // the CLI Kernel mutation path steers the outbox target to 'jsonl' (D16 export)
 		});
 
 		expect(result.written).toBe(true);
@@ -235,7 +235,7 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 			projectionDir,
 			projectRoot,
 			now: '2026-06-20T00:11:00.000Z',
-			target: 'beads',
+			target: 'jsonl',
 		});
 		expect(second.drained).toBe(0);
 		expect(second.written).toBe(false);
@@ -257,7 +257,7 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 			classifyFilesystem: LOCAL_OK_CLASSIFIER,
 		});
 
-		const pending = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T00:10:00.000Z' });
+		const pending = await consumerBroker.listProjectionOutbox({ target: 'jsonl', status: 'pending', now: '2026-06-20T00:10:00.000Z' });
 		expect(pending.length).toBe(1);
 		const row = pending[0];
 
@@ -271,17 +271,17 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 
 		// The row is still pending but in backoff — a now-gated list before the
 		// backoff elapses must NOT return it.
-		const beforeBackoff = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T00:30:00.000Z' });
+		const beforeBackoff = await consumerBroker.listProjectionOutbox({ target: 'jsonl', status: 'pending', now: '2026-06-20T00:30:00.000Z' });
 		expect(beforeBackoff.map(entry => entry.id)).not.toContain(row.id);
 		// After the backoff elapses, the row is eligible again.
-		const afterBackoff = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T02:00:00.000Z' });
+		const afterBackoff = await consumerBroker.listProjectionOutbox({ target: 'jsonl', status: 'pending', now: '2026-06-20T02:00:00.000Z' });
 		expect(afterBackoff.map(entry => entry.id)).toContain(row.id);
 
 		// Dead-letter it: a dead_letters row is inserted and the outbox row leaves
 		// 'pending' so it is never re-drained.
 		const dead = await consumerBroker.deadLetterProjection({
 			outbox_id: row.id,
-			target: 'beads',
+			target: 'jsonl',
 			error: 'boom',
 			payload_json: JSON.stringify({ event_id: row.event_id, attempts: 5 }),
 			now: '2026-06-20T02:00:00.000Z',
@@ -293,7 +293,7 @@ describe('Kernel SQLite driver — acceptance smoke through the public entry poi
 		expect(deadLetters).toHaveLength(1);
 		expect(deadLetters[0].outbox_id).toBe(row.id);
 
-		const stillPending = await consumerBroker.listProjectionOutbox({ target: 'beads', status: 'pending', now: '2026-06-20T03:00:00.000Z' });
+		const stillPending = await consumerBroker.listProjectionOutbox({ target: 'jsonl', status: 'pending', now: '2026-06-20T03:00:00.000Z' });
 		expect(stillPending.map(entry => entry.id)).not.toContain(row.id);
 	});
 });


### PR DESCRIPTION
## Problem

`forge export` — the D16 portability projection that drains kernel issues into
committable `.forge/kernel/*.jsonl` — was a **silent no-op**. Kernel issues never
left the local `.git/forge/kernel.sqlite`, so the backlog never cloned with the
repo, diffed in PRs, or survived disk loss (beads' signature capability). A fresh
`forge issue create` followed by `forge export` wrote nothing and reported
`exported:false`.

## Root causes (both required)

1. **Dispatcher never injected a broker for `export`.**
   `resolveCommandOpts` only built a kernel broker for `ISSUE_COMMANDS`. `export`
   isn't one, so it ran with no `_broker` and the handler always returned
   `exported:false` — "No Kernel broker available".

2. **Outbox target mismatch.**
   CLI kernel mutations enqueued the projection-outbox "dirty marker" under the
   broker's legacy primitive default target `'beads'`, but the D16 JSONL consumer
   drains `'jsonl'` (`DEFAULT_PROJECTION_TARGET`). So the consumer drained **0**
   rows and wrote nothing. D16 explicitly left the append/CAS enqueue path
   untouched ("PR 3 owns it", `docs/work/2026-06-17-kernel-jsonl-projection-d16`);
   that wiring never landed.

## Fix (minimal, design-aligned)

- **`lib/commands/_resolve-command-opts.js`** — add `KERNEL_TOOL_COMMANDS = {export}`
  that injects a migrated kernel broker as the handler's `_broker` via the same CLI
  broker factory issue commands use, independent of the issue-backend selector.
  Builds gracefully: if no broker can be built (e.g. no SQLite runtime) it falls
  through so the handler still skips instead of hard-failing.
- **`lib/forge-issues.js`** — steer the CLI kernel per-op context to
  `projectionTarget: 'jsonl'` (the existing `context.projectionTarget` seam) so
  mutations enqueue the target the consumer drains. The broker's `'beads'` primitive
  default is **unchanged**, so direct-`runGuardedEvent` tests (evaluators,
  broker-guards) are untouched.

## Test evidence

New **`test/commands/export-real-dispatch.test.js`** exercises the REAL dispatch —
`runIssueOperation('create')` → `resolveCommandOpts('export')` → `export` handler
against a real SQLite kernel — and asserts `.forge/kernel/issues.jsonl` is written
containing the issue with **id + status** fidelity.

- **RED before fix:** `commandOpts._broker` is `undefined` (cause #1); even with #1
  alone, `'beads'` rows leave `exported:false` (cause #2). Verified failing.
- **GREEN after fix.**

Updated the two `driver-smoke.test.js` projection tests (which drive creates through
`runIssueOperation` then drain the outbox) and one `forge-issues.test.js` per-op
context assertion to the now-correct `'jsonl'` target.

Ran locally (all green): the new test, `test/commands/export.test.js`,
`test/commands/_resolve-command-opts.test.js`, `test/forge-issues.test.js`,
`test/kernel/driver-smoke.test.js`, `test/kernel/evaluators.test.js`, and every
`test/kernel/*broker*` / `*projection*` suite — **168 passing** — plus
`eslint --max-warnings 0` on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
