### PR TITLE
test(skills): add context-cost gate (description <=1024, body <=500) [Phase A #2]

### DIFF
--- a/test/skills/context-cost.test.js
+++ b/test/skills/context-cost.test.js
@@ -1,0 +1,90 @@
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// ─── skill context-cost gate (progressive-disclosure budget) ──────────────────
+//
+// A skill's description loads into EVERY session (the permanent per-skill cost),
+// and its body loads on every trigger. This gate keeps both within budget so the
+// skill library stays token-lean and descriptions are not truncated by host
+// runtimes. Phase A #2 of the 2026-07-05 efficiency strategy; pairs with the
+// description trim (#294) so descriptions cannot drift back over the cap.
+
+const repoRoot = path.resolve(__dirname, '../..');
+const skillsDir = path.join(repoRoot, 'skills');
+
+const DESCRIPTION_CHAR_CAP = 1024; // Anthropic Agent Skills spec limit (hard)
+const BODY_LINE_CAP = 500; // progressive-disclosure budget (loads on trigger)
+
+// Skills whose body still exceeds BODY_LINE_CAP, pending the Phase A3 references/
+// split. Remove each entry as A3 lands — the "allowlist stays honest" test below
+// forces removal once a skill is back within budget, so the gate tightens itself.
+const BODY_OVER_ALLOWLIST = new Set(['rollback', 'plan']);
+
+function listSkills() {
+  return fs
+    .readdirSync(skillsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')))
+    .map((e) => e.name)
+    .sort();
+}
+
+function parseSkill(name) {
+  const text = fs.readFileSync(path.join(skillsDir, name, 'SKILL.md'), 'utf8');
+  const lines = text.split(/\r?\n/);
+  if (lines[0].trim() !== '---') throw new Error(`${name}/SKILL.md: missing frontmatter`);
+  let fmEnd = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') { fmEnd = i; break; }
+  }
+  if (fmEnd === -1) throw new Error(`${name}/SKILL.md: unterminated frontmatter`);
+  const fm = lines.slice(1, fmEnd).join('\n');
+  const m = fm.match(/description:\s*([\s\S]*?)(?:\n[A-Za-z_-]+:|$)/);
+  const description = m ? m[1].replace(/^>\s*/, '').replace(/\s+/g, ' ').trim() : '';
+  const bodyLines = lines.length - (fmEnd + 1);
+  return { name, description, descLen: description.length, bodyLines };
+}
+
+describe('skill context cost', () => {
+  const skills = listSkills().map(parseSkill);
+
+  test('every skill has a non-empty description', () => {
+    const empty = skills.filter((s) => s.descLen === 0).map((s) => s.name);
+    expect(empty).toEqual([]);
+  });
+
+  test('every skill description is within the 1024-char Anthropic cap', () => {
+    const over = skills.filter((s) => s.descLen > DESCRIPTION_CHAR_CAP);
+    if (over.length) {
+      throw new Error(
+        'Skill descriptions over the 1024-char Anthropic Agent Skills cap ' +
+        '(descriptions load into every session and hosts may truncate the tail):\n' +
+        over.map((s) => `  ${s.name}: ${s.descLen} chars (~${Math.ceil(s.descLen / 4)} tok)`).join('\n')
+      );
+    }
+    expect(over).toHaveLength(0);
+  });
+
+  test('every skill body is <=500 lines (except the documented A3 backlog)', () => {
+    const over = skills.filter((s) => s.bodyLines > BODY_LINE_CAP && !BODY_OVER_ALLOWLIST.has(s.name));
+    if (over.length) {
+      throw new Error(
+        'Skill bodies over the 500-line budget (move detail into references/ per Phase A3):\n' +
+        over.map((s) => `  ${s.name}: ${s.bodyLines} lines`).join('\n')
+      );
+    }
+    expect(over).toHaveLength(0);
+  });
+
+  test('the body allowlist stays honest (drain entries as A3 shrinks bodies)', () => {
+    const stale = [...BODY_OVER_ALLOWLIST]
+      .filter((n) => skills.some((s) => s.name === n))
+      .filter((n) => skills.find((s) => s.name === n).bodyLines <= BODY_LINE_CAP);
+    if (stale.length) {
+      throw new Error(
+        `Remove from BODY_OVER_ALLOWLIST — now within the 500-line budget: ${stale.join(', ')}`
+      );
+    }
+    expect(stale).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Phase A #2 of the 2026-07-05 efficiency strategy — the CI cost-gate that pairs with the description trim (#294) so skill context cost can't drift back over budget.

## Why
A skill **description** loads into every session (the permanent per-skill cost); its **body** loads on every trigger. #292 let descriptions balloon past the 1024-char Anthropic cap unnoticed. This gate prevents recurrence.

## What
`test/skills/context-cost.test.js`:
- **HARD gate** — every description ≤1024 chars (Anthropic Agent Skills spec).
- **Body ≤500 lines**, with a documented allowlist for the two bodies still over budget (`rollback` 719, `plan` 588) that **Phase A3** will split into `references/`.
- **Self-tightening** — a "keep the allowlist honest" test fails if an allowlisted skill drops back under 500 lines, forcing its removal, so the gate ratchets down as A3 lands.

Runs on `skills/**` changes (via the paths fix from #293), so any future skill edit is checked. Passes today (4/4): all 18 descriptions ≤996, only rollback/plan over the body budget (allowlisted).

Refs kernel epic `0f3f69f4`, issue `784bc754`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)