### PR TITLE
feat(skills): optimize + triggering-test descriptions, add evals, and correct body accuracy for all 18 skills

### DIFF
--- a/.codex/skills/claim-safety/SKILL.md
+++ b/.codex/skills/claim-safety/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: claim-safety
 description: >
-  Claim a Forge issue and PROVE you own the lease before doing any work. Use
-  whenever you (or an orchestrator/agent) are about to mutate a claimed issue —
-  after `forge claim`, before `dev`/edit/`close`/`release`, or when two agents
-  might contend for the same work. A claim returning ok:true does NOT prove you
-  won the lease (a duplicate replay also returns ok:true), so this procedure adds
-  the mandatory ownership check via `forge issue owns <id>`. Trigger on "claim an
-  issue safely", "did I win the lease", "verify ownership", "claim conflict",
-  "two agents same issue", or before any claimed-issue mutation.
+  Claim a Forge issue and then PROVE you hold the live lease before you touch it — the
+  ownership-verification procedure built on `forge issue owns <id>`. Use this whenever
+  actually winning the claim matters: right after `forge claim`, before you
+  `dev`/edit/`close`/`release` a claimed issue, when two agents or a subagent fan-out might
+  contend for the same work, or when you need to re-check ownership before an irreversible
+  step. Why it exists: a claim returning `ok:true` does NOT prove you won — a same-actor
+  duplicate replay also returns `ok:true`, and a live lease can be reclaimed once it expires —
+  so `forge issue owns` (exit 0 iff you hold the single, unexpired active lease) is the only
+  real proof, and you re-verify before close/release. Trigger on "claim this issue safely",
+  "did I actually win the lease", "verify/prove ownership", "claim conflict", "two agents
+  grabbed the same issue", "check I still own it before closing", or before ANY mutation of a
+  claimed issue. NOT for plain single-issue create/update/close/comment when there is no
+  ownership question (that is issue-basics), and NOT for read-only selecting or ranking the
+  next ready issue without claiming (that is triage-ready).
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/.codex/skills/claim-safety/evals/evals.json
+++ b/.codex/skills/claim-safety/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "I just ran forge claim on forge-abc — how do I make sure the lease is really mine before I start editing?",
+    "should_trigger": true
+  },
+  {
+    "query": "Two of my agents may have grabbed the same issue at once — how do I tell which one actually holds it?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I close this ticket, confirm nobody reclaimed it while I was working.",
+    "should_trigger": true
+  },
+  {
+    "query": "My claim came back ok:true but I'm not convinced I won the race. Can I trust that?",
+    "should_trigger": true
+  },
+  {
+    "query": "Prove I own forge-42 before the subagent starts mutating it.",
+    "should_trigger": true
+  },
+  {
+    "query": "The lease might have expired mid-task — check I still own it before I release.",
+    "should_trigger": true
+  },
+  {
+    "query": "What's the next ready issue I should pick up?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a feature issue titled 'Add CSV export'.",
+    "should_trigger": false
+  },
+  {
+    "query": "Close forge-19 with reason 'shipped in PR 88'.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-30 all the way through to a PR.",
+    "should_trigger": false
+  },
+  {
+    "query": "Implement the failing auth tests for this task.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/dev/SKILL.md
+++ b/.codex/skills/dev/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: dev
-description: Implements each task from the plan task list using a subagent-driven loop (implementer → spec-compliance reviewer → code-quality reviewer) with TDD and HARD-GATE enforcement. Use for the Forge dev stage when implementing planned tasks — triggers include /dev, dev stage, build the tasks, subagent TDD, implement task list.
+description: >
+  Forge DEV stage — the build engine that turns an already-approved /plan task list into
+  committed, test-backed code. Reads docs/work/<date>-<slug>/tasks.md and design.md, then
+  drives each task through a subagent loop (implementer → spec-compliance reviewer →
+  code-quality reviewer) using RED-GREEN-REFACTOR TDD, HARD-GATE evidence checks, a spec-gap
+  decision score, and per-task progress recorded on the Forge issue via `forge comment`. Use
+  when a plan and task list already exist and it is time to implement them — triggers: "/dev",
+  "start the dev stage", "build the tasks", "implement tasks.md test-first", "run the
+  implementer/reviewer TDD loop", "write the code for the planned tasks one by one", "work
+  through the task list with subagents". This is the per-task coding stage ONLY. Do NOT use it
+  for creating the design doc or task list (that is plan), for the post-build
+  type-check/lint/security/test gate (validate), for pushing the branch or opening the PR
+  (ship), for addressing PR review feedback (review), or for orchestrating several stages /
+  taking an issue end-to-end to a merged PR (smith). Reach for dev specifically when the ask
+  is to author code for tasks that are already planned.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 

--- a/.codex/skills/dev/evals/evals.json
+++ b/.codex/skills/dev/evals/evals.json
@@ -12,7 +12,7 @@
     "should_trigger": true
   },
   {
-    "query": "Build out the task list from the design doc using red-green-refactor",
+    "query": "Implement the already-planned tasks one at a time, red-green-refactor each",
     "should_trigger": true
   },
   {

--- a/.codex/skills/dev/evals/evals.json
+++ b/.codex/skills/dev/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "/dev",
+    "should_trigger": true
+  },
+  {
+    "query": "The plan and task list are done — start implementing the tasks one at a time, tests first.",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the implementer then the spec and quality reviewer subagents over each task in tasks.md",
+    "should_trigger": true
+  },
+  {
+    "query": "Build out the task list from the design doc using red-green-refactor",
+    "should_trigger": true
+  },
+  {
+    "query": "Time to write the code for the planned tasks and TDD each one in this worktree",
+    "should_trigger": true
+  },
+  {
+    "query": "Work through tasks.md subagent by subagent until every task is committed and reviewed",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up the branch, worktree, and TDD task list for this new feature",
+    "should_trigger": false
+  },
+  {
+    "query": "Type-check, lint, and run the full test suite before I open the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Push the validated branch and open the pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR has open review threads from the bots — fix each finding, reply, and mark them resolved.",
+    "should_trigger": false
+  },
+  {
+    "query": "Grab the next ready issue and drive it all the way to a merged PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Which workflow stage am I on and what work is in flight right now?",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/hermes-forge/SKILL.md
+++ b/.codex/skills/hermes-forge/SKILL.md
@@ -63,18 +63,16 @@ reading raw issue stores, design files, or kernel internals directly:
 forge orient --json                # bounded project orientation (envelope)
 forge orient --budget 4000 --json
 forge recap <issue-id> --json      # bounded per-issue recap (envelope)
-forge recap --json                 # legacy activity summary (NOT the envelope)
 ```
 
 `forge orient` and `forge recap <issue-id>` emit the deterministic JSON envelope
 described below (assembly `deterministic-file-assembly-v1`). Parse the JSON; do
 not screen-scrape the human text form.
 
-> Note: bare `forge recap --json` (no issue id) returns the legacy activity
-> summary (`generatedAt`, `issueSummary`, `reviewOutcomes`, `recentIssues`,
-> `insights`) — it does **not** carry `schema_version`, `sections`,
-> `token_budget`, or `assembly`. For the envelope contract, use `forge orient`
-> or `forge recap <issue-id>`.
+> Note: `forge recap` always requires an issue id — bare `forge recap --json`
+> (no id) prints its usage and exits non-zero rather than returning a summary.
+> Use `forge orient` for project-level orientation, or `forge recap <issue-id>`
+> for a single issue; both emit the deterministic envelope.
 
 ### Envelope shape
 
@@ -124,14 +122,13 @@ whole payload.
 
 Truncation is deterministic, never random:
 
-- Non-preserved sections are allocated budget in ascending numeric `priority`
-  order (lower `priority` first); when the budget is exhausted, the
-  later/higher-`priority` sections are the ones trimmed. Preserved sections are
-  kept whole and trimmed only as a last resort if the payload is still over
-  budget. The authoritative per-section signal is each section's `truncated`
-  flag plus its `priority`/`estimated_tokens` — not the nominal
-  `token_budget.truncation_order` list, which is a static hint and may not match
-  the priority-driven trim order.
+- Non-preserved sections are trimmed in the order given by
+  `token_budget.truncation_order`; when the budget is exhausted, sections later
+  in that order are trimmed first. Preserved sections are kept whole and trimmed
+  only as a last resort if the payload is still over budget. The authoritative
+  per-section signal is each section's `truncated` flag and `estimated_tokens` —
+  there is no per-section `priority` field; the overall trim order is
+  `token_budget.truncation_order`.
 - A trimmed section ends with the literal marker
   `[truncated deterministically by token budget]` and has `truncated: true`.
 - `token_budget.truncated === true` means the payload as a whole was trimmed.

--- a/.codex/skills/hermes-forge/SKILL.md
+++ b/.codex/skills/hermes-forge/SKILL.md
@@ -1,12 +1,26 @@
 ---
 name: hermes-forge
 description: >
-  Consumption contract for the Hermes harness on a Forge project. Treat
-  `forge orient` and `forge recap` as the authoritative, token-bounded source
-  of project state, cite every surfaced fact by its provenance, honor the
-  deterministic truncation policy, and write evidence or decisions back ONLY
-  through Forge CLI commands. Hermes-native profile memory never leaks into
-  Forge Kernel state.
+  Consumption contract for how the Hermes harness reads, cites, and writes back Forge project
+  state — Hermes is a CONSUMER of Forge, never a second source of truth. Load this whenever a
+  Hermes session runs on a Forge repo: at session start to orient, before acting on a specific
+  issue, or any time you need CURRENT project state. Always obtain state through `forge
+  orient` / `forge recap <issue-id>` — the deterministic, token-bounded JSON envelope — and
+  never reconstruct it by reading raw issue stores, design files, or kernel internals. This
+  skill governs the envelope discipline: honor the token budget (raise depth with `--budget
+  N`, don't retry blindly), treat any `truncated` section as incomplete, attribute every
+  surfaced fact to its source `path`/`authority`, and surface conflicts instead of silently
+  picking a winner. It also governs writeback: record evidence, decisions, and follow-up work
+  into the Forge Kernel ONLY through Forge CLI commands (`forge comment` / `forge update` /
+  `forge create`), and NEVER leak Hermes profile or session memory into Forge state. Trigger
+  phrases: "orient me / what's the current project state", "where did this fact come from,
+  cite it", "the orient output came back truncated", "how do I persist this decision back into
+  Forge", "is it safe to store this in kernel state". This is the Hermes⇄Forge boundary
+  contract — NOT the general Forge session router that navigates stage skills (kernel), NOT
+  the human-facing "what stage am I in / where am I" report (status), NOT everyday issue
+  create/update/close/search CRUD (issue-basics), NOT surfacing or ranking the next ready
+  issue (triage-ready), and NOT live PR monitoring (shepherd, which runs OUTSIDE Hermes and is
+  not visible through orient).
 compatibility: >
   Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Install
   path — like every Forge skill pack (e.g. parallel-deep-research,

--- a/.codex/skills/hermes-forge/evals/evals.json
+++ b/.codex/skills/hermes-forge/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "I just started a Hermes session on this Forge repo — get me oriented on where the project stands before I touch anything.",
+    "should_trigger": true
+  },
+  {
+    "query": "The forge orient envelope came back with the active-work section flagged truncated. Can I treat that as the full list, or do I need to pull more?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I tell the user which approach we settled on, I need to point at the exact source file and how authoritative it is — where does that decision come from?",
+    "should_trigger": true
+  },
+  {
+    "query": "I uncovered a design decision in this session that the team needs to keep. What's the correct way to write it back into Forge without dragging my Hermes notes into kernel state?",
+    "should_trigger": true
+  },
+  {
+    "query": "Default orientation is clipping the decisions section at 2000 tokens — give me more headroom.",
+    "should_trigger": true
+  },
+  {
+    "query": "Don't rebuild the project picture by grepping the design docs yourself — go through the proper bounded orient/recap surface instead.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which workflow stage am I sitting in right now, and has any of my work gone stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "I'm kicking off a Forge session in Claude — which stage skill do I run to start planning a new feature?",
+    "should_trigger": false
+  },
+  {
+    "query": "Watch PR #418, rerun the flaky required check if it trips, and ping me when it's ready to merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "Open a bug issue for the checkout timeout, set priority 1, and add a note about the repro steps.",
+    "should_trigger": false
+  },
+  {
+    "query": "What's the highest-priority ready issue I should pick up next?",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/issue-basics/SKILL.md
+++ b/.codex/skills/issue-basics/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: issue-basics
 description: >
-  The everyday issue CRUD floor for a Forge project — create, update, claim,
-  release, comment, close, show, list, search, and stats over the kernel via the
-  `forge issue` verbs. This is the parity floor a team needs on day one after
-  migrating off a Beads-style tracker, mapped one-to-one onto real `forge` verbs
-  with their actual flags. Use for routine issue work. Trigger on "create an
-  issue", "update an issue", "claim/close an issue", "comment on an issue", "list
-  issues", "search issues", "reopen", or "add a label".
+  Everyday single-issue CRUD over the `forge issue` verbs — create, update, show, list,
+  search, close, reopen, comment, set priority/labels/assignee, claim or release one issue,
+  and add/remove dependency edges, plus backlog `stats`. Reach for this on ANY routine one-off
+  issue operation: "create an issue/bug/task for X", "update or edit issue <id>", "close (or
+  reopen) this issue", "comment a handoff note on <id>", "list open bugs" or "filter issues by
+  label/priority/status", "search issues for …", "bump this to P1", "reassign to alice", "mark
+  <id> blocked by <id>", "add a label". This is also the parity floor when migrating off a
+  Beads-style tracker (label/reopen/delete map onto their forge equivalents). Scope is
+  single-operation issue plumbing only. It does NOT choose, rank, or explain the next issue to
+  work on or why one is blocked (use triage-ready); it does NOT run the
+  claim-then-prove-lease-ownership safety procedure before mutating shared work (use
+  claim-safety); it does NOT drive an issue through the plan->dev->validate->ship pipeline or
+  open a PR (use smith or the individual stage skills); and it does NOT report the current
+  workflow stage or what is in flight (use status).
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/.codex/skills/issue-basics/SKILL.md
+++ b/.codex/skills/issue-basics/SKILL.md
@@ -32,7 +32,7 @@ failure. **Gate on `ok`** — do not parse `data` until you confirm `ok:true`.
 
 | Need | Command |
 |------|---------|
-| Create an issue | `forge issue create --title "…" --type <task\|feature\|bug\|epic>` |
+| Create an issue | `forge issue create --title "…" --type <task\|bug\|epic\|decision>` |
 | Inspect one issue | `forge issue show <id> [--json]` |
 | List / filter issues | `forge issue list [--status … --type … --priority … --label …] [--json]` |
 | Full-text search | `forge issue search "…" [--json]` |
@@ -47,15 +47,15 @@ failure. **Gate on `ok`** — do not parse `data` until you confirm `ok:true`.
 ## Create — the flags that matter
 
 ```bash
-forge issue create --title "Add rate limiting" --type feature \
-  --priority P1 --label "api,security" --assignee alice \
+forge issue create --title "Add rate limiting" --type task \
+  --priority P1 --label "feature,api,security" --assignee alice \
   --acceptance "429 returned after N req/min; covered by a test"
 ```
 
 | Flag | Meaning | Default |
 |------|---------|---------|
 | `--title "…"` | Human title (a bare leading positional also works) | minted id |
-| `--type <…>` | `task` · `feature` · `bug` · `epic` · `decision` | `task` |
+| `--type <…>` | `task` · `bug` · `epic` · `decision` | `task` |
 | `--priority <…>` | `P0`..`P4` (or bare `0`..`4`); `P0` is highest | unset |
 | `--label "a,b"` | Comma-separated set — one flag, split on `,` (repeats do NOT accumulate) | none |
 | `--body "…"` | Long description (`--description` is an accepted alias) | empty |
@@ -64,8 +64,12 @@ forge issue create --title "Add rate limiting" --type feature \
 | `--parent <id>` | Parent/epic id | none |
 
 `--status` defaults to `open`. Status vocabulary: `open` · `in_progress` ·
-`review` · `done` · `cancelled`. Epics and decisions are non-claimable (they never
-enter the ready queue).
+`review` · `done` · `cancelled`. Unlike `--priority` and `--status` (which reject
+unknown values), `--type` is stored verbatim — a non-canonical value like
+`feature` is accepted without error but carries no kernel behaviour, so stick to
+the four canonical types. Epics and decisions are excluded from the ready queue
+(non-claimability is a queue convention, not enforcement — `forge issue claim`
+currently returns `ok:true` on them too).
 
 ## Update — same field flags, plus close
 
@@ -102,7 +106,7 @@ It is a canonical source you fork, not a fixed policy.
 
 | Knob | Default | How to change |
 |------|---------|---------------|
-| **Default type** | `task` (kernel default) | Decide your create convention — e.g. always pass `--type feature` for user-facing work, `--type bug` for regressions. |
+| **Default type** | `task` (kernel default) | Decide your create convention — e.g. always pass `--label feature` for user-facing work (feature is a label, not a canonical type), `--type bug` for regressions. |
 | **Default priority** | unset | Adopt a house scale (e.g. new work opens at `P2`, incidents at `P0`) and always pass `--priority`. |
 | **Fields required on create** | `--title` only | Require `--acceptance` (and `--label`/`--assignee`) on every create so issues are actionable from birth. |
 | **Id / reference convention** | kernel-minted ids | Standardize how you cite issues in commits/PRs (e.g. `Closes <id>`) and whether you pass an explicit `--id`. |

--- a/.codex/skills/issue-basics/evals/evals.json
+++ b/.codex/skills/issue-basics/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "Open a bug ticket for the checkout 500 error and mark it P0",
+    "should_trigger": true
+  },
+  {
+    "query": "Add a note to forge-abc123 documenting why we chose JWT",
+    "should_trigger": true
+  },
+  {
+    "query": "Show me all open issues tagged backend",
+    "should_trigger": true
+  },
+  {
+    "query": "Reopen forge-77, it wasn't actually fixed",
+    "should_trigger": true
+  },
+  {
+    "query": "Add a dependency so forge-12 is blocked by forge-9",
+    "should_trigger": true
+  },
+  {
+    "query": "Claim forge-abc so I can start on it",
+    "should_trigger": true
+  },
+  {
+    "query": "What's the next ready issue I should pick up?",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain why forge-55 is still blocked and what to unblock first",
+    "should_trigger": false
+  },
+  {
+    "query": "Claim this issue and confirm I hold the lease before I change anything",
+    "should_trigger": false
+  },
+  {
+    "query": "Drive forge-30 all the way through to a merged PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now and what's in flight?",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/kernel/SKILL.md
+++ b/.codex/skills/kernel/SKILL.md
@@ -109,11 +109,12 @@ families. Run them through Bash; never hand-edit the issue store.
 | Search / stats | `forge issue search "…"` · `forge issue stats` |
 | Blocked work | `forge blocked` |
 
-### B — Memory / knowledge (planned)
+### B — Memory / knowledge
 
-`forge remember` / `forge recall` / `forge knowledge search` are roadmap items —
-they are **not on the CLI yet**. Do not invoke them; record durable decisions as
-issue comments (`forge comment`) until the memory verbs land.
+`forge remember <note> [--tag <label>]... [--json]` and `forge recall` are live —
+they persist and retrieve project-memory notes from a file-backed store. Only
+`forge knowledge search` is not on the CLI yet; until it lands, capture durable
+decisions as `forge remember` notes or issue comments (`forge comment`).
 
 ### C — Board / planning / admin
 

--- a/.codex/skills/kernel/SKILL.md
+++ b/.codex/skills/kernel/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: kernel
 description: >
-  Forge kernel surface — the umbrella index for working in a Forge project. Use
-  at the start of any session and whenever you need to orient: it routes to the
-  `smith` orchestrator super-skill, the per-stage workflow skills (plan, dev,
-  validate, ship, review, verify, plus status, research, rollback, sonarcloud,
-  shepherd) and the kernel-native skills (triage-ready, issue-basics), and
-  documents the day-to-day issue, board, and orientation verbs of the `forge`
-  CLI. Trigger on
-  "what's the workflow", "what should I work on", "forge issues", "claim an
-  issue", "project status", "orient", or when deciding between Forge issues and
-  an ad-hoc TodoWrite list.
+  Forge kernel surface — the umbrella index and router for a Forge project. Reach for this
+  FIRST when you are orienting rather than executing: at the very start of a Forge session,
+  when you need the map of how the whole system fits together, or when you are unsure WHICH
+  skill or `forge` verb a task belongs to. It routes to the `smith` end-to-end orchestrator,
+  the per-stage ladder skills (plan, dev, validate, ship, review, verify), the utility skills
+  (status, research, rollback, sonarcloud, shepherd), and the kernel-native issue skills
+  (triage-ready, claim-safety, issue-basics) — and it is the reference for the day-to-day
+  `forge` CLI issue, board, gate, and orientation verbs. Trigger on "how does the Forge
+  workflow work", "walk me through the stage ladder", "which forge command or skill do I use
+  for X", "what are the forge issue verbs", "I'm new to this repo, how is Forge set up", "map
+  the Forge skills for me", or "should this be a Forge issue or a TodoWrite". This is the
+  meta/index layer, so hand off the actual doing: ranking or picking the next ready issue →
+  `triage-ready`; the current stage, "where am I", or active/stale work → `status`;
+  create/update/close/search a single issue → `issue-basics`; claim-then-prove-ownership
+  before mutating → `claim-safety`; drive one issue from plan to a merged PR under human gates
+  → `smith`; token-bounded project state for the Hermes harness → `hermes-forge`.
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/.codex/skills/kernel/evals/evals.json
+++ b/.codex/skills/kernel/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "I just cloned this Forge repo and I'm not sure how any of it works — give me the lay of the land: what's the workflow, what skills exist, and where do I even start?",
+    "should_trigger": true
+  },
+  {
+    "query": "There are a bunch of forge skills and I can't tell which one to use for what — lay out how they fit together and when I'd reach for each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which forge CLI command adds a dependency between two issues, and what's the verb for proving I hold a claim? Just the reference, don't run anything.",
+    "should_trigger": true
+  },
+  {
+    "query": "Is this small cleanup worth filing as a Forge issue, or should I just throw it on a TodoWrite checklist for this session?",
+    "should_trigger": true
+  },
+  {
+    "query": "Walk me through the Forge stage ladder from planning to post-merge verify and what each stage owns.",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me the reference of all the day-to-day forge issue and board verbs — I want the index, not to execute a command yet.",
+    "should_trigger": true
+  },
+  {
+    "query": "What should I pick up next? Rank the ready queue and tell me the top unblocked issue and why.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now, what's my active work, and has anything gone stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a bug issue titled 'login times out after 30s', priority 1, and link it under the auth epic.",
+    "should_trigger": false
+  },
+  {
+    "query": "Claim forge-4h9 for me and confirm I actually hold the lease before I start editing.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-7c2 all the way from planning through a merged PR, pausing for my approval at the plan and the merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "In the Hermes harness, give me the token-bounded project state to work from — treat forge orient as the source of truth.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/parallel-deep-research/SKILL.md
+++ b/.codex/skills/parallel-deep-research/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: parallel-deep-research
 description: >
-  Produces comprehensive research reports that go far beyond what built-in web
-  search can achieve. Sends research tasks to Parallel AI's pro/ultra processors
-  which spend 3-25 minutes autonomously crawling, reading, and synthesizing dozens
-  of sources — returning structured reports with citations. Built-in WebSearch
-  can only run a few queries; this skill runs an entire research pipeline externally.
-  No binary install — requires PARALLEL_API_KEY in .env.local. ALWAYS use this
-  skill instead of doing multiple WebSearch calls when the user needs a comprehensive
-  report, market analysis, competitive landscape, industry deep-dive, strategic
-  recommendations, or multi-source synthesis. This is the RIGHT tool for any
-  research task that would require more than 3-4 web searches to answer properly.
-  Also trigger during /plan Phase 2 research and /research workflows.
+  Heavyweight EXTERNAL research reports — market, industry, competitive, and strategic —
+  delegated to Parallel AI's paid pro/ultra processors, which autonomously crawl, read, and
+  synthesize dozens of sources over 3-25 minutes and return one long structured report with
+  citations, far beyond what a handful of WebSearch calls can produce. Reach for this whenever
+  the user wants a comprehensive market analysis, competitive landscape, industry deep-dive,
+  multi-vendor/technology comparison across many sources, strategic recommendations, market
+  sizing/growth outlook, or any multi-source synthesis that would take more than 3-4 web
+  searches to answer well. Typical phrasings: "market analysis of X", "competitive landscape
+  comparing A/B/C", "industry deep-dive on...", "deep research report on...", "compare these
+  vendors at our scale", "strategic report with predictions for 2027". Requires
+  PARALLEL_API_KEY in .env.local; each run costs money and takes minutes, so it is the WRONG
+  tool for quick facts, a single-page fetch, one-URL scraping, or a small structured-field
+  extraction — use built-in WebSearch/WebFetch for those. It is also NOT the Forge RESEARCH or
+  PLAN stage itself: "run the research stage", "do Phase 2 for this feature", or
+  codebase/OWASP/DRY investigation that gets written into a design doc route to `research` and
+  `plan` — those stages may INVOKE this skill as their external research engine when a topic
+  genuinely needs dozens of sources, but a bare "run the stage" request is not this skill.
 compatibility: Requires PARALLEL_API_KEY in .env.local. Uses curl. Takes 3-25 minutes.
 metadata:
   author: harshanandak

--- a/.codex/skills/parallel-deep-research/evals/evals.json
+++ b/.codex/skills/parallel-deep-research/evals/evals.json
@@ -1,62 +1,46 @@
 [
   {
-    "query": "I need a comprehensive market analysis of the developer tools space — cover the top 20 players, their funding, market positioning, and where the industry is heading over the next 3-5 years. Include data from Gartner, Forrester, and any recent VC investment reports",
+    "query": "I need a comprehensive market analysis of the developer-tools space — top 20 players, their funding, market positioning, and where the industry is heading over the next 3-5 years, pulling from Gartner, Forrester, and recent VC investment reports",
     "should_trigger": true
   },
   {
-    "query": "Write a deep research report on the state of WebAssembly adoption in production — synthesize case studies from companies using WASM, performance benchmarks vs native code, ecosystem maturity analysis, and strategic recommendations for when to adopt it",
+    "query": "Write a deep research report on WebAssembly adoption in production — synthesize company case studies, performance benchmarks vs native code, ecosystem maturity, and clear recommendations for when to adopt it",
     "should_trigger": true
   },
   {
-    "query": "Our CTO wants a competitive landscape analysis comparing Convex, Supabase, Firebase, and PlanetScale for our backend rewrite. Need comprehensive feature comparison, pricing analysis at our scale (50K DAU), community health metrics, and risk assessment for each",
+    "query": "Competitive landscape comparing Convex, Supabase, Firebase, and PlanetScale for our backend rewrite — full feature comparison, pricing at 50K DAU, community-health metrics, and a per-vendor risk assessment",
     "should_trigger": true
   },
   {
-    "query": "Create a strategic report on the AI code generation market — analyze GitHub Copilot, Cursor, Claude Code, and emerging competitors. Cover adoption rates, developer satisfaction surveys, enterprise pricing trends, and predictions for 2027",
+    "query": "Give me an industry deep-dive on the observability market — Datadog vs Grafana Cloud vs New Relic across features, pricing, scalability, and OpenTelemetry support, with customer migration stories and TCO analysis for a 500-node cluster",
     "should_trigger": true
   },
   {
-    "query": "I'm doing /plan Phase 2 research — produce a comprehensive analysis of event-driven architecture patterns in microservices, covering Kafka vs RabbitMQ vs NATS, with production case studies, failure mode analysis, and recommendations for our 100K events/sec throughput requirement",
+    "query": "For our architecture decision, produce a heavily-sourced report on event-driven patterns — Kafka vs RabbitMQ vs NATS at 100K events/sec, with production case studies and failure-mode analysis",
     "should_trigger": true
   },
   {
-    "query": "Write an industry deep-dive into the observability market — compare Datadog, Grafana Cloud, and New Relic across features, pricing, scalability, and OpenTelemetry support. Include customer migration stories and TCO analysis for a 500-node cluster",
-    "should_trigger": true
-  },
-  {
-    "query": "Research and synthesize the current state of edge computing for real-time AI inference — cover hardware options, cloud provider edge offerings, latency benchmarks, and case studies from autonomous vehicles and IoT deployments",
-    "should_trigger": true
-  },
-  {
-    "query": "Quick search: what's the current price of Bitcoin and what were Anthropic's latest announcements?",
+    "query": "Quick — what's the current price of Bitcoin and what were Anthropic's latest announcements?",
     "should_trigger": false
   },
   {
-    "query": "Find the official migration guide URL for ESLint's new flat config format",
+    "query": "Go to https://stripe.com/docs/api and extract the authentication section with all its code examples",
     "should_trigger": false
   },
   {
-    "query": "Search for recent blog posts about Bun 2.0 features and release date",
+    "query": "Scrape https://openai.com/pricing and pull out the per-token cost for each model tier",
     "should_trigger": false
   },
   {
-    "query": "Go to https://stripe.com/docs/api and extract the authentication section with all the code examples",
+    "query": "Run the /research stage for the auth-refactor feature — investigate how our codebase currently handles session tokens, flag OWASP and DRY concerns, and write the findings into the design doc",
     "should_trigger": false
   },
   {
-    "query": "Scrape https://openai.com/pricing and extract the per-token costs for each model tier",
+    "query": "Kick off the plan stage for adding rate limiting — brainstorm the design one question at a time, then set up the branch, worktree, and task list",
     "should_trigger": false
   },
   {
-    "query": "Build a structured company profile for Databricks — return JSON with founding year, funding rounds, valuation, employee count, and tech stack",
-    "should_trigger": false
-  },
-  {
-    "query": "Fix the TypeScript compilation error in src/services/auth.ts — it's complaining about missing type for the session token",
-    "should_trigger": false
-  },
-  {
-    "query": "Add unit tests for the rate limiter middleware in src/middleware/rateLimit.ts",
+    "query": "Fix the TypeScript compilation error in src/services/auth.ts about the missing session-token type",
     "should_trigger": false
   }
 ]

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: plan
 description: >
-  Use for the Forge plan stage to capture design intent through
-  one-question-at-a-time brainstorming, run technical/OWASP/DRY research, then set up
-  the branch, worktree, and a complete TDD task list ready for /dev. Trigger when
-  starting a new feature, planning or scoping work, writing a design doc, or preparing
-  a worktree and task list before development.
+  Forge PLAN stage — the first stop when starting a NEW feature or an unscoped piece of work.
+  Runs one-question-at-a-time brainstorming to capture design intent, writes and commits a
+  design doc, runs technical/OWASP/DRY + codebase research, then sets up the branch, worktree,
+  and a complete TDD task list ready to hand to /dev. Trigger on "let's plan X", "start or
+  scope a new feature", "brainstorm this before we build", "write a design doc", "break this
+  into tasks", or "set up a worktree and task list before coding". Reach for this even when
+  the request sounds like only design or only scoping — plan owns intent → research →
+  task-list setup as a single stage. NOT for driving a feature all the way to a merged PR
+  (that is smith), NOT for implementing the tasks once they already exist (dev), NOT for a
+  standalone deep-research pass into an already-approved design doc (research), NOT for
+  reporting where current work stands or what is stale (status), and NOT for everyday issue
+  create/list/close or picking the next ready issue (issue-basics / triage-ready).
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -515,7 +515,7 @@ If the user approves a dependency mutation, apply it explicitly (only when the t
 bash scripts/dep-guard.sh apply-decision <id> <dependent-id> <depends-on-id> "<approval rationale>"
 ```
 
-That approval step must validate with `forge issue dep cycles`, show `forge graph`, summarize `forge ready`, and persist the decision via `forge update` plus `forge comment`. The Forge Kernel is the canonical machine-readable decision record; the plan docs hold only the concise summary.
+That approval step must inspect blockers with `forge issue blocked` (and `forge issue children <epic-id>` for the epic rollup), summarize `forge ready`, and persist the decision via `forge update` plus `forge comment`. The Forge Kernel is the canonical machine-readable decision record; the plan docs hold only the concise summary.
 
 ### Step 6: User review
 

--- a/.codex/skills/plan/evals/evals.json
+++ b/.codex/skills/plan/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "I want to build a rate-limiter for our public API — help me nail down the design, then break it into tasks before I write any code.",
+    "should_trigger": true
+  },
+  {
+    "query": "Let's kick off the webhook-retry feature: ask me the key decisions one at a time, write it up, and set me up to start developing.",
+    "should_trigger": true
+  },
+  {
+    "query": "Scope out adding SSO to the admin dashboard — pin down requirements and edge cases and give me an ordered TDD task list on its own branch.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before anyone touches the notification service I want a real plan: a worktree, some research on the approach, and a task list /dev can just run.",
+    "should_trigger": true
+  },
+  {
+    "query": "Starting the CSV-export epic today — brainstorm the approach with me and produce a committed design doc plus tasks.",
+    "should_trigger": true
+  },
+  {
+    "query": "Grab the highest-priority ready issue and take it all the way to an open PR — plan, build, validate, ship — just pause for my approval before merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "The design doc and task list are already in docs/work; start implementing the first task with RED-GREEN-REFACTOR.",
+    "should_trigger": false
+  },
+  {
+    "query": "The design is approved and written — now go do the deep web and codebase research and append it under the Technical Research section.",
+    "should_trigger": false
+  },
+  {
+    "query": "Which stage am I on for the billing branch, and is any of my work going stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a bug issue for the broken logout redirect and link it under the auth epic.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/research/SKILL.md
+++ b/.codex/skills/research/SKILL.md
@@ -1,10 +1,25 @@
 ---
 name: research
 description: >
-  Runs deep, parallel web and codebase research and documents findings in the design
-  doc. Use for the Forge research stage when gathering technical research, OWASP
-  analysis, and TDD scenarios before planning or development. Trigger keywords are
-  research, deep research, web search, OWASP, codebase exploration, technical research.
+  Runs the Forge RESEARCH stage — the technical-investigation phase now embedded as /plan
+  Phase 2. Use it when the user wants JUST the research work for a specific feature (not the
+  whole plan flow): deep web research on best practices and known gotchas for the chosen
+  approach, an OWASP Top 10 risk pass documenting which categories apply and how they'll be
+  mitigated, DRY / blast-radius codebase exploration for existing patterns to reuse, and
+  identification of at least three TDD test scenarios — all appended under `## Technical
+  Research` in that feature's `docs/work/YYYY-MM-DD-<slug>/design.md`. Trigger on phrasings
+  like "run the research phase", "do the technical research for this feature", "run an OWASP
+  analysis on this", "explore the codebase for reusable patterns before we build", "check
+  we're not duplicating an existing helper (DRY)", "add the security + best-practices research
+  to the design doc", or "find TDD scenarios for X". If the design doc doesn't exist yet,
+  create it first, then research into it. Pick this skill over its siblings: choose `plan`
+  instead when the user is starting a feature from scratch and wants the FULL stage —
+  one-question-at-a-time design brainstorm plus branch/worktree/task-list setup — not only the
+  research; choose `parallel-deep-research` instead when the ask is an external market,
+  competitive, or industry report via Parallel AI (business analysis, vendor comparison,
+  funding/landscape), not code-level technical/OWASP/DRY research; choose `dev` or `validate`
+  instead when the user wants to implement tasks or run security scans/lint/tests against code
+  rather than research it.
 allowed-tools: Bash, Read, Write, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/.codex/skills/research/evals/evals.json
+++ b/.codex/skills/research/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "The design doc for the rate-limiter is already written — now go do the technical research: best practices, known gotchas for this approach, and drop it under Technical Research in the doc.",
+    "should_trigger": true
+  },
+  {
+    "query": "Run an OWASP Top 10 pass over this new file-upload feature and record which categories actually apply and how we'll mitigate each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before we build the caching layer, search the codebase for anything we can reuse and make sure we're not duplicating an existing helper.",
+    "should_trigger": true
+  },
+  {
+    "query": "Just do the research phase for this feature — web plus codebase investigation and at least three TDD scenarios — skip the brainstorm and the worktree setup.",
+    "should_trigger": true
+  },
+  {
+    "query": "Pull together the security and best-practices research for the OAuth integration and append it to the feature's design doc.",
+    "should_trigger": true
+  },
+  {
+    "query": "Let's plan this feature from scratch — brainstorm the design with me one question at a time, then create the branch, worktree, and task list.",
+    "should_trigger": false
+  },
+  {
+    "query": "I need a competitive landscape report comparing Datadog, Grafana Cloud, and New Relic on pricing and features for a 500-node cluster.",
+    "should_trigger": false
+  },
+  {
+    "query": "Give me a comprehensive market analysis of the vector-database space — top players, funding, and the 3-5 year outlook.",
+    "should_trigger": false
+  },
+  {
+    "query": "Start implementing task 1 with TDD — write the failing test first, then make it pass.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run the security scan, lint, and full test suite before we open the PR.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -332,7 +332,7 @@ gh pr checks <pr-number>
 ### Step 10: Update the Forge issue
 
 ```bash
-forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge comment <id> "PR review complete: all issues addressed, all checks passing"
 forge sync
 ```
 

--- a/.codex/skills/review/SKILL.md
+++ b/.codex/skills/review/SKILL.md
@@ -1,6 +1,22 @@
 ---
 name: review
-description: Processes all pull request feedback after a PR is created — GitHub Actions failures, Greptile inline comments and summary, SonarCloud quality gate, and other CI/CD checks — fixing, replying, and resolving each until every check passes. Use for the Forge review stage when handling PR review feedback, failing checks, Greptile or SonarCloud issues, or running the pre-merge doc gate before merge.
+description: >
+  Forge REVIEW stage — the one skill that drives an already-open pull request to all-green by
+  resolving EVERY piece of feedback on it: failing GitHub Actions / CI checks, Greptile and
+  CodeRabbit inline comments and summaries, and the SonarCloud quality gate. It actively fixes
+  the code, replies to each thread, and marks it resolved until the checks pass, then runs the
+  pre-merge doc gate (CHANGELOG / README / API / AGENTS docs) and hands the PR off for MANUAL
+  merge — it never runs `gh pr merge`. Reach for it whenever a PR already has review feedback
+  or red checks to work through: "address the review comments on PR #123", "the bots flagged
+  issues / my Greptile score is low", "fix the failing checks and resolve the threads",
+  "CodeRabbit and SonarCloud left comments — sort them out", "get my PR merge-ready". This is
+  the MUTATING feedback-resolution stage — distinct from shepherd (only WATCHES an open PR's
+  checks and settle window, changes nothing), verify (POST-merge CI-on-master health check +
+  closing issues), ship (pushing the branch and opening the PR in the first place), validate
+  (PRE-PR local type/lint/test/security on your branch), and the sonarcloud /
+  sonarcloud-analysis skills (which only QUERY SonarCloud data that this stage consumes). Use
+  those for a single tool or a passive watch; use this to work a PR's whole feedback set to
+  done.
 allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 

--- a/.codex/skills/review/evals/evals.json
+++ b/.codex/skills/review/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "PR #204 has three red checks and a pile of Greptile comments — work through all of it and get the PR green.",
+    "should_trigger": true
+  },
+  {
+    "query": "CodeRabbit and SonarCloud both left feedback on my pull request; fix what's valid, reply to the rest, and resolve the threads.",
+    "should_trigger": true
+  },
+  {
+    "query": "The GitHub Actions build is failing on my PR and there are unresolved review threads — sort them out before I merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "My Greptile confidence score is low. Address the inline comments and keep pushing fixes until the quality gate passes.",
+    "should_trigger": true
+  },
+  {
+    "query": "Handle all the reviewer feedback on the auth PR, then update the changelog and docs before we hand it off to merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "Just keep an eye on PR #150 — watch the checks and review threads and ping me when it's settled and mergeable. Don't touch the code.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR is merged to master now — run the post-merge health check and close out the issue.",
+    "should_trigger": false
+  },
+  {
+    "query": "My branch passed validation; push it and open the pull request with the design-doc link.",
+    "should_trigger": false
+  },
+  {
+    "query": "Before I open a PR, run the type-check, lint, full test suite, and security scan on my branch.",
+    "should_trigger": false
+  },
+  {
+    "query": "Just pull up this PR's SonarCloud issues and quality-gate status so I can eyeball them.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/rollback/SKILL.md
+++ b/.codex/skills/rollback/SKILL.md
@@ -194,7 +194,7 @@ Rollback complete!
 **How it works**:
 ```bash
 git checkout HEAD~1 -- <file1> <file2> ...
-git commit -m "Rollback: <files>"
+git commit -m "chore: rollback <files>"
 ```
 
 **Example**:
@@ -212,7 +212,7 @@ bunx forge rollback
 ✓ Amended commit to preserve USER content
 
 Rollback complete!
-  Commit: q4r5s6t "Rollback: AGENTS.md, CLAUDE.md"
+  Commit: q4r5s6t "chore: rollback AGENTS.md, CLAUDE.md"
   Files affected: 2
 ```
 

--- a/.codex/skills/rollback/SKILL.md
+++ b/.codex/skills/rollback/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: rollback
-description: Safely reverts changes — the last commit, a specific commit, a merged PR, individual files, or a commit range — using non-destructive git revert while preserving USER sections and custom commands. Use when an implementation must be undone, a merged PR reverted, files restored, or a change previewed before reverting (rollback, revert, undo, restore).
+description: >
+  Safely revert or undo a change that is already committed or shipped, using non-destructive
+  `git revert` (never `reset --hard`, `push --force`, or `clean`) and auto-preserving USER
+  sections plus custom commands. Drives the interactive `bunx forge rollback` menu: undo the
+  last commit, revert a specific commit by hash, revert a merged PR (git revert -m 1), restore
+  individual files to their prior version, revert a commit range, or dry-run/preview any of
+  these first. Use when the user says roll back, revert, undo, back out, or restore — e.g.
+  "undo the last commit", "undo that change, the approach was wrong", "back out PR #123",
+  "revert the merge commit", "restore src/auth.js to before my last commit", or when a
+  shipped/merged change broke something and must be pulled back (optionally re-flagging its
+  linked Beads issue). This is the RECOVERY skill for changes already in git history. Do NOT
+  use for: replying to or fixing PR review feedback (review), monitoring an open PR's checks
+  toward merge (shepherd), the post-merge CI health check on master (verify), pushing a branch
+  or opening a PR (ship), or ordinary issue status/field edits (issue-basics).
 allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 

--- a/.codex/skills/rollback/evals/evals.json
+++ b/.codex/skills/rollback/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "undo the last commit, the approach was wrong",
+    "should_trigger": true
+  },
+  {
+    "query": "back out PR #482, it's breaking production",
+    "should_trigger": true
+  },
+  {
+    "query": "restore config/database.yml to the version before my last commit",
+    "should_trigger": true
+  },
+  {
+    "query": "show me which files reverting commit a1b2c3d would touch before I actually do it",
+    "should_trigger": true
+  },
+  {
+    "query": "that merged refactor broke everything — revert the whole thing but keep the git history intact",
+    "should_trigger": true
+  },
+  {
+    "query": "what's the safe way to undo a merged pull request?",
+    "should_trigger": true
+  },
+  {
+    "query": "address the Greptile and CodeRabbit comments on my PR",
+    "should_trigger": false
+  },
+  {
+    "query": "keep watching my open PR and tell me when checks pass and it's mergeable",
+    "should_trigger": false
+  },
+  {
+    "query": "master is green after the merge — run the post-merge health check and close the issue",
+    "should_trigger": false
+  },
+  {
+    "query": "push my validated branch and open a pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "set issue forge-9f2 to status review",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/shepherd/SKILL.md
+++ b/.codex/skills/shepherd/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: shepherd
-description: Runs one bounded monitor pass over a pull request — reads CI and check state, takes at most one idempotent action, then hands off; never merges and never resolves review threads. Use when polling PR checks, re-running flaky required checks, posting status replies, or escalating merge-readiness after /review.
+description: >
+  Run ONE bounded, hand-off monitor pass over an already-reviewed OPEN pull request: read the
+  CI/check rollup and the branch-protection required-check set, take at most one idempotent
+  action (re-run a flaky required check, or post a status reply to a thread), then declare
+  merge-readiness — MERGE_READY, still PENDING, or escalate — and exit. There is no in-process
+  loop; a scheduler re-invokes the pass. Use this when the user says things like "is PR #123
+  ready to merge yet?", "poll/watch the checks on my PR", "the required CI job is flaky — kick
+  off a re-run", "keep an eye on this PR until it's green", "babysit the checks after
+  /review", "shepherd PR 45", or "monitor the PR toward merge (and rebase it if it's behind,
+  with --auto-rebase)". It NEVER merges (the human merges in the GitHub UI), NEVER edits code,
+  and NEVER resolves review threads. Do NOT use it to fix or reply-and-resolve PR review
+  feedback from Greptile/CodeRabbit/SonarCloud — that is `review`; nor to open/push the PR in
+  the first place — that is `ship`; nor for the post-merge "CI green on master + close issues"
+  health check — that is `verify`; nor for a general "where am I in the workflow / what's in
+  flight" report — that is `status`.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/.codex/skills/shepherd/evals/evals.json
+++ b/.codex/skills/shepherd/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Is PR #212 ready to merge yet?",
+    "should_trigger": true
+  },
+  {
+    "query": "The lint check on my PR keeps failing intermittently — kick off a re-run of the failed jobs.",
+    "should_trigger": true
+  },
+  {
+    "query": "Keep an eye on pull request 88 and tell me when all the required checks pass.",
+    "should_trigger": true
+  },
+  {
+    "query": "I just wrapped up /review on this PR — babysit the checks and escalate if it isn't mergeable.",
+    "should_trigger": true
+  },
+  {
+    "query": "Shepherd PR 300 and rebase it onto master if it's behind.",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix all the CodeRabbit and Greptile comments on my PR and resolve each review thread.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR just merged to master — confirm CI is green there and close the linked issue.",
+    "should_trigger": false
+  },
+  {
+    "query": "Push my validated feature branch and open a pull request from the template.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow and what work is still in flight right now?",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the SonarCloud issues flagged on this PR.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -95,7 +95,7 @@ bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 
 ### Step 3: Record PR Handoff
 ```bash
-forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge comment <id> "PR created: <pr-url>. Awaiting review and merge verification."
 forge sync
 ```
 

--- a/.codex/skills/ship/SKILL.md
+++ b/.codex/skills/ship/SKILL.md
@@ -1,10 +1,21 @@
 ---
 name: ship
 description: >
-  Pushes the validated branch and opens a pull request populated from the project's
-  PR template with full context and documentation links. Use for the Forge ship stage
-  after /validate passes. Triggers on ship, create PR, open pull request, push branch,
-  gh pr create.
+  Forge SHIP stage: push the already-validated feature branch and open a pull request
+  populated from the project's OWN PR template (design-doc link, Forge issue IDs, real
+  test/commit data), then hand the PR off for MANUAL merge — this skill never merges or
+  auto-merges. Reach for it the moment /validate has passed and you want a PR on the board.
+  Triggers on phrasings like "ship it", "ship this branch", "create/open the PR", "open a pull
+  request", "push and open a PR", "gh pr create", "make/raise a PR from my current branch",
+  "checks passed, now cut the PR". It runs the branch-freshness and parallel-PR
+  merge-simulation checks, force-with-lease pushes, records the ship->review handoff, then
+  stops. This is ONE stage — route elsewhere when the ask is broader or different: the whole
+  plan->dev->validate->ship->review pipeline or "drive it to done" (smith); running
+  type-check/lint/tests/security first (validate); addressing PR review comments or resolving
+  Greptile/SonarCloud/CodeRabbit threads on an existing PR (review); babysitting an
+  already-open PR's checks toward merge (shepherd); the post-merge CI health check and closing
+  issues (verify); or reverting an already-shipped change (rollback). If the PR already
+  exists, this is not the skill.
 allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 

--- a/.codex/skills/ship/evals/evals.json
+++ b/.codex/skills/ship/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Validation came back clean — go ahead and open the pull request for this branch.",
+    "should_trigger": true
+  },
+  {
+    "query": "Push my feature branch and raise a PR, and fill in our PR template with the issue and design-doc links.",
+    "should_trigger": true
+  },
+  {
+    "query": "Dev's done and all the checks passed, cut me a PR.",
+    "should_trigger": true
+  },
+  {
+    "query": "Do a gh pr create for feat/rate-limit using the repo's template, not a hand-written body.",
+    "should_trigger": true
+  },
+  {
+    "query": "Everything's green after validate — ship it, but hand it off for me to merge, don't merge it yourself.",
+    "should_trigger": true
+  },
+  {
+    "query": "Take forge-42 from planning all the way to a merge-ready PR — plan it, build it TDD, validate, then ship, checking with me at the gates.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR's picked up Greptile and CodeRabbit comments — fix them and resolve the threads.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run the type-check, lint, tests and security scan before I push anything.",
+    "should_trigger": false
+  },
+  {
+    "query": "Keep watching PR #128 and ping me the moment its checks go green so I can merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR merged to master — confirm CI is green there and close the linked issue.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/sonarcloud-analysis/SKILL.md
+++ b/.codex/skills/sonarcloud-analysis/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: sonarcloud-analysis
 description: >
-  Pull issues, metrics, quality gates, and analysis data from SonarCloud. ALWAYS
-  use this skill when the user mentions SonarCloud, asks about code quality metrics,
-  wants to check PR quality gates, or needs to review security vulnerabilities and
-  technical debt from static analysis. Also trigger during /review workflow when
-  SonarCloud issues need addressing. Trigger on phrases like "SonarCloud",
-  "quality gate", "code quality metrics", "technical debt", "coverage report",
-  "static analysis issues", "security vulnerabilities from scan".
+  Deep-dive SonarCloud analysis through the SonarCloud REST API, run in an isolated context so
+  the raw JSON does not flood the main conversation. Pull open issues (bugs, vulnerabilities,
+  code smells), coverage and duplication metrics, quality-gate pass/fail status with the exact
+  failed thresholds, security hotspots, quality profiles, and analysis/measure history for a
+  whole project, a branch, or a specific pull request, then hand back a ranked, actionable
+  summary. Reach for this whenever the user names SonarCloud or asks about code-quality
+  metrics, technical debt, coverage numbers, a red or failing quality gate, or security
+  vulnerabilities and hotspots from static analysis — for example "what's our technical debt
+  and which files have the worst maintainability", "why is the SonarCloud gate failing on this
+  PR", "pull every BLOCKER vulnerability from the last scan with file and line", "show
+  coverage by module", or "how have our reliability and security ratings trended this month".
+  Route ELSEWHERE when: the user explicitly types the thin `/sonarcloud <query> <project>`
+  slash command for a quick single lookup (that is the sibling 'sonarcloud' command surface);
+  they want to reply to and resolve PR review threads across Greptile, CodeRabbit, or GitHub
+  Actions (that is 'review'); they want to run the local lint, type-check, test, or security
+  scanner before shipping (that is 'validate'); they want to actually implement or patch a
+  flagged issue (that is 'dev'); or they want an external market or competitor report on
+  SonarSource or DevSecOps vendors (that is 'parallel-deep-research').
 category: Code Quality
 tags: [sonarcloud, code-quality, issues, metrics, security]
 context: fork

--- a/.codex/skills/sonarcloud-analysis/evals/evals.json
+++ b/.codex/skills/sonarcloud-analysis/evals/evals.json
@@ -1,50 +1,46 @@
 [
   {
-    "query": "Check the SonarCloud quality gate status for our latest PR — I want to see if there are any blockers before we can merge, especially around security vulnerabilities and code coverage",
+    "query": "Why is our quality gate red on this pull request? Break down exactly which conditions failed and by how much.",
     "should_trigger": true
   },
   {
-    "query": "Pull the SonarCloud analysis results for our project — show me all the critical and major security vulnerabilities found in the last scan, with file locations and remediation guidance",
+    "query": "How much technical debt has piled up in the codebase, and which files carry the worst maintainability rating?",
     "should_trigger": true
   },
   {
-    "query": "We're in /review and SonarCloud flagged some issues — get the full list of code smells, bugs, and vulnerabilities from the latest analysis so I can address them before the quality gate passes",
+    "query": "Give me the coverage and duplication numbers for the develop branch and flag the modules that regressed.",
     "should_trigger": true
   },
   {
-    "query": "What's our current technical debt ratio in SonarCloud? Show me the metrics dashboard — maintainability rating, reliability rating, security rating, and coverage percentage",
+    "query": "List every unresolved BLOCKER and CRITICAL vulnerability SonarCloud found, with file and line, so I know what to fix first.",
     "should_trigger": true
   },
   {
-    "query": "The SonarCloud quality gate is failing on our PR — pull the specific issues that are blocking it and show me what needs to be fixed, sorted by severity",
+    "query": "Pull the security hotspots that still need review and summarize the risk for each.",
     "should_trigger": true
   },
   {
-    "query": "Get the SonarCloud code coverage report for our project — I want to see which modules have low coverage and identify the files that need more tests before our next release",
+    "query": "Show me how our reliability and security ratings have trended over the last month of analyses.",
     "should_trigger": true
   },
   {
-    "query": "Implement a new REST API endpoint for user profile management with CRUD operations, input validation, and proper error handling",
+    "query": "/sonarcloud issues checkout-service --severity BLOCKER",
     "should_trigger": false
   },
   {
-    "query": "Search for best practices around implementing OAuth2 PKCE flow in a Node.js application",
+    "query": "Go through all the open PR review threads from Greptile and CodeRabbit, reply to each explaining the fix, and mark them resolved.",
     "should_trigger": false
   },
   {
-    "query": "Write a comprehensive market analysis of the DevSecOps tools landscape covering SAST, DAST, and SCA vendors",
+    "query": "Run lint, type-check, the test suite, and the security scanner and give me fresh output before I ship this branch.",
     "should_trigger": false
   },
   {
-    "query": "Scrape https://docs.sonarcloud.io and extract the full list of supported languages and analysis rules",
+    "query": "Fix the SQL-injection vulnerability SonarCloud flagged in login.ts and add a regression test.",
     "should_trigger": false
   },
   {
-    "query": "Build a structured company profile for SonarSource — return JSON with founding year, funding, products, and competitive positioning",
-    "should_trigger": false
-  },
-  {
-    "query": "Add proper citations to docs/research/security-audit-findings.md following our project's citation standards",
+    "query": "Produce a competitive market report comparing SonarCloud, Snyk, and Codacy for our tooling decision.",
     "should_trigger": false
   }
 ]

--- a/.codex/skills/sonarcloud/SKILL.md
+++ b/.codex/skills/sonarcloud/SKILL.md
@@ -1,6 +1,23 @@
 ---
 name: sonarcloud
-description: Pulls issues, metrics, quality gates, security hotspots, and analysis history from SonarCloud via its API. Use for the Forge sonarcloud stage when querying code quality data for a project, branch, or PR — triggers on sonarcloud, code quality, issues, metrics, quality gate, hotspots, coverage.
+description: >
+  Query SonarCloud code-quality data through the `/sonarcloud` slash command — the fast,
+  in-context lookup surface for a project, branch, or (above all) a pull request. Handles the
+  named queries `issues`, `metrics`, `gate` (quality-gate pass/fail with failed conditions),
+  `health` (full report), `pr <number>`, `hotspots` (security), and `history`, plus
+  `--branch`, `--severity`, `--type`, and `--new-code` filters. Reach for this the moment the
+  user types `/sonarcloud ...`, or asks in plain language: "what does SonarCloud say about
+  this PR", "check the SonarCloud quality gate before I ship", "show SonarCloud
+  blocker/critical bugs on the develop branch", "any new-code SonarCloud issues on PR 214",
+  "SonarCloud coverage for my-project". Requires a `SONARCLOUD_TOKEN` (and organization key).
+  This skill only READS and reports SonarCloud results — it does NOT fix findings or
+  reply-to/resolve PR review threads (that is the `review` stage), and it is the lightweight
+  command surface, NOT the isolated deep-analysis session that correlates findings with local
+  source, walks analysis-history trends, or runs duplication deep-dives across many endpoints
+  (that is `sonarcloud-analysis` — send heavyweight or correlation work there). Not for local
+  SAST/security scans of your own code, and not for the Forge issue tracker ("open/ready
+  issues", `forge issue ...`) — here those bare words always mean SonarCloud, not the tracker
+  or validate stage.
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
 ---
 

--- a/.codex/skills/sonarcloud/SKILL.md
+++ b/.codex/skills/sonarcloud/SKILL.md
@@ -58,7 +58,7 @@ Pull code quality data from SonarCloud. Requires `SONARCLOUD_TOKEN` environment 
    - Optional filters (branch, severity, type, new-code, etc.)
 2. Check for `SONARCLOUD_TOKEN` environment variable. If not set, inform user.
 3. Check for `SONARCLOUD_ORG` environment variable or ask user for organization key.
-4. Execute the appropriate API call using curl or the TypeScript client at `next-app/src/lib/integrations/sonarcloud.ts`
+4. Execute the appropriate API call against the SonarCloud REST API (see the API Reference section below for endpoints)
 5. Format and present results clearly:
    - For issues: Group by severity/type, show file, line, message
    - For metrics: Show as table with metric name and value

--- a/.codex/skills/sonarcloud/evals/evals.json
+++ b/.codex/skills/sonarcloud/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "/sonarcloud gate my-project",
+    "should_trigger": true
+  },
+  {
+    "query": "/sonarcloud pr befach-web 214 --new-code",
+    "should_trigger": true
+  },
+  {
+    "query": "What does SonarCloud say about this pull request? Just the quality gate and the blocker issues, quick.",
+    "should_trigger": true
+  },
+  {
+    "query": "Show SonarCloud bugs and vulnerabilities on the develop branch for the api project",
+    "should_trigger": true
+  },
+  {
+    "query": "Any new-code SonarCloud issues on PR 88 before I ship?",
+    "should_trigger": true
+  },
+  {
+    "query": "Pull the SonarCloud coverage and code-smell numbers for my-project so I can eyeball them",
+    "should_trigger": true
+  },
+  {
+    "query": "Open an isolated SonarCloud deep-dive: correlate every flagged vulnerability with the actual source files, walk the analysis history for coverage trends, and hand back a synthesized technical-debt report",
+    "should_trigger": false
+  },
+  {
+    "query": "SonarCloud flagged issues on PR 214 — fix them, reply to each review thread, and mark them resolved",
+    "should_trigger": false
+  },
+  {
+    "query": "Run a SAST security scan over my code and list the vulnerabilities you find",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the open issues that are ready to work on next",
+    "should_trigger": false
+  },
+  {
+    "query": "Run lint and type-check and the test suite before I ship this branch",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/status/SKILL.md
+++ b/.codex/skills/status/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: status
-description: Checks the current Forge workflow stage and surfaces in-progress work, ranked ready issues, stale in-progress reconciliation, recent commits, and team context. Use for the Forge status stage when starting a session or deciding what to work on next. Triggers include status, current stage, what's in progress, where am I, and resume work.
+description: >
+  Report where the project stands right now and what work is in flight -- the Forge status
+  snapshot. Reach for this at session start or whenever the user says "/status", "where am I",
+  "what's in progress", "catch me up", "resume work", "what changed recently", or "what should
+  I pick up next". It runs forge sync, then surfaces the detected workflow stage, the user's
+  active/claimed issues, all issues ranked by composite score (priority, dependency impact,
+  type, staleness) with conflict-risk annotations, stale in-progress issues that were already
+  merged (which it reconciles by closing them), the last ~10 commits, and a forge team
+  workload/dashboard overview. Use it to ORIENT and decide the next move: it reports state and
+  points ahead -- it does not plan, run development, or claim an issue to work it (its only
+  write is closing already-merged stale issues during reconciliation). Not for: routing to a
+  specific stage skill or documenting the full issue-verb surface (that's kernel); deeply
+  ranking and EXPLAINING a single next-ready or blocked issue to hand off (triage-ready);
+  everyday create/update/list/close/comment/search issue operations (issue-basics); the Hermes
+  harness's token-bounded orient/recap state contract (hermes-forge); or the post-merge CI
+  health check that closes issues after a merge lands (verify).
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/.codex/skills/status/evals/evals.json
+++ b/.codex/skills/status/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "/status",
+    "should_trigger": true
+  },
+  {
+    "query": "where am I on this project right now?",
+    "should_trigger": true
+  },
+  {
+    "query": "catch me up -- what's in progress and what got merged recently?",
+    "should_trigger": true
+  },
+  {
+    "query": "I stepped away for a few days, give me the current state of the work before I dive back in",
+    "should_trigger": true
+  },
+  {
+    "query": "show me my active issues and which stage we're at",
+    "should_trigger": true
+  },
+  {
+    "query": "are there any in-progress issues that were already merged and should be closed?",
+    "should_trigger": true
+  },
+  {
+    "query": "what's the single best next issue to start, and explain why that one?",
+    "should_trigger": false
+  },
+  {
+    "query": "why is issue forge-456 blocked -- what's it waiting on?",
+    "should_trigger": false
+  },
+  {
+    "query": "route me to the correct Forge stage skill for opening a PR",
+    "should_trigger": false
+  },
+  {
+    "query": "create an issue titled 'fix flaky login test' and tag it a bug",
+    "should_trigger": false
+  },
+  {
+    "query": "the PR just merged to master -- confirm CI is green and close the linked issues",
+    "should_trigger": false
+  },
+  {
+    "query": "keep an eye on PR #88 until its checks and review threads settle",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/triage-ready/SKILL.md
+++ b/.codex/skills/triage-ready/SKILL.md
@@ -45,8 +45,10 @@ and `forge issue stats` exclusively.
 forge issue stats --json
 ```
 
-Returns `data.counts` (open/in_progress/done/cancelled), `ready_count`,
-`blocked_count`, and `active_claims`. A high `blocked_count` relative to
+Returns `data.counts` (`open`/`done`/`cancelled` — keys are present only when
+non-zero, and there is no `in_progress` bucket: claimed work stays in status
+`open` and is surfaced via `active_claims`), `ready_count`, `blocked_count`, and
+`active_claims`. A high `blocked_count` relative to
 `ready_count` is your signal that dependency repair (not new work) is the real
 bottleneck — hand off to `dependency-planning` / `backlog-hygiene`.
 
@@ -99,8 +101,10 @@ or close — it is strictly read-only.
 
 - **Recompute, never cache.** Readiness is derived; re-run `forge issue ready`
   every session rather than remembering a prior "ready" verdict.
-- **Respect non-claimable types.** Epics and decisions are `claimable:false` and
-  will not appear in `ready`; do not hand them off as work.
+- **Respect non-claimable types.** Epics and decisions never appear in `ready`
+  (the queue surfaces only claimable types — `task`/`bug`), so do not hand them
+  off as work. There is no `claimable` field in the CLI JSON; this is behavioral,
+  not a flag you can read.
 - **Check the envelope.** Every `--json` reply carries `ok`; on `ok:false` read
   `error.message` and retry the query rather than guessing at state.
 - **Read-only.** This skill runs only `stats`/`ready`/`blocked`/`show`. If a fix is

--- a/.codex/skills/triage-ready/SKILL.md
+++ b/.codex/skills/triage-ready/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: triage-ready
 description: >
-  Surfaces and EXPLAINS the right next work in a Forge project — read-only. Ranks
-  the ready queue with `forge issue ready`, shows what is blocked and why with
-  `forge issue blocked`, and summarizes the backlog with `forge issue stats`. Never
-  uses `board` (which reads a legacy snapshot store, not the live kernel). Use when
-  deciding what to pick up next, or to justify why an item is workable. Trigger on
-  "what should I work on", "what's ready", "triage", "next task", "ready queue",
-  "why is this blocked", or "pick my next issue".
+  Surfaces, ranks, and EXPLAINS the single best next issue to pick up in a Forge project —
+  strictly read-only. Recomputes the live ready queue with `forge issue ready`, explains what
+  is blocked and why with `forge issue blocked`, takes the backlog pulse with `forge issue
+  stats`, and justifies the pick from the full record via `forge issue show` — always against
+  the live kernel, never `forge board` (which reflects legacy Beads runtime/snapshot state,
+  not the live kernel) and never a cached "status == ready". Recommends ONE issue with a
+  one-line reason, then hands off; it never claims, comments, closes, or otherwise mutates.
+  Use when the user asks "what should I work on", "what's next", "what's ready", "pick/triage
+  my next task", "top of the ready queue", "which issue should I start", "why is this issue
+  blocked", or "what's blocking the most work". This is the read-and-recommend skill — NOT for
+  claiming or taking ownership of the pick (use claim-safety), not for everyday issue
+  create/update/list/search/close/comment/dep CRUD (use issue-basics), not for reporting the
+  current workflow stage or "where am I / what's in flight" (use status), not for orienting a
+  whole session or routing to stage skills (use kernel), and not for driving an issue through
+  to a merged PR (use smith).
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/.codex/skills/triage-ready/evals/evals.json
+++ b/.codex/skills/triage-ready/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "I just sat down at this repo — what's the highest-priority thing I can actually start right now?",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me the top few off the ready queue and tell me why the first one is unblocked.",
+    "should_trigger": true
+  },
+  {
+    "query": "Why can't I start forge-2agy.2.2 yet? What's holding it up?",
+    "should_trigger": true
+  },
+  {
+    "query": "The backlog feels stuck — is it mostly blocked, and which one dependency would unlock the most work?",
+    "should_trigger": true
+  },
+  {
+    "query": "Pick my next task and justify the choice, don't grab it yet.",
+    "should_trigger": true
+  },
+  {
+    "query": "Claim forge-abc123 for me and confirm I actually hold the lease before I start editing.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a P1 bug titled 'login returns 500' and add a comment linking the repro.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now and what work is in flight?",
+    "should_trigger": false
+  },
+  {
+    "query": "Search every issue mentioning 'oauth' and list the open ones.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-xyz all the way through to a merged PR.",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/validate/SKILL.md
+++ b/.codex/skills/validate/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Bash, Read, Grep, Glob
 > **Note:** Three things share the "validate" name in Forge:
 > - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
-> - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
+> - `bun run check` (scripts/validate.js): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
 Run comprehensive validation including type checking, linting, code review, security review, and tests.
 
@@ -80,7 +80,7 @@ reflect the true state of what will be merged.
 
 ## What This Skill Does
 
-**Quick Start**: Run `bun run check` to execute the full validation pipeline (implemented in `scripts/validate.sh`). The npm script is named `check`; the workflow command is `/validate`. See individual steps below for details.
+**Quick Start**: Run `bun run check` to execute the full validation pipeline (implemented in `scripts/validate.js`). The npm script is named `check`; the workflow command is `/validate`. See individual steps below for details.
 
 ### Step 1: Type Check
 ```bash
@@ -221,7 +221,8 @@ If any check fails:
 forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked
+forge comment <current-id> "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```

--- a/.codex/skills/validate/SKILL.md
+++ b/.codex/skills/validate/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: validate
-description: Runs comprehensive pre-pull-request validation for the Forge validate stage — rebases onto the base branch, then runs type checking, linting, code review, security review (OWASP Top 10), and tests, requiring fresh passing output before shipping. Use for the Forge validate stage or when asked to validate changes, run quality gates, type-check, lint, security-scan, or run the full test suite before opening a PR.
+description: >
+  Forge VALIDATE stage — the pre-pull-request quality gate. Rebases the branch onto the
+  current base branch, then runs type-checking, linting, code review, an OWASP Top 10 security
+  review plus dependency scan, and the full test suite, demanding fresh passing output in THIS
+  session before anything ships. Reach for this whenever a branch is code-complete and someone
+  says: validate my changes, run the quality gates, run the pre-PR checks, type-check and lint
+  before the PR, run the security scan, or run the full test suite before opening a PR — and
+  for the literal `/validate` command or `bun run check`. This is the gate that runs AFTER
+  code is written but BEFORE a PR exists, so discriminate carefully: it does not implement
+  features or write tests (that is `/dev`), it does not push the branch or open the PR (that
+  is `/ship`), it does not answer PR review feedback from Greptile / SonarCloud / CodeRabbit
+  (that is `/review`), and it is not the post-merge CI health check (that is `/verify`).
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/.codex/skills/validate/evals/evals.json
+++ b/.codex/skills/validate/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Branch is code-complete — run all the pre-PR checks and make sure everything's green before I ship",
+    "should_trigger": true
+  },
+  {
+    "query": "/validate",
+    "should_trigger": true
+  },
+  {
+    "query": "Rebase onto master, then type-check, lint, and run the whole test suite so I know it's clean",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the OWASP security review and full test pass on this branch before we open the PR",
+    "should_trigger": true
+  },
+  {
+    "query": "I'm at the validate stage — take my changes through the quality gates",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement the next task using TDD, red-green-refactor",
+    "should_trigger": false
+  },
+  {
+    "query": "Push this validated branch and open the pull request from the template",
+    "should_trigger": false
+  },
+  {
+    "query": "Go through the Greptile and CodeRabbit comments on my PR and resolve the threads",
+    "should_trigger": false
+  },
+  {
+    "query": "It's merged now — check CI is green on master and close the issue",
+    "should_trigger": false
+  },
+  {
+    "query": "Pull the SonarCloud issues for this PR",
+    "should_trigger": false
+  }
+]

