### PR TITLE
fix(agents): drop '/check' substring from AGENTS.md that broke master CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,7 +308,7 @@ forge close <id>      # Complete work
 ## Project Learnings
 
 - **Scope discipline**: Do ONLY what was explicitly asked. Answer a question → stop. Check something → stop. Never auto-continue to next steps or pending work unless told to.
-- **Stage names**: The validation stage is `/validate` (not `/check`) — renamed in PR #50.
+- **Stage names**: The validation stage command is `/validate` — renamed in PR #50; do not use the old name.
 - **Unused params**: Prefix with `_` (e.g., `_searchTerm`) — ESLint `no-unused-vars` enforced with `--max-warnings 0`.
 - **Pre-push test env**: `test-env/` fixture tests can fail during actual `git push` due to git mid-push state. Fix the root cause — never use `LEFTHOOK=0`.
 - **Skill sync**: Canonical skills live in `skills/<name>/SKILL.md`; per-agent copies are generated from them. Never hand-edit generated agent skill copies — edit the canonical `skills/` source.


### PR DESCRIPTION
## Problem
PR #301 (CLAUDE.md→AGENTS.md consolidation) moved the "Project Learnings" note *"The validation stage is `/validate` (not `/check`)"* into AGENTS.md. `test/commands/validate.test.js:478` asserts AGENTS.md must **not** contain the substring `/check`, so **master CI went red** (Unit Shard, Full Matrix, Targeted PR Tests, Code Coverage) — which then fails every PR that rebases onto master (#300 and the in-flight orient/skills PRs).

## Fix
Reword the learning to preserve its intent (use `/validate`; it was renamed in PR #50; don't use the old name) **without the literal `/check` substring**. One-line change.

## Verify
`bun test test/commands/validate.test.js` → 23 pass / 0 fail (was 22/1). `grep -c '/check' AGENTS.md` → 0.

Unblocks master + all in-flight release-sweep PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the validation stage command name and noted that `/validate` should be used instead of the previous name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->