### PR TITLE
fix(readme): restore Package Size badge (test-enforced, unblocks master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Tests](https://github.com/harshanandak/forge/actions/workflows/test.yml/badge.svg)](https://github.com/harshanandak/forge/actions/workflows/test.yml)
 [![ESLint](https://github.com/harshanandak/forge/actions/workflows/eslint.yml/badge.svg)](https://github.com/harshanandak/forge/actions/workflows/eslint.yml)
 [![Coverage](https://img.shields.io/badge/coverage-80%25-brightgreen.svg)](https://github.com/harshanandak/forge)
+[![Package Size](https://github.com/harshanandak/forge/actions/workflows/size-check.yml/badge.svg)](https://github.com/harshanandak/forge/actions/workflows/size-check.yml)
 [![CodeQL](https://github.com/harshanandak/forge/actions/workflows/codeql.yml/badge.svg)](https://github.com/harshanandak/forge/actions/workflows/codeql.yml)
 [![Security Policy](https://img.shields.io/badge/security-policy-blue.svg)](https://github.com/harshanandak/forge/blob/master/SECURITY.md)
 


### PR DESCRIPTION
## What & why
The #307 README rewrite dropped the **Package Size** badge. `test/workflows/size-check.test.js` (`README badge integration > README should have size badge`) asserts the README contains a size badge. Because #307 was docs-only, CI path-filtering skipped the full unit shards, so the break landed on master silently — and now surfaces on every **code** PR (#308, #309) that triggers the full shard suite.

## Fix
Restore the Package Size badge line. `bun test test/workflows/size-check.test.js` → **11 pass, 0 fail**. Zero `bd`/`.beads`/`dolt` tokens.

Unblocks master + the in-flight #308/#309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)