--- a/.codex/skills/verify/SKILL.md
+++ b/.codex/skills/verify/SKILL.md
@@ -1,6 +1,18 @@
 ---
 name: verify
-description: Post-merge health check for the Forge verify stage — confirms the merge landed on master, checks CI is clean and deployments are up, cleans up the merged worktree/branch, and closes resolved issues. Use for the Forge verify stage, or when asked to verify a PR merged correctly, confirm post-merge CI health, check deployments after merge, or validate everything is healthy after merging.
+description: >
+  Runs the Forge verify stage — the post-merge health check performed AFTER a PR has been
+  merged. Switches to master and pulls, confirms the merge actually landed (`gh pr list
+  --state merged`), checks CI is green on master after the merge, confirms any deployments are
+  up, removes the merged worktree and safe-deletes the local branch, and closes the
+  kernel/Beads issues the PR resolved (`forge close --reason=...`). Use when asked to verify a
+  merge went cleanly, confirm post-merge CI health on master, check deployments after merging,
+  clean up a merged branch or worktree, or close the issue now that its PR is merged — and
+  whenever `/verify` is invoked. This is strictly the POST-merge stage: reach for shepherd
+  instead to monitor a still-open PR toward merge, review to fix and resolve PR feedback
+  before merge, ship to push the branch and open the PR, rollback to undo an already-shipped
+  change, status to merely report the current stage without acting, and issue-basics to close
+  an issue that is unrelated to a just-merged PR.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/.codex/skills/verify/SKILL.md
+++ b/.codex/skills/verify/SKILL.md
@@ -71,7 +71,7 @@ Check if the project has a deployment target:
 gh run list --branch master --limit 1
 
 # Check Vercel deployments for the merged PR (use number from Step 2)
