### PR TITLE
chore(cli): make `forge issue` the canonical issue surface (450c6e34)

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -2358,6 +2358,16 @@ async function _interactiveSetup() {
 }
 
 // Parse CLI flags
+// Issue command aliases hidden from `forge --help`: the bare passthroughs that
+// duplicate `forge issue <sub>` plus the plural `issues`. They stay registered and
+// routable (back-compat), but are omitted from help so `forge issue` reads as the
+// single canonical issue surface (kernel issue 450c6e34). The canonical `issue` is
+// deliberately NOT listed here — it stays documented.
+const ISSUE_ALIAS_COMMANDS = [
+  'create', 'update', 'claim', 'close', 'show', 'list',
+  'ready', 'blocked', 'stale', 'orphans', 'lint', 'issues',
+];
+
 function parseFlags() {
   const flags = {
     quick: false,
@@ -2382,7 +2392,8 @@ function parseFlags() {
 
   // Issue passthrough commands delegate all flags to bd.
   // Skip global parsing so flags like --type, -p, --help reach the handler intact.
-  const issuePassthroughCommands = ['create', 'update', 'claim', 'close', 'show', 'list', 'ready', 'blocked', 'stale', 'orphans', 'lint', 'issue', 'issues'];
+  // Canonical `issue` plus the hidden back-compat aliases (single source of truth).
+  const issuePassthroughCommands = [...ISSUE_ALIAS_COMMANDS, 'issue'];
   if (issuePassthroughCommands.includes(args[0])) {
     return flags;
   }
@@ -2642,8 +2653,18 @@ function showHelp() {
   console.log('  Run `forge init --help` for all profile/classification/harness flags.');
   console.log('');
 
-  // Append auto-discovered registry commands
+  // Append auto-discovered registry commands. Hidden issue aliases (the bare
+  // passthroughs + plural `issues`, plus any command self-declaring `hidden: true`)
+  // still route and execute, but are trimmed from this enumeration so `forge issue`
+  // reads as the single canonical issue surface. This registry instance is loaded
+  // solely to render help, so deleting from its Map only affects the printed list —
+  // command dispatch (main) uses a separate registry and is unaffected.
   const helpRegistry = loadCommands(path.join(__dirname, '..', 'lib', 'commands'));
+  for (const [name, cmd] of [...helpRegistry.commands]) {
+    if (ISSUE_ALIAS_COMMANDS.includes(name) || cmd.hidden === true) {
+      helpRegistry.commands.delete(name);
+    }
+  }
   const registryHelp = helpRegistry.getHelp();
   if (registryHelp) {
     console.log('Additional commands:');

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -16,7 +16,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 ## command
 
 - [ ] bin/forge.js (26)
-  - lines: 2235 (bd), 2237 (bd), 2383 (bd), 2815 (bd), 2824 (bd), 2837 (bd), 2850 (.beads), 2870 (bd), 2872 (bd), 2874 (bd), 2909 (bd), 2933 (bd), 3019 (bd), 3063 (bd), 3087 (bd), 3093 (bd), 3097 (bd), 3102 (bd), 3108 (bd), 3118 (bd), 3250 (bd), 3255 (bd), 3266 (bd), 3333 (bd), 4034 (bd), 4532 (bd)
+  - lines: 2235 (bd), 2237 (bd), 2393 (bd), 2836 (bd), 2845 (bd), 2858 (bd), 2871 (.beads), 2891 (bd), 2893 (bd), 2895 (bd), 2930 (bd), 2954 (bd), 3040 (bd), 3084 (bd), 3108 (bd), 3114 (bd), 3118 (bd), 3123 (bd), 3129 (bd), 3139 (bd), 3271 (bd), 3276 (bd), 3287 (bd), 3354 (bd), 4055 (bd), 4553 (bd)
 - [ ] lib/commands/_resolve-command-opts.js (2)
   - lines: 8 (bd), 10 (bd)
 - [ ] lib/commands/dev.js (1)

--- a/lib/commands/issues.js
+++ b/lib/commands/issues.js
@@ -26,6 +26,10 @@ module.exports = {
   name: 'issues',
   description: 'Manage issues through the Forge authority layer',
   usage: 'forge issues <subcommand> [...]',
+  // Undocumented back-compat alias for the canonical `forge issue` surface. It stays
+  // registered and executable, but `hidden: true` omits it from `forge --help` so the
+  // singular `issue` reads as the one canonical issue surface (kernel issue 450c6e34).
+  hidden: true,
   flags: {},
   handler: async (args, _flags, projectRoot, opts = {}) => {
     const [subcommand, ...rest] = normalizeArgs(args);

--- a/test/forge-cli-registry.test.js
+++ b/test/forge-cli-registry.test.js
@@ -45,6 +45,35 @@ function runForge(cliArgs, envOverrides = {}) {
   }
 }
 
+/**
+ * Parse the command names listed under the "Additional commands:" section of
+ * `forge --help`. Each registry entry is rendered as `  <name>  <description>`
+ * (two-space indent, two-or-more spaces before the description), so we match that
+ * shape rather than substring-scanning the whole banner — command names like
+ * `list` also appear in prose (e.g. `--agents <list>`).
+ *
+ * @param {string} stdout - Full `forge --help` output
+ * @returns {string[]} Command names enumerated in the section
+ */
+function parseAdditionalCommands(stdout) {
+  const idx = stdout.indexOf('Additional commands:');
+  if (idx === -1) return [];
+  return stdout
+    .slice(idx)
+    .split('\n')
+    .map(line => /^ {2}(\S+) {2,}\S/.exec(line))
+    .filter(Boolean)
+    .map(match => match[1]);
+}
+
+// Bare issue passthroughs that duplicate `forge issue <sub>`. They stay routable
+// as undocumented back-compat aliases but must NOT appear in `forge --help`, so the
+// canonical `forge issue` surface is unambiguous (kernel issue 450c6e34).
+const HIDDEN_ISSUE_ALIASES = [
+  'create', 'update', 'claim', 'close', 'show', 'list',
+  'ready', 'blocked', 'stale', 'orphans', 'lint', 'issues',
+];
+
 describe('CLI Registry Integration', () => {
   describe('registry command dispatch', () => {
     test('real stage commands load into the registry', () => {
@@ -156,6 +185,59 @@ describe('CLI Registry Integration', () => {
     test('forge --help includes "Additional commands" section', () => {
       const { stdout } = runForge(['--help']);
       expect(stdout).toContain('Additional commands');
+    });
+
+    test('forge --help documents the canonical `issue` surface', () => {
+      const { stdout } = runForge(['--help']);
+      const names = parseAdditionalCommands(stdout);
+      expect(names).toContain('issue');
+    });
+
+    test('forge --help hides the plural `issues` back-compat alias', () => {
+      const { stdout } = runForge(['--help']);
+      const names = parseAdditionalCommands(stdout);
+      expect(names).not.toContain('issues');
+    });
+
+    test('forge --help hides the bare issue passthrough aliases', () => {
+      const { stdout } = runForge(['--help']);
+      const names = parseAdditionalCommands(stdout);
+      for (const alias of HIDDEN_ISSUE_ALIASES) {
+        expect(names).not.toContain(alias);
+      }
+    });
+  });
+
+  describe('hidden issue aliases stay executable (back-compat)', () => {
+    test('hidden aliases remain routable in the registry', () => {
+      const { commands } = loadCommands(path.join(__dirname, '..', 'lib', 'commands'));
+      // Canonical surface is present AND documented; the aliases keep routing even
+      // though `forge --help` no longer enumerates them.
+      expect(commands.has('issue')).toBe(true);
+      for (const alias of HIDDEN_ISSUE_ALIASES) {
+        expect(commands.has(alias)).toBe(true);
+      }
+    });
+
+    test('the plural `issues` alias still executes', () => {
+      // No subcommand: the issues handler returns its own usage. Proves the alias
+      // dispatches rather than falling through to setup/minimal-install.
+      const { stdout, status } = runForge(['issues']);
+      expect(status).toBe(0);
+      expect(stdout).toContain('forge issues');
+      expect(stdout).not.toContain('FORGE_SETUP_REQUIRED');
+    });
+
+    test('a bare passthrough alias still executes (forge list --help)', () => {
+      // `--help` short-circuits to the subcommand usage before any backend dispatch,
+      // so this asserts routing without minting an issue. If the alias were removed
+      // from the registry it would fall through to the setup/minimal-install path.
+      const { stdout, stderr, status } = runForge(['list', '--help']);
+      const combined = stdout + stderr;
+      expect(status).toBe(0);
+      expect(combined).toContain('forge list');
+      expect(combined).not.toContain('FORGE_SETUP_REQUIRED');
+      expect(combined).not.toContain('npx forge setup');
     });
   });
 


### PR DESCRIPTION
## Summary

Consolidates the CLI issue surface for 0.1.0 (kernel issue `450c6e34`). Three overlapping ways to list/manage issues signalled no canonical surface: `forge issue` (canonical), `forge issues` (plural), and ~10 bare top-level passthroughs (`create`/`list`/`show`/…).

This is a **visibility-only, non-breaking** change: `forge issue` stays the one documented surface; the plural `issues` and the bare passthroughs are hidden from `forge --help` but remain **fully registered and executable** as undocumented back-compat aliases.

## What changed

- **`bin/forge.js`** — new module-level `ISSUE_ALIAS_COMMANDS` (single source of truth for the hidden aliases). Reused for the flag-parsing passthrough set (identical membership → behavior unchanged) and to trim hidden aliases (plus any command self-declaring `hidden: true`) from the help enumeration **only**. Command dispatch uses a separate registry instance and is untouched, so every alias still routes and executes.
- **`lib/commands/issues.js`** — self-declares `hidden: true`.
- **`test/forge-cli-registry.test.js`** — asserts (a) `forge issue` stays documented + works, (b) the plural + bare aliases are gone from `forge --help`, (c) every hidden alias still routes/executes.
- **`docs/work/.../bd-call-site-kill-list.md`** — regenerated D20 artifact (bin/forge.js line numbers shifted; **counts and tokens unchanged**, diff is line-numbers-only).

## Scope notes

- `comment` is intentionally kept visible — it is not one of the bin/forge.js bare passthroughs.
- No new `bd`/`.beads`/`dolt` tokens introduced.

## Verification

- `release check --target 0.1.0`: **PASS, 0 blockers**.
- Lint clean on changed files (`--max-warnings 0`).
- Full `bun test test/`: green except the known fresh-clone-no-beads worktree artifact (`node_modules` junction can't be created in a worktree — environmental, unrelated).

Refs kernel issue `450c6e34`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer command visibility in `forge --help`, showing the canonical `issue` command while keeping back-compat aliases available for direct use.
* **Bug Fixes**
  * Hidden issue-related aliases no longer appear in the help command list, reducing confusion and duplicate entries.
  * Existing alias commands continue to run as expected, including help output and normal command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->