### PR TITLE
chore: packaging fixes for 0.1.0 (stray test, engines.node, doc-gate docs)

### DIFF
--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -127,6 +127,20 @@ forge add
 
 `forge migrate` is dry-run oriented in the current public docs. Do not present it as a migration executor.
 
+## Doc Gate
+
+`forge doc-gate` inspects a repository's documentation structure and enforces that code changes ship with a documentation update. It is a thin CLI wrapper over the validated doc-gate detector and gate.
+
+```bash
+forge doc-gate detect [--json]
+forge doc-gate check --base <ref> --head <ref> [--skip] [--json]
+```
+
+- `detect` runs the repo-structure detector against the current working directory and prints a human-readable summary — detected source surface, toolchain, CI provider, CHANGELOG, and AGENTS.md, plus an overall verdict — or a structured object with `--json`. Any verdict, including `ESCALATE→agent` or `MANUAL-CONFIG`, exits 0; it exits non-zero only on a real error (not a git repository, or no commits yet).
+- `check` compares the `--base` and `--head` refs and **fails when a code change lands without an accompanying documentation update**. A `pass` or `abstain` decision exits 0; a hard `fail` exits 1. Use `--skip` to record an explicit skip without supplying refs.
+
+Both subcommands require a git working tree with at least one commit (`HEAD`). The related `forge doc-gate init` (scaffold a doc-gate declaration file) and `forge doc-gate okf` (OKF bundle generation) subcommands are also registered; run `forge doc-gate` with no arguments for full usage.
+
 ## Kernel Filesystem Safety
 
 The Forge Kernel stores its SQLite database under `.git/forge/kernel.sqlite`. SQLite WAL mode corrupts when a cloud-sync client (OneDrive, Dropbox, Google Drive, iCloud) or a network filesystem (UNC / SMB / NFS / mapped drive) rewrites the database mid-write. A default-on gate in `broker.initialize()` therefore **refuses** to initialize the kernel on those filesystems — the throw happens *before* any database file is created, so nothing is written to the unsafe location.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
   ],
   "author": "Harsha Nandak",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.16.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/harshanandak/forge.git"
@@ -88,6 +91,7 @@
     "scripts/",
     "!scripts/github-beads-sync/",
     "!scripts/github-beads-sync.config.json",
+    "!scripts/**/*.test.js",
     ".github/PLUGIN_TEMPLATE.json",
     ".forge/hooks/",
     ".forge/protected-paths.yaml",


### PR DESCRIPTION
Packaging-only nits for the 0.1.0 release. No version bump, no CHANGELOG release entry (owned by the release-cut PR).

## Changes

### 1. Stop shipping the stray test file
`npm pack --dry-run` included `scripts/beads-context.test.js` (~17 KB) because the `files` field includes `scripts/` broadly. Added a `"!scripts/**/*.test.js"` negation.

**Verified empirically** with `npm pack --dry-run --json`:
- Before: **755** files (1 test shipped: `scripts/beads-context.test.js`)
- After: **754** files — exactly that one test removed, **nothing else dropped/added**, and no `*.test.js`/`*.spec.js` remain in the tarball.

### 2. Add `engines.node`
Set `"engines": { "node": ">=22.16.0" }`. The kernel SQLite driver (the **default** issue backend) hard-requires `node:sqlite` with **backup API support** and throws below that version — `lib/kernel/sqlite-driver.js:48-52,82` explicitly state "run with Node >= 22.16 or Bun >= 1.2". That is the real floor for Node users: it is stricter than `node:sqlite`'s 22.5.0 introduction, because 22.5–22.15 lack the `backup` API the driver needs and would hit a hard runtime throw. CI runs Node 22 and 24, both satisfied; `engines` is advisory (npm warns, does not block).

### 3. Document `forge doc-gate detect|check`
Added a "Doc Gate" section to `docs/reference/COMMANDS.md` (matching the existing command-doc style) covering `detect` and `check`, and noting the also-registered `init`/`okf` subcommands.

## Verification
- `npm pack --dry-run`: stray test excluded, 755 → 754, count sane, no unintended drops.
- `bun test test/package-distribution.test.js test/integration/package-distribution.test.js`: **88 pass, 0 fail**.
- `eslint . --max-warnings 0`: clean.
- Pushed via `forge push --quick` (branch-protection + lint ran; full suite deferred to CI). The local full suite has 6 **pre-existing** failures unrelated to this change (5 `packages/skills` tests erroring on missing `chalk`/`inquirer` workspace deps; 1 `scripts/beads-context.test.js` `review premerge` assertion fixed by a separate PR). CI is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)