-gh pr view <number> --json deployments
+gh pr view <number> --json statusCheckRollup
 ```
 
 If deployments exist:

--- a/.codex/skills/verify/SKILL.md
+++ b/.codex/skills/verify/SKILL.md
@@ -41,10 +41,11 @@ Confirm the merge actually landed on master. If the PR isn't merged yet, stop an
 
 ### Step 2: Confirm PR Is Merged
 
-Detect the most recently merged PR from the current HEAD commit:
+Detect the PR that produced the current HEAD commit — scope the lookup to that
+commit's SHA so you don't pick up an unrelated newer merge:
 
 ```bash
-gh pr list --state merged --base master --limit 1 --json number,state,mergedAt,mergedBy
+gh pr list --state merged --base master --search "$(git rev-parse HEAD)" --limit 1 --json number,state,mergedAt,mergedBy
 ```
 
 - `state` should be `MERGED`

--- a/.codex/skills/verify/evals/evals.json
+++ b/.codex/skills/verify/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "The PR just merged — make sure master is still healthy",
+    "should_trigger": true
+  },
+  {
+    "query": "Confirm the auth-refresh change actually landed on master and CI passed after merge",
+    "should_trigger": true
+  },
+  {
+    "query": "/verify",
+    "should_trigger": true
+  },
+  {
+    "query": "Now that #89 is merged, close the issue it resolved and delete the feature branch",
+    "should_trigger": true
+  },
+  {
+    "query": "Did the deployment go out okay after we merged this?",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the post-merge checks and clean up the merged worktree",
+    "should_trigger": true
+  },
+  {
+    "query": "Watch my open PR and re-run the flaky required check until it can merge",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix and resolve all the Greptile and SonarCloud threads on the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Push this validated branch and open a pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "This merge broke production — revert the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow and what's in progress right now?",
+    "should_trigger": false
+  },
+  {
+    "query": "Close forge-abc, we've decided not to do it",
+    "should_trigger": false
+  }
+]

--- a/skills/claim-safety/SKILL.md
+++ b/skills/claim-safety/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: claim-safety
 description: >
-  Claim a Forge issue and PROVE you own the lease before doing any work. Use
-  whenever you (or an orchestrator/agent) are about to mutate a claimed issue —
-  after `forge claim`, before `dev`/edit/`close`/`release`, or when two agents
-  might contend for the same work. A claim returning ok:true does NOT prove you
-  won the lease (a duplicate replay also returns ok:true), so this procedure adds
-  the mandatory ownership check via `forge issue owns <id>`. Trigger on "claim an
-  issue safely", "did I win the lease", "verify ownership", "claim conflict",
-  "two agents same issue", or before any claimed-issue mutation.
+  Claim a Forge issue and then PROVE you hold the live lease before you touch it — the
+  ownership-verification procedure built on `forge issue owns <id>`. Use this whenever
+  actually winning the claim matters: right after `forge claim`, before you
+  `dev`/edit/`close`/`release` a claimed issue, when two agents or a subagent fan-out might
+  contend for the same work, or when you need to re-check ownership before an irreversible
+  step. Why it exists: a claim returning `ok:true` does NOT prove you won — a same-actor
+  duplicate replay also returns `ok:true`, and a live lease can be reclaimed once it expires —
+  so `forge issue owns` (exit 0 iff you hold the single, unexpired active lease) is the only
+  real proof, and you re-verify before close/release. Trigger on "claim this issue safely",
+  "did I actually win the lease", "verify/prove ownership", "claim conflict", "two agents
+  grabbed the same issue", "check I still own it before closing", or before ANY mutation of a
+  claimed issue. NOT for plain single-issue create/update/close/comment when there is no
+  ownership question (that is issue-basics), and NOT for read-only selecting or ranking the
+  next ready issue without claiming (that is triage-ready).
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/skills/claim-safety/evals/evals.json
+++ b/skills/claim-safety/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "I just ran forge claim on forge-abc — how do I make sure the lease is really mine before I start editing?",
+    "should_trigger": true
+  },
+  {
+    "query": "Two of my agents may have grabbed the same issue at once — how do I tell which one actually holds it?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I close this ticket, confirm nobody reclaimed it while I was working.",
+    "should_trigger": true
+  },
+  {
+    "query": "My claim came back ok:true but I'm not convinced I won the race. Can I trust that?",
+    "should_trigger": true
+  },
+  {
+    "query": "Prove I own forge-42 before the subagent starts mutating it.",
+    "should_trigger": true
+  },
+  {
+    "query": "The lease might have expired mid-task — check I still own it before I release.",
+    "should_trigger": true
+  },
+  {
+    "query": "What's the next ready issue I should pick up?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a feature issue titled 'Add CSV export'.",
+    "should_trigger": false
+  },
+  {
+    "query": "Close forge-19 with reason 'shipped in PR 88'.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-30 all the way through to a PR.",
+    "should_trigger": false
+  },
+  {
+    "query": "Implement the failing auth tests for this task.",
+    "should_trigger": false
+  }
+]

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: dev
-description: Implements each task from the plan task list using a subagent-driven loop (implementer → spec-compliance reviewer → code-quality reviewer) with TDD and HARD-GATE enforcement. Use for the Forge dev stage when implementing planned tasks — triggers include /dev, dev stage, build the tasks, subagent TDD, implement task list.
+description: >
+  Forge DEV stage — the build engine that turns an already-approved /plan task list into
+  committed, test-backed code. Reads docs/work/<date>-<slug>/tasks.md and design.md, then
+  drives each task through a subagent loop (implementer → spec-compliance reviewer →
+  code-quality reviewer) using RED-GREEN-REFACTOR TDD, HARD-GATE evidence checks, a spec-gap
+  decision score, and per-task progress recorded on the Forge issue via `forge comment`. Use
+  when a plan and task list already exist and it is time to implement them — triggers: "/dev",
+  "start the dev stage", "build the tasks", "implement tasks.md test-first", "run the
+  implementer/reviewer TDD loop", "write the code for the planned tasks one by one", "work
+  through the task list with subagents". This is the per-task coding stage ONLY. Do NOT use it
+  for creating the design doc or task list (that is plan), for the post-build
+  type-check/lint/security/test gate (validate), for pushing the branch or opening the PR
+  (ship), for addressing PR review feedback (review), or for orchestrating several stages /
+  taking an issue end-to-end to a merged PR (smith). Reach for dev specifically when the ask
+  is to author code for tasks that are already planned.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/dev/evals/evals.json
+++ b/skills/dev/evals/evals.json
@@ -12,7 +12,7 @@
     "should_trigger": true
   },
   {
-    "query": "Build out the task list from the design doc using red-green-refactor",
+    "query": "Implement the already-planned tasks one at a time, red-green-refactor each",
     "should_trigger": true
   },
   {

--- a/skills/dev/evals/evals.json
+++ b/skills/dev/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "/dev",
+    "should_trigger": true
+  },
+  {
+    "query": "The plan and task list are done — start implementing the tasks one at a time, tests first.",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the implementer then the spec and quality reviewer subagents over each task in tasks.md",
+    "should_trigger": true
+  },
+  {
+    "query": "Build out the task list from the design doc using red-green-refactor",
+    "should_trigger": true
+  },
+  {
+    "query": "Time to write the code for the planned tasks and TDD each one in this worktree",
+    "should_trigger": true
+  },
+  {
+    "query": "Work through tasks.md subagent by subagent until every task is committed and reviewed",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up the branch, worktree, and TDD task list for this new feature",
+    "should_trigger": false
+  },
+  {
+    "query": "Type-check, lint, and run the full test suite before I open the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Push the validated branch and open the pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR has open review threads from the bots — fix each finding, reply, and mark them resolved.",
+    "should_trigger": false
+  },
+  {
+    "query": "Grab the next ready issue and drive it all the way to a merged PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Which workflow stage am I on and what work is in flight right now?",
+    "should_trigger": false
+  }
+]

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -63,18 +63,16 @@ reading raw issue stores, design files, or kernel internals directly:
 forge orient --json                # bounded project orientation (envelope)
 forge orient --budget 4000 --json
 forge recap <issue-id> --json      # bounded per-issue recap (envelope)
-forge recap --json                 # legacy activity summary (NOT the envelope)
 ```
 
 `forge orient` and `forge recap <issue-id>` emit the deterministic JSON envelope
 described below (assembly `deterministic-file-assembly-v1`). Parse the JSON; do
 not screen-scrape the human text form.
 
