### PR TITLE
fix(worktree): populate node_modules on create and surface deps failures

### DIFF
--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -27,7 +27,10 @@ const path = require('node:path');
  * @returns {string|null} Package manager command or null
  */
 function detectPackageManager(projectRoot, fsApi) {
+  // Bun ships two lockfile formats: the legacy binary `bun.lockb` and the current
+  // text `bun.lock`. Recognize both so a Bun repo isn't mis-detected as npm.
   if (fsApi.existsSync(path.join(projectRoot, 'bun.lockb'))) return 'bun';
+  if (fsApi.existsSync(path.join(projectRoot, 'bun.lock'))) return 'bun';
   if (fsApi.existsSync(path.join(projectRoot, 'pnpm-lock.yaml'))) return 'pnpm';
   if (fsApi.existsSync(path.join(projectRoot, 'yarn.lock'))) return 'yarn';
   if (fsApi.existsSync(path.join(projectRoot, 'package-lock.json'))) return 'npm';
@@ -51,17 +54,76 @@ function branchExists(branchName, runFile) {
 }
 
 /**
- * Run package install in the new worktree if a package manager is detected.
+ * True when a link failure is a privilege/support problem (Windows without the
+ * symlink privilege, restricted FS) rather than a real error. In that case we
+ * degrade to a package install instead of hard-failing.
+ * @param {Error} error
+ * @returns {boolean}
+ */
+function isLinkPermissionError(error) {
+  return ['EPERM', 'EACCES', 'ENOSYS', 'UV_EPERM'].includes(error && error.code);
+}
+
+/**
+ * Run package install in the new worktree if a package manager is detected, and
+ * SURFACE failures (spawn error or non-zero exit) instead of swallowing them.
  * @param {string} worktreePath - Absolute path to the new worktree
  * @param {string} projectRoot - Absolute path to the project root
  * @param {Function} spawnFn - spawnSync-compatible function
  * @param {object} fsApi - fs module (for DI)
+ * @returns {{ linked: boolean, installed: boolean }}
+ * @throws {Error} when the install cannot be spawned or exits non-zero.
  */
 function runInstall(worktreePath, projectRoot, spawnFn, fsApi) {
   const pkgManager = detectPackageManager(projectRoot, fsApi);
-  if (pkgManager) {
-    spawnFn(pkgManager, ['install'], { cwd: worktreePath, stdio: 'pipe' });
+  if (!pkgManager) return { linked: false, installed: false };
+
+  const result = spawnFn(pkgManager, ['install'], { cwd: worktreePath, stdio: 'pipe' });
+  if (result && result.error) {
+    throw new Error(`Dependency install failed: could not run '${pkgManager} install' in ${worktreePath}: ${result.error.message}`);
   }
+  if (result && typeof result.status === 'number' && result.status !== 0) {
+    throw new Error(`Dependency install failed: '${pkgManager} install' exited with code ${result.status} in ${worktreePath}`);
+  }
+  return { linked: false, installed: true };
+}
+
+/**
+ * Populate the new worktree's node_modules. Fast path: link to the main repo's
+ * shared install (a junction on Windows, a directory symlink on POSIX) so a fresh
+ * worktree is immediately usable without a full reinstall — this repo's own
+ * worktrees follow that pattern. Fallback: run the detected package manager's
+ * install when there is no shared install to link. Both paths surface failures.
+ * @param {string} worktreePath - Absolute path to the new worktree
+ * @param {string} projectRoot - Absolute path to the project root
+ * @param {object} deps
+ * @param {Function} deps.spawnFn - spawnSync-compatible function
+ * @param {object} deps.fsApi - fs module (for DI)
+ * @param {string} deps.platform - process.platform value
+ * @returns {{ linked: boolean, installed: boolean }}
+ * @throws {Error} when linking fails for a non-privilege reason or install fails.
+ */
+function setupWorktreeDeps(worktreePath, projectRoot, { spawnFn, fsApi, platform }) {
+  const srcModules = path.join(projectRoot, 'node_modules');
+  const destModules = path.join(worktreePath, 'node_modules');
+
+  // Already populated (e.g. git checkout carried it) — nothing to do.
+  if (fsApi.existsSync(destModules)) return { linked: false, installed: false };
+
+  // Fast path: link to the shared install when the main repo has one.
+  if (fsApi.existsSync(srcModules)) {
+    const linkType = platform === 'win32' ? 'junction' : 'dir';
+    try {
+      fsApi.symlinkSync(srcModules, destModules, linkType);
+      return { linked: true, installed: false };
+    } catch (error) {
+      // Degrade to a real install only when the link was refused for lack of
+      // privilege/support; any other failure is surfaced to the caller.
+      if (!isLinkPermissionError(error)) throw error;
+    }
+  }
+
+  return runInstall(worktreePath, projectRoot, spawnFn, fsApi);
 }
 
 /**
@@ -121,15 +183,27 @@ async function handleCreate(slug, flags, projectRoot, opts) {
     runFile('git', ['worktree', 'add', worktreePath, '-b', branchName], { stdio: 'pipe' });
   }
 
-  // Step 3: Run package install
+  // Step 3: Populate node_modules (link to the shared install, else install).
   // No per-worktree issue-store bootstrap is needed — the Kernel DB lives in the
   // shared git common dir, so the new worktree already sees the same kernel.
-  runInstall(worktreePath, projectRoot, runSpawn, fsApi);
+  let deps;
+  try {
+    deps = setupWorktreeDeps(worktreePath, projectRoot, {
+      spawnFn: runSpawn,
+      fsApi,
+      platform: opts._platform || process.platform,
+    });
+  } catch (error) {
+    // Surface the failure instead of leaving a worktree with no usable deps.
+    return { success: false, error: error.message, worktreePath, branch: branchName };
+  }
 
   return {
     success: true,
     worktreePath,
     branch: branchName,
+    depsLinked: deps.linked,
+    depsInstalled: deps.installed,
   };
 }
 
@@ -238,5 +312,12 @@ module.exports = {
     }
 
     return handleRemove(slug, projectRoot, opts);
+  },
+
+  // Exposed for unit tests; not part of the CLI surface.
+  _internal: {
+    detectPackageManager,
+    setupWorktreeDeps,
+    runInstall,
   },
 };

--- a/test/commands/worktree-deps.test.js
+++ b/test/commands/worktree-deps.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+// Regression coverage for `forge worktree create` dependency setup.
+//
+// Root cause fixed here: `handleCreate` only ran `<pkgManager> install` and
+// swallowed its exit code, so a fresh worktree ended up with no usable
+// node_modules (and any install failure was silent). The established pattern for
+// this repo's own worktrees is a node_modules link to the main repo's shared
+// install (junction on Windows, directory symlink on POSIX) — fast, no reinstall.
+//
+// These tests assert: (1) the link is created with the right target/type per
+// platform, (2) install failures are SURFACED (not swallowed), and (3) a real
+// `forge worktree create` yields a usable node_modules (skipped gracefully where
+// the OS/user cannot create links).
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const mod = require('../../lib/commands/worktree');
+
+// Non-throwing git stub: satisfies the bare-repo guard (`rev-parse
+// --show-toplevel`), the branch-existence probe, and `git worktree add`.
+function gitStub(calls = []) {
+  return (cmd, args) => {
+    calls.push({ cmd, args });
+    if (cmd === 'git' && args.includes('--show-toplevel')) return Buffer.from('/fake/root\n');
+    if (cmd === 'git' && args[0] === 'branch' && args[1] === '--list') return Buffer.from('');
+    return Buffer.from('');
+  };
+}
+
+describe('forge worktree create — node_modules link to shared install', () => {
+  function runLinkScenario() {
+    const projectRoot = '/fake/root';
+    const worktreePath = path.resolve(projectRoot, '.worktrees', 'linkme');
+    const srcModules = path.join(projectRoot, 'node_modules');
+    const destModules = path.join(worktreePath, 'node_modules');
+
+    const symlinkCalls = [];
+    const spawnCalls = [];
+    const mockFs = {
+      mkdirSync: () => {},
+      // Main repo has node_modules; the new worktree does not yet.
+      existsSync: (p) => p === srcModules,
+      symlinkSync: (target, dest, type) => { symlinkCalls.push({ target, dest, type }); },
+      readdirSync: () => [],
+      cpSync: () => {},
+    };
+    const mockSpawn = (cmd, args, opts) => { spawnCalls.push({ cmd, args, opts }); return { status: 0 }; };
+
+    return { projectRoot, srcModules, destModules, symlinkCalls, spawnCalls, mockFs, mockSpawn };
+  }
+
+  test('links node_modules with a junction on Windows', async () => {
+    const s = runLinkScenario();
+    const result = await mod.handler(
+      ['create', 'linkme'], {}, s.projectRoot,
+      { _exec: gitStub(), _spawn: s.mockSpawn, _fs: s.mockFs, _platform: 'win32' },
+    );
+
+    expect(result.success).toBe(true);
+    expect(s.symlinkCalls).toHaveLength(1);
+    expect(s.symlinkCalls[0].target).toBe(s.srcModules);
+    expect(s.symlinkCalls[0].dest).toBe(s.destModules);
+    expect(s.symlinkCalls[0].type).toBe('junction');
+    // Fast path linked — no package install was spawned.
+    expect(s.spawnCalls.find(c => c.args && c.args[0] === 'install')).toBeFalsy();
+  });
+
+  test('links node_modules with a directory symlink on POSIX', async () => {
+    const s = runLinkScenario();
+    const result = await mod.handler(
+      ['create', 'linkme'], {}, s.projectRoot,
+      { _exec: gitStub(), _spawn: s.mockSpawn, _fs: s.mockFs, _platform: 'linux' },
+    );
+
+    expect(result.success).toBe(true);
+    expect(s.symlinkCalls).toHaveLength(1);
+    expect(s.symlinkCalls[0].type).toBe('dir');
+    expect(s.symlinkCalls[0].target).toBe(s.srcModules);
+  });
+});
+
+describe('forge worktree create — surfaces dependency failures', () => {
+  test('a non-zero install exit is reported, not swallowed', async () => {
+    const projectRoot = '/fake/root';
+    // No main node_modules to link → falls back to install, which "fails".
+    const mockFs = {
+      mkdirSync: () => {},
+      existsSync: (p) => p.endsWith('package.json') || p.endsWith('bun.lock'),
+      symlinkSync: () => {},
+      readdirSync: () => [],
+      cpSync: () => {},
+    };
+    const failingSpawn = () => ({ status: 1 });
+
+    const result = await mod.handler(
+      ['create', 'install-fails'], {}, projectRoot,
+      { _exec: gitStub(), _spawn: failingSpawn, _fs: mockFs, _platform: 'linux' },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/install/i);
+  });
+
+  test('a spawn error (package manager missing) is reported, not swallowed', async () => {
+    const projectRoot = '/fake/root';
+    const mockFs = {
+      mkdirSync: () => {},
+      existsSync: (p) => p.endsWith('package.json'),
+      symlinkSync: () => {},
+      readdirSync: () => [],
+      cpSync: () => {},
+    };
+    const erroringSpawn = () => ({ error: new Error('spawn npm ENOENT') });
+
+    const result = await mod.handler(
+      ['create', 'no-pkg-mgr'], {}, projectRoot,
+      { _exec: gitStub(), _spawn: erroringSpawn, _fs: mockFs, _platform: 'linux' },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/install|ENOENT/i);
+  });
+});
+
+describe('forge worktree create — real filesystem link', () => {
+  // Exercises the real link on disk (no git — a real `git worktree add` would
+  // register against the shared repo in some CI/hook environments). This proves a
+  // freshly-created worktree gets a *usable* node_modules reaching the shared
+  // install's packages. Skipped gracefully where the OS/user cannot create links,
+  // mirroring the file-checker symlink test.
+  const { setupWorktreeDeps } = mod._internal;
+
+  test('links the worktree node_modules to the shared install so packages resolve', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-wt-link-'));
+    try {
+      const projectRoot = path.join(tmp, 'main');
+      const worktreePath = path.join(tmp, 'main', '.worktrees', 'deps-e2e');
+      fs.mkdirSync(worktreePath, { recursive: true });
+
+      // Real shared install with a sentinel package we can require through the link.
+      fs.mkdirSync(path.join(projectRoot, 'node_modules', '.marker-pkg'), { recursive: true });
+      fs.writeFileSync(path.join(projectRoot, 'node_modules', '.marker-pkg', 'index.js'), 'module.exports = 42;\n');
+
+      let result;
+      try {
+        result = setupWorktreeDeps(worktreePath, projectRoot, {
+          spawnFn: () => ({ status: 0 }),
+          fsApi: fs,
+          platform: process.platform,
+        });
+      } catch (error) {
+        // No privilege to create links on this host → skip (not a fix failure).
+        if (['EPERM', 'EACCES', 'ENOSYS', 'UV_EPERM'].includes(error.code)) return;
+        throw error;
+      }
+
+      expect(result.linked).toBe(true);
+      const marker = path.join(worktreePath, 'node_modules', '.marker-pkg', 'index.js');
+      expect(fs.existsSync(marker)).toBe(true);
+      expect(fs.readFileSync(marker, 'utf8')).toContain('42');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 20000);
+});


### PR DESCRIPTION
## Problem

`forge worktree create <slug>` produced a worktree with **no usable `node_modules`**, so a freshly-created worktree couldn't run tests or `forge` until dependencies were set up by hand. Worse, `runInstall` **swallowed the install result**, so any failure was completely silent.

## Root causes

1. **The intended `node_modules` link was never implemented.** `handler`'s JSDoc and the existing worktree tests already reference `_platform` + `symlinkSync`, but `handleCreate` only called `runInstall` — it never linked the new worktree's `node_modules` to the main repo's shared install. This repo's own worktrees follow exactly that pattern (their `node_modules` is a junction/symlink to `<mainRepo>/node_modules`). On this Bun repo `runInstall` also mis-detected the package manager: it checked the obsolete binary `bun.lockb`, not the current text `bun.lock`, so it fell through to `npm`.
2. **Failures were swallowed.** `runInstall` ran `spawnFn(pkgManager, ['install'])` and ignored the returned `.status`/`.error`, so a spawn error or non-zero exit left a broken worktree with no signal.

## Fix (`lib/commands/worktree.js`)

- New `setupWorktreeDeps`: **fast path** links `node_modules` to `<projectRoot>/node_modules` — a directory **junction on Windows** (`symlinkSync(target, dest, 'junction')`), a **directory symlink on POSIX** — so a fresh worktree is immediately usable with no reinstall. **Fallback**: run the detected package manager's install only when there is no shared install to link. Link-privilege failures (EPERM/EACCES/ENOSYS) degrade to install rather than hard-failing.
- `runInstall` now **throws on spawn error / non-zero exit**; `handleCreate` catches it and returns `{ success: false, error }` (and reports `depsLinked` / `depsInstalled`) — failures are surfaced, not silent.
- `detectPackageManager` recognizes the modern text `bun.lock` in addition to `bun.lockb`.

## Why link (not install)

The established pattern for this repo's worktrees is a shared-`node_modules` link — fast, deterministic, and avoids a full per-worktree reinstall of a large dependency tree. The install path remains as a correct fallback for projects without a shared install.

## Test evidence (`test/commands/worktree-deps.test.js`, RED before the fix)

- links `node_modules` with a **junction (win32)** / **directory symlink (posix)** — asserted via the `_platform` DI;
- **surfaces** a non-zero install exit and a spawn error instead of swallowing them;
- **real filesystem**: a linked worktree resolves a real package through the shared install (skips gracefully where the OS/user cannot create links, like the file-checker symlink test).

Real-CLI confirmation: `forge worktree create deps-proof` yields `.worktrees/deps-proof/node_modules` resolving to the shared install (`fastest-levenshtein` resolves through it). All worktree + registry suites green (47 tests); `eslint . --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved worktree setup to better handle shared dependencies, including linking `node_modules` when possible and falling back to install if linking isn’t supported.
  * Bun projects are now detected more reliably, reducing incorrect package manager detection.

* **Bug Fixes**
  * Dependency setup failures now surface clear errors instead of being silently ignored.
  * Worktree creation now returns clearer success/failure details, including whether dependencies were linked or installed.

* **Tests**
  * Added coverage for dependency linking, fallback install behavior, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->