-> Note: bare `forge recap --json` (no issue id) returns the legacy activity
-> summary (`generatedAt`, `issueSummary`, `reviewOutcomes`, `recentIssues`,
-> `insights`) — it does **not** carry `schema_version`, `sections`,
-> `token_budget`, or `assembly`. For the envelope contract, use `forge orient`
-> or `forge recap <issue-id>`.
+> Note: `forge recap` always requires an issue id — bare `forge recap --json`
+> (no id) prints its usage and exits non-zero rather than returning a summary.
+> Use `forge orient` for project-level orientation, or `forge recap <issue-id>`
+> for a single issue; both emit the deterministic envelope.
 
 ### Envelope shape
 
@@ -124,14 +122,13 @@ whole payload.
 
 Truncation is deterministic, never random:
 
-- Non-preserved sections are allocated budget in ascending numeric `priority`
-  order (lower `priority` first); when the budget is exhausted, the
-  later/higher-`priority` sections are the ones trimmed. Preserved sections are
-  kept whole and trimmed only as a last resort if the payload is still over
-  budget. The authoritative per-section signal is each section's `truncated`
-  flag plus its `priority`/`estimated_tokens` — not the nominal
-  `token_budget.truncation_order` list, which is a static hint and may not match
-  the priority-driven trim order.
+- Non-preserved sections are trimmed in the order given by
+  `token_budget.truncation_order`; when the budget is exhausted, sections later
+  in that order are trimmed first. Preserved sections are kept whole and trimmed
+  only as a last resort if the payload is still over budget. The authoritative
+  per-section signal is each section's `truncated` flag and `estimated_tokens` —
+  there is no per-section `priority` field; the overall trim order is
+  `token_budget.truncation_order`.
 - A trimmed section ends with the literal marker
   `[truncated deterministically by token budget]` and has `truncated: true`.
 - `token_budget.truncated === true` means the payload as a whole was trimmed.

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -1,12 +1,26 @@
 ---
 name: hermes-forge
 description: >
-  Consumption contract for the Hermes harness on a Forge project. Treat
-  `forge orient` and `forge recap` as the authoritative, token-bounded source
-  of project state, cite every surfaced fact by its provenance, honor the
-  deterministic truncation policy, and write evidence or decisions back ONLY
-  through Forge CLI commands. Hermes-native profile memory never leaks into
-  Forge Kernel state.
+  Consumption contract for how the Hermes harness reads, cites, and writes back Forge project
+  state — Hermes is a CONSUMER of Forge, never a second source of truth. Load this whenever a
+  Hermes session runs on a Forge repo: at session start to orient, before acting on a specific
+  issue, or any time you need CURRENT project state. Always obtain state through `forge
+  orient` / `forge recap <issue-id>` — the deterministic, token-bounded JSON envelope — and
+  never reconstruct it by reading raw issue stores, design files, or kernel internals. This
+  skill governs the envelope discipline: honor the token budget (raise depth with `--budget
+  N`, don't retry blindly), treat any `truncated` section as incomplete, attribute every
+  surfaced fact to its source `path`/`authority`, and surface conflicts instead of silently
+  picking a winner. It also governs writeback: record evidence, decisions, and follow-up work
+  into the Forge Kernel ONLY through Forge CLI commands (`forge comment` / `forge update` /
+  `forge create`), and NEVER leak Hermes profile or session memory into Forge state. Trigger
+  phrases: "orient me / what's the current project state", "where did this fact come from,
+  cite it", "the orient output came back truncated", "how do I persist this decision back into
+  Forge", "is it safe to store this in kernel state". This is the Hermes⇄Forge boundary
+  contract — NOT the general Forge session router that navigates stage skills (kernel), NOT
+  the human-facing "what stage am I in / where am I" report (status), NOT everyday issue
+  create/update/close/search CRUD (issue-basics), NOT surfacing or ranking the next ready
+  issue (triage-ready), and NOT live PR monitoring (shepherd, which runs OUTSIDE Hermes and is
+  not visible through orient).
 compatibility: >
   Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Install
   path — like every Forge skill pack (e.g. parallel-deep-research,

--- a/skills/hermes-forge/evals/evals.json
+++ b/skills/hermes-forge/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "I just started a Hermes session on this Forge repo — get me oriented on where the project stands before I touch anything.",
+    "should_trigger": true
+  },
+  {
+    "query": "The forge orient envelope came back with the active-work section flagged truncated. Can I treat that as the full list, or do I need to pull more?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I tell the user which approach we settled on, I need to point at the exact source file and how authoritative it is — where does that decision come from?",
+    "should_trigger": true
+  },
+  {
+    "query": "I uncovered a design decision in this session that the team needs to keep. What's the correct way to write it back into Forge without dragging my Hermes notes into kernel state?",
+    "should_trigger": true
+  },
+  {
+    "query": "Default orientation is clipping the decisions section at 2000 tokens — give me more headroom.",
+    "should_trigger": true
+  },
+  {
+    "query": "Don't rebuild the project picture by grepping the design docs yourself — go through the proper bounded orient/recap surface instead.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which workflow stage am I sitting in right now, and has any of my work gone stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "I'm kicking off a Forge session in Claude — which stage skill do I run to start planning a new feature?",
+    "should_trigger": false
+  },
+  {
+    "query": "Watch PR #418, rerun the flaky required check if it trips, and ping me when it's ready to merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "Open a bug issue for the checkout timeout, set priority 1, and add a note about the repro steps.",
+    "should_trigger": false
+  },
+  {
+    "query": "What's the highest-priority ready issue I should pick up next?",
+    "should_trigger": false
+  }
+]

--- a/skills/issue-basics/SKILL.md
+++ b/skills/issue-basics/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: issue-basics
 description: >
-  The everyday issue CRUD floor for a Forge project — create, update, claim,
-  release, comment, close, show, list, search, and stats over the kernel via the
-  `forge issue` verbs. This is the parity floor a team needs on day one after
-  migrating off a Beads-style tracker, mapped one-to-one onto real `forge` verbs
-  with their actual flags. Use for routine issue work. Trigger on "create an
-  issue", "update an issue", "claim/close an issue", "comment on an issue", "list
-  issues", "search issues", "reopen", or "add a label".
+  Everyday single-issue CRUD over the `forge issue` verbs — create, update, show, list,
+  search, close, reopen, comment, set priority/labels/assignee, claim or release one issue,
+  and add/remove dependency edges, plus backlog `stats`. Reach for this on ANY routine one-off
+  issue operation: "create an issue/bug/task for X", "update or edit issue <id>", "close (or
+  reopen) this issue", "comment a handoff note on <id>", "list open bugs" or "filter issues by
+  label/priority/status", "search issues for …", "bump this to P1", "reassign to alice", "mark
+  <id> blocked by <id>", "add a label". This is also the parity floor when migrating off a
+  Beads-style tracker (label/reopen/delete map onto their forge equivalents). Scope is
+  single-operation issue plumbing only. It does NOT choose, rank, or explain the next issue to
+  work on or why one is blocked (use triage-ready); it does NOT run the
+  claim-then-prove-lease-ownership safety procedure before mutating shared work (use
+  claim-safety); it does NOT drive an issue through the plan->dev->validate->ship pipeline or
+  open a PR (use smith or the individual stage skills); and it does NOT report the current
+  workflow stage or what is in flight (use status).
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/skills/issue-basics/SKILL.md
+++ b/skills/issue-basics/SKILL.md
@@ -32,7 +32,7 @@ failure. **Gate on `ok`** — do not parse `data` until you confirm `ok:true`.
 
 | Need | Command |
 |------|---------|
-| Create an issue | `forge issue create --title "…" --type <task\|feature\|bug\|epic>` |
+| Create an issue | `forge issue create --title "…" --type <task\|bug\|epic\|decision>` |
 | Inspect one issue | `forge issue show <id> [--json]` |
 | List / filter issues | `forge issue list [--status … --type … --priority … --label …] [--json]` |
 | Full-text search | `forge issue search "…" [--json]` |
@@ -47,15 +47,15 @@ failure. **Gate on `ok`** — do not parse `data` until you confirm `ok:true`.
 ## Create — the flags that matter
 
 ```bash
-forge issue create --title "Add rate limiting" --type feature \
-  --priority P1 --label "api,security" --assignee alice \
+forge issue create --title "Add rate limiting" --type task \
+  --priority P1 --label "feature,api,security" --assignee alice \
   --acceptance "429 returned after N req/min; covered by a test"
 ```
 
 | Flag | Meaning | Default |
 |------|---------|---------|
 | `--title "…"` | Human title (a bare leading positional also works) | minted id |
-| `--type <…>` | `task` · `feature` · `bug` · `epic` · `decision` | `task` |
+| `--type <…>` | `task` · `bug` · `epic` · `decision` | `task` |
 | `--priority <…>` | `P0`..`P4` (or bare `0`..`4`); `P0` is highest | unset |
 | `--label "a,b"` | Comma-separated set — one flag, split on `,` (repeats do NOT accumulate) | none |
 | `--body "…"` | Long description (`--description` is an accepted alias) | empty |
@@ -64,8 +64,12 @@ forge issue create --title "Add rate limiting" --type feature \
 | `--parent <id>` | Parent/epic id | none |
 
 `--status` defaults to `open`. Status vocabulary: `open` · `in_progress` ·
-`review` · `done` · `cancelled`. Epics and decisions are non-claimable (they never
-enter the ready queue).
+`review` · `done` · `cancelled`. Unlike `--priority` and `--status` (which reject
+unknown values), `--type` is stored verbatim — a non-canonical value like
+`feature` is accepted without error but carries no kernel behaviour, so stick to
+the four canonical types. Epics and decisions are excluded from the ready queue
+(non-claimability is a queue convention, not enforcement — `forge issue claim`
+currently returns `ok:true` on them too).
 
 ## Update — same field flags, plus close
 
@@ -102,7 +106,7 @@ It is a canonical source you fork, not a fixed policy.
 
 | Knob | Default | How to change |
 |------|---------|---------------|
-| **Default type** | `task` (kernel default) | Decide your create convention — e.g. always pass `--type feature` for user-facing work, `--type bug` for regressions. |
+| **Default type** | `task` (kernel default) | Decide your create convention — e.g. always pass `--label feature` for user-facing work (feature is a label, not a canonical type), `--type bug` for regressions. |
 | **Default priority** | unset | Adopt a house scale (e.g. new work opens at `P2`, incidents at `P0`) and always pass `--priority`. |
 | **Fields required on create** | `--title` only | Require `--acceptance` (and `--label`/`--assignee`) on every create so issues are actionable from birth. |
 | **Id / reference convention** | kernel-minted ids | Standardize how you cite issues in commits/PRs (e.g. `Closes <id>`) and whether you pass an explicit `--id`. |

--- a/skills/issue-basics/evals/evals.json
+++ b/skills/issue-basics/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "Open a bug ticket for the checkout 500 error and mark it P0",
+    "should_trigger": true
+  },
+  {
+    "query": "Add a note to forge-abc123 documenting why we chose JWT",
+    "should_trigger": true
+  },
+  {
+    "query": "Show me all open issues tagged backend",
+    "should_trigger": true
+  },
+  {
+    "query": "Reopen forge-77, it wasn't actually fixed",
+    "should_trigger": true
+  },
+  {
+    "query": "Add a dependency so forge-12 is blocked by forge-9",
+    "should_trigger": true
+  },
+  {
+    "query": "Claim forge-abc so I can start on it",
+    "should_trigger": true
+  },
+  {
+    "query": "What's the next ready issue I should pick up?",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain why forge-55 is still blocked and what to unblock first",
+    "should_trigger": false
+  },
+  {
+    "query": "Claim this issue and confirm I hold the lease before I change anything",
+    "should_trigger": false
+  },
+  {
+    "query": "Drive forge-30 all the way through to a merged PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now and what's in flight?",
+    "should_trigger": false
+  }
+]

--- a/skills/kernel/SKILL.md
+++ b/skills/kernel/SKILL.md
@@ -109,11 +109,12 @@ families. Run them through Bash; never hand-edit the issue store.
 | Search / stats | `forge issue search "…"` · `forge issue stats` |
 | Blocked work | `forge blocked` |
 
-### B — Memory / knowledge (planned)
+### B — Memory / knowledge
 
-`forge remember` / `forge recall` / `forge knowledge search` are roadmap items —
-they are **not on the CLI yet**. Do not invoke them; record durable decisions as
-issue comments (`forge comment`) until the memory verbs land.
+`forge remember <note> [--tag <label>]... [--json]` and `forge recall` are live —
+they persist and retrieve project-memory notes from a file-backed store. Only
+`forge knowledge search` is not on the CLI yet; until it lands, capture durable
+decisions as `forge remember` notes or issue comments (`forge comment`).
 
 ### C — Board / planning / admin
 

--- a/skills/kernel/SKILL.md
+++ b/skills/kernel/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: kernel
 description: >
-  Forge kernel surface — the umbrella index for working in a Forge project. Use
-  at the start of any session and whenever you need to orient: it routes to the
-  `smith` orchestrator super-skill, the per-stage workflow skills (plan, dev,
-  validate, ship, review, verify, plus status, research, rollback, sonarcloud,
-  shepherd) and the kernel-native skills (triage-ready, issue-basics), and
-  documents the day-to-day issue, board, and orientation verbs of the `forge`
-  CLI. Trigger on
-  "what's the workflow", "what should I work on", "forge issues", "claim an
-  issue", "project status", "orient", or when deciding between Forge issues and
-  an ad-hoc TodoWrite list.
+  Forge kernel surface — the umbrella index and router for a Forge project. Reach for this
+  FIRST when you are orienting rather than executing: at the very start of a Forge session,
+  when you need the map of how the whole system fits together, or when you are unsure WHICH
+  skill or `forge` verb a task belongs to. It routes to the `smith` end-to-end orchestrator,
+  the per-stage ladder skills (plan, dev, validate, ship, review, verify), the utility skills
+  (status, research, rollback, sonarcloud, shepherd), and the kernel-native issue skills
+  (triage-ready, claim-safety, issue-basics) — and it is the reference for the day-to-day
+  `forge` CLI issue, board, gate, and orientation verbs. Trigger on "how does the Forge
+  workflow work", "walk me through the stage ladder", "which forge command or skill do I use
+  for X", "what are the forge issue verbs", "I'm new to this repo, how is Forge set up", "map
+  the Forge skills for me", or "should this be a Forge issue or a TodoWrite". This is the
+  meta/index layer, so hand off the actual doing: ranking or picking the next ready issue →
+  `triage-ready`; the current stage, "where am I", or active/stale work → `status`;
+  create/update/close/search a single issue → `issue-basics`; claim-then-prove-ownership
+  before mutating → `claim-safety`; drive one issue from plan to a merged PR under human gates
+  → `smith`; token-bounded project state for the Hermes harness → `hermes-forge`.
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/skills/kernel/evals/evals.json
+++ b/skills/kernel/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "I just cloned this Forge repo and I'm not sure how any of it works — give me the lay of the land: what's the workflow, what skills exist, and where do I even start?",
+    "should_trigger": true
+  },
+  {
+    "query": "There are a bunch of forge skills and I can't tell which one to use for what — lay out how they fit together and when I'd reach for each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which forge CLI command adds a dependency between two issues, and what's the verb for proving I hold a claim? Just the reference, don't run anything.",
+    "should_trigger": true
+  },
+  {
+    "query": "Is this small cleanup worth filing as a Forge issue, or should I just throw it on a TodoWrite checklist for this session?",
+    "should_trigger": true
+  },
+  {
+    "query": "Walk me through the Forge stage ladder from planning to post-merge verify and what each stage owns.",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me the reference of all the day-to-day forge issue and board verbs — I want the index, not to execute a command yet.",
+    "should_trigger": true
+  },
+  {
+    "query": "What should I pick up next? Rank the ready queue and tell me the top unblocked issue and why.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now, what's my active work, and has anything gone stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a bug issue titled 'login times out after 30s', priority 1, and link it under the auth epic.",
+    "should_trigger": false
+  },
+  {
+    "query": "Claim forge-4h9 for me and confirm I actually hold the lease before I start editing.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-7c2 all the way from planning through a merged PR, pausing for my approval at the plan and the merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "In the Hermes harness, give me the token-bounded project state to work from — treat forge orient as the source of truth.",
+    "should_trigger": false
+  }
+]

--- a/skills/parallel-deep-research/SKILL.md
+++ b/skills/parallel-deep-research/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: parallel-deep-research
 description: >
-  Produces comprehensive research reports that go far beyond what built-in web
-  search can achieve. Sends research tasks to Parallel AI's pro/ultra processors
-  which spend 3-25 minutes autonomously crawling, reading, and synthesizing dozens
-  of sources — returning structured reports with citations. Built-in WebSearch
-  can only run a few queries; this skill runs an entire research pipeline externally.
-  No binary install — requires PARALLEL_API_KEY in .env.local. ALWAYS use this
-  skill instead of doing multiple WebSearch calls when the user needs a comprehensive
-  report, market analysis, competitive landscape, industry deep-dive, strategic
-  recommendations, or multi-source synthesis. This is the RIGHT tool for any
-  research task that would require more than 3-4 web searches to answer properly.
-  Also trigger during /plan Phase 2 research and /research workflows.
+  Heavyweight EXTERNAL research reports — market, industry, competitive, and strategic —
+  delegated to Parallel AI's paid pro/ultra processors, which autonomously crawl, read, and
+  synthesize dozens of sources over 3-25 minutes and return one long structured report with
+  citations, far beyond what a handful of WebSearch calls can produce. Reach for this whenever
+  the user wants a comprehensive market analysis, competitive landscape, industry deep-dive,
+  multi-vendor/technology comparison across many sources, strategic recommendations, market
+  sizing/growth outlook, or any multi-source synthesis that would take more than 3-4 web
+  searches to answer well. Typical phrasings: "market analysis of X", "competitive landscape
+  comparing A/B/C", "industry deep-dive on...", "deep research report on...", "compare these
+  vendors at our scale", "strategic report with predictions for 2027". Requires
+  PARALLEL_API_KEY in .env.local; each run costs money and takes minutes, so it is the WRONG
+  tool for quick facts, a single-page fetch, one-URL scraping, or a small structured-field
+  extraction — use built-in WebSearch/WebFetch for those. It is also NOT the Forge RESEARCH or
+  PLAN stage itself: "run the research stage", "do Phase 2 for this feature", or
+  codebase/OWASP/DRY investigation that gets written into a design doc route to `research` and
+  `plan` — those stages may INVOKE this skill as their external research engine when a topic
+  genuinely needs dozens of sources, but a bare "run the stage" request is not this skill.
 compatibility: Requires PARALLEL_API_KEY in .env.local. Uses curl. Takes 3-25 minutes.
 metadata:
   author: harshanandak

--- a/skills/parallel-deep-research/evals/evals.json
+++ b/skills/parallel-deep-research/evals/evals.json
@@ -1,62 +1,46 @@
 [
   {
-    "query": "I need a comprehensive market analysis of the developer tools space — cover the top 20 players, their funding, market positioning, and where the industry is heading over the next 3-5 years. Include data from Gartner, Forrester, and any recent VC investment reports",
+    "query": "I need a comprehensive market analysis of the developer-tools space — top 20 players, their funding, market positioning, and where the industry is heading over the next 3-5 years, pulling from Gartner, Forrester, and recent VC investment reports",
     "should_trigger": true
   },
   {
-    "query": "Write a deep research report on the state of WebAssembly adoption in production — synthesize case studies from companies using WASM, performance benchmarks vs native code, ecosystem maturity analysis, and strategic recommendations for when to adopt it",
+    "query": "Write a deep research report on WebAssembly adoption in production — synthesize company case studies, performance benchmarks vs native code, ecosystem maturity, and clear recommendations for when to adopt it",
     "should_trigger": true
   },
   {
-    "query": "Our CTO wants a competitive landscape analysis comparing Convex, Supabase, Firebase, and PlanetScale for our backend rewrite. Need comprehensive feature comparison, pricing analysis at our scale (50K DAU), community health metrics, and risk assessment for each",
+    "query": "Competitive landscape comparing Convex, Supabase, Firebase, and PlanetScale for our backend rewrite — full feature comparison, pricing at 50K DAU, community-health metrics, and a per-vendor risk assessment",
     "should_trigger": true
   },
   {
-    "query": "Create a strategic report on the AI code generation market — analyze GitHub Copilot, Cursor, Claude Code, and emerging competitors. Cover adoption rates, developer satisfaction surveys, enterprise pricing trends, and predictions for 2027",
+    "query": "Give me an industry deep-dive on the observability market — Datadog vs Grafana Cloud vs New Relic across features, pricing, scalability, and OpenTelemetry support, with customer migration stories and TCO analysis for a 500-node cluster",
     "should_trigger": true
   },
   {
-    "query": "I'm doing /plan Phase 2 research — produce a comprehensive analysis of event-driven architecture patterns in microservices, covering Kafka vs RabbitMQ vs NATS, with production case studies, failure mode analysis, and recommendations for our 100K events/sec throughput requirement",
+    "query": "For our architecture decision, produce a heavily-sourced report on event-driven patterns — Kafka vs RabbitMQ vs NATS at 100K events/sec, with production case studies and failure-mode analysis",
     "should_trigger": true
   },
   {
-    "query": "Write an industry deep-dive into the observability market — compare Datadog, Grafana Cloud, and New Relic across features, pricing, scalability, and OpenTelemetry support. Include customer migration stories and TCO analysis for a 500-node cluster",
-    "should_trigger": true
-  },
-  {
-    "query": "Research and synthesize the current state of edge computing for real-time AI inference — cover hardware options, cloud provider edge offerings, latency benchmarks, and case studies from autonomous vehicles and IoT deployments",
-    "should_trigger": true
-  },
-  {
-    "query": "Quick search: what's the current price of Bitcoin and what were Anthropic's latest announcements?",
+    "query": "Quick — what's the current price of Bitcoin and what were Anthropic's latest announcements?",
     "should_trigger": false
   },
   {
-    "query": "Find the official migration guide URL for ESLint's new flat config format",
+    "query": "Go to https://stripe.com/docs/api and extract the authentication section with all its code examples",
     "should_trigger": false
   },
   {
-    "query": "Search for recent blog posts about Bun 2.0 features and release date",
+    "query": "Scrape https://openai.com/pricing and pull out the per-token cost for each model tier",
     "should_trigger": false
   },
   {
-    "query": "Go to https://stripe.com/docs/api and extract the authentication section with all the code examples",
+    "query": "Run the /research stage for the auth-refactor feature — investigate how our codebase currently handles session tokens, flag OWASP and DRY concerns, and write the findings into the design doc",
     "should_trigger": false
   },
   {
-    "query": "Scrape https://openai.com/pricing and extract the per-token costs for each model tier",
+    "query": "Kick off the plan stage for adding rate limiting — brainstorm the design one question at a time, then set up the branch, worktree, and task list",
     "should_trigger": false
   },
   {
-    "query": "Build a structured company profile for Databricks — return JSON with founding year, funding rounds, valuation, employee count, and tech stack",
-    "should_trigger": false
-  },
-  {
-    "query": "Fix the TypeScript compilation error in src/services/auth.ts — it's complaining about missing type for the session token",
-    "should_trigger": false
-  },
-  {
-    "query": "Add unit tests for the rate limiter middleware in src/middleware/rateLimit.ts",
+    "query": "Fix the TypeScript compilation error in src/services/auth.ts about the missing session-token type",
     "should_trigger": false
   }
 ]

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,11 +1,18 @@
 ---
 name: plan
 description: >
-  Use for the Forge plan stage to capture design intent through
-  one-question-at-a-time brainstorming, run technical/OWASP/DRY research, then set up
-  the branch, worktree, and a complete TDD task list ready for /dev. Trigger when
-  starting a new feature, planning or scoping work, writing a design doc, or preparing
-  a worktree and task list before development.
+  Forge PLAN stage — the first stop when starting a NEW feature or an unscoped piece of work.
+  Runs one-question-at-a-time brainstorming to capture design intent, writes and commits a
+  design doc, runs technical/OWASP/DRY + codebase research, then sets up the branch, worktree,
+  and a complete TDD task list ready to hand to /dev. Trigger on "let's plan X", "start or
+  scope a new feature", "brainstorm this before we build", "write a design doc", "break this
+  into tasks", or "set up a worktree and task list before coding". Reach for this even when
+  the request sounds like only design or only scoping — plan owns intent → research →
+  task-list setup as a single stage. NOT for driving a feature all the way to a merged PR
+  (that is smith), NOT for implementing the tasks once they already exist (dev), NOT for a
+  standalone deep-research pass into an already-approved design doc (research), NOT for
+  reporting where current work stands or what is stale (status), and NOT for everyday issue
+  create/list/close or picking the next ready issue (issue-basics / triage-ready).
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -515,7 +515,7 @@ If the user approves a dependency mutation, apply it explicitly (only when the t
 bash scripts/dep-guard.sh apply-decision <id> <dependent-id> <depends-on-id> "<approval rationale>"
 ```
 
-That approval step must validate with `forge issue dep cycles`, show `forge graph`, summarize `forge ready`, and persist the decision via `forge update` plus `forge comment`. The Forge Kernel is the canonical machine-readable decision record; the plan docs hold only the concise summary.
+That approval step must inspect blockers with `forge issue blocked` (and `forge issue children <epic-id>` for the epic rollup), summarize `forge ready`, and persist the decision via `forge update` plus `forge comment`. The Forge Kernel is the canonical machine-readable decision record; the plan docs hold only the concise summary.
 
 ### Step 6: User review
 

--- a/skills/plan/evals/evals.json
+++ b/skills/plan/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "I want to build a rate-limiter for our public API — help me nail down the design, then break it into tasks before I write any code.",
+    "should_trigger": true
+  },
+  {
+    "query": "Let's kick off the webhook-retry feature: ask me the key decisions one at a time, write it up, and set me up to start developing.",
+    "should_trigger": true
+  },
+  {
+    "query": "Scope out adding SSO to the admin dashboard — pin down requirements and edge cases and give me an ordered TDD task list on its own branch.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before anyone touches the notification service I want a real plan: a worktree, some research on the approach, and a task list /dev can just run.",
+    "should_trigger": true
+  },
+  {
+    "query": "Starting the CSV-export epic today — brainstorm the approach with me and produce a committed design doc plus tasks.",
+    "should_trigger": true
+  },
+  {
+    "query": "Grab the highest-priority ready issue and take it all the way to an open PR — plan, build, validate, ship — just pause for my approval before merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "The design doc and task list are already in docs/work; start implementing the first task with RED-GREEN-REFACTOR.",
+    "should_trigger": false
+  },
+  {
+    "query": "The design is approved and written — now go do the deep web and codebase research and append it under the Technical Research section.",
+    "should_trigger": false
+  },
+  {
+    "query": "Which stage am I on for the billing branch, and is any of my work going stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a bug issue for the broken logout redirect and link it under the auth epic.",
+    "should_trigger": false
+  }
+]

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,10 +1,25 @@
 ---
 name: research
 description: >
-  Runs deep, parallel web and codebase research and documents findings in the design
-  doc. Use for the Forge research stage when gathering technical research, OWASP
-  analysis, and TDD scenarios before planning or development. Trigger keywords are
-  research, deep research, web search, OWASP, codebase exploration, technical research.
+  Runs the Forge RESEARCH stage — the technical-investigation phase now embedded as /plan
+  Phase 2. Use it when the user wants JUST the research work for a specific feature (not the
+  whole plan flow): deep web research on best practices and known gotchas for the chosen
+  approach, an OWASP Top 10 risk pass documenting which categories apply and how they'll be
+  mitigated, DRY / blast-radius codebase exploration for existing patterns to reuse, and
+  identification of at least three TDD test scenarios — all appended under `## Technical
+  Research` in that feature's `docs/work/YYYY-MM-DD-<slug>/design.md`. Trigger on phrasings
+  like "run the research phase", "do the technical research for this feature", "run an OWASP
+  analysis on this", "explore the codebase for reusable patterns before we build", "check
+  we're not duplicating an existing helper (DRY)", "add the security + best-practices research
+  to the design doc", or "find TDD scenarios for X". If the design doc doesn't exist yet,
+  create it first, then research into it. Pick this skill over its siblings: choose `plan`
+  instead when the user is starting a feature from scratch and wants the FULL stage —
+  one-question-at-a-time design brainstorm plus branch/worktree/task-list setup — not only the
+  research; choose `parallel-deep-research` instead when the ask is an external market,
+  competitive, or industry report via Parallel AI (business analysis, vendor comparison,
+  funding/landscape), not code-level technical/OWASP/DRY research; choose `dev` or `validate`
+  instead when the user wants to implement tasks or run security scans/lint/tests against code
+  rather than research it.
 allowed-tools: Bash, Read, Write, Grep, Glob, WebSearch, WebFetch
 ---
 

--- a/skills/research/evals/evals.json
+++ b/skills/research/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "The design doc for the rate-limiter is already written — now go do the technical research: best practices, known gotchas for this approach, and drop it under Technical Research in the doc.",
+    "should_trigger": true
+  },
+  {
+    "query": "Run an OWASP Top 10 pass over this new file-upload feature and record which categories actually apply and how we'll mitigate each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before we build the caching layer, search the codebase for anything we can reuse and make sure we're not duplicating an existing helper.",
+    "should_trigger": true
+  },
+  {
+    "query": "Just do the research phase for this feature — web plus codebase investigation and at least three TDD scenarios — skip the brainstorm and the worktree setup.",
+    "should_trigger": true
+  },
+  {
+    "query": "Pull together the security and best-practices research for the OAuth integration and append it to the feature's design doc.",
+    "should_trigger": true
+  },
+  {
+    "query": "Let's plan this feature from scratch — brainstorm the design with me one question at a time, then create the branch, worktree, and task list.",
+    "should_trigger": false
+  },
+  {
+    "query": "I need a competitive landscape report comparing Datadog, Grafana Cloud, and New Relic on pricing and features for a 500-node cluster.",
+    "should_trigger": false
+  },
+  {
+    "query": "Give me a comprehensive market analysis of the vector-database space — top players, funding, and the 3-5 year outlook.",
+    "should_trigger": false
+  },
+  {
+    "query": "Start implementing task 1 with TDD — write the failing test first, then make it pass.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run the security scan, lint, and full test suite before we open the PR.",
+    "should_trigger": false
+  }
+]

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -332,7 +332,7 @@ gh pr checks <pr-number>
 ### Step 10: Update the Forge issue
 
 ```bash
-forge update <id> --comment "PR review complete: all issues addressed, all checks passing"
+forge comment <id> "PR review complete: all issues addressed, all checks passing"
 forge sync
 ```
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,22 @@
 ---
 name: review
-description: Processes all pull request feedback after a PR is created — GitHub Actions failures, Greptile inline comments and summary, SonarCloud quality gate, and other CI/CD checks — fixing, replying, and resolving each until every check passes. Use for the Forge review stage when handling PR review feedback, failing checks, Greptile or SonarCloud issues, or running the pre-merge doc gate before merge.
+description: >
+  Forge REVIEW stage — the one skill that drives an already-open pull request to all-green by
+  resolving EVERY piece of feedback on it: failing GitHub Actions / CI checks, Greptile and
+  CodeRabbit inline comments and summaries, and the SonarCloud quality gate. It actively fixes
+  the code, replies to each thread, and marks it resolved until the checks pass, then runs the
+  pre-merge doc gate (CHANGELOG / README / API / AGENTS docs) and hands the PR off for MANUAL
+  merge — it never runs `gh pr merge`. Reach for it whenever a PR already has review feedback
+  or red checks to work through: "address the review comments on PR #123", "the bots flagged
+  issues / my Greptile score is low", "fix the failing checks and resolve the threads",
+  "CodeRabbit and SonarCloud left comments — sort them out", "get my PR merge-ready". This is
+  the MUTATING feedback-resolution stage — distinct from shepherd (only WATCHES an open PR's
+  checks and settle window, changes nothing), verify (POST-merge CI-on-master health check +
+  closing issues), ship (pushing the branch and opening the PR in the first place), validate
+  (PRE-PR local type/lint/test/security on your branch), and the sonarcloud /
+  sonarcloud-analysis skills (which only QUERY SonarCloud data that this stage consumes). Use
+  those for a single tool or a passive watch; use this to work a PR's whole feedback set to
+  done.
 allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 

--- a/skills/review/evals/evals.json
+++ b/skills/review/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "PR #204 has three red checks and a pile of Greptile comments — work through all of it and get the PR green.",
+    "should_trigger": true
+  },
+  {
+    "query": "CodeRabbit and SonarCloud both left feedback on my pull request; fix what's valid, reply to the rest, and resolve the threads.",
+    "should_trigger": true
+  },
+  {
+    "query": "The GitHub Actions build is failing on my PR and there are unresolved review threads — sort them out before I merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "My Greptile confidence score is low. Address the inline comments and keep pushing fixes until the quality gate passes.",
+    "should_trigger": true
+  },
+  {
+    "query": "Handle all the reviewer feedback on the auth PR, then update the changelog and docs before we hand it off to merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "Just keep an eye on PR #150 — watch the checks and review threads and ping me when it's settled and mergeable. Don't touch the code.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR is merged to master now — run the post-merge health check and close out the issue.",
+    "should_trigger": false
+  },
+  {
+    "query": "My branch passed validation; push it and open the pull request with the design-doc link.",
+    "should_trigger": false
+  },
+  {
+    "query": "Before I open a PR, run the type-check, lint, full test suite, and security scan on my branch.",
+    "should_trigger": false
+  },
+  {
+    "query": "Just pull up this PR's SonarCloud issues and quality-gate status so I can eyeball them.",
+    "should_trigger": false
+  }
+]

--- a/skills/rollback/SKILL.md
+++ b/skills/rollback/SKILL.md
@@ -194,7 +194,7 @@ Rollback complete!
 **How it works**:
 ```bash
 git checkout HEAD~1 -- <file1> <file2> ...
-git commit -m "Rollback: <files>"
+git commit -m "chore: rollback <files>"
 ```
 
 **Example**:
@@ -212,7 +212,7 @@ bunx forge rollback
 ✓ Amended commit to preserve USER content
 
 Rollback complete!
-  Commit: q4r5s6t "Rollback: AGENTS.md, CLAUDE.md"
+  Commit: q4r5s6t "chore: rollback AGENTS.md, CLAUDE.md"
   Files affected: 2
 ```
 

--- a/skills/rollback/SKILL.md
+++ b/skills/rollback/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: rollback
-description: Safely reverts changes — the last commit, a specific commit, a merged PR, individual files, or a commit range — using non-destructive git revert while preserving USER sections and custom commands. Use when an implementation must be undone, a merged PR reverted, files restored, or a change previewed before reverting (rollback, revert, undo, restore).
+description: >
+  Safely revert or undo a change that is already committed or shipped, using non-destructive
+  `git revert` (never `reset --hard`, `push --force`, or `clean`) and auto-preserving USER
+  sections plus custom commands. Drives the interactive `bunx forge rollback` menu: undo the
+  last commit, revert a specific commit by hash, revert a merged PR (git revert -m 1), restore
+  individual files to their prior version, revert a commit range, or dry-run/preview any of
+  these first. Use when the user says roll back, revert, undo, back out, or restore — e.g.
+  "undo the last commit", "undo that change, the approach was wrong", "back out PR #123",
+  "revert the merge commit", "restore src/auth.js to before my last commit", or when a
+  shipped/merged change broke something and must be pulled back (optionally re-flagging its
+  linked Beads issue). This is the RECOVERY skill for changes already in git history. Do NOT
+  use for: replying to or fixing PR review feedback (review), monitoring an open PR's checks
+  toward merge (shepherd), the post-merge CI health check on master (verify), pushing a branch
+  or opening a PR (ship), or ordinary issue status/field edits (issue-basics).
 allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 

--- a/skills/rollback/evals/evals.json
+++ b/skills/rollback/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "undo the last commit, the approach was wrong",
+    "should_trigger": true
+  },
+  {
+    "query": "back out PR #482, it's breaking production",
+    "should_trigger": true
+  },
+  {
+    "query": "restore config/database.yml to the version before my last commit",
+    "should_trigger": true
+  },
+  {
+    "query": "show me which files reverting commit a1b2c3d would touch before I actually do it",
+    "should_trigger": true
+  },
+  {
+    "query": "that merged refactor broke everything — revert the whole thing but keep the git history intact",
+    "should_trigger": true
+  },
+  {
+    "query": "what's the safe way to undo a merged pull request?",
+    "should_trigger": true
+  },
+  {
+    "query": "address the Greptile and CodeRabbit comments on my PR",
+    "should_trigger": false
+  },
+  {
+    "query": "keep watching my open PR and tell me when checks pass and it's mergeable",
+    "should_trigger": false
+  },
+  {
+    "query": "master is green after the merge — run the post-merge health check and close the issue",
+    "should_trigger": false
+  },
+  {
+    "query": "push my validated branch and open a pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "set issue forge-9f2 to status review",
+    "should_trigger": false
+  }
+]

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: shepherd
-description: Runs one bounded monitor pass over a pull request — reads CI and check state, takes at most one idempotent action, then hands off; never merges and never resolves review threads. Use when polling PR checks, re-running flaky required checks, posting status replies, or escalating merge-readiness after /review.
+description: >
+  Run ONE bounded, hand-off monitor pass over an already-reviewed OPEN pull request: read the
+  CI/check rollup and the branch-protection required-check set, take at most one idempotent
+  action (re-run a flaky required check, or post a status reply to a thread), then declare
+  merge-readiness — MERGE_READY, still PENDING, or escalate — and exit. There is no in-process
+  loop; a scheduler re-invokes the pass. Use this when the user says things like "is PR #123
+  ready to merge yet?", "poll/watch the checks on my PR", "the required CI job is flaky — kick
+  off a re-run", "keep an eye on this PR until it's green", "babysit the checks after
+  /review", "shepherd PR 45", or "monitor the PR toward merge (and rebase it if it's behind,
+  with --auto-rebase)". It NEVER merges (the human merges in the GitHub UI), NEVER edits code,
+  and NEVER resolves review threads. Do NOT use it to fix or reply-and-resolve PR review
+  feedback from Greptile/CodeRabbit/SonarCloud — that is `review`; nor to open/push the PR in
+  the first place — that is `ship`; nor for the post-merge "CI green on master + close issues"
+  health check — that is `verify`; nor for a general "where am I in the workflow / what's in
+  flight" report — that is `status`.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/skills/shepherd/evals/evals.json
+++ b/skills/shepherd/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Is PR #212 ready to merge yet?",
+    "should_trigger": true
+  },
+  {
+    "query": "The lint check on my PR keeps failing intermittently — kick off a re-run of the failed jobs.",
+    "should_trigger": true
+  },
+  {
+    "query": "Keep an eye on pull request 88 and tell me when all the required checks pass.",
+    "should_trigger": true
+  },
+  {
+    "query": "I just wrapped up /review on this PR — babysit the checks and escalate if it isn't mergeable.",
+    "should_trigger": true
+  },
+  {
+    "query": "Shepherd PR 300 and rebase it onto master if it's behind.",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix all the CodeRabbit and Greptile comments on my PR and resolve each review thread.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR just merged to master — confirm CI is green there and close the linked issue.",
+    "should_trigger": false
+  },
+  {
+    "query": "Push my validated feature branch and open a pull request from the template.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow and what work is still in flight right now?",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the SonarCloud issues flagged on this PR.",
+    "should_trigger": false
+  }
+]

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -95,7 +95,7 @@ bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
 
 ### Step 3: Record PR Handoff
 ```bash
-forge update <id> --comment "PR created: <pr-url>. Awaiting review and merge verification."
+forge comment <id> "PR created: <pr-url>. Awaiting review and merge verification."
 forge sync
 ```
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,10 +1,21 @@
 ---
 name: ship
 description: >
-  Pushes the validated branch and opens a pull request populated from the project's
-  PR template with full context and documentation links. Use for the Forge ship stage
-  after /validate passes. Triggers on ship, create PR, open pull request, push branch,
-  gh pr create.
+  Forge SHIP stage: push the already-validated feature branch and open a pull request
+  populated from the project's OWN PR template (design-doc link, Forge issue IDs, real
+  test/commit data), then hand the PR off for MANUAL merge — this skill never merges or
+  auto-merges. Reach for it the moment /validate has passed and you want a PR on the board.
+  Triggers on phrasings like "ship it", "ship this branch", "create/open the PR", "open a pull
+  request", "push and open a PR", "gh pr create", "make/raise a PR from my current branch",
+  "checks passed, now cut the PR". It runs the branch-freshness and parallel-PR
+  merge-simulation checks, force-with-lease pushes, records the ship->review handoff, then
+  stops. This is ONE stage — route elsewhere when the ask is broader or different: the whole
+  plan->dev->validate->ship->review pipeline or "drive it to done" (smith); running
+  type-check/lint/tests/security first (validate); addressing PR review comments or resolving
+  Greptile/SonarCloud/CodeRabbit threads on an existing PR (review); babysitting an
+  already-open PR's checks toward merge (shepherd); the post-merge CI health check and closing
+  issues (verify); or reverting an already-shipped change (rollback). If the PR already
+  exists, this is not the skill.
 allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 

--- a/skills/ship/evals/evals.json
+++ b/skills/ship/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Validation came back clean — go ahead and open the pull request for this branch.",
+    "should_trigger": true
+  },
+  {
+    "query": "Push my feature branch and raise a PR, and fill in our PR template with the issue and design-doc links.",
+    "should_trigger": true
+  },
+  {
+    "query": "Dev's done and all the checks passed, cut me a PR.",
+    "should_trigger": true
+  },
+  {
+    "query": "Do a gh pr create for feat/rate-limit using the repo's template, not a hand-written body.",
+    "should_trigger": true
+  },
+  {
+    "query": "Everything's green after validate — ship it, but hand it off for me to merge, don't merge it yourself.",
+    "should_trigger": true
+  },
+  {
+    "query": "Take forge-42 from planning all the way to a merge-ready PR — plan it, build it TDD, validate, then ship, checking with me at the gates.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR's picked up Greptile and CodeRabbit comments — fix them and resolve the threads.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run the type-check, lint, tests and security scan before I push anything.",
+    "should_trigger": false
+  },
+  {
+    "query": "Keep watching PR #128 and ping me the moment its checks go green so I can merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR merged to master — confirm CI is green there and close the linked issue.",
+    "should_trigger": false
+  }
+]

--- a/skills/sonarcloud-analysis/SKILL.md
+++ b/skills/sonarcloud-analysis/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: sonarcloud-analysis
 description: >
-  Pull issues, metrics, quality gates, and analysis data from SonarCloud. ALWAYS
-  use this skill when the user mentions SonarCloud, asks about code quality metrics,
-  wants to check PR quality gates, or needs to review security vulnerabilities and
-  technical debt from static analysis. Also trigger during /review workflow when
-  SonarCloud issues need addressing. Trigger on phrases like "SonarCloud",
-  "quality gate", "code quality metrics", "technical debt", "coverage report",
-  "static analysis issues", "security vulnerabilities from scan".
+  Deep-dive SonarCloud analysis through the SonarCloud REST API, run in an isolated context so
+  the raw JSON does not flood the main conversation. Pull open issues (bugs, vulnerabilities,
+  code smells), coverage and duplication metrics, quality-gate pass/fail status with the exact
+  failed thresholds, security hotspots, quality profiles, and analysis/measure history for a
+  whole project, a branch, or a specific pull request, then hand back a ranked, actionable
+  summary. Reach for this whenever the user names SonarCloud or asks about code-quality
+  metrics, technical debt, coverage numbers, a red or failing quality gate, or security
+  vulnerabilities and hotspots from static analysis — for example "what's our technical debt
+  and which files have the worst maintainability", "why is the SonarCloud gate failing on this
+  PR", "pull every BLOCKER vulnerability from the last scan with file and line", "show
+  coverage by module", or "how have our reliability and security ratings trended this month".
+  Route ELSEWHERE when: the user explicitly types the thin `/sonarcloud <query> <project>`
+  slash command for a quick single lookup (that is the sibling 'sonarcloud' command surface);
+  they want to reply to and resolve PR review threads across Greptile, CodeRabbit, or GitHub
+  Actions (that is 'review'); they want to run the local lint, type-check, test, or security
+  scanner before shipping (that is 'validate'); they want to actually implement or patch a
+  flagged issue (that is 'dev'); or they want an external market or competitor report on
+  SonarSource or DevSecOps vendors (that is 'parallel-deep-research').
 category: Code Quality
 tags: [sonarcloud, code-quality, issues, metrics, security]
 context: fork

--- a/skills/sonarcloud-analysis/evals/evals.json
+++ b/skills/sonarcloud-analysis/evals/evals.json
@@ -1,50 +1,46 @@
 [
   {
-    "query": "Check the SonarCloud quality gate status for our latest PR — I want to see if there are any blockers before we can merge, especially around security vulnerabilities and code coverage",
+    "query": "Why is our quality gate red on this pull request? Break down exactly which conditions failed and by how much.",
     "should_trigger": true
   },
   {
-    "query": "Pull the SonarCloud analysis results for our project — show me all the critical and major security vulnerabilities found in the last scan, with file locations and remediation guidance",
+    "query": "How much technical debt has piled up in the codebase, and which files carry the worst maintainability rating?",
     "should_trigger": true
   },
   {
-    "query": "We're in /review and SonarCloud flagged some issues — get the full list of code smells, bugs, and vulnerabilities from the latest analysis so I can address them before the quality gate passes",
+    "query": "Give me the coverage and duplication numbers for the develop branch and flag the modules that regressed.",
     "should_trigger": true
   },
   {
-    "query": "What's our current technical debt ratio in SonarCloud? Show me the metrics dashboard — maintainability rating, reliability rating, security rating, and coverage percentage",
+    "query": "List every unresolved BLOCKER and CRITICAL vulnerability SonarCloud found, with file and line, so I know what to fix first.",
     "should_trigger": true
   },
   {
-    "query": "The SonarCloud quality gate is failing on our PR — pull the specific issues that are blocking it and show me what needs to be fixed, sorted by severity",
+    "query": "Pull the security hotspots that still need review and summarize the risk for each.",
     "should_trigger": true
   },
   {
-    "query": "Get the SonarCloud code coverage report for our project — I want to see which modules have low coverage and identify the files that need more tests before our next release",
+    "query": "Show me how our reliability and security ratings have trended over the last month of analyses.",
     "should_trigger": true
   },
   {
-    "query": "Implement a new REST API endpoint for user profile management with CRUD operations, input validation, and proper error handling",
+    "query": "/sonarcloud issues checkout-service --severity BLOCKER",
     "should_trigger": false
   },
   {
-    "query": "Search for best practices around implementing OAuth2 PKCE flow in a Node.js application",
+    "query": "Go through all the open PR review threads from Greptile and CodeRabbit, reply to each explaining the fix, and mark them resolved.",
     "should_trigger": false
   },
   {
-    "query": "Write a comprehensive market analysis of the DevSecOps tools landscape covering SAST, DAST, and SCA vendors",
+    "query": "Run lint, type-check, the test suite, and the security scanner and give me fresh output before I ship this branch.",
     "should_trigger": false
   },
   {
-    "query": "Scrape https://docs.sonarcloud.io and extract the full list of supported languages and analysis rules",
+    "query": "Fix the SQL-injection vulnerability SonarCloud flagged in login.ts and add a regression test.",
     "should_trigger": false
   },
   {
-    "query": "Build a structured company profile for SonarSource — return JSON with founding year, funding, products, and competitive positioning",
-    "should_trigger": false
-  },
-  {
-    "query": "Add proper citations to docs/research/security-audit-findings.md following our project's citation standards",
+    "query": "Produce a competitive market report comparing SonarCloud, Snyk, and Codacy for our tooling decision.",
     "should_trigger": false
   }
 ]

--- a/skills/sonarcloud/SKILL.md
+++ b/skills/sonarcloud/SKILL.md
@@ -1,6 +1,23 @@
 ---
 name: sonarcloud
-description: Pulls issues, metrics, quality gates, security hotspots, and analysis history from SonarCloud via its API. Use for the Forge sonarcloud stage when querying code quality data for a project, branch, or PR — triggers on sonarcloud, code quality, issues, metrics, quality gate, hotspots, coverage.
+description: >
+  Query SonarCloud code-quality data through the `/sonarcloud` slash command — the fast,
+  in-context lookup surface for a project, branch, or (above all) a pull request. Handles the
+  named queries `issues`, `metrics`, `gate` (quality-gate pass/fail with failed conditions),
+  `health` (full report), `pr <number>`, `hotspots` (security), and `history`, plus
+  `--branch`, `--severity`, `--type`, and `--new-code` filters. Reach for this the moment the
+  user types `/sonarcloud ...`, or asks in plain language: "what does SonarCloud say about
+  this PR", "check the SonarCloud quality gate before I ship", "show SonarCloud
+  blocker/critical bugs on the develop branch", "any new-code SonarCloud issues on PR 214",
+  "SonarCloud coverage for my-project". Requires a `SONARCLOUD_TOKEN` (and organization key).
+  This skill only READS and reports SonarCloud results — it does NOT fix findings or
+  reply-to/resolve PR review threads (that is the `review` stage), and it is the lightweight
+  command surface, NOT the isolated deep-analysis session that correlates findings with local
+  source, walks analysis-history trends, or runs duplication deep-dives across many endpoints
+  (that is `sonarcloud-analysis` — send heavyweight or correlation work there). Not for local
+  SAST/security scans of your own code, and not for the Forge issue tracker ("open/ready
+  issues", `forge issue ...`) — here those bare words always mean SonarCloud, not the tracker
+  or validate stage.
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
 ---
 

--- a/skills/sonarcloud/SKILL.md
+++ b/skills/sonarcloud/SKILL.md
@@ -58,7 +58,7 @@ Pull code quality data from SonarCloud. Requires `SONARCLOUD_TOKEN` environment 
    - Optional filters (branch, severity, type, new-code, etc.)
 2. Check for `SONARCLOUD_TOKEN` environment variable. If not set, inform user.
 3. Check for `SONARCLOUD_ORG` environment variable or ask user for organization key.
-4. Execute the appropriate API call using curl or the TypeScript client at `next-app/src/lib/integrations/sonarcloud.ts`
+4. Execute the appropriate API call against the SonarCloud REST API (see the API Reference section below for endpoints)
 5. Format and present results clearly:
    - For issues: Group by severity/type, show file, line, message
    - For metrics: Show as table with metric name and value

--- a/skills/sonarcloud/evals/evals.json
+++ b/skills/sonarcloud/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "/sonarcloud gate my-project",
+    "should_trigger": true
+  },
+  {
+    "query": "/sonarcloud pr befach-web 214 --new-code",
+    "should_trigger": true
+  },
+  {
+    "query": "What does SonarCloud say about this pull request? Just the quality gate and the blocker issues, quick.",
+    "should_trigger": true
+  },
+  {
+    "query": "Show SonarCloud bugs and vulnerabilities on the develop branch for the api project",
+    "should_trigger": true
+  },
+  {
+    "query": "Any new-code SonarCloud issues on PR 88 before I ship?",
+    "should_trigger": true
+  },
+  {
+    "query": "Pull the SonarCloud coverage and code-smell numbers for my-project so I can eyeball them",
+    "should_trigger": true
+  },
+  {
+    "query": "Open an isolated SonarCloud deep-dive: correlate every flagged vulnerability with the actual source files, walk the analysis history for coverage trends, and hand back a synthesized technical-debt report",
+    "should_trigger": false
+  },
+  {
+    "query": "SonarCloud flagged issues on PR 214 — fix them, reply to each review thread, and mark them resolved",
+    "should_trigger": false
+  },
+  {
+    "query": "Run a SAST security scan over my code and list the vulnerabilities you find",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the open issues that are ready to work on next",
+    "should_trigger": false
+  },
+  {
+    "query": "Run lint and type-check and the test suite before I ship this branch",
+    "should_trigger": false
+  }
+]

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: status
-description: Checks the current Forge workflow stage and surfaces in-progress work, ranked ready issues, stale in-progress reconciliation, recent commits, and team context. Use for the Forge status stage when starting a session or deciding what to work on next. Triggers include status, current stage, what's in progress, where am I, and resume work.
+description: >
+  Report where the project stands right now and what work is in flight -- the Forge status
+  snapshot. Reach for this at session start or whenever the user says "/status", "where am I",
+  "what's in progress", "catch me up", "resume work", "what changed recently", or "what should
+  I pick up next". It runs forge sync, then surfaces the detected workflow stage, the user's
+  active/claimed issues, all issues ranked by composite score (priority, dependency impact,
+  type, staleness) with conflict-risk annotations, stale in-progress issues that were already
+  merged (which it reconciles by closing them), the last ~10 commits, and a forge team
+  workload/dashboard overview. Use it to ORIENT and decide the next move: it reports state and
+  points ahead -- it does not plan, run development, or claim an issue to work it (its only
+  write is closing already-merged stale issues during reconciliation). Not for: routing to a
+  specific stage skill or documenting the full issue-verb surface (that's kernel); deeply
+  ranking and EXPLAINING a single next-ready or blocked issue to hand off (triage-ready);
+  everyday create/update/list/close/comment/search issue operations (issue-basics); the Hermes
+  harness's token-bounded orient/recap state contract (hermes-forge); or the post-merge CI
+  health check that closes issues after a merge lands (verify).
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/skills/status/evals/evals.json
+++ b/skills/status/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "/status",
+    "should_trigger": true
+  },
+  {
+    "query": "where am I on this project right now?",
+    "should_trigger": true
+  },
+  {
+    "query": "catch me up -- what's in progress and what got merged recently?",
+    "should_trigger": true
+  },
+  {
+    "query": "I stepped away for a few days, give me the current state of the work before I dive back in",
+    "should_trigger": true
+  },
+  {
+    "query": "show me my active issues and which stage we're at",
+    "should_trigger": true
+  },
+  {
+    "query": "are there any in-progress issues that were already merged and should be closed?",
+    "should_trigger": true
+  },
+  {
+    "query": "what's the single best next issue to start, and explain why that one?",
+    "should_trigger": false
+  },
+  {
+    "query": "why is issue forge-456 blocked -- what's it waiting on?",
+    "should_trigger": false
+  },
+  {
+    "query": "route me to the correct Forge stage skill for opening a PR",
+    "should_trigger": false
+  },
+  {
+    "query": "create an issue titled 'fix flaky login test' and tag it a bug",
+    "should_trigger": false
+  },
+  {
+    "query": "the PR just merged to master -- confirm CI is green and close the linked issues",
+    "should_trigger": false
+  },
+  {
+    "query": "keep an eye on PR #88 until its checks and review threads settle",
+    "should_trigger": false
+  }
+]

--- a/skills/triage-ready/SKILL.md
+++ b/skills/triage-ready/SKILL.md
@@ -45,8 +45,10 @@ and `forge issue stats` exclusively.
 forge issue stats --json
 ```
 
-Returns `data.counts` (open/in_progress/done/cancelled), `ready_count`,
-`blocked_count`, and `active_claims`. A high `blocked_count` relative to
+Returns `data.counts` (`open`/`done`/`cancelled` — keys are present only when
+non-zero, and there is no `in_progress` bucket: claimed work stays in status
+`open` and is surfaced via `active_claims`), `ready_count`, `blocked_count`, and
+`active_claims`. A high `blocked_count` relative to
 `ready_count` is your signal that dependency repair (not new work) is the real
 bottleneck — hand off to `dependency-planning` / `backlog-hygiene`.
 
@@ -99,8 +101,10 @@ or close — it is strictly read-only.
 
 - **Recompute, never cache.** Readiness is derived; re-run `forge issue ready`
   every session rather than remembering a prior "ready" verdict.
-- **Respect non-claimable types.** Epics and decisions are `claimable:false` and
-  will not appear in `ready`; do not hand them off as work.
+- **Respect non-claimable types.** Epics and decisions never appear in `ready`
+  (the queue surfaces only claimable types — `task`/`bug`), so do not hand them
+  off as work. There is no `claimable` field in the CLI JSON; this is behavioral,
+  not a flag you can read.
 - **Check the envelope.** Every `--json` reply carries `ok`; on `ok:false` read
   `error.message` and retry the query rather than guessing at state.
 - **Read-only.** This skill runs only `stats`/`ready`/`blocked`/`show`. If a fix is

--- a/skills/triage-ready/SKILL.md
+++ b/skills/triage-ready/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: triage-ready
 description: >
-  Surfaces and EXPLAINS the right next work in a Forge project — read-only. Ranks
-  the ready queue with `forge issue ready`, shows what is blocked and why with
-  `forge issue blocked`, and summarizes the backlog with `forge issue stats`. Never
-  uses `board` (which reads a legacy snapshot store, not the live kernel). Use when
-  deciding what to pick up next, or to justify why an item is workable. Trigger on
-  "what should I work on", "what's ready", "triage", "next task", "ready queue",
-  "why is this blocked", or "pick my next issue".
+  Surfaces, ranks, and EXPLAINS the single best next issue to pick up in a Forge project —
+  strictly read-only. Recomputes the live ready queue with `forge issue ready`, explains what
+  is blocked and why with `forge issue blocked`, takes the backlog pulse with `forge issue
+  stats`, and justifies the pick from the full record via `forge issue show` — always against
+  the live kernel, never `forge board` (which reflects legacy Beads runtime/snapshot state,
+  not the live kernel) and never a cached "status == ready". Recommends ONE issue with a
+  one-line reason, then hands off; it never claims, comments, closes, or otherwise mutates.
+  Use when the user asks "what should I work on", "what's next", "what's ready", "pick/triage
+  my next task", "top of the ready queue", "which issue should I start", "why is this issue
+  blocked", or "what's blocking the most work". This is the read-and-recommend skill — NOT for
+  claiming or taking ownership of the pick (use claim-safety), not for everyday issue
+  create/update/list/search/close/comment/dep CRUD (use issue-basics), not for reporting the
+  current workflow stage or "where am I / what's in flight" (use status), not for orienting a
+  whole session or routing to stage skills (use kernel), and not for driving an issue through
+  to a merged PR (use smith).
 allowed-tools: Read, Bash(forge:*)
 ---
 

--- a/skills/triage-ready/evals/evals.json
+++ b/skills/triage-ready/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "I just sat down at this repo — what's the highest-priority thing I can actually start right now?",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me the top few off the ready queue and tell me why the first one is unblocked.",
+    "should_trigger": true
+  },
+  {
+    "query": "Why can't I start forge-2agy.2.2 yet? What's holding it up?",
+    "should_trigger": true
+  },
+  {
+    "query": "The backlog feels stuck — is it mostly blocked, and which one dependency would unlock the most work?",
+    "should_trigger": true
+  },
+  {
+    "query": "Pick my next task and justify the choice, don't grab it yet.",
+    "should_trigger": true
+  },
+  {
+    "query": "Claim forge-abc123 for me and confirm I actually hold the lease before I start editing.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a P1 bug titled 'login returns 500' and add a comment linking the repro.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now and what work is in flight?",
+    "should_trigger": false
+  },
+  {
+    "query": "Search every issue mentioning 'oauth' and list the open ones.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-xyz all the way through to a merged PR.",
+    "should_trigger": false
+  }
+]

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Bash, Read, Grep, Glob
 > **Note:** Three things share the "validate" name in Forge:
 > - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
 > - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
-> - `bun run check` (scripts/validate.sh): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
+> - `bun run check` (scripts/validate.js): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
 
 Run comprehensive validation including type checking, linting, code review, security review, and tests.
 
@@ -80,7 +80,7 @@ reflect the true state of what will be merged.
 
 ## What This Skill Does
 
-**Quick Start**: Run `bun run check` to execute the full validation pipeline (implemented in `scripts/validate.sh`). The npm script is named `check`; the workflow command is `/validate`. See individual steps below for details.
+**Quick Start**: Run `bun run check` to execute the full validation pipeline (implemented in `scripts/validate.js`). The npm script is named `check`; the workflow command is `/validate`. See individual steps below for details.
 
 ### Step 1: Type Check
 ```bash
@@ -221,7 +221,8 @@ If any check fails:
 forge create "Fix <issue-description>"
 
 # Mark current issue as blocked
-forge update <current-id> --status blocked --comment "Blocked by <new-issue-id>"
+forge update <current-id> --status blocked
+forge comment <current-id> "Blocked by <new-issue-id>"
 
 # Output what needs fixing
 ```

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: validate
-description: Runs comprehensive pre-pull-request validation for the Forge validate stage — rebases onto the base branch, then runs type checking, linting, code review, security review (OWASP Top 10), and tests, requiring fresh passing output before shipping. Use for the Forge validate stage or when asked to validate changes, run quality gates, type-check, lint, security-scan, or run the full test suite before opening a PR.
+description: >
+  Forge VALIDATE stage — the pre-pull-request quality gate. Rebases the branch onto the
+  current base branch, then runs type-checking, linting, code review, an OWASP Top 10 security
+  review plus dependency scan, and the full test suite, demanding fresh passing output in THIS
+  session before anything ships. Reach for this whenever a branch is code-complete and someone
+  says: validate my changes, run the quality gates, run the pre-PR checks, type-check and lint
+  before the PR, run the security scan, or run the full test suite before opening a PR — and
+  for the literal `/validate` command or `bun run check`. This is the gate that runs AFTER
+  code is written but BEFORE a PR exists, so discriminate carefully: it does not implement
+  features or write tests (that is `/dev`), it does not push the branch or open the PR (that
+  is `/ship`), it does not answer PR review feedback from Greptile / SonarCloud / CodeRabbit
+  (that is `/review`), and it is not the post-merge CI health check (that is `/verify`).
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/skills/validate/evals/evals.json
+++ b/skills/validate/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Branch is code-complete — run all the pre-PR checks and make sure everything's green before I ship",
+    "should_trigger": true
+  },
+  {
+    "query": "/validate",
+    "should_trigger": true
+  },
+  {
+    "query": "Rebase onto master, then type-check, lint, and run the whole test suite so I know it's clean",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the OWASP security review and full test pass on this branch before we open the PR",
+    "should_trigger": true
+  },
+  {
+    "query": "I'm at the validate stage — take my changes through the quality gates",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement the next task using TDD, red-green-refactor",
+    "should_trigger": false
+  },
+  {
+    "query": "Push this validated branch and open the pull request from the template",
+    "should_trigger": false
+  },
+  {
+    "query": "Go through the Greptile and CodeRabbit comments on my PR and resolve the threads",
+    "should_trigger": false
+  },
+  {
+    "query": "It's merged now — check CI is green on master and close the issue",
+    "should_trigger": false
+  },
+  {
+    "query": "Pull the SonarCloud issues for this PR",
+    "should_trigger": false
+  }
+]

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,6 +1,18 @@
 ---
 name: verify
-description: Post-merge health check for the Forge verify stage — confirms the merge landed on master, checks CI is clean and deployments are up, cleans up the merged worktree/branch, and closes resolved issues. Use for the Forge verify stage, or when asked to verify a PR merged correctly, confirm post-merge CI health, check deployments after merge, or validate everything is healthy after merging.
+description: >
+  Runs the Forge verify stage — the post-merge health check performed AFTER a PR has been
+  merged. Switches to master and pulls, confirms the merge actually landed (`gh pr list
+  --state merged`), checks CI is green on master after the merge, confirms any deployments are
+  up, removes the merged worktree and safe-deletes the local branch, and closes the
+  kernel/Beads issues the PR resolved (`forge close --reason=...`). Use when asked to verify a
+  merge went cleanly, confirm post-merge CI health on master, check deployments after merging,
+  clean up a merged branch or worktree, or close the issue now that its PR is merged — and
+  whenever `/verify` is invoked. This is strictly the POST-merge stage: reach for shepherd
+  instead to monitor a still-open PR toward merge, review to fix and resolve PR feedback
+  before merge, ship to push the branch and open the PR, rollback to undo an already-shipped
+  change, status to merely report the current stage without acting, and issue-basics to close
+  an issue that is unrelated to a just-merged PR.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -71,7 +71,7 @@ Check if the project has a deployment target:
 gh run list --branch master --limit 1
 
 # Check Vercel deployments for the merged PR (use number from Step 2)
-gh pr view <number> --json deployments
+gh pr view <number> --json statusCheckRollup
 ```
 
 If deployments exist:

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -41,10 +41,11 @@ Confirm the merge actually landed on master. If the PR isn't merged yet, stop an
 
 ### Step 2: Confirm PR Is Merged
 
-Detect the most recently merged PR from the current HEAD commit:
+Detect the PR that produced the current HEAD commit — scope the lookup to that
+commit's SHA so you don't pick up an unrelated newer merge:
 
 ```bash
-gh pr list --state merged --base master --limit 1 --json number,state,mergedAt,mergedBy
+gh pr list --state merged --base master --search "$(git rev-parse HEAD)" --limit 1 --json number,state,mergedAt,mergedBy
 ```
 
 - `state` should be `MERGED`

--- a/skills/verify/evals/evals.json
+++ b/skills/verify/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "The PR just merged — make sure master is still healthy",
+    "should_trigger": true
+  },
+  {
+    "query": "Confirm the auth-refresh change actually landed on master and CI passed after merge",
+    "should_trigger": true
+  },
+  {
+    "query": "/verify",
+    "should_trigger": true
+  },
+  {
+    "query": "Now that #89 is merged, close the issue it resolved and delete the feature branch",
+    "should_trigger": true
+  },
+  {
+    "query": "Did the deployment go out okay after we merged this?",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the post-merge checks and clean up the merged worktree",
+    "should_trigger": true
+  },
+  {
+    "query": "Watch my open PR and re-run the flaky required check until it can merge",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix and resolve all the Greptile and SonarCloud threads on the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Push this validated branch and open a pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "This merge broke production — revert the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow and what's in progress right now?",
+    "should_trigger": false
+  },
+  {
+    "query": "Close forge-abc, we've decided not to do it",
+    "should_trigger": false
+  }
+]


### PR DESCRIPTION
## What

Brings the **entire skill library (18 skills)** to the skill-creator standard across two axes:

### 1. Triggering (descriptions + evals)
- **Description rewrite** per skill — pushy (Claude under-triggers) and explicitly **discriminating** against sibling skills (an explicit "use X not this" NOT-block) so a query routes to exactly one skill.
- **`evals/evals.json`** per skill — realistic `should_trigger:true` queries + `should_trigger:false` **near-miss** queries drawn from sibling territory (the discrimination tests).

### 2. Body CLI-accuracy (verified corrections)
Each fix was verified against the **live `forge` CLI / source**, not the agents' first-pass claims (which had cross-skill contradictions):
- **issue-basics**: `feature` is not a canonical type (kernel types = task/bug/epic/decision); `--type` is unvalidated; epics/decisions are queue-excluded by convention, not claim-time enforcement.
- **triage-ready**: stats has no `in_progress` bucket; no `claimable` field in CLI JSON.
- **kernel**: `forge remember`/`forge recall` are live (were mislabeled "planned").
- **hermes-forge**: orient sections have no `priority` field (order via `token_budget.truncation_order`); bare `forge recap` requires an issue id.
- **plan**: `forge issue dep cycles` / `forge graph` aren't real → `forge issue blocked` / `children`.
- **validate**: `bun run check` → `scripts/validate.js`; `forge update` has no `--comment`.
- **ship/review**: `forge update --comment` → `forge comment`.
- **verify**: `gh pr view --json deployments` (invalid) → `statusCheckRollup`.
- **sonarcloud**: removed dead TS-client path reference.
- **rollback**: `Rollback:` → `chore: rollback` commit prefix.

## How it was produced & tested

A 3-stage multi-agent pass (54 agents): **audit** (verify every cited flag against live `--help`) → **adversarial verify** (independently re-check routing + accuracy) → **blind routing test** (a judge predicts fire/no-fire over the full optimized description set with the answer key hidden; scored deterministically). **All 18 skills: 100% trigger pass-rate, 0 misroutes.** Every body fix was then independently re-verified against the CLI/source before applying. `.codex` mirror regenerated (`inSync`); skill tests green.

## Deferred
The rollback skill's `bd update --status reverted` path is a Beads/kernel **migration decision**, not a doc edit — carved out as kernel issue `4109f471`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)