### PR TITLE
feat(codex): generate repo-local .agents/skills for teammate-clone discovery (55dfeccf)

### DIFF
--- a/.agents/skills/claim-safety/SKILL.md
+++ b/.agents/skills/claim-safety/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: claim-safety
+description: >
+  Claim a Forge issue and then PROVE you hold the live lease before you touch it, using `forge
+  issue owns <id>` (exit 0 iff you hold the single unexpired lease). Use this whenever winning
+  the claim matters: right after `forge claim`, before you `dev`/edit/`close`/`release` a
+  claimed issue, when two agents or a subagent fan-out contend for the same work, or before
+  any irreversible step. A claim's `ok:true` does NOT prove you won — duplicate replays return
+  it and expired leases get reclaimed; only `owns` proves it, so re-verify before
+  close/release. Trigger on "claim this issue safely", "did I actually win the lease",
+  "verify/prove ownership", "claim conflict", "two agents grabbed the same issue", "check I
+  still own it before closing", or before ANY mutation of a claimed issue. NOT for plain
+  single-issue create/update/close/comment with no ownership question (that is issue-basics),
+  and NOT for read-only selecting or ranking the next ready issue without claiming (that is
+  triage-ready).
+allowed-tools: Read, Bash(forge:*)
+---
+
+# Claim safety — claim, then prove you own the lease
+
+Claiming is not owning. The Forge kernel keys a claim's idempotency on
+`claim.create:<issue_id>:<actor>`, so a **same-key duplicate replay returns
+`ok:true`** echoing the *current* call's `claim_id`. A genuine cross-actor
+conflict returns `ok:false` (the partial-UNIQUE active-lease index guarantees one
+lease) — but `ok:true` **alone does not prove sole ownership**. A live lease can
+also be **reclaimed on expiry** (an expired lease is superseded by the next
+claimant). Therefore every worker MUST verify ownership before mutating a claimed
+issue, and RE-verify before `close`/`release`.
+
+This is a reusable, standalone procedure: any skill or agent that mutates a
+claimed issue embeds it (it is NOT folded into one orchestrator).
+
+## The verification primitive
+
+```bash
+forge issue owns <id>          # exit 0 iff YOU hold the live lease; non-zero otherwise
+forge issue owns <id> --json   # { ok:true, data:{ owned, claimed_by, expired, actor, expires_at } }
+```
+
+`owns` resolves your actor the same way the kernel does — `FORGE_ACTOR` →
+`FORGE_SESSION_ID` → default `forge` — then reports `owned:true` iff you hold the
+**single active claim** AND that lease **has not expired**. It exits `0` when you
+own it and non-zero (conflict, code 4) when you do not, with a clear "you do not
+own the lease for `<id>` (held by `<actor>`)" message. It is a strict READ — it
+never mutates kernel state. (`data.claimed_by` is lease-derived; there is no
+`claims` command.)
+
+## Procedure
+
+1. **Select** work — `forge issue ready --json` (see the `triage-ready` skill).
+   Never claim epics/decisions or defer-windowed items.
+2. **Claim** — `FORGE_ACTOR=<your-actor> forge claim <id>`. Always run under a
+   distinct actor so a losing claim reaches the conflict guard instead of
+   collapsing to a shared-actor duplicate.
+3. **Prove ownership BEFORE working** — `forge issue owns <id>`.
+   - **exit 0 (OWNED)** → the lease is yours; proceed to work.
+   - **non-zero (NOT OWNED)** → you lost the race, or your claim collapsed to a
+     foreign/duplicate-collapsed claim. Do NOT work the issue. **Reselect** via
+     `forge issue ready --json` and start over at step 1.
+4. **Work** the issue (`dev`/edit/etc.).
+5. **RE-verify before `close`/`release`** — a live lease can be reclaimed on
+   expiry while you worked. Run `forge issue owns <id>` again:
+   - **OWNED** → `forge release check --target <release-ref> --json` (release-readiness; omit `--target` to use the project default), then
+     `forge close <id> --reason "…"` or `forge release <id>`.
+   - **NOT OWNED** → the lease was reclaimed (likely expired). Do NOT close/
+     release someone else's lease; reselect and, if the work is still needed,
+     re-claim and reconcile.
+
+## Contract (what each result means)
+
+| `forge claim` result | Meaning | Action |
+|----------------------|---------|--------|
+| `ok:false` (conflict, code 4) | A live lease is held by another actor | Reselect (`ready`) |
+| `ok:true` | Provisionally yours — **not proof** (duplicate replays also return ok:true) | **Run `forge issue owns <id>`** |
+
+| `forge issue owns` | Meaning | Action |
+|--------------------|---------|--------|
+| exit 0, `owned:true` | You hold the live, unexpired lease | Work / close / release |
+| non-zero, `owned:false` | Someone else holds it, or your lease expired | Reselect; never mutate |
+
+## Fork points
+
+- **Actor source** — how `<your-actor>` is derived (`FORGE_ACTOR` explicit id →
+  `FORGE_SESSION_ID` → default `forge`). Use a distinct per-agent actor so
+  contending claims reach the conflict guard rather than collapsing to a duplicate.
+- **Expiry / lease TTL** — whether claims carry an `expires_at` and how long;
+  `owns` treats an expired lease as NOT owned (it can be reclaimed).
+- **Re-verify cadence** — verify after claim and again before `close`/`release`;
+  a longer task may re-verify more often (e.g. before each irreversible step).
+- **Reselection policy** — on NOT-OWNED, how the next item is chosen (ranking /
+  filters live in the `triage-ready` skill).
+- **Fail-closed posture** — with no usable clock/state, treat ownership as NOT
+  proven (mirror the readiness model's "no usable clock ⇒ not workable").
+
+## Reliability notes
+
+- A genuine cross-actor conflict returns `ok:false` — there is no phantom
+  `ok:true`-on-conflict. The real hazards are (a) a duplicate replay's `ok:true`
+  and (b) expiry-driven reclaim. `owns` closes both.
+- Full multi-agent safety depends on the actor-identity kernel fix (distinct
+  actors per agent, kernel `d71a824b`): without distinct actors, two agents
+  share one idempotency key and `owns` cannot tell them apart.

--- a/.agents/skills/claim-safety/evals/evals.json
+++ b/.agents/skills/claim-safety/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "I just ran forge claim on forge-abc — how do I make sure the lease is really mine before I start editing?",
+    "should_trigger": true
+  },
+  {
+    "query": "Two of my agents may have grabbed the same issue at once — how do I tell which one actually holds it?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I close this ticket, confirm nobody reclaimed it while I was working.",
+    "should_trigger": true
+  },
+  {
+    "query": "My claim came back ok:true but I'm not convinced I won the race. Can I trust that?",
+    "should_trigger": true
+  },
+  {
+    "query": "Prove I own forge-42 before the subagent starts mutating it.",
+    "should_trigger": true
+  },
+  {
+    "query": "The lease might have expired mid-task — check I still own it before I release.",
+    "should_trigger": true
+  },
+  {
+    "query": "What's the next ready issue I should pick up?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a feature issue titled 'Add CSV export'.",
+    "should_trigger": false
+  },
+  {
+    "query": "Close forge-19 with reason 'shipped in PR 88'.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-30 all the way through to a PR.",
+    "should_trigger": false
+  },
+  {
+    "query": "Implement the failing auth tests for this task.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -224,7 +224,7 @@ Do NOT mark task complete or move to next task until ALL confirmed in this sessi
 4. Run it fresh — show the actual output. "Last run was fine" is not evidence.
 5. Tests run fresh — actual output shows passing.
 6. Implementer has committed (git log shows the commit).
-7. Progress recorded on the Forge issue — `forge comment <id> "task <task-num>/<total> done: <title> (<commit-sha>, <test-count> tests, <gate-count> gates)"` ran successfully (exit code 0). If the beads-context helper is present, `bash scripts/beads-context.sh update-progress <id> <task-num> <total> "<title>" <commit-sha> <test-count> <gate-count>` may log it in structured form instead. Do NOT hard-block when the helper is absent — the Forge comment is the kernel-native record. If the recording command errors: STOP, show the error, do not proceed to the next task.
+7. Progress recorded on the Forge issue — `forge comment <id> "task <task-num>/<total> done: <title> (<commit-sha>, <test-count> tests, <gate-count> gates)"` ran successfully (exit code 0). The Forge comment is the kernel-native record. If the recording command errors: STOP, show the error, do not proceed to the next task.
 
 Forbidden phrases (these are not evidence):
 - "should pass"
@@ -288,29 +288,15 @@ Do NOT declare /dev complete until:
 ### Record stage transition
 
 ```bash
-# Confirm the issue carries design + acceptance context (helper when present; otherwise inspect the issue).
-# Only falls back to `forge issue show` when the helper is absent — a real validate failure stays visible.
-if [ -f scripts/beads-context.sh ]; then
-  bash scripts/beads-context.sh validate <id>
-else
-  forge issue show <id>
-fi
+# Confirm the issue carries design + acceptance context.
+forge issue show <id>
 
-# Record the dev→validate transition (structured helper when present; kernel-native comment otherwise).
-# The fallback comment mirrors the same envelope the helper emits (Stage:/Summary:/Decisions:/Artifacts:/Next:).
-if [ -f scripts/beads-context.sh ]; then
-  bash scripts/beads-context.sh stage-transition <id> dev validate \
-    --summary "<N tasks done, M decision gates fired>" \
-    --decisions "<key spec gaps and how they were resolved>" \
-    --artifacts "<changed source files and test files>" \
-    --next "<validation priorities — lint issues, type concerns>"
-else
-  forge comment <id> "Stage: dev complete → ready for validate
+# Record the dev→validate transition kernel-natively (Stage:/Summary:/Decisions:/Artifacts:/Next: envelope).
+forge comment <id> "Stage: dev complete → ready for validate
 Summary: <N tasks done, M decision gates fired>
 Decisions: <key spec gaps and how they were resolved>
 Artifacts: <changed source files and test files>
 Next: <validation priorities — lint issues, type concerns>"
-fi
 ```
 
 ---

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: dev
+description: >
+  Forge DEV stage — implement an already-planned /plan task list into committed, test-backed
+  code. Reads tasks.md + design.md, then drives each task through a subagent TDD loop
+  (implementer → spec-compliance reviewer → code-quality reviewer) with RED-GREEN-REFACTOR,
+  HARD-GATE evidence checks, and a spec-gap decision score. Use when a plan and task list
+  already exist and it is time to implement — triggers: "/dev", "start the dev stage", "build
+  the tasks", "implement tasks.md test-first", "run the implementer/reviewer TDD loop", "write
+  the code for the planned tasks one by one", "work through the task list with subagents".
+  Per-task coding ONLY. Do NOT use for creating the design doc or task list (that is plan),
+  for the post-build type-check/lint/security/test gate (validate), for pushing the branch or
+  opening the PR (ship), for addressing PR review feedback (review), or for orchestrating
+  several stages / taking an issue end-to-end to a merged PR (smith).
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+Implement each task from the /plan task list using a subagent-driven loop: implementer → spec compliance reviewer → code quality reviewer per task.
+
+# Dev
+
+This skill reads the task list created by `/plan` and implements each task using a three-stage subagent loop. TDD is enforced inside each implementer subagent.
+
+## Usage
+
+```bash
+/dev
+```
+
+---
+
+## Setup
+
+### Step 1: Load context
+
+```bash
+# Find task list and design doc
+ls docs/work/
+```
+
+Read:
+- **Task list**: `docs/work/YYYY-MM-DD-<slug>/tasks.md` — extract ALL task text upfront
+- **Design doc**: `docs/work/YYYY-MM-DD-<slug>/plan.md` — including ambiguity policy section
+
+### Step 2: Create decisions log
+
+Create an empty decisions log at the start of every /dev session:
+
+```bash
+# docs/work/YYYY-MM-DD-<slug>/decisions.md
+```
+
+Format for each entry:
+```
+## Decision N
+**Date**: YYYY-MM-DD
+**Task**: Task N — <title>
+**Gap**: [what the spec didn't cover]
+**Score**: [filled checklist total]
+**Route**: PROCEED / SPEC-REVIEWER / BLOCKED
+**Choice made**: [if PROCEED: what was decided and why]
+**Status**: RESOLVED / PENDING-DEVELOPER-INPUT
+```
+
+### Step 3: Pre-flight checks
+
+```
+<HARD-GATE: /dev start>
+Do NOT write any code until ALL confirmed:
+1. git branch --show-current output is NOT main or master
+2. git worktree list shows the worktree path for this feature
+3. Task list file confirmed to exist (use Read tool — do not assume)
+4. Decisions log file created
+</HARD-GATE>
+```
+
+---
+
+
+### Multi-developer conflict check (soft block)
+
+Before starting the per-task loop, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state (non-blocking)
+forge sync || true
+
+# Check for conflicts with the current Forge issue
+bash scripts/conflict-detect.sh --issue <forge-id>
+```
+
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `forge comment <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Per-Task Loop
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Per-Task Loop.
+
+---
+
+## Per-Task Loop
+
+Repeat for each task in the task list, in order:
+
+### Step A: Dispatch implementer subagent
+
+Provide the subagent with:
+- **Full task text** (copy the complete task content — do NOT send just the file path)
+- **Relevant design doc sections** for this task
+- **Recent git log** showing what has already been implemented
+
+The implementer subagent:
+1. Asks clarifying questions before writing any code
+2. Implements using RED-GREEN-REFACTOR
+3. Self-reviews for correctness
+4. Commits with a descriptive message
+
+```
+<HARD-GATE: TDD enforcement (inside implementer subagent)>
+Do NOT write any production code until:
+1. A FAILING test exists for that code
+2. The test has been run and output shows it FAILING
+3. The failure reason matches the expected missing behavior
+
+If code was written before its test: delete it. Start with the test.
+"The test would obviously fail" is not evidence. Run it and show the output.
+</HARD-GATE>
+```
+
+---
+
+### Step B: Decision gate (when implementer hits a spec gap)
+
+If the implementer encounters something not specified in the design doc, STOP and fill this checklist BEFORE deciding how to proceed:
+
+```
+Gap: [describe exactly what the spec doesn't cover]
+
+Score each dimension (0=No / 1=Possibly / 2=Yes):
+[ ] 1. Files affected beyond the current task?
+[ ] 2. Changes a function signature or public export?
+[ ] 3. Changes a shared module used by other tasks?
+[ ] 4. Changes or touches persistent data or schema?
+[ ] 5. Changes user-visible behavior not discussed in design doc?
+[ ] 6. Affects auth, permissions, or data exposure?
+[ ] 7. Hard to reverse without cascading changes to other files?
+TOTAL: ___ / 14
+
+Mandatory overrides — any of these = automatically BLOCKED:
+[ ] Security dimension (6) scored 2
+[ ] Schema migration or data model change
+[ ] Removes or changes an existing public API endpoint
+[ ] Affects a task that is already implemented and committed
+```
+
+**Score routing**:
+- **0-3**: PROCEED — make the decision, document in decisions log with full reasoning
+- **4-7**: SPEC-REVIEWER — route this decision to spec reviewer. Continue other independent tasks while waiting
+- **8+, or any mandatory override triggered**: BLOCKED — document in decisions log with Status=PENDING-DEVELOPER-INPUT. Complete all other independent tasks first. Surface to developer at /dev exit
+
+Log the decision entry before continuing.
+
+---
+
+### Step C: Spec compliance review
+
+After the implementer finishes the task, dispatch a **spec compliance reviewer** subagent.
+
+Provide:
+- Full task text (what was supposed to be implemented)
+- Relevant design doc sections
+- `git diff` for this task's commits
+
+Reviewer checks:
+- All requirements from the task text are implemented
+- Nothing extra was added beyond task scope
+- Edge cases documented in design doc are handled
+- TDD evidence: test exists, test was run failing, then passing
+
+If spec issues found: implementer fixes → re-review → repeat until ✅
+
+```
+<HARD-GATE: spec before quality>
+Do NOT dispatch code quality reviewer until spec compliance reviewer returns ✅ for this task.
+Running quality review before spec compliance is the wrong order.
+</HARD-GATE>
+```
+
+---
+
+### Step D: Code quality review
+
+After spec ✅, dispatch a **code quality reviewer** subagent.
+
+Provide:
+- git SHAs for this task's commits
+- The changed code (`git diff`)
+
+Reviewer checks:
+- Naming: clear, descriptive, consistent with codebase conventions
+- Structure: functions not too long, proper separation of concerns
+- Duplication: no copy-paste that could be extracted
+- Test coverage: tests cover happy path and at least one error path
+- No magic numbers, no commented-out code, no TODO without a Forge issue
+
+If quality issues found: implementer fixes → re-review → repeat until ✅
+
+---
+
+### Step E: Task completion
+
+```
+<HARD-GATE: task completion>
+NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.
+
+Do NOT mark task complete or move to next task until ALL confirmed in this session:
+1. Spec compliance reviewer returned ✅
+2. Code quality reviewer returned ✅
+3. Identify what command proves this task is done (e.g. `bun test`, a CLI invocation, a script run).
+4. Run it fresh — show the actual output. "Last run was fine" is not evidence.
+5. Tests run fresh — actual output shows passing.
+6. Implementer has committed (git log shows the commit).
+7. Progress recorded on the Forge issue — `forge comment <id> "task <task-num>/<total> done: <title> (<commit-sha>, <test-count> tests, <gate-count> gates)"` ran successfully (exit code 0). If the beads-context helper is present, `bash scripts/beads-context.sh update-progress <id> <task-num> <total> "<title>" <commit-sha> <test-count> <gate-count>` may log it in structured form instead. Do NOT hard-block when the helper is absent — the Forge comment is the kernel-native record. If the recording command errors: STOP, show the error, do not proceed to the next task.
+
+Forbidden phrases (these are not evidence):
+- "should pass"
+- "looks good"
+- "seems to work"
+</HARD-GATE>
+```
+
+Mark task complete. Move to next task.
+
+---
+
+## /dev Completion
+
+After all tasks are complete (or BLOCKED):
+
+### Final code review
+
+Dispatch a final code reviewer for the full implementation:
+- Overall coherence: does the feature hang together as a whole?
+- Cross-task consistency: naming, patterns, style consistent across all tasks?
+- Integration: do all the pieces connect correctly?
+
+### Surface BLOCKED decisions
+
+If any decisions have Status=PENDING-DEVELOPER-INPUT:
+
+```
+⏸️  /dev blocked — developer input needed
+
+The following decisions were deferred during implementation:
+
+Decision 1: [gap description]
+  Task: Task N — <title>
+  Score: 11/14 (mandatory override: schema change)
+  Options considered: [A] vs [B]
+  Recommendation: [A] because [reason]
+  Blocked tasks: Task 6, Task 7 (depend on this decision)
+
+Decision 2: ...
+
+Please review and respond. After decisions are resolved, the implementer
+will complete the blocked tasks and re-run spec + quality review.
+```
+
+Wait for developer input. After decisions resolved: implement blocked tasks → spec review → quality review → complete.
+
+### /dev exit gate
+
+```
+<HARD-GATE: /dev exit>
+Do NOT declare /dev complete until:
+1. All tasks are marked complete OR have BLOCKED status with PENDING-DEVELOPER-INPUT
+2. BLOCKED decisions have been surfaced to developer and are awaiting input
+3. Final code reviewer has approved (or issues fixed and re-reviewed)
+4. All decisions in decisions log have Status of RESOLVED or PENDING-DEVELOPER-INPUT
+5. No unresolved spec or quality issues remain
+</HARD-GATE>
+```
+
+### Record stage transition
+
+```bash
+# Confirm the issue carries design + acceptance context (helper when present; otherwise inspect the issue).
+# Only falls back to `forge issue show` when the helper is absent — a real validate failure stays visible.
+if [ -f scripts/beads-context.sh ]; then
+  bash scripts/beads-context.sh validate <id>
+else
+  forge issue show <id>
+fi
+
+# Record the dev→validate transition (structured helper when present; kernel-native comment otherwise).
+# The fallback comment mirrors the same envelope the helper emits (Stage:/Summary:/Decisions:/Artifacts:/Next:).
+if [ -f scripts/beads-context.sh ]; then
+  bash scripts/beads-context.sh stage-transition <id> dev validate \
+    --summary "<N tasks done, M decision gates fired>" \
+    --decisions "<key spec gaps and how they were resolved>" \
+    --artifacts "<changed source files and test files>" \
+    --next "<validation priorities — lint issues, type concerns>"
+else
+  forge comment <id> "Stage: dev complete → ready for validate
+Summary: <N tasks done, M decision gates fired>
+Decisions: <key spec gaps and how they were resolved>
+Artifacts: <changed source files and test files>
+Next: <validation priorities — lint issues, type concerns>"
+fi
+```
+
+---
+
+## Decision Gate Calibration
+
+The frequency of decision gates is a **plan quality metric**:
+- **0 gates fired**: Excellent — Phase 1 Q&A covered all cases
+- **1-2 gates fired**: Good — minor gaps, normal
+- **3-5 gates fired**: Plan was incomplete — note for Phase 1 improvement next feature
+- **5+ gates fired**: Phase 1 Q&A was insufficient — the ambiguity policy field needed to be more specific
+
+Document the gate count in the final commit message.
+
+---
+
+## Dynamic Output
+
+The completion summary is generated from the live task list, decisions log, Forge issue state, commits, and validation output at runtime. Do not copy a static example into this skill file; run `/dev` to view the current task/status summary.
+
+## Integration with Workflow
+
+```
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /dev       -> Implement each task with subagent-driven TDD (you are here)
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Pre-merge gate: doc updates + CI-green checkpoint embedded in /ship and /review (not a separate stage).
+```
+
+## Tips
+
+- **Send full task text to subagents**: Never send the file path — copy the complete task text directly into the subagent prompt
+- **TDD lives inside the implementer**: The implementer subagent is responsible for RED-GREEN-REFACTOR, not the orchestrating /dev session
+- **Spec before quality — always**: A task that passes quality review but fails spec compliance has still failed
+- **Decision gates are rare with a good plan**: If gates fire frequently, the Phase 1 Q&A needs more depth next time
+- **BLOCKED ≠ failed**: Surfacing a blocked decision with documentation and a recommendation is the correct behavior

--- a/.agents/skills/dev/evals/evals.json
+++ b/.agents/skills/dev/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "/dev",
+    "should_trigger": true
+  },
+  {
+    "query": "The plan and task list are done — start implementing the tasks one at a time, tests first.",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the implementer then the spec and quality reviewer subagents over each task in tasks.md",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement the already-planned tasks one at a time, red-green-refactor each",
+    "should_trigger": true
+  },
+  {
+    "query": "Time to write the code for the planned tasks and TDD each one in this worktree",
+    "should_trigger": true
+  },
+  {
+    "query": "Work through tasks.md subagent by subagent until every task is committed and reviewed",
+    "should_trigger": true
+  },
+  {
+    "query": "Set up the branch, worktree, and TDD task list for this new feature",
+    "should_trigger": false
+  },
+  {
+    "query": "Type-check, lint, and run the full test suite before I open the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Push the validated branch and open the pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR has open review threads from the bots — fix each finding, reply, and mark them resolved.",
+    "should_trigger": false
+  },
+  {
+    "query": "Grab the next ready issue and drive it all the way to a merged PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Which workflow stage am I on and what work is in flight right now?",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/hermes-forge/SKILL.md
+++ b/.agents/skills/hermes-forge/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: hermes-forge
+description: >
+  Hermes⇄Forge boundary: Hermes CONSUMES Forge state, never a second source of truth. Use
+  whenever a Hermes session runs on a Forge repo: at session start, before acting on an issue,
+  or when you need CURRENT state. Read state ONLY via `forge orient` / `forge recap
+  <issue-id>` (bounded JSON envelope), citing each source's `path`/`authority`; never
+  reconstruct it from raw stores or kernel internals. Writeback ONLY via `forge
+  comment`/`update`/`create`; NEVER leak Hermes profile or session memory into Forge state.
+  Triggers: "orient me / current project state", "where did this fact come from, cite it",
+  "orient came back truncated", "persist a decision into Forge", "safe to store in kernel
+  state?". NOT the Forge session router over stage skills (kernel), NOT the human "what stage
+  am I in" report (status), NOT everyday issue create/update/close/search CRUD (issue-basics),
+  NOT ranking the next ready issue (triage-ready), NOT live PR monitoring (shepherd—outside
+  Hermes, unseen by orient).
+compatibility: >
+  Requires the Forge CLI (`forge`) on PATH in a Forge-initialized repo. Install
+  path — like every Forge skill pack (e.g. parallel-deep-research,
+  sonarcloud-analysis) this is delivered by the unified Skills CLI; run
+  `skills sync` to install it into `.hermes/skills/hermes-forge/`. (`forge setup`
+  initializes the skills registry via `skills init` but does not sync packs to
+  agents.) Read-only orientation works anywhere; writeback requires a Forge
+  Kernel issue backend. CLI-only — no direct file or profile writes into Forge
+  state.
+metadata:
+  author: forge
+  version: "1.0.0"
+  roadmap: forge-2agy.9.7.x
+---
+
+# Hermes ⇄ Forge consumption contract
+
+Hermes is a *consumer* of Forge project state, not an owner of it. This skill
+defines how a Hermes session reads, cites, and writes back to a Forge project
+without ever becoming a second source of truth.
+
+The boundary between what Forge owns and what Hermes owns is specified in the
+Forge repo at `docs/reference/HERMES_INTEGRATION.md` (repo-relative path — this
+skill is synced to `.hermes/skills/hermes-forge/`, so relative links would not
+resolve from the installed location).
+
+## When to use
+
+- At the start of any Hermes session on a Forge repo (orientation).
+- Before acting on a specific issue (issue recap).
+- Whenever you need current project state — never reconstruct it from raw files.
+
+## Authority: orient / recap are the only state source
+
+The Forge Kernel is the single source of truth. Hermes obtains project state
+**exclusively** through two thin CLI wrappers and must not infer state by
+reading raw issue stores, design files, or kernel internals directly:
+
+```bash
+forge orient --json                # bounded project orientation (envelope)
+forge orient --budget 4000 --json
+forge recap <issue-id> --json      # bounded per-issue recap (envelope)
+```
+
+`forge orient` and `forge recap <issue-id>` emit the deterministic JSON envelope
+described below (assembly `deterministic-file-assembly-v1`). Parse the JSON; do
+not screen-scrape the human text form.
+
+> Note: `forge recap` always requires an issue id — bare `forge recap --json`
+> (no id) prints its usage and exits non-zero rather than returning a summary.
+> Use `forge orient` for project-level orientation, or `forge recap <issue-id>`
+> for a single issue; both emit the deterministic envelope.
+
+### Envelope shape
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Contract version (currently `1`). Reject unknown majors. |
+| `kind` | `orientation`, `issue_recap`, or `prime`. |
+| `generated_at` | Assembly timestamp. |
+| `assembly` | `deterministic-file-assembly-v1` — same inputs ⇒ same output. |
+| `token_budget` | Budget accounting (see below). |
+| `sections[]` | Ordered content blocks, each independently cited. |
+| `sources[]` | Deduplicated provenance across all sections. |
+| `next_commands[]` | Suggested follow-up `forge` commands. Prefer these for navigation. |
+
+Each `sections[]` entry: `{ id, title, content, sources, truncated, estimated_tokens }`.
+
+## Token budget
+
+`forge orient` / `forge recap <issue-id>` are bounded so they fit a context
+window deterministically.
+
+- Default budget: **2000** estimated tokens. Minimum honored: **40**.
+- Estimation is approximate: `token_budget.approximate === true`,
+  `token_budget.chars_per_token === 4`.
+- `token_budget.requested` is what you asked for; `token_budget.used` is the
+  estimate actually emitted.
+- Raise the ceiling with `--budget N` when you need more depth; do not retry
+  blindly — request a specific larger budget.
+
+## Citation & provenance model
+
+Every fact Hermes surfaces to a user MUST be attributable. Each section carries
+`sources: [{ path, source_kind, authority, role }]`:
+
+- `path` — the file the content came from.
+- `source_kind` — the kind of artifact (e.g. design, decision, claim, queue).
+- `authority` — how authoritative the source is. Prefer higher-authority
+  sources when two sources conflict; surface the conflict rather than silently
+  picking one.
+- `role` — the role the source plays in the section.
+
+When Hermes states a project fact, cite at least the `path` and `authority` of
+the backing source. The top-level `sources[]` is the deduplicated set for the
+whole payload.
+
+## Truncation policy
+
+Truncation is deterministic, never random:
+
+- Non-preserved sections are trimmed in the order given by
+  `token_budget.truncation_order`; when the budget is exhausted, sections later
+  in that order are trimmed first. Preserved sections are kept whole and trimmed
+  only as a last resort if the payload is still over budget. The authoritative
+  per-section signal is each section's `truncated` flag and `estimated_tokens` —
+  there is no per-section `priority` field; the overall trim order is
+  `token_budget.truncation_order`.
+- A trimmed section ends with the literal marker
+  `[truncated deterministically by token budget]` and has `truncated: true`.
+- `token_budget.truncated === true` means the payload as a whole was trimmed.
+
+Treat any `truncated` section as **incomplete**. Do not present a truncated
+section as exhaustive; if completeness matters, re-request with a higher
+`--budget` or recap the specific issue.
+
+## Writeback path: Hermes → Forge Kernel
+
+Evidence and decisions discovered during a Hermes session flow back into the
+Forge Kernel **only** through Forge CLI commands. Use the issue command surface
+documented in the Forge repo at
+`docs/reference/forge-kernel-issue-command-contract.md`:
+
+```bash
+forge comment <id> <body...>   # attach evidence, a decision, or a note to an issue
+forge update <id...> [flags]   # update issue state/fields
+forge create [title] [flags]   # open a new issue for follow-up work
+```
+
+> Note: `forge audit` is verify-only (`forge audit verify`) and does **not**
+> append evidence — record evidence as an issue comment via `forge comment`.
+
+These writes land in the Forge Kernel issue store, where they become part of the
+issue's durable history (view them via the issue itself, e.g. `forge show <id>`).
+Note the read/write asymmetry: the bounded `forge orient` / `forge recap`
+envelope is assembled from project docs, `docs/work` artifacts, and the issue
+summary — it surfaces issue/design/decision state but does **not** echo
+individual issue comments back. Do not assume evidence added via `forge comment`
+reappears verbatim in the next orient/recap payload; it lives in the issue
+history, reachable from the issue record.
+
+## No-profile-write guard (hard boundary)
+
+Hermes **MUST NOT write Hermes profile** state, conversation memory, or any
+Hermes-native artifact into Forge Kernel state — not into kernel storage, not
+into design/decision files, not into the issue backend. Hermes-native memory
+stays in Hermes' own store.
+
+- ✅ Read state via `forge orient` / `forge recap`.
+- ✅ Write evidence/decisions via `forge comment` / `forge update`.
+- ❌ Never persist Hermes profile/session memory into Forge Kernel state.
+- ❌ Never edit Forge state files directly to record Hermes-side context.
+
+If a piece of context only matters to Hermes, it belongs in Hermes-native
+memory. If it is a project fact, decision, or evidence item, write it through
+the Forge CLI so it becomes part of the shared, cited source of truth.
+
+## PR shepherd (external scheduler, not orientation)
+
+The PR shepherd runs **outside** Hermes. An external scheduler invokes
+`forge shepherd <pr>` as discrete bounded passes — each pass reads CI/check
+state, takes at most one idempotent action (re-run a flaky required check), or
+escalates, then exits. It **never merges** (the human merges in the GitHub UI)
+and **never resolves review threads**.
+
+Hermes does not run the shepherd and does not learn shepherd progress through
+`forge orient` (which is deterministic-source orientation with no live PR
+awareness). Shepherd progress is durable on the **PR itself** — its comments and
+labels. When a Hermes session needs PR/CI status, read the PR directly; do not
+expect `orient` to carry it.

--- a/.agents/skills/hermes-forge/evals/evals.json
+++ b/.agents/skills/hermes-forge/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "I just started a Hermes session on this Forge repo — get me oriented on where the project stands before I touch anything.",
+    "should_trigger": true
+  },
+  {
+    "query": "The forge orient envelope came back with the active-work section flagged truncated. Can I treat that as the full list, or do I need to pull more?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I tell the user which approach we settled on, I need to point at the exact source file and how authoritative it is — where does that decision come from?",
+    "should_trigger": true
+  },
+  {
+    "query": "I uncovered a design decision in this session that the team needs to keep. What's the correct way to write it back into Forge without dragging my Hermes notes into kernel state?",
+    "should_trigger": true
+  },
+  {
+    "query": "Default orientation is clipping the decisions section at 2000 tokens — give me more headroom.",
+    "should_trigger": true
+  },
+  {
+    "query": "Don't rebuild the project picture by grepping the design docs yourself — go through the proper bounded orient/recap surface instead.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which workflow stage am I sitting in right now, and has any of my work gone stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "I'm kicking off a Forge session in Claude — which stage skill do I run to start planning a new feature?",
+    "should_trigger": false
+  },
+  {
+    "query": "Watch PR #418, rerun the flaky required check if it trips, and ping me when it's ready to merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "Open a bug issue for the checkout timeout, set priority 1, and add a note about the repro steps.",
+    "should_trigger": false
+  },
+  {
+    "query": "What's the highest-priority ready issue I should pick up next?",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/issue-basics/SKILL.md
+++ b/.agents/skills/issue-basics/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: issue-basics
+description: >
+  Everyday single-issue CRUD over the `forge issue` verbs:
+  create/update/show/list/search/close/reopen/comment, set priority/labels/assignee, claim or
+  release one issue, add/remove dependency edges, plus backlog `stats`. Use for ANY routine
+  one-off issue op: "create an issue/bug/task for X", "update/edit issue <id>", "close or
+  reopen this issue", "comment a handoff note on <id>", "list/filter open bugs by
+  status/label/priority", "bump this to P1", "reassign to alice", "mark <id> blocked by <id>".
+  Also the parity floor migrating off a Beads-style tracker (label/reopen/delete map to forge
+  equivalents). Single-operation plumbing only. Does NOT choose, rank, or explain the next
+  issue to work on or why it's blocked (use triage-ready); does NOT run
+  claim-then-prove-lease-ownership safety (use claim-safety); does NOT drive an issue through
+  the plan->dev->validate->ship pipeline or open a PR (use smith or stage skills); does NOT
+  report the current stage or what's in flight (use status).
+allowed-tools: Read, Bash(forge:*)
+---
+
+# Issue basics — the CRUD floor
+
+Everyday issue operations over the Forge kernel. Every command here is a real
+`forge issue` verb (confirm with `forge issue --help`). The kernel is the single
+source of truth — never hand-edit the issue store.
+
+Every `--json` reply is the same envelope: `{ ok, schema_version, command, data,
+next_commands }` on success, or `{ ok:false, error:{ message, exit_code } }` on
+failure. **Gate on `ok`** — do not parse `data` until you confirm `ok:true`.
+
+## The core loop
+
+| Need | Command |
+|------|---------|
+| Create an issue | `forge issue create --title "…" --type <task\|bug\|epic\|decision>` |
+| Inspect one issue | `forge issue show <id> [--json]` |
+| List / filter issues | `forge issue list [--status … --type … --priority … --label …] [--json]` |
+| Full-text search | `forge issue search "…" [--json]` |
+| Backlog counts | `forge issue stats [--json]` |
+| Claim work (DB-enforced lease) | `forge issue claim <id>` |
+| Release a claim | `forge issue release <id>` |
+| Update fields | `forge issue update <id> [flags]` |
+| Add a handoff note | `forge issue comment <id> "…"` |
+| Close (one or many) | `forge issue close <id...> --reason "…"` |
+| Dependencies | `forge issue dep add\|remove <id> <blocks-id>` |
+
+## Create — the flags that matter
+
+```bash
+forge issue create --title "Add rate limiting" --type task \
+  --priority P1 --label "feature,api,security" --assignee alice \
+  --acceptance "429 returned after N req/min; covered by a test"
+```
+
+| Flag | Meaning | Default |
+|------|---------|---------|
+| `--title "…"` | Human title (a bare leading positional also works) | minted id |
+| `--type <…>` | `task` · `bug` · `epic` · `decision` | `task` |
+| `--priority <…>` | `P0`..`P4` (or bare `0`..`4`); `P0` is highest | unset |
+| `--label "a,b"` | Comma-separated set — one flag, split on `,` (repeats do NOT accumulate) | none |
+| `--body "…"` | Long description (`--description` is an accepted alias) | empty |
+| `--assignee <who>` | Persistent assignee | unset |
+| `--acceptance "…"` | Acceptance criteria (`--design`, `--notes` also persist) | unset |
+| `--parent <id>` | Parent/epic id | none |
+
+`--status` defaults to `open`. Status vocabulary: `open` · `in_progress` ·
+`review` · `done` · `cancelled`. Unlike `--priority` and `--status` (which reject
+unknown values), `--type` is stored verbatim — a non-canonical value like
+`feature` is accepted without error but carries no kernel behaviour, so stick to
+the four canonical types. Epics and decisions are excluded from the ready queue
+(non-claimability is a queue convention, not enforcement — `forge issue claim`
+currently returns `ok:true` on them too).
+
+## Update — same field flags, plus close
+
+`forge issue update <id>` takes `--status`, `--title`, `--body`/`--description`,
+`--priority`, `--label` (reparents the whole set), `--parent`, `--assignee`,
+`--acceptance`, `--design`, `--notes`. `forge issue close <id> --reason "…"`
+records the reason on the close event and accepts multiple ids in one call.
+
+## Migrating from a Beads-style tracker — verb disposition
+
+Nothing you relied on silently disappears; a few verbs map onto a `forge` flag or
+are intentionally unsupported:
+
+| Old verb | Forge equivalent |
+|----------|------------------|
+| `label` (add/remove) | **No subcommand** — pass the full set via `--label "a,b"` on `create`/`update` (last-value-wins). |
+| `reopen` | `forge issue update <id> --status open`. |
+| `delete` | **Unsupported by design** — the kernel is append-only/event-sourced. Use `forge issue close <id> --reason "…"` instead. |
+
+## Reliability
+
+- **Check `ok` before trusting output.** On `ok:false`, read `error.message` and
+  fix the input rather than retrying blindly.
+- **Claim before you mutate shared work.** `forge issue claim <id>` takes a
+  DB-enforced lease; hand off to the `claim-safety` procedure before acting on a
+  claimed issue you intend to change. `forge issue release <id>` if you abandon it.
+- **Record decisions as comments, not memory.** `forge issue comment <id> "…"`
+  survives the session; scratch notes do not.
+
+## Fork points
+
+Editable conventions — set these once for your team and this skill enforces them.
+It is a canonical source you fork, not a fixed policy.
+
+| Knob | Default | How to change |
+|------|---------|---------------|
+| **Default type** | `task` (kernel default) | Decide your create convention — e.g. always pass `--label feature` for user-facing work (feature is a label, not a canonical type), `--type bug` for regressions. |
+| **Default priority** | unset | Adopt a house scale (e.g. new work opens at `P2`, incidents at `P0`) and always pass `--priority`. |
+| **Fields required on create** | `--title` only | Require `--acceptance` (and `--label`/`--assignee`) on every create so issues are actionable from birth. |
+| **Id / reference convention** | kernel-minted ids | Standardize how you cite issues in commits/PRs (e.g. `Closes <id>`) and whether you pass an explicit `--id`. |
+| **Label taxonomy** | free-form | Pin an allowed label set your team agrees on and pass it consistently via `--label "a,b"`. |

--- a/.agents/skills/issue-basics/evals/evals.json
+++ b/.agents/skills/issue-basics/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "Open a bug ticket for the checkout 500 error and mark it P0",
+    "should_trigger": true
+  },
+  {
+    "query": "Add a note to forge-abc123 documenting why we chose JWT",
+    "should_trigger": true
+  },
+  {
+    "query": "Show me all open issues tagged backend",
+    "should_trigger": true
+  },
+  {
+    "query": "Reopen forge-77, it wasn't actually fixed",
+    "should_trigger": true
+  },
+  {
+    "query": "Add a dependency so forge-12 is blocked by forge-9",
+    "should_trigger": true
+  },
+  {
+    "query": "Claim forge-abc so I can start on it",
+    "should_trigger": true
+  },
+  {
+    "query": "What's the next ready issue I should pick up?",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain why forge-55 is still blocked and what to unblock first",
+    "should_trigger": false
+  },
+  {
+    "query": "Claim this issue and confirm I hold the lease before I change anything",
+    "should_trigger": false
+  },
+  {
+    "query": "Drive forge-30 all the way through to a merged PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now and what's in flight?",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/kernel/SKILL.md
+++ b/.agents/skills/kernel/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: kernel
+description: >
+  Forge kernel — umbrella index/router for a Forge project. Reach for this FIRST when
+  orienting rather than executing: at session start, when you need the map of how the system
+  fits together, or when unsure WHICH skill or `forge` verb a task belongs to. It indexes
+  `smith` (end-to-end orchestrator), the stage ladder (plan → dev → validate → ship → review →
+  verify), the utility/issue skills, and the day-to-day `forge` CLI verbs. Trigger on "how
+  does the Forge workflow work", "which forge command or skill for X", "I'm new here, how is
+  Forge set up", or "should this be a Forge issue or a TodoWrite". Index layer only — hand off
+  the doing: rank/pick the next ready issue → `triage-ready`; current stage / "where am I" /
+  active or stale work → `status`; create/update/close/search one issue → `issue-basics`;
+  claim-then-prove ownership before mutating → `claim-safety`; drive one issue from plan to a
+  merged PR under gates → `smith`; token-bounded state for the Hermes harness →
+  `hermes-forge`.
+allowed-tools: Read, Bash(forge:*)
+---
+
+# Forge kernel surface
+
+Forge is a TDD-first workflow harness. The agent-facing surface is **skills + the
+`forge` CLI** — there are no slash-command files. This umbrella skill is the
+entry point: it tells you which stage skill to use and which `forge` verb runs
+each day-to-day operation. Every skill is a thin guide over a real `forge`
+command; the CLI remains the implementation, the skills are the surface.
+
+## Stage skills (the TDD ladder)
+
+The default workflow is a configurable ladder of per-stage skills. Use the whole
+flow when it fits, or invoke an individual stage when the active plan permits a
+smaller path.
+
+| Stage | Skill | Purpose |
+|-------|-------|---------|
+| utility | `status` | Check current context, active work, recent completions |
+| 1 | `plan` | Design intent → research → branch + worktree + task list |
+| 2 | `dev` | Subagent-driven TDD per task (implementer → spec → quality review) |
+| 3 | `validate` | Type check, lint, code review, security, tests — all fresh output |
+| 4 | `ship` | Push branch and open the PR with design-doc reference |
+| 5 | `review` | Address ALL PR feedback (GitHub Actions, Greptile, SonarCloud) |
+| 6 | `verify` | Post-merge health check (CI on main, close issues) |
+
+**Pre-merge gate** (not a numbered stage): before merge, finish the doc updates on
+the feature branch and confirm CI is green, then hand off the PR for manual merge.
+The gate is embedded in `ship` and `review` — it is not a standalone skill.
+
+Utility skills outside the linear ladder: `research` (deep web research),
+`rollback` (safe revert operations), `sonarcloud` (code-quality queries),
+`shepherd` (cross-harness PR monitoring).
+
+Procedure skills (reusable operations any stage/agent embeds): `claim-safety`
+(claim an issue and PROVE you own the lease via `forge issue owns <id>` before
+mutating it — a claim returning ok:true does not by itself prove ownership).
+
+```
+status → plan → dev → validate → ship → review → verify
+```
+
+## Orchestrator super-skill
+
+`smith` is the flagship: a thin orchestrator that COMPOSES the skills above into
+the right path for a piece of work — pick (`triage-ready`) → claim
+(`claim-safety`) → `plan` → `dev` → `validate` → `ship` → `review` → `verify` —
+driving autonomously between human gates and pausing AT them. The human gates are
+durable kernel EVENTS (`forge gate check|approve|reject|status <issue> <gate>`;
+gates `gate.intent` · `gate.plan-approval` · `gate.merge`), so a gated run is
+resume-safe across compaction. During planning `smith` calibrates how many gates
+the work needs from its size × importance × complexity and proposes that tier at
+the intent gate (the human confirms or overrides). Reach for `smith` to run a
+whole issue end to end under human control; invoke an individual stage skill to
+run a single step.
+
+## Kernel-native skills
+
+Read-and-repair skills that work directly against the kernel's issue store. They
+complement the ladder: reach for them to decide *what* to do and to run the
+everyday issue operations, then route into a stage skill to execute.
+
+| Skill | Purpose |
+|-------|---------|
+| `triage-ready` | Read-only "what should I work on" — ranks and *explains* the ready queue via `forge issue ready` / `blocked` / `stats` (never `board`), then hands off the pick. |
+| `issue-basics` | The everyday CRUD floor — create/update/claim/release/comment/close/show/list/search/stats over the `forge issue` verbs, plus the label/reopen/delete disposition for teams migrating in. |
+
+## Day-to-day verbs (the `forge` CLI)
+
+The kernel verbs are the operations you reach for inside any stage — find work,
+claim it, fix in place, query the board, orient. They are grouped in four
+families. Run them through Bash; never hand-edit the issue store.
+
+### A — Issue lifecycle (the core loop)
+
+| Need | Command |
+|------|---------|
+| Find ready work | `forge ready [--json]` |
+| Inspect an issue | `forge show <id> [--json]` |
+| List / filter issues | `forge list [--status …] [--json]` |
+| Create an issue | `forge create --title "…" --type <feature\|bug\|task>` |
+| Claim work (DB-enforced lease) | `forge claim <id>` |
+| Prove you own the lease | `forge issue owns <id>` — exit 0 iff you hold the live lease (see the `claim-safety` skill) |
+| Release a claim | `forge release <id>` |
+| Update fields | `forge update <id> --priority <n>` (etc.) |
+| Add a handoff comment | `forge comment <id> "…"` |
+| Close an issue | `forge close <id> --reason "…"` |
+| Dependencies | `forge issue dep add\|remove <id> <id>` |
+| Search / stats | `forge issue search "…"` · `forge issue stats` |
+| Blocked work | `forge blocked` |
+
+### B — Memory / knowledge
+
+`forge remember <note> [--tag <label>]... [--json]` and `forge recall` are live —
+they persist and retrieve project-memory notes from a file-backed store. Only
+`forge knowledge search` is not on the CLI yet; until it lands, capture durable
+decisions as `forge remember` notes or issue comments (`forge comment`).
+
+### C — Board / planning / admin
+
+| Need | Command |
+|------|---------|
+| Team board | `forge board [--json]` |
+| Export the issue projection | `forge export [--import]` |
+| Release-readiness gate | `forge release check --target <ref>` |
+| Sync team state | `forge sync` |
+
+### D — Orientation / session
+
+| Need | Command |
+|------|---------|
+| Prime a session | `forge prime [--json]` |
+| Full orientation | `forge orient [--json]` |
+| Recap an issue / context | `forge recap [<id>] [--json]` |
+
+## Forge issues vs. TodoWrite — decision table
+
+| Situation | Use |
+|-----------|-----|
+| Work spans sessions, has blockers, or needs recovery after compaction | **Forge issues** (`forge create`/`claim`/`close`) |
+| Cross-agent or cross-worktree coordination | **Forge issues** (DB-enforced leases) |
+| Durable decisions, design rationale, handoff notes | **Forge issue comments** |
+| Ephemeral, single-session checklist for the current task | **TodoWrite** |
+| Steps you will finish and discard within this turn | **TodoWrite** |
+
+When in doubt, prefer a Forge issue: it survives the session and is visible to
+the team. TodoWrite is for scratch tracking only.
+
+## Session protocol
+
+1. **Orient first.** Start with the `status` skill (or `forge prime` /
+   `forge orient`) — never reconstruct project state from raw files.
+2. **Claim before you build — then prove it.** `forge claim <id>` takes the lease;
+   one issue at a time. A claim's ok:true does not by itself prove ownership, so
+   confirm with `forge issue owns <id>` before working and again before
+   `close`/`release` (the `claim-safety` skill). `forge release <id>` if you abandon it.
+3. **Work the ladder.** `plan` → `dev` → `validate` → `ship` → `review` →
+   `verify`, skipping stages only when the plan allows. The pre-merge doc gate
+   runs inside `ship` and `review` before merge — it is not a separate stage.
+4. **Record evidence as you go.** Progress and decisions go to
+   `forge comment <id> "…"`, not to memory.
+5. **Hand off cleanly.** Close completed issues (`forge close <id> --reason …`)
+   and `forge sync` so the team sees the result.
+
+## Core principles
+
+- **TDD-first** — write tests before implementation (RED → GREEN → REFACTOR).
+- **Research-first** — understand before building; document decisions.
+- **Security built-in** — OWASP Top 10 analysis for every feature.
+- **Documentation progressive** — update at each stage, verify at the end.

--- a/.agents/skills/kernel/evals/evals.json
+++ b/.agents/skills/kernel/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "I just cloned this Forge repo and I'm not sure how any of it works — give me the lay of the land: what's the workflow, what skills exist, and where do I even start?",
+    "should_trigger": true
+  },
+  {
+    "query": "There are a bunch of forge skills and I can't tell which one to use for what — lay out how they fit together and when I'd reach for each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which forge CLI command adds a dependency between two issues, and what's the verb for proving I hold a claim? Just the reference, don't run anything.",
+    "should_trigger": true
+  },
+  {
+    "query": "Is this small cleanup worth filing as a Forge issue, or should I just throw it on a TodoWrite checklist for this session?",
+    "should_trigger": true
+  },
+  {
+    "query": "Walk me through the Forge stage ladder from planning to post-merge verify and what each stage owns.",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me the reference of all the day-to-day forge issue and board verbs — I want the index, not to execute a command yet.",
+    "should_trigger": true
+  },
+  {
+    "query": "What should I pick up next? Rank the ready queue and tell me the top unblocked issue and why.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now, what's my active work, and has anything gone stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a bug issue titled 'login times out after 30s', priority 1, and link it under the auth epic.",
+    "should_trigger": false
+  },
+  {
+    "query": "Claim forge-4h9 for me and confirm I actually hold the lease before I start editing.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-7c2 all the way from planning through a merged PR, pausing for my approval at the plan and the merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "In the Hermes harness, give me the token-bounded project state to work from — treat forge orient as the source of truth.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/memory/SKILL.md
+++ b/.agents/skills/memory/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: memory
+description: >
+  Capture and retrieve durable project memory the right way -- and, when the graph
+  backend is enabled, use temporal knowledge-graph memory. Reach for this whenever
+  you are about to write down a lasting fact, decision, convention, or gotcha ("remember
+  that...", "note for later", "save this"), or when you need to recall what was learned
+  before ("what did we decide about X", "have we seen this"). It explains WHEN to use
+  `forge remember` / `forge recall` versus a per-issue `forge issue comment`, how the
+  two public backends work (local JSONL default, opt-in Graphiti; kernel is internal-only),
+  and -- when Graphiti is enabled -- how to add episodes and search facts via the graphiti-memory MCP tools
+  (add_memory, search_memory_facts, search_nodes) with group_id scoping and provenance.
+  The local backend is always the offline floor. Not for: issue create/list/close ops
+  (issue-basics), workflow status (status), or transient scratch notes.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Memory
+
+Durable project memory for agents. This skill teaches you where a fact belongs,
+which backend is active, and how to use graph memory when it is enabled.
+
+## The one rule
+
+Persistent, project-level knowledge goes to **`forge remember`** — never to a
+`MEMORY.md` file, never to a scratch note that dies with the session. Retrieve it
+with **`forge recall`**. Both verbs route through one backend router; the default
+is a local file store, so they always work offline with zero setup.
+
+## When to use what
+
+- **`forge remember "<note>"`** — a lasting fact that outlives this issue: a
+  convention, a decision and its rationale, a non-obvious gotcha, an environment
+  quirk, a "we tried X, it failed because Y". Add `--tag <label>` for retrieval.
+- **`forge recall "<query>"`** — before assuming, check what is already known.
+  Search first; do not re-derive knowledge the project already recorded.
+- **`forge issue comment <id> "<note>"`** — progress or context that belongs to
+  ONE issue's lifecycle (status, a blocker, a hand-off). Issue-scoped, not global.
+- **Rule of thumb:** would a future session on a *different* issue want this? →
+  `remember`. Is it only meaningful inside this issue? → `issue comment`.
+
+## Backends (config: `memory.backend` in `.forge/config.yaml`)
+
+The router picks a backend; `remember`/`recall` behave the same from your side.
+The public backends are exactly two:
+
+- **`local`** (DEFAULT) — flat JSONL at `.forge/memory/notes.jsonl`. Instant,
+  offline, no dependencies, travels with the repo in git. This is the floor and
+  is always available.
+- **`graphiti`** — opt-in temporal **knowledge graph** served to agents over MCP.
+  Richer recall (relational, temporal, provenance-tracked) but needs a graph DB
+  and an LLM. See "Graph memory" below. When selected, the CLI still writes to
+  the local store as a safety floor; the graph is consumed by agents via MCP.
+
+Check the active backend with `forge doctor` — it reports the memory backend and,
+for graphiti, whether the configured MCP server path is present (read-only,
+non-fatal).
+
+## Graph memory (when `memory.backend: graphiti`)
+
+Graphiti turns notes into a **bi-temporal knowledge graph**: you add *episodes*
+(text/JSON), an LLM extracts *entities* (nodes) and *facts* (edges), and every
+fact keeps two timelines — when it was true in the world and when the system
+learned it. Superseded facts are **invalidated, not deleted**, so you can ask
+"what is true now" or "what was true at time T", with a pointer back to the
+source episode (provenance).
+
+When enabled and the `graphiti-memory` MCP server is wired into your agent, use
+its tools directly:
+
+- **`add_memory`** — record a durable fact/decision as an episode. Pass a clear
+  `name`, the content, and the project `group_id` (namespaces one project's
+  memory). Ingestion is LLM-backed, so treat it as async — confirm it queued,
+  don't block on it. Prefer this for facts that *evolve* (status, ownership,
+  versions, preferences).
+- **`search_memory_facts`** — retrieve relationships/facts (edges) for a query,
+  with validity windows. Use this before assuming a fact; it returns *current*
+  truth plus history.
+- **`search_nodes`** — find entities (people, services, components) and their
+  summaries.
+- Scope every call with the project's `group_id` so memory stays per-project.
+- Respect provenance: facts trace back to episodes — cite them when it matters.
+
+If graph memory is unreachable or unconfigured, fall back to `forge remember`
+(local) — never lose the note. `forge doctor` surfaces a clear error when the
+graphiti backend is selected but not configured.
+
+## Good memory hygiene
+
+- Write **atomic** facts, not essays — one decision or gotcha per note.
+- Include the **why**, not just the what (rationale ages better than commands).
+- Tag consistently so recall is precise.
+- Recall **before** you act on an assumption; record **after** you learn something.
+
+## Setup pointers
+
+- Local is the default — nothing to install.
+- To opt into graph memory: set `memory.backend: graphiti` (plus a
+  `memory.graphiti` block) in `.forge/config.yaml`, then run FalkorDB + the
+  Graphiti MCP server. Wiring the server into each agent's MCP config is a
+  follow-up step. Full how-to (graph DB, LLM/embedder, privacy/cost):
+  `docs/guides/memory-backends.md`. Design rationale: `docs/work/2026-07-06-graphiti-memory/research.md`.

--- a/.agents/skills/parallel-deep-research/SKILL.md
+++ b/.agents/skills/parallel-deep-research/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: parallel-deep-research
+description: >
+  Heavyweight EXTERNAL research reports — market, industry, competitive, strategic — via
+  Parallel AI's paid pro/ultra processors that crawl and synthesize dozens of sources into one
+  long cited report. Use when the user wants a market analysis, competitive landscape,
+  industry deep-dive, multi-vendor/technology comparison, strategic recommendations, or market
+  sizing/growth outlook — any multi-source synthesis needing more than 3-4 web searches.
+  Typical phrasings: "market analysis of X", "competitive landscape comparing A/B/C",
+  "industry deep-dive on...", "deep research report on...", "strategic report with predictions
+  for 2027". WRONG tool for quick facts, a single-page fetch, one-URL scraping, or small
+  structured-field extraction — use built-in WebSearch/WebFetch. Also NOT the Forge RESEARCH
+  or PLAN stage: "run the research stage", "do Phase 2", or codebase/OWASP/DRY investigation
+  into a design doc route to `research` and `plan` (they may INVOKE this skill). Requires
+  PARALLEL_API_KEY.
+compatibility: Requires PARALLEL_API_KEY in .env.local. Uses curl. Takes 3-25 minutes.
+metadata:
+  author: harshanandak
+  version: "1.0.0"
+---
+
+# Parallel Deep Research
+
+Comprehensive research reports with multi-source synthesis. Use `pro` (3-9 min, $0.10) or `ultra` (5-25 min, $0.30) for deep analysis.
+
+> **Safety:** The `input` is transmitted to Parallel AI's external service and may be logged or retained. Never include secrets, API keys/tokens, PII, or private/proprietary repo content — send only information safe to share with a third party.
+>
+> **CLI alternative (recommended)**: Install `parallel-cli` for official skill:
+> `npx skills add parallel-web/parallel-agent-skills --skill parallel-deep-research`
+
+## Setup
+
+```bash
+API_KEY=$(grep "^PARALLEL_API_KEY=" .env.local | cut -d= -f2)
+```
+
+## Create Research Task
+
+```bash
+curl -s -X POST "https://api.parallel.ai/v1/tasks/runs" \
+  -H "x-api-key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Analyze the AI chatbot market. Include: size, growth, key players, trends, competitive threats",
+    "processor": "pro"
+  }'
+```
+
+Response: `{"run_id": "trun_abc123...", "status": "queued"}`
+
+## Get Result (polling)
+
+The result endpoint returns both status and output in one call. Poll until `status` is `completed`.
+
+```bash
+RUN_ID="trun_abc123..."
+MAX_POLLS=180  # 30 min max (180 × 10s)
+
+for i in $(seq 1 $MAX_POLLS); do
+  RESULT=$(curl -s "https://api.parallel.ai/v1/tasks/runs/$RUN_ID/result" \
+    -H "x-api-key: $API_KEY")
+
+  STATUS=$(echo "$RESULT" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+  if [ "$STATUS" = "completed" ]; then
+    echo "$RESULT"
+    break
+  elif [ "$STATUS" = "failed" ]; then
+    echo "Task failed: $RESULT"
+    break
+  fi
+
+  echo "Poll $i/$MAX_POLLS — Status: $STATUS"
+  sleep 10
+done
+
+if [ "$i" = "$MAX_POLLS" ] && [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ]; then
+  echo "Timeout: task did not complete within 30 minutes"
+fi
+```
+
+## Processors
+
+| Processor | Speed | Cost | Use For |
+|-----------|-------|------|---------|
+| pro | 3-9 min | $0.10/task | Market analysis, strategic reports |
+| ultra | 5-25 min | $0.30/task | Comprehensive deep research |
+
+## Example: Market Analysis
+
+```json
+{
+  "input": "Analyze the AI chip market in 2024. Include market size, growth rate, key players (NVIDIA, AMD, Intel), emerging competitors, and 2025 outlook.",
+  "processor": "pro"
+}
+```
+
+Result: Markdown report with citations.
+
+## When to Use
+
+- Market research and competitive analysis
+- Strategic reports requiring multiple sources
+- Research that needs synthesis across many documents
+- Any task that would need more than 3-4 web searches to answer properly
+
+For quick facts or single-source lookups, use built-in WebSearch instead.
+
+## Timeout
+
+Set polling timeout to 1800s (30 min) for ultra tasks. Pro tasks typically complete in 3-9 min.

--- a/.agents/skills/parallel-deep-research/evals/README.md
+++ b/.agents/skills/parallel-deep-research/evals/README.md
@@ -1,0 +1,27 @@
+# Eval Sets
+
+These eval files use a flat JSON array format targeting `scripts/eval_win.py`:
+
+```json
+[{"query": "...", "should_trigger": true}]
+```
+
+This is **not** compatible with the skill-creator plugin's `run_loop.py` which expects:
+
+```json
+{"skill_name": "...", "evals": [{"id": "...", "prompt": "...", "should_trigger": true}]}
+```
+
+To convert for `run_loop.py`:
+
+```bash
+python3 -c "
+import json, pathlib, uuid
+data = json.loads(pathlib.Path('evals.json').read_text())
+out = {'skill_name': 'SKILL-NAME-HERE', 'evals': [
+    {'id': str(uuid.uuid4()), 'prompt': item['query'], 'should_trigger': item['should_trigger']}
+    for item in data
+]}
+print(json.dumps(out, indent=2))
+" > evals_skill_creator.json
+```

--- a/.agents/skills/parallel-deep-research/evals/evals.json
+++ b/.agents/skills/parallel-deep-research/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "I need a comprehensive market analysis of the developer-tools space — top 20 players, their funding, market positioning, and where the industry is heading over the next 3-5 years, pulling from Gartner, Forrester, and recent VC investment reports",
+    "should_trigger": true
+  },
+  {
+    "query": "Write a deep research report on WebAssembly adoption in production — synthesize company case studies, performance benchmarks vs native code, ecosystem maturity, and clear recommendations for when to adopt it",
+    "should_trigger": true
+  },
+  {
+    "query": "Competitive landscape comparing Convex, Supabase, Firebase, and PlanetScale for our backend rewrite — full feature comparison, pricing at 50K DAU, community-health metrics, and a per-vendor risk assessment",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me an industry deep-dive on the observability market — Datadog vs Grafana Cloud vs New Relic across features, pricing, scalability, and OpenTelemetry support, with customer migration stories and TCO analysis for a 500-node cluster",
+    "should_trigger": true
+  },
+  {
+    "query": "For our architecture decision, produce a heavily-sourced report on event-driven patterns — Kafka vs RabbitMQ vs NATS at 100K events/sec, with production case studies and failure-mode analysis",
+    "should_trigger": true
+  },
+  {
+    "query": "Quick — what's the current price of Bitcoin and what were Anthropic's latest announcements?",
+    "should_trigger": false
+  },
+  {
+    "query": "Go to https://stripe.com/docs/api and extract the authentication section with all its code examples",
+    "should_trigger": false
+  },
+  {
+    "query": "Scrape https://openai.com/pricing and pull out the per-token cost for each model tier",
+    "should_trigger": false
+  },
+  {
+    "query": "Run the /research stage for the auth-refactor feature — investigate how our codebase currently handles session tokens, flag OWASP and DRY concerns, and write the findings into the design doc",
+    "should_trigger": false
+  },
+  {
+    "query": "Kick off the plan stage for adding rate limiting — brainstorm the design one question at a time, then set up the branch, worktree, and task list",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix the TypeScript compilation error in src/services/auth.ts about the missing session-token type",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -1,0 +1,558 @@
+---
+name: plan
+description: >
+  Forge PLAN stage — first stop when starting a NEW or unscoped feature. Sets up an
+  isolated worktree up front, then runs one-question-at-a-time brainstorming for design
+  intent, commits a design doc, does technical/OWASP/DRY + codebase research, and produces a
+  TDD task list for /dev. Trigger on "let's plan X", "scope a new feature", "brainstorm before we
+  build", "write a design doc", "break this into tasks", or "set up a worktree and task list
+  before coding". Reach for this even when the ask sounds like only design or only scoping —
+  plan owns intent → research → task-list setup as one stage. NOT for driving a feature to a
+  merged PR (that is smith), NOT for implementing tasks that already exist (dev), NOT for a
+  standalone deep-research pass into an approved design doc (research), NOT for reporting
+  where work stands or what is stale (status), and NOT for everyday issue create/list/close or
+  picking the next ready issue (issue-basics / triage-ready).
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+Plan a feature from scratch: brainstorm design intent, research technical approach, then set up branch, worktree, and a complete task list ready for /dev.
+
+# Plan
+
+`/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
+
+- `plan.intent_capture`
+- `plan.parallel_research`
+- `plan.parallel_critics`
+- `plan.synthesis`
+- `plan.final_lock`
+
+Do not assume every invocation must run every sub-skill. Run only the requested/required sub-skill when the user asks for partial planning work, and record skipped nodes as skipped rather than silently deleting them from the graph. External planner artifacts may satisfy `/dev` entry without running `/plan`, per D34, if they provide the required structured task list and acceptance criteria.
+
+Planning template behavior is resolved through the runtime graph and `.forge/config.yaml`, not through a separate planner-only config file. Use `forge options why <plan-subskill>`, `forge options diff`, and `forge options lint` to inspect configured planning mode, convergence threshold, critic set, and partial invocation choices.
+
+---
+
+```
+<HARD-GATE: /plan entry — worktree isolation>
+Before ANY planning work begins:
+
+1. Run: git branch --show-current
+2. If the current branch is NOT master/main:
+   - STOP. Do not begin Phase 1.
+   - Tell the user: "You are on '<branch>'. Planning must start from a clean worktree on master.
+     Run: git checkout master — then re-run /plan."
+3. If on master, create the worktree NOW before asking any questions:
+   a. forge worktree create <slug> --branch feat/<slug>
+   b. cd .worktrees/<slug>
+4. Confirm: "Working in isolated worktree: .worktrees/<slug> (branch: feat/<slug>)"
+5. Create the epic issue and record the stage transition:
+   ```bash
+   forge create --title="<feature-name>" --type=epic
+   forge update <id> --status=in_progress
+   # Optional context logging: run the transition helper only when present (kernel-only setups skip it).
+   # Only skips when the helper is absent — a real logging failure from the helper stays visible.
+   if [ -f scripts/beads-context.sh ]; then bash scripts/beads-context.sh stage-transition <id> none plan; fi
+   ```
+6. ONLY THEN begin Phase 1.
+
+Rationale: Planning commits (design docs, task lists) belong only to this feature's branch.
+If planning runs in the main directory on a non-master branch, those commits contaminate
+whatever branch is currently checked out. The worktree ensures zero cross-contamination
+between parallel features or sessions.
+</HARD-GATE>
+```
+
+---
+
+## Usage
+
+```bash
+/plan <feature-slug>
+/plan <feature-slug> --strategic   # Major architecture change: creates design doc PR before Phase 2
+/plan <feature-slug> --continue    # After --strategic PR is merged: run Phase 2 + 3
+/plan <feature-slug> --only=critics # Partial invocation: run one planning sub-skill and record evidence
+/plan <feature-slug> --only=lock    # Partial invocation: lock an already-supported plan
+```
+
+---
+
+
+### Multi-developer conflict check (soft block)
+
+Before proceeding to Phase 1, check for cross-developer conflicts:
+
+```bash
+# Auto-sync to get latest team state
+forge sync || true
+
+# Check for conflicts with this issue's planned work area
+bash scripts/conflict-detect.sh --issue <forge-id>
+```
+
+If exit code 2 (validation error): show error message, abort — do not show conflict prompt.
+
+If exit code 1 (conflicts found):
+- Display the conflict output to the developer
+- Ask: "Other developers are working in overlapping areas. Proceed anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `forge comment <id> "Conflict override: proceeding despite overlap with <conflicting-issues>"`, then continue to Phase 1
+- Audit: record conflict override per OWASP A09
+
+If exit code 0: proceed silently to Phase 1.
+
+---
+
+### Parallel PR coordination check (soft block)
+
+Before proceeding to Phase 1, check for merge conflicts and dependency issues with in-flight PRs:
+
+```bash
+# Run merge simulation if on a feature branch
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" != "master" ]] && [[ "$current_branch" != "main" ]]; then
+  bash scripts/pr-coordinator.sh merge-sim "$current_branch" 2>&1 || true
+fi
+
+# Show current merge queue
+bash scripts/pr-coordinator.sh merge-order 2>&1 || true
+
+# Check for stale worktrees (informational)
+bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
+```
+
+If merge conflicts or unmet dependencies are found:
+- Display the findings to the developer
+- Ask: "In-flight PRs have potential conflicts. Proceed with planning anyway? (y/n)"
+- If `n`: exit cleanly, no side effects
+- If `y`: log override via `forge comment <id> "PR coordination override: proceeding despite in-flight conflicts"`, then continue to Phase 1
+
+---
+
+### Team identity verification
+
+Before starting planning, verify team identity is mapped:
+
+```bash
+forge team verify 2>&1 || true
+```
+
+If verify reports issues, address them before proceeding (the output will include `FORGE_AGENT_7f3a:PROMPT:` directives with exact commands to run).
+
+---
+
+## Phase 1: Design Intent (Brainstorming)
+
+**Goal**: Capture WHAT to build — purpose, constraints, success criteria, edge cases, approach.
+
+### Step 0: Dependency ripple check (advisory)
+
+Before exploring context or asking questions, check for potential conflicts with in-flight work:
+
+```bash
+# If a Forge issue ID is known (e.g., from /status or forge ready):
+# Advisory only — runs when the dep-guard tooling is present; a failure is non-fatal.
+if [ -f scripts/dep-guard.sh ]; then
+  bash scripts/dep-guard.sh check-ripple <forge-issue-id> || echo "dep-guard ripple check skipped (advisory)"
+fi
+
+# If no issue exists yet (first-time plan):
+forge list --status=open,in_progress
+```
+
+Review the output. If overlaps are detected:
+- Consider whether the overlapping issue should be a dependency
+- Note any shared areas for the design Q&A
+- This check is **advisory only** — always proceed to Step 1 regardless of findings
+
+#### Ripple Analyst Agent (spawned when contract overlaps found)
+
+When `check-ripple` detects overlapping issues AND contract metadata is available, spawn a Ripple Analyst subagent with this prompt:
+
+**Input to agent**:
+- Current issue's contract changes (from `extract-contracts` output)
+- Consumer code snippets (from `find-consumers` output for each changed contract)
+- Overlapping issue's title, description, and contract metadata
+
+**Agent instructions**:
+1. For each overlapping contract, imagine 2-3 concrete break scenarios:
+   - "If [contract X] changes [specific behavior], then [consumer Y] will [specific failure]"
+2. Rate overall impact as one of:
+   - **NONE**: No real conflict despite keyword overlap
+   - **LOW**: Consumers need trivial adjustment (add parameter, rename call)
+   - **HIGH**: Consumer needs significant rework (parsing logic, data handling changes)
+   - **CRITICAL**: Consumer is in an active in_progress issue's task list
+3. **When uncertain, default to HIGH** — conservative over permissive
+4. Recommend one action:
+   - Add dependency (`forge issue dep add <source> <target>`)
+   - Coordinate with other issue's developer
+   - Scope down current feature to avoid overlap
+   - Proceed as-is (no real conflict)
+
+**Output format**:
+```
+Impact: [NONE|LOW|HIGH|CRITICAL]
+Confidence: [high|medium|low]
+
+Break scenarios:
+1. [scenario description]
+2. [scenario description]
+
+Recommendation: [action]
+Reason: [why this action]
+```
+
+This agent is advisory only. The developer always makes the final decision.
+
+### Step 1: Explore project context
+
+Before asking any questions, read relevant files:
+- Recent commits related to this area
+- Existing code in affected modules
+- Any related docs, tests, or prior research
+
+### Step 2: Ask clarifying questions — one at a time
+
+Ask each question in sequence. Wait for user response. Use multiple choice where possible.
+
+Questions to cover (adapt to feature, don't ask mechanical copies):
+1. **Purpose** — What problem does this solve? Who benefits?
+2. **Constraints** — What must this NOT do? What are the hard limits?
+3. **Success criteria** — How will we know it's done? What is the minimum viable result?
+4. **Edge cases** — What happens when [key dependency] fails / [input] is missing / [state] is ambiguous?
+5. **Technical preferences** — Library A or B? Pattern X or Y? (when real options exist)
+
+### Step 3: Propose approaches
+
+Propose 2-3 concrete approaches with:
+- Trade-offs (speed vs safety, complexity vs flexibility)
+- A clear recommendation with reasoning
+- Get user approval on the chosen approach
+
+### Step 4: Write design doc
+
+Save to `docs/work/YYYY-MM-DD-<slug>/plan.md` with these sections:
+- **Feature**: slug, date, status
+- **Purpose**: what problem it solves
+- **Success criteria**: measurable, specific
+- **Out of scope**: explicit boundaries
+- **Approach selected**: which option and why
+- **Constraints**: hard limits
+- **Edge cases**: decisions made during Q&A
+- **Ambiguity policy**: Use 7-dimension rubric scoring per /dev decision gate. >= 80% confidence: proceed and document. < 80%: stop and ask.
+
+Commit the design doc:
+```bash
+git add docs/work/YYYY-MM-DD-<slug>/plan.md
+git commit -m "docs: add design doc for <slug>"
+```
+
+---
+
+**--strategic flag** (for major architecture changes):
+
+After committing the design doc, push to a proposal branch and open PR:
+```bash
+git checkout -b feat/<slug>-proposal
+git push -u origin feat/<slug>-proposal
+gh pr create --title "Design: <feature-name>" \
+  --body "Design doc for review. See docs/work/YYYY-MM-DD-<slug>/plan.md"
+```
+
+**STOP here.** Present the PR URL. Wait for the user to merge the proposal PR.
+After merge, run `/plan <slug> --continue` to proceed to Phase 2 + 3.
+
+---
+
+```
+<HARD-GATE: Phase 1 exit>
+Do NOT begin Phase 2 (web research) until:
+1. User has approved the design in this session OR external-planner evidence satisfies the `/dev` entry contract from D34
+2. Design doc exists at docs/work/YYYY-MM-DD-<slug>/plan.md
+3. Design doc includes: success criteria, edge cases, out-of-scope, ambiguity policy
+4. Design doc is committed to git
+</HARD-GATE>
+```
+
+---
+
+## Phase 2: Technical Research
+
+**Goal**: Find HOW to build it — best practices, known issues, security risks, TDD scenarios.
+
+Record the phase transition before starting research (optional context logging; kernel-only setups skip it — a real helper failure stays visible):
+```bash
+if [ -f scripts/beads-context.sh ]; then bash scripts/beads-context.sh stage-transition <id> plan research; fi
+```
+
+Delegate the technical investigation to the **research** skill, which owns this bundle so it
+can be invoked on its own and reused mid-flow by other stages:
+
+```
+Skill("research")   # run in "Plan bundle" mode for this feature's design doc
+```
+
+Hand research the approved approach and the design doc path. It runs the following in parallel
+and appends the results under a `## Technical Research` section in the design doc (not a
+separate file):
+
+- **Web research** — best practices, implementation patterns, and known gotchas for the chosen
+  approach. (For an external market/vendor landscape, research escalates to
+  `parallel-deep-research`; code-level questions use WebSearch/Context7.)
+- **OWASP Top 10 analysis** — for each relevant category: the risk, whether it applies, and the
+  mitigation to implement.
+- **DRY check** — Grep/Glob/Read for existing implementations; if found, switch "Approach
+  selected" to "extend existing <file>:<line>" instead of "create new".
+- **Blast-radius search** (mandatory for remove/rename/replace) — grep the ENTIRE repo (exact +
+  case-insensitive + filename glob) and record every hit (including `package.json`, setup
+  scripts, `.github/workflows/`, agent config, and docs), adding a cleanup task for each.
+- **Codebase exploration** (Explore agent) — similar patterns to reuse, affected files, and
+  test infrastructure to leverage.
+- **TDD test scenarios** — at least 3: happy path, error/failure path, and one Phase-1 edge case.
+
+If the research skill is not available in the active toolset, run the same bundle inline with
+WebSearch/WebFetch, Grep/Glob/Read, and the Explore agent — the Phase 2 exit gate below verifies
+the outputs regardless of who produced them.
+
+---
+
+```
+<HARD-GATE: Phase 2 exit>
+Do NOT begin Phase 3 (setup) until:
+1. OWASP analysis is documented in design doc
+2. At least 3 TDD test scenarios are identified
+3. Approach selection is confirmed (which library/pattern to use)
+4. If feature involves removal/rename: blast-radius search completed, all references added to task list
+</HARD-GATE>
+```
+
+---
+
+## Phase 3: Setup + Task List
+
+**Goal**: Create branch, worktree, and a complete task list ready for /dev.
+
+Record the phase transition before starting setup (optional context logging; kernel-only setups skip it — a real helper failure stays visible):
+```bash
+if [ -f scripts/beads-context.sh ]; then bash scripts/beads-context.sh stage-transition <id> research setup; fi
+```
+
+### Step 1: Link child issues to the epic
+
+The epic was created in the Entry HARD-GATE (Phase 1 entry). If this feature requires child issues (sub-tasks tracked separately), create them now and link to the epic:
+
+```bash
+forge create --title="<sub-task-name>" --type=feature --parent=<epic-id>
+```
+
+### Step 2: Branch + worktree
+
+**ALWAYS branch from master, never from the current branch.** If the working directory is on any branch other than master, the new feature branch would inherit all unmerged changes from that branch — contaminating the new feature's history.
+
+**Note**: If the Entry HARD-GATE already created the branch and worktree (and you are already inside `.worktrees/<slug>`), skip Steps 2b–2d — they are already done.
+
+```bash
+# Step 2a: Check if branch and worktree were already created by Entry HARD-GATE
+CURRENT=$(git branch --show-current)
+if [ "$CURRENT" = "feat/<slug>" ]; then
+  echo "✓ Branch feat/<slug> already exists (Entry HARD-GATE created it) — skipping 2b–2d"
+else
+  # Step 2b: Verify .worktrees/ is gitignored — add if missing
+  git check-ignore -v .worktrees/ || echo ".worktrees/" >> .gitignore
+
+  # Step 2c: Create an isolated worktree rooted on master
+  git checkout master
+  forge worktree create <slug> --branch feat/<slug>
+  cd .worktrees/<slug>
+fi
+```
+
+**Why this matters**: Multiple parallel features or sessions each get their own isolated worktree. Changes to one feature never bleed into another. The main working directory can stay on any branch without affecting new feature branches.
+
+### Step 3: Project setup in worktree
+
+Auto-detect and run install:
+```bash
+# e.g., bun install / npm install / pip install -r requirements.txt
+```
+
+### Step 4: Baseline test run
+
+```bash
+# Run full test suite in worktree
+bun test   # or project test command
+```
+
+If tests fail: report which tests are failing and ask user whether to investigate or proceed anyway. Do not silently proceed past failing baseline tests.
+
+### Step 5: Task list creation
+
+Read the design doc. Break implementation into granular tasks.
+
+**Task format** (each task MUST have ALL of these):
+```
+Task N: <descriptive title>
+File(s): <exact file paths>
+What to implement: <complete description — not "add feature X", but what specifically>
+TDD steps:
+  1. Write test: <test file path, what assertion, what input/output>
+  2. Run test: confirm it fails with [specific expected error message]
+  3. Implement: <exact function/class/component to write>
+  4. Run test: confirm it passes
+  5. Commit: `<type>: <message>`
+Expected output: <what running the test/code produces when done>
+```
+
+**Ordering rules**:
+- Foundational/shared modules FIRST (types, utils, constants)
+- Feature logic SECOND
+- Integration/wiring THIRD
+- Uncertain/ambiguous tasks LAST (so they can be deferred if blocked)
+- **File ownership**: Each task MUST include an `OWNS:` line listing files it will modify
+- No two tasks in the same wave can own the same file
+- Cross-wave ownership is allowed (sequential execution prevents conflicts)
+
+**YAGNI filter** (after initial task draft, before saving):
+
+For each task, confirm it maps to a specific requirement, success criterion, or edge case in the design doc. Run `applyYAGNIFilter({ task, designDoc })` for each task.
+
+- Tasks that match → keep as-is.
+- Tasks with no anchor → flagged as "potential scope creep". Present flagged tasks to the user: "These tasks have no anchor in the design doc. Keep (specify which requirement it serves) or remove?"
+- If ALL tasks are flagged → return `allFlagged: true` and tell the user: "Design doc doesn't cover all tasks — needs amendment." Do not save the task list until the design doc is updated or tasks are removed.
+
+**Before finalizing**: flag any tasks that touch areas not fully specified in the design doc. Present flagged tasks to user for quick clarification before saving.
+
+Save to `docs/work/YYYY-MM-DD-<slug>/tasks.md`.
+
+### Step 5b: Issue context (design + acceptance)
+
+After saving the task list, attach design context and acceptance criteria to the Forge issue so downstream stages (`/dev`, `/validate`, `/review`) can retrieve it without re-reading the design doc. These are native Kernel issue fields — no separate tracker required.
+
+```bash
+# Link design metadata (task count + task file path) to the Forge issue
+forge update <id> --design "<task-count> tasks | docs/work/YYYY-MM-DD-<slug>/tasks.md"
+
+# Record the success criteria from the design doc on the issue
+forge update <id> --acceptance "<success-criteria from design doc>"
+```
+
+Both commands must exit with code 0. If either fails, investigate (wrong issue ID? bad flag value?) before continuing.
+
+### Step 5c: Contract extraction and logic-level dependency review (advisory, optional)
+
+After saving the task list and issue context, extract and store contract metadata, then run the logic-level Phase 3 dependency review. **This step uses the `dep-guard` dependency tooling; on a kernel-only setup it is skipped — it is advisory and never a hard block.**
+
+```bash
+if [ -f scripts/dep-guard.sh ]; then
+  # extract-contracts exits 1 when there simply are no contracts (normal, not an error),
+  # so store-contracts only runs when contracts were actually extracted.
+  if bash scripts/dep-guard.sh extract-contracts docs/work/YYYY-MM-DD-<slug>/tasks.md > /tmp/contracts.txt; then
+    # Contracts found — store them. A real store-contracts failure stays visible (not masked).
+    bash scripts/dep-guard.sh store-contracts <id> "$(cat /tmp/contracts.txt)"
+  fi
+  # check-ripple is advisory (needs the dependency-guard tooling); a failure is non-fatal.
+  bash scripts/dep-guard.sh check-ripple <id> || echo "dep-guard ripple check skipped (advisory)"
+fi
+```
+
+`extract-contracts` exits 1 when no contracts are found (not an error — just nothing to store). `store-contracts` must exit 0 if called.
+
+When available, `check-ripple` is advisory but logic-aware. It should:
+- read the issue data via JSON
+- analyze import/call-chain, contract, and behavioral dependency signals
+- show rubric score, confidence, issue pairs, and proposed dependency updates with pros/cons
+- stop for user approval whenever a dependency mutation is proposed
+
+If the user approves a dependency mutation, apply it explicitly (only when the tooling is present):
+
+```bash
+bash scripts/dep-guard.sh apply-decision <id> <dependent-id> <depends-on-id> "<approval rationale>"
+```
+
+That approval step must inspect blockers with `forge issue blocked` (and `forge issue children <epic-id>` for the epic rollup), summarize `forge ready`, and persist the decision via `forge update` plus `forge comment`. The Forge Kernel is the canonical machine-readable decision record; the plan docs hold only the concise summary.
+
+### Step 6: User review
+
+Present the full task list. Allow the user to reorder, split, or remove tasks.
+
+---
+
+```
+<HARD-GATE: /plan exit>
+For a full `/plan` handoff only, do NOT hand off from `/plan` to `/dev` until ALL are confirmed:
+1. git branch --show-current output shows feat/<slug>
+2. git worktree list shows .worktrees/<slug>
+3. Baseline tests ran — either passing OR user confirmed to proceed past failures
+4. Forge issue is created and in_progress (`forge issue show <id>` confirms status=in_progress)
+5. Task list exists at docs/work/YYYY-MM-DD-<slug>/tasks.md
+6. User has confirmed task list is correct
+7. Design captured on the Forge issue — `forge update <id> --design ...` ran successfully (exit code 0)
+8. Acceptance criteria captured on the Forge issue — `forge update <id> --acceptance ...` ran successfully (exit code 0)
+9. Contract metadata stored via `dep-guard store-contracts` (exit code 0) — or skipped if no contracts found OR the beads-backed dep-guard tooling is unavailable
+10. `dep-guard check-ripple` reviewed with the user before any `apply-decision` dependency mutation — or skipped when the dep-guard tooling is unavailable
+
+If `/dev` is entered from an external planner, this `/plan` exit gate is not required. Instead, the external artifact must satisfy the L1 `/dev` entry contract: structured task list, acceptance criteria, and enough design intent for TDD implementation.
+
+If only a sub-skill was invoked, do not claim full `/plan` completion. Record that sub-skill's evidence, gate outcome, and skipped graph nodes.
+</HARD-GATE>
+```
+
+After all HARD-GATE items pass, confirm issue context and record the stage transition. The structured transition helper is optional; on a kernel-only setup, log the handoff directly on the Forge issue:
+
+```bash
+# Confirm the issue carries design + acceptance context (helper when present; otherwise inspect the issue).
+# Only falls back to `forge issue show` when the helper is absent — a real validate failure stays visible.
+if [ -f scripts/beads-context.sh ]; then
+  bash scripts/beads-context.sh validate <id>
+else
+  forge issue show <id>
+fi
+
+# Record the plan→dev transition (structured helper when present; kernel-native comment otherwise).
+# The fallback comment mirrors the same envelope the helper emits (Stage:/Summary:/Decisions:/Artifacts:/Next:).
+if [ -f scripts/beads-context.sh ]; then
+  bash scripts/beads-context.sh stage-transition <id> plan dev \
+    --summary "<design approach chosen, task count>" \
+    --decisions "<key trade-offs resolved during Q&A>" \
+    --artifacts "docs/work/YYYY-MM-DD-<slug>/plan.md docs/work/YYYY-MM-DD-<slug>/tasks.md" \
+    --next "<first dev task focus area>"
+else
+  forge comment <id> "Stage: plan complete → ready for dev
+Summary: <design approach chosen, task count>
+Decisions: <key trade-offs resolved during Q&A>
+Artifacts: docs/work/YYYY-MM-DD-<slug>/plan.md docs/work/YYYY-MM-DD-<slug>/tasks.md
+Next: <first dev task focus area>"
+fi
+```
+
+---
+
+## Dynamic Phase 3 Output
+
+Phase 3 output is generated from the live Forge issue, branch/worktree setup, baseline validation, and task list paths at runtime. It reports the Forge issue, branch, worktree, `docs/work/YYYY-MM-DD-<slug>/plan.md`, and `docs/work/YYYY-MM-DD-<slug>/tasks.md` from the actual run instead of a static example.
+
+## Integration with Workflow
+
+```
+Utility: /status     -> Understand current context before starting
+
+Default template:
+  /plan     -> Optional default planner; external planners may satisfy /dev entry
+  /dev      -> Implement each task with subagent-driven TDD and continuous validation
+  /ship     -> Push + create PR
+  /review   -> Address GitHub Actions, Greptile, SonarCloud
+  /verify   -> Post-merge CI check on default branch
+
+Manual/support surfaces:
+  /validate  -> Cold-start or recovery validation, not a required stage boundary
+
+Pre-merge gate: doc updates + CI-green checkpoint embedded in /ship and /review (not a separate stage).
+```
+
+## Tips
+
+- **Phase 1 quality = /dev autonomy**: Every ambiguity resolved in Phase 1 is a decision gate that won't fire during /dev
+- **One question at a time**: Don't dump all questions at once — dialogue produces better design decisions than a questionnaire
+- **Task granularity**: Target 2-5 minutes per task. If a task takes longer, split it
+- **Uncertain tasks go last**: Anything ambiguous at the end of the task list can be deferred if blocked without stopping other work
+- **Baseline failures matter**: Pre-existing test failures hide regressions. Fix or explicitly document them before /dev starts

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -50,9 +50,8 @@ Before ANY planning work begins:
    ```bash
    forge create --title="<feature-name>" --type=epic
    forge update <id> --status=in_progress
-   # Optional context logging: run the transition helper only when present (kernel-only setups skip it).
-   # Only skips when the helper is absent — a real logging failure from the helper stays visible.
-   if [ -f scripts/beads-context.sh ]; then bash scripts/beads-context.sh stage-transition <id> none plan; fi
+   # Record the none→plan stage transition kernel-natively on the Forge issue.
+   forge comment <id> "Stage: none → plan"
    ```
 6. ONLY THEN begin Phase 1.
 
@@ -280,9 +279,9 @@ Do NOT begin Phase 2 (web research) until:
 
 **Goal**: Find HOW to build it — best practices, known issues, security risks, TDD scenarios.
 
-Record the phase transition before starting research (optional context logging; kernel-only setups skip it — a real helper failure stays visible):
+Record the phase transition before starting research (kernel-native):
 ```bash
-if [ -f scripts/beads-context.sh ]; then bash scripts/beads-context.sh stage-transition <id> plan research; fi
+forge comment <id> "Stage: plan → research"
 ```
 
 Delegate the technical investigation to the **research** skill, which owns this bundle so it
@@ -332,9 +331,9 @@ Do NOT begin Phase 3 (setup) until:
 
 **Goal**: Create branch, worktree, and a complete task list ready for /dev.
 
-Record the phase transition before starting setup (optional context logging; kernel-only setups skip it — a real helper failure stays visible):
+Record the phase transition before starting setup (kernel-native):
 ```bash
-if [ -f scripts/beads-context.sh ]; then bash scripts/beads-context.sh stage-transition <id> research setup; fi
+forge comment <id> "Stage: research → setup"
 ```
 
 ### Step 1: Link child issues to the epic
@@ -497,32 +496,18 @@ If only a sub-skill was invoked, do not claim full `/plan` completion. Record th
 </HARD-GATE>
 ```
 
-After all HARD-GATE items pass, confirm issue context and record the stage transition. The structured transition helper is optional; on a kernel-only setup, log the handoff directly on the Forge issue:
+After all HARD-GATE items pass, confirm issue context and record the stage transition kernel-natively on the Forge issue:
 
 ```bash
-# Confirm the issue carries design + acceptance context (helper when present; otherwise inspect the issue).
-# Only falls back to `forge issue show` when the helper is absent — a real validate failure stays visible.
-if [ -f scripts/beads-context.sh ]; then
-  bash scripts/beads-context.sh validate <id>
-else
-  forge issue show <id>
-fi
+# Confirm the issue carries design + acceptance context.
+forge issue show <id>
 
-# Record the plan→dev transition (structured helper when present; kernel-native comment otherwise).
-# The fallback comment mirrors the same envelope the helper emits (Stage:/Summary:/Decisions:/Artifacts:/Next:).
-if [ -f scripts/beads-context.sh ]; then
-  bash scripts/beads-context.sh stage-transition <id> plan dev \
-    --summary "<design approach chosen, task count>" \
-    --decisions "<key trade-offs resolved during Q&A>" \
-    --artifacts "docs/work/YYYY-MM-DD-<slug>/plan.md docs/work/YYYY-MM-DD-<slug>/tasks.md" \
-    --next "<first dev task focus area>"
-else
-  forge comment <id> "Stage: plan complete → ready for dev
+# Record the plan→dev transition kernel-natively (Stage:/Summary:/Decisions:/Artifacts:/Next: envelope).
+forge comment <id> "Stage: plan complete → ready for dev
 Summary: <design approach chosen, task count>
 Decisions: <key trade-offs resolved during Q&A>
 Artifacts: docs/work/YYYY-MM-DD-<slug>/plan.md docs/work/YYYY-MM-DD-<slug>/tasks.md
 Next: <first dev task focus area>"
-fi
 ```
 
 ---

--- a/.agents/skills/plan/evals/evals.json
+++ b/.agents/skills/plan/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "I want to build a rate-limiter for our public API — help me nail down the design, then break it into tasks before I write any code.",
+    "should_trigger": true
+  },
+  {
+    "query": "Let's kick off the webhook-retry feature: ask me the key decisions one at a time, write it up, and set me up to start developing.",
+    "should_trigger": true
+  },
+  {
+    "query": "Scope out adding SSO to the admin dashboard — pin down requirements and edge cases and give me an ordered TDD task list on its own branch.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before anyone touches the notification service I want a real plan: a worktree, some research on the approach, and a task list /dev can just run.",
+    "should_trigger": true
+  },
+  {
+    "query": "Starting the CSV-export epic today — brainstorm the approach with me and produce a committed design doc plus tasks.",
+    "should_trigger": true
+  },
+  {
+    "query": "Grab the highest-priority ready issue and take it all the way to an open PR — plan, build, validate, ship — just pause for my approval before merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "The design doc and task list are already in docs/work; start implementing the first task with RED-GREEN-REFACTOR.",
+    "should_trigger": false
+  },
+  {
+    "query": "The design is approved and written — now go do the deep web and codebase research and append it under the Technical Research section.",
+    "should_trigger": false
+  },
+  {
+    "query": "Which stage am I on for the billing branch, and is any of my work going stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a bug issue for the broken logout redirect and link it under the auth epic.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/research/SKILL.md
+++ b/.agents/skills/research/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: research
+description: >
+  Forge RESEARCH — a first-class, freely-invocable investigation skill any agent can call
+  standalone OR mid-workflow (mid-/dev, mid-/validate, mid-/plan), not a plan-only stage. Use
+  it to verify/fact-check a claim against primary sources; web-search best practices, gotchas,
+  and docs; find better options/patterns and weigh trade-offs; see both sides (steelman the
+  right way AND red-team the wrong way); pull inspiration from stronger sources; and run the
+  /plan Phase 2 bundle (web research + OWASP Top 10 + DRY/blast-radius codebase exploration +
+  3+ TDD scenarios) under `## Technical Research`. Trigger on "verify/fact-check this",
+  "research X",
+  "find a better way/option", "is this true", "get inspiration", "run the research phase", or
+  mid-task "investigate before I decide". Pick over siblings: `parallel-deep-research` for a
+  heavyweight EXTERNAL market/competitive report (paid Parallel AI); `plan` for the full plan
+  stage (brainstorm + tasks); `dev` or `validate` to implement or scan rather than investigate.
+allowed-tools: Bash, Read, Write, Grep, Glob, WebSearch, WebFetch
+---
+
+Investigate anything, from anywhere: verify a claim, search the web, find better options, pull
+inspiration from stronger sources, weigh perspectives, and package technical research for a plan.
+
+# Research
+
+`/research` is a **first-class capability**, not a stage. Any agent may invoke it at any point —
+standalone, or in the middle of another skill — whenever a question needs evidence before a
+decision. It is broader than `parallel-deep-research`: that sibling is a heavyweight external
+market/industry report; this skill is your everyday "go find out and come back with evidence."
+
+## When to use it
+
+- **Verify a claim** — "is this API deprecated?", "does this library support X?", "is this the
+  current best practice?" Confirm or refute against primary sources.
+- **Find a better way / better options** — enumerate real alternatives and compare trade-offs.
+- **Web research** — best practices, gotchas, current docs, changelogs, version differences.
+- **Inspiration / prior art** — pull stronger plans, patterns, and reference implementations
+  from better sources than memory.
+- **Multi-perspective** — see it done the right way AND the wrong way; steelman and red-team.
+- **Codebase research** — DRY, blast-radius, reusable patterns already in the repo.
+- **/plan Phase 2 bundle** — the packaged deliverable `plan` delegates to (see "Plan bundle").
+
+## How to invoke
+
+Standalone (user asks directly):
+
+```bash
+/research <question or claim>
+```
+
+From inside another skill or agent — call the Skill tool mid-flow:
+
+```
+Skill("research")   # then hand it the specific question + why you're asking
+```
+
+Always give research: (1) the concrete question or claim, (2) the decision it feeds, and
+(3) any constraints (stack, versions, repo area). Research returns **evidence, not opinion**:
+cited findings, and — when a caller needs it — a recommendation with the trade-offs shown.
+
+---
+
+## Modes
+
+Pick the mode(s) that fit the question. Most investigations combine two or three.
+
+### Mode A — Verify / fact-check a claim
+
+1. State the claim in one sentence and what would confirm vs refute it.
+2. Pull **primary sources** first (official docs, source code, specs, changelogs) via WebSearch
+   → WebFetch. Secondary sources (blogs, SO) only corroborate.
+3. Adversarially check: look for the counter-evidence, not just confirmation.
+4. Return: `CONFIRMED / REFUTED / MIXED / UNKNOWN` + the cited evidence + a one-line reason.
+
+Never answer a factual claim from memory. Fetch the source, cite it (URL + the line that
+settles it). "I'm confident" is not evidence.
+
+### Mode B — Explore options / find a better way
+
+1. Frame the decision and the constraints (perf, safety, complexity, lock-in, maturity).
+2. Enumerate 2–4 concrete options — include the "boring/obvious" one and at least one you did
+   not start with.
+3. For each: what it is, when it wins, when it loses, adoption/maintenance signal.
+4. Recommend one, with the trade-off that decides it. Show the runners-up so the caller can
+   overrule.
+
+### Mode C — Web search (quick → deep)
+
+Depth ladder — escalate only as needed:
+
+| Depth | Tool | Use for |
+|-------|------|---------|
+| Quick | built-in `WebSearch` / `WebFetch` | a fact, a doc page, one gotcha |
+| Deep, cited | `Skill("deep-research")` | multi-source, adversarially verified report |
+| External report | `Skill("parallel-deep-research")` | market/competitive/industry landscape (paid) |
+
+Search terms that work: `"[stack] [feature] best practices [year]"`,
+`"[library] [feature] pitfalls"`, `"[approach] known issues"`. Prefer official docs via
+Context7/grep.app MCP when available for library/API questions.
+
+### Mode D — Inspiration / better plans from better sources
+
+Look outward before inventing: canonical implementations, well-run OSS repos, design docs,
+RFCs. Pull the *shape* of a stronger solution and adapt it — don't copy blindly. Note the
+source so the plan can cite where the idea came from.
+
+### Mode E — Multi-perspective (steelman + red-team)
+
+For anything consequential, gather both:
+
+- **Steelman (the right way)** — the strongest case for the approach and how experts do it.
+- **Red-team (the wrong way)** — failure modes, anti-patterns, "why teams regret this",
+  security and edge-case traps.
+
+Return both columns so the decision is made with eyes open, not just the happy path.
+
+### Mode F — Codebase research (DRY + blast-radius)
+
+Use actual search tools — never rely on memory:
+
+```
+Grep("<function or concept>")   # existing implementations to reuse
+Glob("**/*.<ext>")              # narrow to affected file types
+Read(<match>)                   # inspect matches in context
+```
+
+- **DRY**: if a match exists, prefer "extend existing <file>:<line>" over "create new".
+- **Blast-radius** (for remove/rename/replace): grep the entire repo (exact + case-insensitive
+  + `Glob("**/*<thing>*")`), then list every hit — including `package.json`, install/setup
+  scripts, CI workflows, agent config, and docs — so nothing is missed.
+
+For broad multi-location sweeps, spawn the `Explore` agent and keep only its summary.
+
+---
+
+## Plan bundle (what `/plan` Phase 2 delegates to)
+
+When invoked by `/plan` for a feature's design doc, run the full technical bundle and append it
+under a `## Technical Research` section in `docs/work/YYYY-MM-DD-<slug>/plan.md`:
+
+1. **Web research** (Mode C) — best practices, gotchas, patterns for the chosen approach.
+2. **OWASP Top 10 pass** — for each relevant category (A01–A10): the risk, whether it applies,
+   and the planned mitigation.
+3. **DRY check** (Mode F) — reusable existing implementations.
+4. **Blast-radius search** (Mode F) — required for any remove/rename/replace; every reference
+   captured for the task list.
+5. **Codebase exploration** — similar patterns, affected files, test infra to leverage.
+6. **TDD scenarios** — at minimum 3: happy path, error/failure path, and one Phase-1 edge case.
+
+The caller's HARD-GATE (in `/plan`) still verifies these outputs exist — research produces
+them; the gate enforces them. Do not treat delegation as a way to skip the gate.
+
+---
+
+## Invoked mid-flow (examples)
+
+- **Mid-/validate** — a security or type failure surfaces and the fix is unclear: call
+  `Skill("research")` to verify the correct API/pattern against primary sources before editing
+  (feeds the D2 root-cause trace), then return to validation.
+- **Mid-/dev** — a decision gate fires on a spec gap: research the options (Mode B) and current
+  best practice (Mode C) so the decision is evidence-backed, then log the decision and continue.
+- **Mid-/plan** — an approach looks shaky during brainstorming: research alternatives and
+  red-team the front-runner (Mode E) before committing the design.
+- **Any agent, any time** — "before I decide, let me check" is always a valid reason to invoke.
+
+## Output contract
+
+- Cite every non-obvious claim (URL or `file:line`) — findings without sources are opinions.
+- Lead with the answer/recommendation, then the evidence, then the runners-up.
+- When invoked by `/plan`, append to the design doc's `## Technical Research` section (not a
+  separate file). When invoked mid-flow, return a concise evidence-backed answer to the caller.
+- Flag what you could NOT verify as `UNKNOWN` rather than guessing.
+
+## Integration with workflow
+
+```
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; delegates its Phase 2 technical research to /research
+  /dev       -> Implement each task with subagent-driven TDD (may call /research at a spec gap)
+  /validate  -> Type check, lint, tests, security (may call /research to root-cause a failure)
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Research is callable standalone or from any of the above — it is a capability, not a gate.
+```
+
+## Tips
+
+- **Evidence beats memory** — always fetch and cite; never settle a fact from recall.
+- **Escalate depth deliberately** — quick WebSearch first; reach for `deep-research` or
+  `parallel-deep-research` only when a single search can't answer it.
+- **Both perspectives** — for consequential calls, always red-team, not just steelman.
+- **Delegation ≠ skipping gates** — when `/plan` delegates the bundle, its HARD-GATE still
+  checks OWASP + 3 TDD scenarios + blast-radius are present.

--- a/.agents/skills/research/evals/evals.json
+++ b/.agents/skills/research/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "The design doc for the rate-limiter is already written — now go do the technical research: best practices, known gotchas for this approach, and drop it under Technical Research in the doc.",
+    "should_trigger": true
+  },
+  {
+    "query": "Run an OWASP Top 10 pass over this new file-upload feature and record which categories actually apply and how we'll mitigate each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before we build the caching layer, search the codebase for anything we can reuse and make sure we're not duplicating an existing helper.",
+    "should_trigger": true
+  },
+  {
+    "query": "Just do the research phase for this feature — web plus codebase investigation and at least three TDD scenarios — skip the brainstorm and the worktree setup.",
+    "should_trigger": true
+  },
+  {
+    "query": "Pull together the security and best-practices research for the OAuth integration and append it to the feature's design doc.",
+    "should_trigger": true
+  },
+  {
+    "query": "Let's plan this feature from scratch — brainstorm the design with me one question at a time, then create the branch, worktree, and task list.",
+    "should_trigger": false
+  },
+  {
+    "query": "I need a competitive landscape report comparing Datadog, Grafana Cloud, and New Relic on pricing and features for a 500-node cluster.",
+    "should_trigger": false
+  },
+  {
+    "query": "Give me a comprehensive market analysis of the vector-database space — top players, funding, and the 3-5 year outlook.",
+    "should_trigger": false
+  },
+  {
+    "query": "Start implementing task 1 with TDD — write the failing test first, then make it pass.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run the security scan, lint, and full test suite before we open the PR.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,489 @@
+---
+name: review
+description: >
+  Forge REVIEW stage — drives an already-open PR to all-green by resolving EVERY piece of
+  feedback: failing GitHub Actions / CI checks, Greptile and CodeRabbit inline comments and
+  summaries, and the SonarCloud quality gate. It fixes the code, replies to each thread and
+  marks it resolved until checks pass, then runs the pre-merge doc gate and hands the PR off
+  for MANUAL merge — never runs `gh pr merge`. Use whenever a PR has review feedback or red
+  checks: "address the review comments on PR #123", "the bots flagged issues / Greptile score
+  is low", "fix the failing checks and resolve the threads", "CodeRabbit and SonarCloud left
+  comments", "get my PR merge-ready". This MUTATING feedback-resolution stage is distinct from
+  shepherd (only WATCHES an open PR, changes nothing), verify (POST-merge CI health check +
+  closing issues), ship (pushes the branch + opens the PR), validate (PRE-PR local
+  type/lint/test/security), and sonarcloud / sonarcloud-analysis (only QUERY SonarCloud data).
+allowed-tools: Bash, Read, Edit, Grep, Glob
+---
+
+Process ALL pull request issues including GitHub Actions failures, Greptile inline comments, SonarCloud analysis, and other CI/CD checks.
+
+# Review
+
+This skill handles ALL issues that arise after creating a pull request.
+
+## Usage
+
+```bash
+/review <pr-number>
+```
+
+## What This Skill Does
+
+### Step 1: Fetch Complete PR Status
+```bash
+# Get full PR details including all checks
+gh pr view <pr-number> --json number,url,isDraft,reviews,statusCheckRollup,comments
+
+# Check individual status checks
+gh pr checks <pr-number>
+```
+
+Review ALL status checks:
+- GitHub Actions workflows
+- Greptile code review (inline comments + summary)
+- SonarCloud quality gate
+- Any other CI/CD integrations
+- Vercel deployments
+- Security scanners
+
+### Step 2: Address GitHub Actions Failures
+
+If any GitHub Actions workflows fail:
+
+```bash
+# View failed workflow logs
+gh run view <run-id> --log-failed
+
+# Identify failure cause:
+# - Build failures
+# - Test failures
+# - Lint/type check failures
+# - Deployment failures
+# - Security scan failures
+```
+
+**For each failure**:
+1. **Analyze the error**: Read logs to understand root cause
+2. **Fix the issue**: Make necessary code changes
+3. **Re-run checks**: GitHub Actions will auto-rerun on push
+4. **Document fix**: Note what was fixed in commit message
+
+**Common GitHub Actions Issues**:
+- Build failures: Missing dependencies, compilation errors
+- Test failures: Failing test cases (should not happen if /validate passed)
+- Lint failures: Code style violations
+- Type failures: TypeScript type errors
+- Deployment failures: Env vars, configuration issues
+
+### Step 3: Process Greptile Review
+
+Greptile provides TWO types of feedback:
+1. **Inline comments** on specific code lines
+2. **Summary** with overall recommendations
+
+**IMPORTANT**: Use the **systematic Greptile resolution process** documented in `.claude/rules/greptile-review-process.md`. This process has been standardized to ensure:
+- All threads are replied to directly (not as separate PR comments)
+- All threads are marked as resolved after fixing
+- No manual tracking overhead for maintainers
+
+#### 3A. Check Greptile Inline Comments (Use Systematic Process)
+
+**Step 1: List all unresolved threads**
+```bash
+bash .claude/scripts/greptile-resolve.sh list <pr-number> --unresolved
+```
+
+This shows:
+- Thread ID (for resolving)
+- Comment ID (for replying)
+- File path and line number
+- Issue description
+
+**Step 2: For EACH unresolved thread:**
+
+1. **Understand the issue**
+   - Read the comment carefully
+   - Check the file and line number
+
+2. **Categorize the comment**:
+   - **Valid**: Should be implemented (security issue, bug, clear improvement)
+   - **Invalid**: Greptile misunderstood context
+   - **Conflicting**: Contradicts research decisions with good reason
+   - **Out of scope**: Valid but not for this PR
+
+3. **Fix the issue** (if valid)
+   - Make code changes
+   - Commit with clear message
+
+4. **Reply and resolve** (for ALL comments, even invalid ones)
+   ```bash
+   # For valid issues (fixed):
+   bash .claude/scripts/greptile-resolve.sh reply-and-resolve <pr-number> <comment-id> <thread-id> \
+     "✅ Fixed: [description]
+
+     Changed: [what was changed]
+     Reason: [why this fixes the issue]
+     Commit: [commit-sha]"
+
+   # For invalid/conflicting issues:
+   bash .claude/scripts/greptile-resolve.sh reply-and-resolve <pr-number> <comment-id> <thread-id> \
+     "This approach is correct because:
+     - Reasoning: [from design doc]
+     - Evidence: [link to source]
+     - Alternative considered: [what Greptile suggested]
+     - Why rejected: [specific reason]
+
+     See: docs/work/YYYY-MM-DD-<slug>/plan.md (Decision #X)"
+   ```
+
+**Step 3: Verify all resolved**
+```bash
+bash .claude/scripts/greptile-resolve.sh stats <pr-number>
+```
+Should show: "✓ All Greptile threads resolved!"
+
+**See complete process**: `.claude/rules/greptile-review-process.md`
+
+#### 3B. Check Greptile Summary
+```bash
+# Greptile usually posts a summary comment on the PR
+# Review the overall assessment and recommendations
+```
+
+The summary typically includes:
+- Overall code quality assessment
+- Key issues to address
+- Security concerns
+- Performance considerations
+- Best practice violations
+
+### Step 4: Analyze SonarCloud (via sonarcloud skill)
+
+```bash
+# Use sonarcloud skill to query PR-specific issues
+/sonarcloud
+```
+
+**What SonarCloud does**: Static code analysis for quality, security, and maintainability
+
+**How it helps**:
+- Identifies code smells and technical debt
+- Finds security vulnerabilities (complementing OWASP Top 10)
+- Calculates code coverage
+- Tracks code duplication
+- Assesses maintainability
+
+**Query PR-specific data**:
+- Quality gate status (pass/fail)
+- New issues introduced in this PR
+- Security hotspots
+- Code coverage changes
+- Technical debt added
+
+**Prioritize issues**:
+1. **Blocker/Critical**: Must fix before merge
+2. **Major**: Should fix if valid
+3. **Minor/Info**: Optional improvements
+
+### Step 5: Check Other CI/CD Tools
+
+Review any other automated checks:
+- **Vercel**: Preview deployment successful?
+- **Security scanners**: Any vulnerabilities detected?
+- **Custom scripts**: Any failures?
+- **Dependency checks**: Outdated or vulnerable packages?
+
+### Step 6: Categorize and Prioritize ALL Issues
+
+Create a master list of all issues from:
+- GitHub Actions failures
+- Greptile inline comments
+- Greptile summary recommendations
+- SonarCloud issues
+- Other CI/CD tool failures
+
+Prioritize by:
+1. **Critical**: Blocks merge (failing tests, security vulnerabilities, build failures)
+2. **High**: Should address (valid bugs, important improvements)
+3. **Medium**: Optional but valuable (code quality, best practices)
+4. **Low**: Nice to have (minor refactorings, style suggestions)
+
+### Step 7: Address Issues Systematically
+
+For **GitHub Actions failures** (Critical):
+```bash
+# Fix the issue
+# Commit with clear description
+git add .
+git commit -m "fix: resolve GitHub Actions failure in <workflow-name>
+
+- Fixed: [specific issue]
+- Root cause: [explanation]
+- Solution: [what was changed]"
+
+git push
+# Actions will auto-rerun
+```
+
+For **Greptile inline comments** (Use Systematic Script):
+```bash
+# Use the standardized Greptile resolution script
+# See .claude/rules/greptile-review-process.md for complete process
+
+# For valid comments (fixed):
+bash .claude/scripts/greptile-resolve.sh reply-and-resolve <pr-number> <comment-id> <thread-id> \
+  "✅ Fixed: [description]
+
+  Changed: [what was changed]
+  Reason: [why this fixes the issue]
+  Commit: [commit-sha]"
+
+# For invalid/conflicting comments:
+bash .claude/scripts/greptile-resolve.sh reply-and-resolve <pr-number> <comment-id> <thread-id> \
+  "This approach is correct because:
+  - Reasoning: [from design doc]
+  - Evidence: [link to source]
+  - Alternative considered: [what Greptile suggested]
+  - Why rejected: [specific reason]
+
+  See: docs/work/YYYY-MM-DD-<slug>/plan.md (Decision #X)"
+
+# Verify all threads resolved:
+bash .claude/scripts/greptile-resolve.sh stats <pr-number>
+```
+
+For **Greptile summary recommendations**:
+```bash
+# Add a PR comment addressing the summary
+gh pr comment <pr-number> --body "## Greptile Summary Response
+
+Addressed all key recommendations:
+- [Recommendation 1]: ✓ Fixed in commit <sha>
+- [Recommendation 2]: ✓ Explained (see inline response)
+- [Recommendation 3]: ⏭️ Out of scope for this PR (created issue forge-xxx)
+
+All critical and high-priority items resolved."
+```
+
+For **SonarCloud issues** (via sonarcloud skill):
+```bash
+# For critical/blocker issues: Fix immediately
+# For security vulnerabilities: Fix immediately
+# For code smells: Fix if valid, justify if not
+
+# After fixes, SonarCloud will re-analyze on next push
+```
+
+For **other CI/CD failures**:
+```bash
+# Debug the specific tool's logs
+# Fix the underlying issue
+# Commit and push
+# Verify the check passes
+```
+
+### Step 8: Commit ALL Fixes
+
+```bash
+git add .
+git commit -m "fix: address ALL PR review feedback
+
+GitHub Actions:
+- Fixed: [list of workflow failures resolved]
+
+Greptile:
+- Fixed: [list of valid inline comments addressed]
+- Explained: [list of invalid comments with reasoning]
+- Summary: [key recommendations addressed]
+
+SonarCloud:
+- Fixed: [security vulnerabilities and critical issues]
+- Justified: [code smells that are intentional]
+
+Other CI/CD:
+- Fixed: [any other tool failures]
+
+All review feedback resolved, all checks passing."
+
+git push
+```
+
+### Step 9: Verify ALL Checks Pass
+
+```bash
+# Check status immediately, then poll for at most 60 seconds
+gh pr checks <pr-number>
+
+# If checks are still pending after 60 seconds: STOP and tell the user to return
+# when CI finishes or new review feedback appears.
+#
+# Ensure all completed status checks are green:
+# ✓ GitHub Actions workflows
+# ✓ Greptile review (no unresolved critical comments)
+# ✓ SonarCloud quality gate
+# ✓ Other CI/CD checks
+```
+
+### Step 10: Update the Forge issue
+
+```bash
+forge comment <id> "PR review complete: all issues addressed, all checks passing"
+forge sync
+```
+
+## Example Output
+
+```
+✓ GitHub Actions: 3 workflows
+  - Build: ✓ Passing (was failing, fixed missing dependency)
+  - Tests: ✓ Passing
+  - Deploy Preview: ✓ Passing
+
+✓ Greptile Review:
+  Inline Comments: 8 total
+  - Valid: 5 → Fixed & replied inline
+  - Invalid: 2 → Explained with research evidence & replied inline
+  - Out of scope: 1 → Noted for future work & replied inline
+  - All marked resolved ✓
+
+  Summary:
+  - Key recommendations: 3/3 addressed
+  - Overall assessment: Ready for merge
+  - Posted summary response comment ✓
+
+✓ SonarCloud (via sonarcloud skill):
+  Quality Gate: ✓ Passing
+  Issues: 3 total
+  - Security: 1 → Fixed (SQL injection risk)
+  - Code smells: 2 → 1 fixed, 1 justified
+  - Coverage: Maintained at 85%
+
+✓ Vercel Preview: ✓ Deployed successfully
+✓ Security Scan: ✓ No vulnerabilities
+
+✓ All Issues Addressed:
+  - Critical: 2/2 fixed (GitHub Actions build, SonarCloud security)
+  - High: 5/5 fixed (Greptile valid comments)
+  - Medium: 3/3 addressed (1 fixed, 2 explained)
+  - Low: 0 (none found)
+
+✓ Fixes committed: 3c4d5e6
+✓ All checks passing: ✓
+✓ Forge issue updated: Ready for merge
+
+Next: pre-merge gate — finish docs + confirm CI green, then hand off the PR for merge
+```
+
+```
+<HARD-GATE: /review exit>
+Do NOT declare /review complete until:
+1. bash .claude/scripts/greptile-resolve.sh stats <pr-number> shows "All Greptile threads resolved"
+2. ALL human reviewer comments are either resolved or have a reply with explanation
+3. gh pr checks <pr-number> shows all checks passing
+4. Context check: confirm design + acceptance on the Forge issue (`forge issue show <id>`); if the beads-context helper is present, run `bash scripts/beads-context.sh validate <id>` and address any warnings
+5. Stage transition recorded (structured helper when present; kernel-native comment otherwise):
+   if [ -f scripts/beads-context.sh ]; then
+     bash scripts/beads-context.sh stage-transition <id> review verify \
+       --summary "<all feedback addressed summary>" \
+       --decisions "<comment resolutions — valid fixes and justified rejections>" \
+       --artifacts "<fixed files, commit SHAs>" \
+       --next "<pre-merge gate: finish docs + CI green, then hand off for merge>"
+   else
+     forge comment <id> "Stage: review complete → ready for verify
+Summary: <all feedback addressed summary>
+Decisions: <comment resolutions — valid fixes and justified rejections>
+Artifacts: <fixed files, commit SHAs>
+Next: <pre-merge gate: finish docs + CI green, then hand off for merge>"
+   fi
+</HARD-GATE>
+```
+
+## Pre-merge gate (before merge)
+
+Pre-merge is a doc-update **gate/checkpoint**, not a separate stage — run it here, once feedback is addressed and before the PR is handed off for merge, whenever the change touches anything documented:
+
+1. **Finish the docs on the feature branch** (update only what genuinely changed):
+   - `CHANGELOG.md` (always) — entry under `## [Unreleased]` using Keep a Changelog categories, with PR number + issue ID.
+   - `README.md` (user-facing), `docs/reference/API_REFERENCE.md` (API), architecture docs (structural).
+   - `CLAUDE.md` — **USER section only** (between the USER markers); never touch other managed blocks.
+   - `AGENTS.md` (agent config, skills, or cross-agent workflow changes).
+   Commit the doc updates to the feature branch and push.
+2. **Confirm CI is green** — doc commits re-trigger CI; poll briefly (~60s), then hand off if still pending.
+3. **Sync the issue store** — `forge sync`.
+4. **Hand off for MANUAL merge** — present the PR and stop. **Never run `gh pr merge`; never auto-merge.** The user merges in the GitHub UI, then runs `/verify`.
+
+## Integration with Workflow
+
+```
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Pre-merge gate: doc updates + CI-green checkpoint embedded in /ship and /review (not a separate stage).
+```
+
+## Understanding the Tools
+
+### Greptile
+- **What it is**: AI-powered code review bot
+- **How it helps**:
+  - Context-aware code analysis
+  - Catches bugs and security issues
+  - Suggests improvements and best practices
+  - Provides inline comments and summary
+- **How to use feedback**:
+  - Inline comments: Address specific code issues
+  - Summary: Get overall assessment and key recommendations
+  - Reply directly to each comment (not separate)
+  - Mark resolved after addressing
+
+### SonarCloud (via sonarcloud skill)
+- **What it is**: Static code analysis platform
+- **How it helps**:
+  - Quality gate enforcement
+  - Security vulnerability detection
+  - Code smell identification
+  - Technical debt tracking
+  - Test coverage analysis
+- **How to use the skill**:
+  - Query PR-specific issues
+  - Get quality metrics
+  - Identify security hotspots
+  - Track code coverage changes
+- **Prioritization**:
+  - Blocker/Critical: Must fix
+  - Major: Should fix if valid
+  - Minor/Info: Optional
+
+### GitHub Actions
+- **What it is**: CI/CD automation platform
+- **How it helps**:
+  - Automated testing
+  - Build verification
+  - Deployment automation
+  - Security scanning
+  - Quality checks
+- **Common failures**:
+  - Build: Dependencies, compilation
+  - Tests: Failing test cases
+  - Lint: Code style violations
+  - Deploy: Configuration issues
+
+## Tips
+
+- **Address ALL issues**: Not just Greptile and SonarCloud
+- **Prioritize critical**: Fix blockers first (GitHub Actions failures, security issues)
+- **Reply inline to Greptile**: Respond to each comment directly
+- **Post summary response**: Address Greptile's overall assessment
+- **Use sonarcloud skill**: Don't just check the web UI
+- **Verify all checks**: Ensure everything is green before the pre-merge gate / merge
+- **Update the Forge issue**: Keep issue status current
+- **Research if needed**: Use WebSearch for unclear suggestions
+- **Document fixes**: Clear commit messages for all fixes
+- **Don't leave unresolved**: Address every comment and check

--- a/.agents/skills/review/evals/evals.json
+++ b/.agents/skills/review/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "PR #204 has three red checks and a pile of Greptile comments — work through all of it and get the PR green.",
+    "should_trigger": true
+  },
+  {
+    "query": "CodeRabbit and SonarCloud both left feedback on my pull request; fix what's valid, reply to the rest, and resolve the threads.",
+    "should_trigger": true
+  },
+  {
+    "query": "The GitHub Actions build is failing on my PR and there are unresolved review threads — sort them out before I merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "My Greptile confidence score is low. Address the inline comments and keep pushing fixes until the quality gate passes.",
+    "should_trigger": true
+  },
+  {
+    "query": "Handle all the reviewer feedback on the auth PR, then update the changelog and docs before we hand it off to merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "Just keep an eye on PR #150 — watch the checks and review threads and ping me when it's settled and mergeable. Don't touch the code.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR is merged to master now — run the post-merge health check and close out the issue.",
+    "should_trigger": false
+  },
+  {
+    "query": "My branch passed validation; push it and open the pull request with the design-doc link.",
+    "should_trigger": false
+  },
+  {
+    "query": "Before I open a PR, run the type-check, lint, full test suite, and security scan on my branch.",
+    "should_trigger": false
+  },
+  {
+    "query": "Just pull up this PR's SonarCloud issues and quality-gate status so I can eyeball them.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/rollback/SKILL.md
+++ b/.agents/skills/rollback/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: rollback
+description: >
+  Safely revert or undo a change that is already committed or shipped, using non-destructive
+  `git revert` (never `reset --hard`, `push --force`, or `clean`). Drives the interactive
+  `bunx forge rollback` menu: undo the last commit, revert a commit by hash, revert a merged
+  PR (git revert -m 1), restore individual files to a prior version, revert a commit range, or
+  dry-run/preview first. Use when the user says roll back, revert, undo, back out, or restore
+  — e.g. "undo the last commit", "undo that change, the approach was wrong", "back out PR
+  #123", "revert the merge commit", "restore src/auth.js to before my last commit", or when a
+  shipped/merged change broke something and must be pulled back. Do NOT use for: replying to
+  or fixing PR review feedback (review), monitoring an open PR's checks toward merge
+  (shepherd), the post-merge CI health check on master (verify), pushing a branch or opening a
+  PR (ship), or ordinary issue status/field edits (issue-basics).
+allowed-tools: Bash, Read, Edit, Grep, Glob
+---
+
+Comprehensive rollback system with multiple methods and automatic USER content preservation.
+
+# Rollback
+
+This skill provides safe rollback operations with comprehensive validation and USER section preservation.
+
+## Usage
+
+```bash
+bunx forge rollback
+```
+
+Interactive menu with 6 options:
+1. **Rollback last commit** - Quick undo of most recent change
+2. **Rollback specific commit** - Target any commit by hash
+3. **Rollback merged PR** - Revert an entire PR merge
+4. **Rollback specific files** - Restore only certain files
+5. **Rollback entire branch** - Revert multiple commits
+6. **Preview rollback** - Dry run mode (shows changes without executing)
+
+## How It Works
+
+### Safety Features
+
+**1. Working Directory Check**
+- Requires clean working directory (no uncommitted changes)
+- Prevents accidental data loss
+- Prompts to commit or stash changes first
+
+**2. Input Validation**
+- Commit hashes: Must match `/^[0-9a-f]{4,40}$/i` or be 'HEAD'
+- File paths: Validated to be within project (prevents path traversal)
+- Methods: Whitelisted to 'commit', 'pr', 'partial', 'branch'
+- Shell metacharacters: Rejected (`;`, `|`, `&`, `$`, `` ` ``, `(`, `)`, `<`, `>`, `\n`, `\r`)
+
+**3. USER Section Preservation**
+- Automatically extracts USER sections before rollback
+- Restores USER sections after rollback
+- Preserves custom commands in `.claude/commands/custom/`
+- Amends rollback commit to include restored content
+
+**4. Dry Run Mode**
+- Preview affected files without executing
+- Shows what would change
+- No git operations performed
+
+**5. Non-Destructive**
+- Uses `git revert` (creates new commit)
+- Never uses `git reset --hard` (destructive)
+- Preserves full git history
+- Can be undone with another rollback
+
+### USER Section Preservation
+
+**What Gets Preserved**:
+```markdown
+<!-- USER:START -->
+Your custom content here
+<!-- USER:END -->
+
+<!-- USER:START:custom-name -->
+Named USER section
+<!-- USER:END:custom-name -->
+```
+
+**Process**:
+1. Extract all USER sections from AGENTS.md, CLAUDE.md, etc.
+2. Backup custom commands from `.claude/commands/custom/`
+3. Execute rollback operation
+4. Restore USER sections to current file content
+5. Restore custom command files
+6. Amend rollback commit to include restored content
+
+**Result**: Your customizations survive rollback operations.
+
+## Rollback methods
+
+Six methods, selected interactively. Full step-by-step walkthroughs (commands,
+prompts, expected output) are in [references/methods.md](references/methods.md) —
+read it when running a specific rollback.
+
+1. **Rollback last commit** — undo the most recent commit.
+2. **Rollback specific commit** — revert one commit by hash.
+3. **Rollback merged PR** — revert a merge commit.
+4. **Rollback specific files** — restore named files from the previous commit.
+5. **Rollback entire branch** — reset a range.
+6. **Preview (dry run)** — show what a rollback would do, change nothing.
+
+## Integration, issue status & troubleshooting
+
+When to reach for rollback, how it fits the workflow, how revert state is recorded,
+and error recovery are in
+[references/workflow-integration.md](references/workflow-integration.md).

--- a/.agents/skills/rollback/evals/evals.json
+++ b/.agents/skills/rollback/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "undo the last commit, the approach was wrong",
+    "should_trigger": true
+  },
+  {
+    "query": "back out PR #482, it's breaking production",
+    "should_trigger": true
+  },
+  {
+    "query": "restore config/database.yml to the version before my last commit",
+    "should_trigger": true
+  },
+  {
+    "query": "show me which files reverting commit a1b2c3d would touch before I actually do it",
+    "should_trigger": true
+  },
+  {
+    "query": "that merged refactor broke everything — revert the whole thing but keep the git history intact",
+    "should_trigger": true
+  },
+  {
+    "query": "what's the safe way to undo a merged pull request?",
+    "should_trigger": true
+  },
+  {
+    "query": "address the Greptile and CodeRabbit comments on my PR",
+    "should_trigger": false
+  },
+  {
+    "query": "keep watching my open PR and tell me when checks pass and it's mergeable",
+    "should_trigger": false
+  },
+  {
+    "query": "master is green after the merge — run the post-merge health check and close the issue",
+    "should_trigger": false
+  },
+  {
+    "query": "push my validated branch and open a pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "set issue forge-9f2 to status review",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/rollback/references/methods.md
+++ b/.agents/skills/rollback/references/methods.md
@@ -1,0 +1,204 @@
+# Rollback methods (reference)
+
+Detailed walkthroughs for each rollback method. Read the one you need; the skill body summarizes them.
+
+## Rollback Methods
+
+### 1. Rollback Last Commit
+
+**Use when**: Quick undo of most recent change
+
+**How it works**:
+```bash
+git revert HEAD --no-edit
+```
+
+**Example**:
+```bash
+bunx forge rollback
+# Select: 1. Rollback last commit
+
+✓ Working directory is clean
+✓ Extracting USER sections...
+✓ Executing: git revert HEAD --no-edit
+✓ Restoring USER sections...
+✓ Amended commit to preserve USER content
+
+Rollback complete!
+  Commit: a1b2c3d "Revert: add authentication feature"
+  Files affected: 5
+```
+
+### 2. Rollback Specific Commit
+
+**Use when**: Need to revert a commit from earlier in history
+
+**How it works**:
+```bash
+git revert <commit-hash> --no-edit
+```
+
+**Example**:
+```bash
+bunx forge rollback
+# Select: 2. Rollback specific commit
+# Enter: a1b2c3d
+
+✓ Validating commit hash...
+✓ Working directory is clean
+✓ Extracting USER sections...
+✓ Executing: git revert a1b2c3d --no-edit
+✓ Restoring USER sections...
+✓ Amended commit to preserve USER content
+
+Rollback complete!
+  Commit: x9y8z7w "Revert: a1b2c3d"
+  Files affected: 8
+```
+
+**Input validation**:
+- Accepts 4-40 character hex strings
+- Accepts 'HEAD'
+- Rejects shell metacharacters
+- Rejects invalid formats
+
+### 3. Rollback Merged PR
+
+**Use when**: Need to revert an entire merged pull request
+
+**How it works**:
+```bash
+git revert -m 1 <merge-commit-hash> --no-edit
+```
+
+**Example**:
+```bash
+bunx forge rollback
+# Select: 3. Rollback merged PR
+# Enter: def456 (merge commit hash)
+
+✓ Validating commit hash...
+✓ Working directory is clean
+✓ Extracting USER sections...
+✓ Executing: git revert -m 1 def456 --no-edit
+✓ Restoring USER sections...
+✓ Amended commit to preserve USER content
+✓ Beads integration: Issue #123 marked as 'reverted'
+
+Rollback complete!
+  Commit: m1n2o3p "Revert: Merge pull request #123"
+  Files affected: 15
+  Beads issue: #123 status → reverted
+```
+
+**Beads Integration**:
+- Parses commit message for issue number (`#123`)
+- If found, runs: `forge update <id> --status reverted --comment "PR reverted"`
+- Silently skips if Beads not installed
+- Updates issue tracking automatically
+
+### 4. Rollback Specific Files
+
+**Use when**: Only certain files need to be restored
+
+**How it works**:
+```bash
+git checkout HEAD~1 -- <file1> <file2> ...
+git commit -m "chore: rollback <files>"
+```
+
+**Example**:
+```bash
+bunx forge rollback
+# Select: 4. Rollback specific files
+# Enter: AGENTS.md,CLAUDE.md
+
+✓ Validating file paths...
+✓ Working directory is clean
+✓ Extracting USER sections...
+✓ Executing: git checkout HEAD~1 -- AGENTS.md CLAUDE.md
+✓ Committing changes...
+✓ Restoring USER sections...
+✓ Amended commit to preserve USER content
+
+Rollback complete!
+  Commit: q4r5s6t "chore: rollback AGENTS.md, CLAUDE.md"
+  Files affected: 2
+```
+
+**Path validation**:
+- Comma-separated file paths
+- Validates paths are within project root
+- Prevents path traversal (`../../../etc/passwd`)
+- Rejects shell metacharacters
+- Uses `path.resolve()` + `startsWith()` check
+
+### 5. Rollback Entire Branch
+
+**Use when**: Need to revert a range of commits
+
+**How it works**:
+```bash
+git revert <start-commit>..<end-commit> --no-edit
+```
+
+**Example**:
+```bash
+bunx forge rollback
+# Select: 5. Rollback entire branch
+# Enter: abc123..def456
+
+✓ Validating commit range...
+✓ Working directory is clean
+✓ Extracting USER sections...
+✓ Executing: git revert abc123..def456 --no-edit
+✓ Restoring USER sections...
+✓ Amended commit to preserve USER content
+
+Rollback complete!
+  Commits reverted: 7
+  Files affected: 24
+```
+
+**Range validation**:
+- Format: `start..end`
+- Both commits must be valid hashes (4-40 chars)
+- Rejects invalid formats
+- Checks for `..` separator
+
+### 6. Preview Rollback (Dry Run)
+
+**Use when**: Want to see what would change without executing
+
+**How it works**:
+- Prompts for method and target
+- Validates inputs
+- Shows affected files
+- No git operations performed
+
+**Example**:
+```bash
+bunx forge rollback
+# Select: 6. Preview rollback (dry run)
+# Enter method: partial
+# Enter target: AGENTS.md,package.json
+
+✓ Validating inputs...
+✓ DRY RUN MODE - No changes will be made
+
+Preview of rollback:
+  Method: partial
+  Target: AGENTS.md, package.json
+
+  Files that would be affected:
+    - AGENTS.md
+    - package.json
+
+  USER sections that would be preserved:
+    - AGENTS.md: 2 sections
+
+  Custom commands that would be preserved:
+    - .claude/commands/custom/my-workflow.md
+
+No changes made (dry run).
+```

--- a/.agents/skills/rollback/references/workflow-integration.md
+++ b/.agents/skills/rollback/references/workflow-integration.md
@@ -1,0 +1,444 @@
+# Rollback: workflow integration, issue status & troubleshooting (reference)
+
+## Integration with Workflow
+
+### When to Use Rollback
+
+**During Development** (`/dev`):
+- Implemented wrong approach
+- Tests reveal fundamental issues
+- Need to start over with different strategy
+
+**After Shipping** (`/ship`):
+- PR feedback requires complete redesign
+- CI/CD failures indicate architecture problems
+- Breaking changes need to be reverted
+
+**After Merging** (pre-merge gate + user merge):
+- Production issues discovered
+- Need to revert feature entirely
+- Rollback PR merge commit
+
+**Recovery Scenarios**:
+- Accidentally committed sensitive data (follow the secret-removal runbook; rollback alone does not purge history)
+- Merge conflict resolution went wrong
+- Refactor broke existing functionality
+
+### Workflow Integration
+
+```bash
+# Standard workflow
+/status → /plan → /dev → /validate → /ship → /review → /verify   (pre-merge doc gate runs inside /ship and /review)
+
+# Recovery workflow
+/dev → (issues discovered) → bunx forge rollback → /dev (retry)
+/ship → (CI fails) → bunx forge rollback → /dev (fix) → /ship
+/verify → (production issues) → bunx forge rollback → /plan (redesign)
+```
+
+### Example: Failed Feature Implementation
+
+```bash
+# 1. Development phase - implement feature
+/dev
+# ... implementation ...
+git commit -m "feat: add payment integration"
+
+# 2. Check phase - tests fail
+/validate
+# ERROR: Security vulnerability in payment handling
+
+# 3. Rollback the implementation
+bunx forge rollback
+# Select: 1. Rollback last commit
+
+# 4. Plan with security in mind
+/plan payment-integration
+
+# 5. Implement correctly
+/dev
+# ... proper implementation with security ...
+
+# 6. Verify and ship
+/validate → /ship
+```
+
+## Beads Integration
+
+If Beads is installed (`bunx forge setup`), rollback automatically updates issue tracking.
+
+### PR Rollback → Issue Status
+
+When rolling back a merged PR:
+1. Parse commit message for issue number (`#123`, `fixes #456`, etc.)
+2. If issue number found:
+   ```bash
+   forge update <id> --status reverted --comment "PR reverted by rollback"
+   ```
+3. Silently skip if:
+   - Beads not installed
+   - No issue number in commit message
+   - Issue doesn't exist
+
+### Manual Beads Update
+
+If automatic detection doesn't work:
+```bash
+# After rollback
+forge update 123 --status reverted --comment "Rolled back due to production issues"
+```
+
+## Troubleshooting
+
+### Error: "Working directory not clean"
+
+**Cause**: Uncommitted changes in working directory
+
+**Solution**:
+```bash
+# Option 1: Commit changes
+git add .
+git commit -m "wip: current work"
+
+# Option 2: Stash changes
+git stash
+
+# Then retry rollback
+bunx forge rollback
+```
+
+### Error: "Invalid commit hash format"
+
+**Cause**: Commit hash doesn't match required pattern
+
+**Valid formats**:
+- `HEAD` (special keyword)
+- `a1b2c3d` (4-40 character hex string)
+- `abc123def456` (longer hash)
+
+**Invalid formats**:
+- `abc;rm -rf /` (contains shell metacharacter)
+- `12` (too short, < 4 chars)
+- `not-a-hash` (not hexadecimal)
+
+**Solution**:
+```bash
+# Get valid commit hash
+git log --oneline
+# Copy full or abbreviated hash (4+ chars)
+```
+
+### Error: "Path outside project"
+
+**Cause**: File path resolves to outside project root
+
+**Examples**:
+- `../../../etc/passwd` (path traversal)
+- `/absolute/path/outside/project`
+
+**Solution**:
+```bash
+# Use relative paths within project
+bunx forge rollback
+# Select: 4. Rollback specific files
+# Enter: src/auth.js,docs/API.md (relative paths)
+```
+
+### Error: "Invalid characters in path"
+
+**Cause**: File path contains shell metacharacters
+
+**Rejected characters**: `;`, `|`, `&`, `$`, `` ` ``, `(`, `)`, `<`, `>`, `\n`, `\r`
+
+**Solution**:
+```bash
+# Remove special characters from filename
+mv "file;name.js" "filename.js"
+
+# Or escape properly (not recommended)
+```
+
+### Error: "Branch range must use format: start..end"
+
+**Cause**: Branch range doesn't include `..` separator
+
+**Valid formats**:
+- `abc123..def456`
+- `a1b2c3d..x9y8z7w`
+
+**Invalid formats**:
+- `abc123-def456` (wrong separator)
+- `abc123` (no range)
+
+**Solution**:
+```bash
+# Use correct format
+bunx forge rollback
+# Select: 5. Rollback entire branch
+# Enter: <start-commit>..<end-commit>
+```
+
+### Merge Conflicts During Rollback
+
+**Cause**: Revert conflicts with subsequent changes
+
+**Solution**:
+```bash
+# 1. Rollback creates conflict markers
+git status
+# On branch: main
+# Unmerged paths:
+#   both modified: src/auth.js
+
+# 2. Resolve conflicts manually
+# Edit src/auth.js, remove markers
+
+# 3. Complete the revert
+git add src/auth.js
+git revert --continue
+
+# 4. USER sections restored automatically
+```
+
+### USER Sections Not Restored
+
+**Cause**: Markers missing or malformed
+
+**Check markers**:
+```bash
+grep -n "USER:START" AGENTS.md
+grep -n "USER:END" AGENTS.md
+```
+
+**Valid markers**:
+```markdown
+<!-- USER:START -->
+Content
+<!-- USER:END -->
+
+<!-- USER:START:name -->
+Named section
+<!-- USER:END:name -->
+```
+
+**Invalid markers**:
+```markdown
+<!-- USER START --> (missing colon)
+<!-- USER:START (missing closing -->)
+<!-- USER:END --> (no matching START)
+```
+
+**Solution**:
+```bash
+# Fix markers before rollback
+# Ensure all USER:START have matching USER:END
+```
+
+## Safety Notes
+
+### Input Validation
+
+All inputs are validated **before** use in git commands:
+
+**Commit hashes**:
+```javascript
+if (target !== 'HEAD' && !/^[0-9a-f]{4,40}$/i.test(target)) {
+  return { valid: false, error: 'Invalid commit hash format' };
+}
+```
+
+**File paths**:
+```javascript
+const resolved = path.resolve(projectRoot, file);
+const rel = path.relative(projectRoot, resolved);
+if (rel.startsWith('..') || path.isAbsolute(rel)) {
+  return { valid: false, error: 'Path outside project' };
+}
+```
+
+**Shell metacharacters**:
+```javascript
+if (/[;|&$`()<>\r\n]/.test(file)) {
+  return { valid: false, error: 'Invalid characters in path' };
+}
+```
+
+### Non-Destructive Operations
+
+**Uses**:
+- `git revert` (creates new commit, preserves history)
+- `git checkout HEAD~1 -- <files>` (restores specific files)
+
+**Never uses**:
+- `git reset --hard` (destroys commits)
+- `git push --force` (overwrites remote)
+- `git clean -f` (deletes untracked files)
+
+### Data Preservation
+
+**Always preserved**:
+- USER sections in all files
+- Custom commands in `.claude/commands/custom/`
+- Git history (revert creates new commits)
+- Untracked files (not affected)
+
+**Never lost**:
+- Your customizations
+- Work in progress (if committed/stashed)
+- Remote branches (local operation only)
+
+### Recommended Workflow
+
+```bash
+# 1. Always commit work before rollback
+git add .
+git commit -m "wip: current state"
+
+# 2. Use dry run to preview
+bunx forge rollback
+# Select: 6. Preview rollback (dry run)
+
+# 3. Execute rollback
+bunx forge rollback
+# Select appropriate method
+
+# 4. Verify USER sections preserved
+grep -A5 "USER:START" AGENTS.md
+
+# 5. Push if needed (after verification)
+git push
+```
+
+## Examples
+
+### Example 1: Quick Undo Last Commit
+
+```bash
+# Scenario: Just committed but realized approach is wrong
+
+git log --oneline
+# abc123d (HEAD) feat: add caching layer
+# def456e fix: validation bug
+
+bunx forge rollback
+# 1. Rollback last commit
+
+# Output:
+# ✓ Working directory is clean
+# ✓ Extracting USER sections...
+# ✓ Executing: git revert HEAD --no-edit
+# ✓ Restoring USER sections...
+# ✓ Rollback complete!
+
+git log --oneline
+# xyz789f (HEAD) Revert: feat: add caching layer
+# abc123d feat: add caching layer
+# def456e fix: validation bug
+```
+
+### Example 2: Revert Merged PR
+
+```bash
+# Scenario: PR #123 caused production issues
+
+git log --oneline
+# merge789 (HEAD) Merge pull request #123
+# feat456a feat: add real-time updates
+# bugfix123 fix: websocket connection
+
+bunx forge rollback
+# 3. Rollback merged PR
+# Enter: merge789
+
+# Output:
+# ✓ Validating commit hash...
+# ✓ Working directory is clean
+# ✓ Extracting USER sections...
+# ✓ Executing: git revert -m 1 merge789 --no-edit
+# ✓ Restoring USER sections...
+# ✓ Beads: Issue #123 → status: reverted
+# ✓ Rollback complete!
+
+forge show 123
+# ID: 123
+# Title: Add real-time updates
+# Status: reverted
+# Comments:
+#   - PR reverted by rollback
+```
+
+### Example 3: Restore Specific Files
+
+```bash
+# Scenario: Accidentally updated wrong files in last commit
+
+git show HEAD --name-only
+# commit abc123
+# feat: update documentation
+#   AGENTS.md (should not have changed)
+#   docs/API.md
+#   README.md
+
+bunx forge rollback
+# 4. Rollback specific files
+# Enter: AGENTS.md
+
+# Output:
+# ✓ Validating file paths...
+# ✓ Working directory is clean
+# ✓ Extracting USER sections...
+# ✓ Executing: git checkout HEAD~1 -- AGENTS.md
+# ✓ Committing changes...
+# ✓ Restoring USER sections...
+# ✓ Rollback complete!
+#   Files affected: 1
+
+git status
+# On branch: main
+# nothing to commit, working tree clean
+# (AGENTS.md restored to previous version)
+```
+
+### Example 4: Dry Run Preview
+
+```bash
+# Scenario: Want to see what rollback would do
+
+bunx forge rollback
+# 6. Preview rollback (dry run)
+# Method: commit
+# Target: HEAD
+
+# Output:
+# ✓ Validating inputs...
+# ✓ DRY RUN MODE - No changes will be made
+#
+# Preview of rollback:
+#   Method: commit
+#   Target: HEAD
+#
+#   Files that would be affected:
+#     - src/auth/middleware.js
+#     - src/auth/validators.js
+#     - tests/auth.test.js
+#
+#   USER sections that would be preserved:
+#     - AGENTS.md: 2 sections
+#     - CLAUDE.md: 1 section
+#
+#   Custom commands that would be preserved:
+#     - .claude/commands/custom/deploy.md
+#
+# No changes made (dry run).
+
+# Decision: Proceed with rollback
+bunx forge rollback
+# 1. Rollback last commit
+```
+
+## See Also
+
+- [/dev](.claude/commands/dev.md) - TDD development workflow
+- [/validate](.claude/commands/validate.md) - Validation before shipping
+- [AGENTS.md](../../AGENTS.md) - Complete workflow guide
+- [Beads](https://github.com/beadshq/beads) - Issue tracking integration

--- a/.agents/skills/shepherd/SKILL.md
+++ b/.agents/skills/shepherd/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: shepherd
+description: >
+  Monitor an already-reviewed OPEN pull request toward merge: read the CI/check rollup and the
+  branch-protection required-check set, take at most one idempotent action (re-run a flaky
+  required check, or post a status reply to a thread), then declare MERGE_READY, PENDING, or
+  escalate. Use when the user says "is PR #123 ready to merge yet?", "poll/watch the checks on
+  my PR", "the required CI job is flaky — kick off a re-run", "keep an eye on this PR until
+  it's green", "babysit the checks after /review", "shepherd PR 45", or "monitor the PR toward
+  merge (rebase if behind, --auto-rebase)". NEVER merges (the human merges in the GitHub UI),
+  edits code, or resolves review threads. Do NOT use to fix or reply-and-resolve PR feedback
+  from Greptile/CodeRabbit/SonarCloud — that is `review`; nor to open/push the PR — that is
+  `ship`; nor for the post-merge "CI green on master + close issues" check — that is `verify`;
+  nor for a general "where am I / what's in flight" report — that is `status`.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+Run one bounded monitor pass over a pull request: read CI and check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.
+
+# Shepherd
+
+`shepherd` is a **utility command, not a workflow stage.** It automates the polling / rerun / escalation loop that today is done by hand after `/review`. It does **not** replace `/review` (which still owns semantic review and its stage transition) and does **not** perform the pre-merge doc gate (embedded in `/ship` and `/review`).
+
+## Usage
+
+```bash
+forge shepherd <pr-number>
+forge shepherd <pr-number> --auto-rebase   # opt-in, default OFF
+```
+
+## Bounded-pass model (one pass = one invocation)
+
+Each `forge shepherd <pr>` invocation is **ONE discrete bounded pass**: it reads PR state, takes at most the allowed Tier-A action, then **exits**. It never sits in-process polling "until merge-ready."
+
+This mirrors the project's documented ergonomic from `/review`, the pre-merge gate, and the Greptile process: **poll briefly, then stop and hand off.** Any pass that finds checks still pending exits as `PENDING`, and the next scheduled pass picks up where it left off.
+
+A `--watch` affordance, if you want one, lives in an **external scheduler** (e.g. cron or a `/loop`) that re-invokes the bounded pass on an interval with debounce (>= 60s between passes, cancel-in-progress). There is no in-process infinite loop.
+
+## What it never does
+
+- **Never merges.** There is no merge action and no server-side auto-merge latch. The shepherd terminates at `MERGE_READY` and hands off to the human, who merges in the GitHub UI (mirroring the pre-merge gate's merge handoff).
+- **Never resolves review threads.** It may post a status **reply** to a thread (via the existing `.claude/scripts/greptile-resolve.sh reply` helper), but thread **resolution** is semantic and stays with `/review`.
+
+## Action ladder
+
+- **Tier-A (autonomous, idempotent, reversible):** re-run a flaky **required** check via `gh run rerun --failed` (capped by a rerun budget). Post status replies to threads (reply only).
+- **Tier-B (opt-in per-flag, default OFF):** `--auto-rebase` rebases onto the base and force-pushes with lease. Preconditions: clean working tree, HEAD unchanged during the pass. A lease rejection is a **hard-stop + escalate** — the shepherd never re-arms the lease, because doing so would clobber the concurrent human push the lease exists to protect.
+- **Tier-C (human escalation):** merge conflicts, required-check failures a rerun did not fix, an unreadable required-check set, unknown mergeability, auth/scope failures, oscillation, and budget exhaustion all stop and escalate with context posted to the PR.
+
+## Merge-readiness gate
+
+Merge-ready is declared **only** when the branch-protection required-check set is **known** AND all of it is green AND the branch is not behind base. The required set is read from `gh api repos/{owner}/{repo}/branches/{base}/protection/required_status_checks`. If branch protection is unreadable (insufficient token scope, or the branch is not protected), the shepherd does **not** guess — it escalates with the readable rollup attached.
+
+## Concurrency & safety
+
+- The advisory `shepherd:active` marker is **not** mutual exclusion. The real guard is a per-action HEAD-SHA re-read: before any mutating action the shepherd re-reads the head SHA, and if HEAD moved since the pass started it **aborts** the action.
+- Auth taxonomy: token expiry (401) pauses and surfaces; insufficient scope (403) is a permanent **hard-stop**; a secondary rate limit (403 + `Retry-After`) honors the delay and resumes on the next pass.
+
+## Per-harness behavior
+
+- **Claude Code / Codex:** invoke `forge shepherd <pr>` directly; an external scheduler may drive repeated bounded passes.
+- **Cursor:** manually-invoked only. Run `forge shepherd <pr>` from a terminal — there is no polling-loop affordance and no hook reliance on this surface.
+
+## State
+
+Progress is durable in GitHub: PR **comments** and **labels** plus `git`. There is no separate local state store.

--- a/.agents/skills/shepherd/evals/evals.json
+++ b/.agents/skills/shepherd/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Is PR #212 ready to merge yet?",
+    "should_trigger": true
+  },
+  {
+    "query": "The lint check on my PR keeps failing intermittently — kick off a re-run of the failed jobs.",
+    "should_trigger": true
+  },
+  {
+    "query": "Keep an eye on pull request 88 and tell me when all the required checks pass.",
+    "should_trigger": true
+  },
+  {
+    "query": "I just wrapped up /review on this PR — babysit the checks and escalate if it isn't mergeable.",
+    "should_trigger": true
+  },
+  {
+    "query": "Shepherd PR 300 and rebase it onto master if it's behind.",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix all the CodeRabbit and Greptile comments on my PR and resolve each review thread.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR just merged to master — confirm CI is green there and close the linked issue.",
+    "should_trigger": false
+  },
+  {
+    "query": "Push my validated feature branch and open a pull request from the template.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow and what work is still in flight right now?",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the SonarCloud issues flagged on this PR.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: ship
+description: >
+  Forge SHIP stage: push the validated feature branch and open a PR populated from the
+  project's OWN PR template (design-doc link, Forge issue IDs, real test/commit data), then
+  hand off for MANUAL merge; never merges or auto-merges. Use once /validate passes and you
+  want a PR on the board. Triggers: "ship it", "ship this branch", "open the PR", "push and
+  open a PR", "gh pr create", "checks passed, now cut the PR". Runs branch-freshness +
+  parallel-PR merge-sim checks, force-with-lease push, records the ship->review handoff, then
+  stops. One stage only; not for: the whole plan->dev->validate->ship->review pipeline or
+  drive-to-done (smith); type-check/lint/tests/security first (validate); addressing PR
+  comments or resolving Greptile/SonarCloud/CodeRabbit threads on an existing PR (review);
+  babysitting an open PR toward merge (shepherd); post-merge CI health check + closing issues
+  (verify); reverting an already-shipped change (rollback). If the PR already exists, this is
+  not the skill.
+allowed-tools: Bash, Read, Edit, Grep, Glob
+---
+
+Push code and create a pull request with full context and documentation links.
+
+# Ship
+
+This skill creates a PR after validation passes.
+
+## Usage
+
+```bash
+/ship
+```
+
+```
+<HARD-GATE: /ship entry>
+Do NOT create PR until:
+1. /validate was run in this session with all four outputs shown (type, lint, tests, security)
+2. All checks confirmed passing — not assumed, not "was passing earlier"
+3. Forge issue is in_progress (`forge issue show <id>` confirms status)
+4. git branch --show-current output is NOT main or master
+</HARD-GATE>
+```
+
+## What This Skill Does
+
+### Step 1: Verify /validate Passed
+Ensure all four validation checks completed successfully with fresh output in this session.
+
+### Step 2: Freshness Check — Is Branch Still Current?
+
+Even though /validate rebased onto the base branch, time may have passed since then (user reviewed design doc, took a break, etc.). This lightweight check catches staleness before pushing.
+
+```bash
+BASE=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
+if [ -z "$BASE" ] || [ "$BASE" = "(unknown)" ]; then BASE="master"; fi
+git fetch origin "$BASE" || { echo "✗ Fetch failed — cannot verify freshness"; exit 1; }
+BEHIND=$(git rev-list --count HEAD..origin/"$BASE")
+```
+
+- If `BEHIND > 0`: **STOP**. Print: "$BASE has advanced since /validate ($BEHIND new commits). Run /validate again to rebase and re-check."
+- If `BEHIND = 0`: Continue to push.
+- If fetch fails: the `|| { ...; exit 1; }` guard catches this — **STOP**. Do NOT push without confirming freshness.
+
+This is NOT a full rebase — just a check. The rebase happens in /validate where the full test suite runs afterward.
+
+### Parallel PR coordination (soft block)
+
+Before creating the PR, check merge readiness:
+
+```bash
+# Run merge simulation against base branch
+bash scripts/pr-coordinator.sh merge-sim "$(git branch --show-current)" 2>&1
+
+# Show recommended merge order
+bash scripts/pr-coordinator.sh merge-order 2>&1 || true
+
+# Auto-label the PR after creation (called after gh pr create below)
+# bash scripts/pr-coordinator.sh auto-label <issue-id>
+```
+
+If merge simulation finds conflicts:
+- Display conflicted files
+- Ask: "Merge conflicts detected with base branch. These PRs should merge first: [list]. Proceed with PR creation anyway? (y/n)"
+- If `n`: exit cleanly
+- If `y`: log override via `forge comment <id> "Ship override: creating PR despite merge conflicts"`, then continue
+
+After PR creation completes:
+```bash
+# Auto-label the newly created PR
+bash scripts/pr-coordinator.sh auto-label <issue-id>
+
+# Check for stale worktrees (informational)
+bash scripts/pr-coordinator.sh stale-worktrees 2>&1 || true
+```
+
+### Step 3: Record PR Handoff
+```bash
+forge comment <id> "PR created: <pr-url>. Awaiting review and merge verification."
+forge sync
+```
+
+Do not mark the Forge issue done during `/ship`. Completion happens only after merge and post-merge verification.
+
+### Step 4: Push Branch
+
+Use `--force-with-lease` because `/validate` may have rebased the branch, rewriting history. This is safe: it only forces the push if the remote branch hasn't been updated by someone else since the last fetch.
+
+```bash
+git push --force-with-lease -u origin <branch-name>
+```
+
+### Step 5: Create PR Using Project's PR Template
+
+**CRITICAL**: Always use the project's own PR template. Never use a hardcoded body.
+
+**Step 5a: Locate the PR template**
+
+Check for a PR template in the project (in order of precedence):
+```bash
+# Check standard locations
+PR_TEMPLATE=""
+for path in .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md docs/pull_request_template.md pull_request_template.md; do
+  if [ -f "$path" ]; then
+    PR_TEMPLATE="$path"
+    break
+  fi
+done
+```
+
+**Step 5b: Read and populate the template**
+
+If a PR template exists:
+1. **Read the template file** using the Read tool
+2. **Fill in every section** with actual data from the current PR context:
+   - Replace HTML comments (`<!-- ... -->`) with real content
+   - Check applicable checkboxes (`- [x]`)
+   - Fill in Forge issue IDs (replace `forge-xxx` with actual ID)
+   - Fill in test results, validation status, and other concrete data
+   - Reference the design doc: `docs/work/YYYY-MM-DD-<slug>/plan.md`
+3. **Do NOT remove any sections** — fill them all, even if "N/A"
+4. **Do NOT restructure the template** — keep the project's chosen format
+
+If no PR template exists, use this minimal fallback:
+```
+## Summary
+[1-3 sentences: what this PR does and why]
+
+## Changes
+[Bulleted list of key changes]
+
+## Testing
+[How it was tested, test results]
+
+## Issue
+Closes forge-xxx
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+**Step 5c: Create the PR**
+
+```bash
+gh pr create --title "<type>: <concise description>" --body "<populated-template-content>"
+```
+
+Rules for the PR body:
+- **Use the project's template structure** — never substitute your own format
+- **Fill in concrete data** — commit counts, test results, actual file paths, real Forge IDs
+- **Check applicable checkboxes** — `[x]` for items that apply, `[ ]` for items that don't
+- **Include "Closes forge-xxx"** in the Issue section (required for auto-close in /verify)
+
+### Step 6: Confirm Context and Record Stage Transition
+```bash
+# Confirm the issue carries design + acceptance context (helper when present; otherwise inspect the issue).
+# Only falls back to `forge issue show` when the helper is absent — a real validate failure stays visible.
+if [ -f scripts/beads-context.sh ]; then
+  bash scripts/beads-context.sh validate <id>
+else
+  forge issue show <id>
+fi
+
+# Record the ship→review transition (structured helper when present; kernel-native comment otherwise).
+# The fallback comment mirrors the same envelope the helper emits (Stage:/Summary:/Decisions:/Artifacts:/Next:).
+if [ -f scripts/beads-context.sh ]; then
+  bash scripts/beads-context.sh stage-transition <id> ship review \
+    --summary "<PR created, checks pending>" \
+    --decisions "<template sections filled, issue linked>" \
+    --artifacts "<PR URL, branch name>" \
+    --next "<review focus areas>"
+else
+  forge comment <id> "Stage: ship complete → ready for review
+Summary: <PR created, checks pending>
+Decisions: <template sections filled, issue linked>
+Artifacts: <PR URL, branch name>
+Next: <review focus areas>"
+fi
+```
+
+### Team sync after PR
+
+After PR is created, sync issue state to GitHub and verify 1:1 mapping:
+
+```bash
+# Sync issue state to GitHub
+forge team sync 2>&1 || true
+
+# Verify 1:1 mapping
+forge team verify 2>&1 || true
+```
+
+## Output
+
+`/ship` reports live validation status, branch freshness, Forge issue PR handoff state, push status, PR URL, template sections, linked issue IDs, and CI polling state. Values come from the current branch, issue tracker, and GitHub response; do not copy static IDs, URLs, or branch names into this skill file.
+
+When checks are still pending after the polling window, stop after reporting the PR number and direct the next session to `/review <pr-number>` once automated checks complete or new feedback appears.
+
+## Pre-merge gate (before merge)
+
+Pre-merge is a doc-update **gate/checkpoint**, not a separate stage — run it here, before the PR is handed off for merge, whenever the change touches anything documented:
+
+1. **Finish the docs on the feature branch** (update only what genuinely changed):
+   - `CHANGELOG.md` (always) — entry under `## [Unreleased]` using Keep a Changelog categories, with PR number + issue ID.
+   - `README.md` (user-facing), `docs/reference/API_REFERENCE.md` (API), architecture docs (structural).
+   - `CLAUDE.md` — **USER section only** (between the USER markers); never touch other managed blocks.
+   - `AGENTS.md` (agent config, skills, or cross-agent workflow changes).
+   Commit the doc updates to the feature branch and push.
+2. **Confirm CI is green** — doc commits re-trigger CI; poll briefly (~60s), then hand off if still pending. New review feedback → run `/review` again.
+3. **Sync the issue store** — `forge sync`.
+4. **Hand off for MANUAL merge** — present the PR and stop. **Never run `gh pr merge`; never auto-merge.** The user merges in the GitHub UI, then runs `/verify`.
+
+## Integration with Workflow
+
+```
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Pre-merge gate: doc updates + CI-green checkpoint embedded in /ship and /review (not a separate stage).
+```
+
+## Tips
+
+- **Use the project's PR template**: Always read `.github/pull_request_template.md` (or equivalent) and populate it — never substitute your own format
+- **Fill every section**: Even if "N/A" — empty/missing sections cause review friction
+- **Include "Closes forge-xxx"**: Required for auto-close in /verify
+- **Concrete data only**: Test counts, file paths, commit SHAs — not placeholder text
+- **Poll briefly, then stop**: Check PR status for up to 60 seconds, then hand off if checks are still pending
+- **NO auto-merge**: Always wait for /review phase

--- a/.agents/skills/ship/evals/evals.json
+++ b/.agents/skills/ship/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Validation came back clean — go ahead and open the pull request for this branch.",
+    "should_trigger": true
+  },
+  {
+    "query": "Push my feature branch and raise a PR, and fill in our PR template with the issue and design-doc links.",
+    "should_trigger": true
+  },
+  {
+    "query": "Dev's done and all the checks passed, cut me a PR.",
+    "should_trigger": true
+  },
+  {
+    "query": "Do a gh pr create for feat/rate-limit using the repo's template, not a hand-written body.",
+    "should_trigger": true
+  },
+  {
+    "query": "Everything's green after validate — ship it, but hand it off for me to merge, don't merge it yourself.",
+    "should_trigger": true
+  },
+  {
+    "query": "Take forge-42 from planning all the way to a merge-ready PR — plan it, build it TDD, validate, then ship, checking with me at the gates.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR's picked up Greptile and CodeRabbit comments — fix them and resolve the threads.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run the type-check, lint, tests and security scan before I push anything.",
+    "should_trigger": false
+  },
+  {
+    "query": "Keep watching PR #128 and ping me the moment its checks go green so I can merge.",
+    "should_trigger": false
+  },
+  {
+    "query": "The PR merged to master — confirm CI is green there and close the linked issue.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/smith/SKILL.md
+++ b/.agents/skills/smith/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: smith
+description: >
+  The flagship Forge orchestrator: given a goal or a ready issue, it composes the
+  stage skills (triage-ready · claim-safety · plan · dev · validate · ship · review
+  · verify) into the right path for the work, running autonomously between human
+  gates and pausing at them. Use this whenever the user wants to work the next ready
+  issue, drive a feature or fix end-to-end, "take this through to a PR", orchestrate
+  the whole workflow with human checkpoints, or asks some form of "what should I
+  work on and get it done" — even if they never say "smith" or "orchestrate". Reach
+  for it especially when the request spans multiple stages (plan → build → ship) or
+  asks to keep a human in the loop at intent, plan, or merge. Prefer a single stage
+  skill only when the user explicitly wants just that one step (e.g. "just open the
+  PR").
+allowed-tools: Read, Bash(forge:*)
+---
+
+# Smith — the orchestrator super-skill
+
+Smith is a thin orchestrator. It adds no stage behaviour of its own; every step
+below is an existing skill or `forge` verb. What smith contributes is *judgement*:
+which path to take for this piece of work, and how densely to involve the human.
+It is maximally driving between gates and deliberately stops at them — the goal is
+conversational autonomy, not unattended autonomy.
+
+Keep the word "kernel" internal — it is the event store under the hood, not a
+term users should see.
+
+Deeper lookup tables live in
+[references/autonomy-and-gates.md](references/autonomy-and-gates.md): read that
+when you calibrate a specific issue or need the exact gate IDs and commands.
+
+## The orchestration procedure
+
+1. **Pick the work with `triage-ready`.** Rank the ready queue
+   (`forge issue ready --json`) and explain why the top pick is genuinely
+   workable. Readiness is a *derived* model, so recompute it each time rather than
+   trusting a remembered "ready" — you want the item that is actually unblocked
+   now, not a stale guess. Hand off one issue.
+
+2. **Claim it, then prove you own it, with `claim-safety`.**
+   `FORGE_ACTOR=<actor> forge claim <id>`, then `forge issue owns <id>` (exit 0 =
+   owned). A claim returning `ok:true` is not proof — a duplicate replay returns
+   `ok:true` too, and a live lease can be reclaimed once it expires. Proving
+   ownership is what stops two agents from quietly working the same issue. If you
+   are not the owner, don't work it; reselect via `triage-ready`.
+
+3. **Calibrate autonomy during planning.** Read the issue's size × importance ×
+   complexity, map it to a tier (lean / standard / high), and *propose that tier
+   directly to the human* — a short "here's how much oversight I think this needs."
+   This proposal is a plain conversational checkpoint at the start of planning; it
+   is deliberately **not** itself one of the enforcement gates, so it stays reachable
+   even for the Lean tier (which may require no intent gate at all). The human
+   confirms or overrides, and the chosen tier decides **which enforcement gates you
+   require approval for on this issue** (step 5). Keep the two mechanisms distinct:
+   `forge gate enable|disable <gate>` is the **repo-wide default** (a gate the user
+   turned off is always skipped), whereas the per-issue tier is *your* runtime
+   decision about which of the still-enabled gates to actually require for this one
+   issue. Matching checkpoint density to stakes is the whole point: a docs typo
+   should not drag through a full brainstorm, and a risky refactor should not run
+   unattended. When your read is uncertain, lean toward *more* gates — an extra
+   approval costs seconds, a missing one can cost a lot of rework. See the
+   reference for the tier → gate mapping.
+
+4. **Drive the stages along the path that fits.** Sequence
+   `plan → dev → validate → ship → review → verify`, invoking each stage skill as
+   its step arrives. The stage skills already encode the TDD, validation, and
+   review discipline, so smith's job is only to pick the path by change
+   classification (critical / standard / simple / hotfix / docs / refactor): a docs
+   typo skips brainstorming and most of the ladder; a critical feature runs the
+   full ladder.
+
+5. **Stop at every enabled human gate.** Before advancing past a gate, run:
+
+   ```bash
+   forge gate check <issue> <gate>     # exit 0 iff the gate is disabled or approved
+   ```
+
+   On exit 0, proceed. On non-zero, stop and ask the human to
+   `forge gate approve <issue> <gate> [--reason "…"]` (or
+   `forge gate reject <issue> <gate> --reason "…"` to send it back); inspect
+   history any time with `forge gate status <issue>`. Approvals are recorded as
+   durable events, which is what lets smith re-check and continue after a crash or
+   compaction instead of re-asking. The three human gates are `gate.intent`,
+   `gate.plan-approval`, and `gate.merge` (details in the reference).
+
+6. **Re-prove ownership and check readiness before closing.** A lease can expire
+   and be reclaimed while you work, so run `forge issue owns <id>` again before you
+   close — you don't want to close someone else's issue. Then confirm the tree is
+   actually shippable:
+
+   ```bash
+   forge release check --target <version> --json   # success:true ⇒ healthy
+   ```
+
+   Close only when ownership holds and readiness is healthy
+   (`forge close <id> --reason "…"`), then `forge sync`.
+
+## Autonomy tiers at a glance
+
+Full table and the reasoning are in the reference; the short version:
+
+- **Lean** — small · simple · low-importance work: enforce just `gate.merge`, or
+  run under CI with the human gates disabled.
+- **Standard** (default) — an ordinary feature/bug: enforce `gate.intent`,
+  `gate.plan-approval`, and `gate.merge`.
+- **High** — large · important · or complex work: enforce all three, plus
+  per-milestone check-ins and a pre-ship pass.
+
+The tier is a **per-issue** decision: smith requires `check`/approval only for the
+gates its tier calls for on *this* issue and simply skips the rest — it does not
+toggle repo config per issue. Separately, `forge gate disable <gate-id>` is the
+**repo-wide** off switch (a disabled gate makes `check` fall through for *every*
+issue) — use it when the user never wants that checkpoint at all. So a lean run
+skips a checkpoint by not requiring it for this issue; disabling a gate removes it
+everywhere.
+
+## Reliability
+
+- **The human always wins, and uncertainty adds oversight.** Smith proposes a
+  tier; it never lowers the human-loop density on its own, and a rejected gate
+  sends the work back rather than proceeding.
+- **Re-check gates on resume.** After any interruption, trust the recorded events
+  (`check` / `status`), not your memory of what was approved.
+- **Prove ownership twice** — after claiming and again before close/release.
+- **Never bypass a gate or a hook.** A failed gate or failing hook is a stop to
+  resolve, not an obstacle to route around (no `LEFTHOOK=0`, no `--no-verify`).
+
+## Fork points
+
+Smith is a default assembly, not a fixed ladder — re-carve it:
+
+| Knob | Default | How to change |
+|------|---------|---------------|
+| **Stakes heuristic** | size × importance × complexity → tier | Re-weight it (e.g. weight blast-radius or reversibility higher), or map your own change-classes to tiers. |
+| **Tier → gate set** | lean / standard / high (see reference) | Change which human gates each tier enforces; enact per repo with `forge gate enable\|disable <gate-id>`. |
+| **Gate density** | intent · plan-approval · merge | Add a checkpoint (enable a gate or add a per-milestone pause) or drop one (disable it); the human overrides smith's proposal at `gate.intent`. |
+| **Composed flow** | triage → claim → plan → dev → validate → ship → review → verify | Skip stages by change class (docs typo → doc-only path), reorder, or swap in your own `plan`/`dev`/`review` adapter. |
+| **Release target** | `forge release check` default | Pass `--target <version>` for the release you are certifying. |
+
+Smith is the assembled hammer; the sub-skills are the head and handle; the gates
+are the grip adjustments. Ship a good default, then let users re-carve it.

--- a/.agents/skills/smith/evals/evals.json
+++ b/.agents/skills/smith/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "Grab the next ready issue off the board and take it all the way through to a PR for me — plan it, build it TDD, validate, and open the PR, but stop and check with me before it actually merges.",
+    "should_trigger": true
+  },
+  {
+    "query": "I want you to orchestrate the whole workflow for the payments-webhook feature end to end: design the plan, do the dev, run validation, ship it, handle the review comments — just keep me in the loop at the plan-approval and merge points.",
+    "should_trigger": true
+  },
+  {
+    "query": "What should I pick up next? Whatever's highest-priority and ready, claim it and drive it to done with the usual human checkpoints — I don't want to babysit every step but I do want to approve the design and the merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "Take issue forge-9k2 from planning through a merged PR. It's a big risky refactor so keep me involved — I want to sign off at intent, at the plan, and per milestone before you push.",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the full plan through ship flow on the login-rate-limit bug, but it's a tiny fix so don't over-gate it — just let me approve the merge and go.",
+    "should_trigger": true
+  },
+  {
+    "query": "Autonomously work through the ready queue and get each task to a PR, pausing for my approval before any merge.",
+    "should_trigger": true
+  },
+  {
+    "query": "Just open the PR for my current branch, it's already validated and I've written the description.",
+    "should_trigger": false
+  },
+  {
+    "query": "What stage am I in and what's my active work right now? Anything gone stale?",
+    "should_trigger": false
+  },
+  {
+    "query": "Go through the CodeRabbit and SonarCloud comments on PR #288 and address them, then re-request review.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a feature issue for adding dark mode to the settings page, priority 2, and link it under the theming epic.",
+    "should_trigger": false
+  },
+  {
+    "query": "Just claim forge-abc for me so nobody else picks it up while I look at it.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/smith/references/autonomy-and-gates.md
+++ b/.agents/skills/smith/references/autonomy-and-gates.md
@@ -1,0 +1,94 @@
+# Autonomy calibration & human gates — reference
+
+Read this when you are calibrating how much to involve the human on a specific
+issue, or when you need the exact gate commands and IDs. `SKILL.md` carries the
+procedure; this file carries the lookup tables and the reasoning behind them.
+
+## The three human gates
+
+Forge registers three human gates in the runtime graph as **approval-satisfied
+events** (`requires: []`), additive to the evidence exit-gates. They are the
+points where smith pauses and hands control to the human.
+
+| Gate | Fires | What the human is deciding |
+|------|-------|----------------------------|
+| `gate.intent` | before planning / brainstorm | Do we agree on the goal, and on the autonomy tier smith proposed, before any design work? |
+| `gate.plan-approval` | after the design doc + task DAG exist, before `dev` | Is this plan the right one (approve), or should it be redirected? |
+| `gate.merge` | after `review`, before merge | Is the PR good to merge? |
+
+The evidence exit-gates — `gate.plan-exit`, `gate.dev-exit`,
+`gate.validate-exit`, `gate.ship-entry` — are a different kind: they are
+satisfied by artifacts *inside* the stage skills (a design doc, TDD tests,
+validation output), not by a human. Smith relies on each stage skill's own exit
+checks for those and does not gate on them itself.
+
+### Why gates are events, not prose
+
+Each approval is written to the issue's event stream as a durable
+`gate.approved` / `gate.rejected` record. That is what makes a gated run
+**resume-safe**: if smith is interrupted by a crash or a context compaction, it
+re-reads the event with `check` / `status` on resume and knows whether it may
+proceed — instead of re-asking the human or guessing from memory. Prose in a
+transcript cannot survive a compaction; an event can.
+
+### Gate commands
+
+```bash
+forge gate check <issue> <gate>              # exit 0 iff the gate is DISABLED or APPROVED
+forge gate approve <issue> <gate> [--reason] # human records approval (durable event)
+forge gate reject  <issue> <gate> --reason   # human sends the work back
+forge gate status  <issue> [--json]          # list this issue's gate events (who/when)
+forge gate enable|disable <gate-id>          # repo default toggle: workflow.gates.<id>.enabled
+```
+
+`check` is the enforcement primitive smith calls before advancing past a gate. It
+exits 0 when the gate is disabled for the repo *or* an approval event exists, so a
+disabled gate simply falls through — that is how a lean tier skips a checkpoint.
+
+## Autonomy calibration — stakes → gate density
+
+Match checkpoint density to what is at stake. A one-line docs fix and a risky
+refactor need very different amounts of oversight: forcing the docs fix through a
+full brainstorm wastes everyone's time, while letting the refactor run unattended
+risks a large wrong turn. Smith reads the issue's **size × importance ×
+complexity**, proposes a tier at `gate.intent`, and the human confirms or
+overrides.
+
+| Tier | Stakes read | Enforced human gates | Extra checkpoints |
+|------|-------------|----------------------|-------------------|
+| **Lean** | small · simple · low-importance (docs typo, one-line fix) | just `gate.merge`, or none under CI | skip the intent brainstorm; lean on CI + the evidence exit-gates |
+| **Standard** (default) | an ordinary feature or bug | `gate.intent` · `gate.plan-approval` · `gate.merge` | the evidence exit-gates as configured |
+| **High** | large · important · or complex (critical feature, risky refactor) | all three human gates, enabled | per-milestone / per-task human check-ins (pause + `forge comment`), an explicit pre-ship review pass |
+
+### How a tier is enacted
+
+The tier maps to *which gate events are required* for this issue. The human enacts
+add/drop with `forge gate enable|disable <gate-id>` (the repo default), and smith
+enforces every *enabled* gate via `check`. Because approvals are per-issue events,
+the human can add or drop a checkpoint mid-flight and smith re-reads it on the next
+step — the calibration is not frozen at planning time.
+
+### Why uncertainty adds gates rather than removing them
+
+Smith only *proposes* a tier; it never lowers oversight on its own. When its read
+of size/importance/complexity is low-confidence, it defaults to **more**
+checkpoints, because an unwanted extra approval is a few seconds of the human's
+time, while a missed one can mean a large amount of wasted or wrong work. The
+human always wins the final say.
+
+## Composition map — smith invents nothing
+
+Every step is an existing skill or `forge` verb; smith only sequences them.
+
+| Step | Composed skill / verb |
+|------|-----------------------|
+| Pick work | `triage-ready` (`forge issue ready` / `blocked` / `stats`) |
+| Claim + prove ownership | `claim-safety` (`forge claim` → `forge issue owns`) |
+| Human gates | `forge gate check` / `approve` / `reject` / `status` |
+| Plan | `plan` (intent brainstorm → design doc → task DAG) |
+| Build | `dev` (per-task implementer → spec → quality TDD) |
+| Validate | `validate` (types · lint · security · tests) |
+| Ship | `ship` (push + PR) |
+| Review | `review` (address CI / bot feedback) |
+| Verify | `verify` (post-merge health) |
+| Release readiness | `forge release check --target <version> --json` |

--- a/.agents/skills/sonarcloud-analysis/SKILL.md
+++ b/.agents/skills/sonarcloud-analysis/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: sonarcloud-analysis
+description: >
+  SonarCloud deep-dive via its REST API: pull open issues (bugs, vulnerabilities, code
+  smells), coverage/duplication metrics, quality-gate pass/fail with failed thresholds,
+  security hotspots, and measure/analysis history for a whole project, branch, or PR, then
+  return a ranked summary. Use whenever the user names SonarCloud or asks about code-quality
+  metrics, technical debt, a red/failing quality gate, or static-analysis
+  vulnerabilities/hotspots — e.g. 'why is the SonarCloud gate failing on this PR' or 'pull
+  every BLOCKER vulnerability with file and line'. NOT for: the thin `/sonarcloud <query>
+  <project>` slash command for a quick lookup (sibling 'sonarcloud'); replying to/resolving PR
+  review threads across Greptile, CodeRabbit, or GitHub Actions ('review'); running local
+  lint/type-check/test/security scans pre-ship ('validate'); implementing or patching a
+  flagged issue ('dev'); or an external market/competitor report on SonarSource or DevSecOps
+  vendors ('parallel-deep-research').
+category: Code Quality
+tags: [sonarcloud, code-quality, issues, metrics, security]
+context: fork
+tools: [Bash, WebFetch, Read, Grep, Glob]
+model: sonnet
+---
+
+<role>
+You are a SonarCloud code quality analyst with expertise in static analysis, security vulnerability assessment, and technical debt management. You operate with your own isolated context to perform comprehensive code quality analysis without polluting the main conversation.
+</role>
+
+<capabilities>
+- Query SonarCloud API for issues, metrics, and quality gates
+- Analyze code quality across branches and pull requests
+- Identify security vulnerabilities and hotspots
+- Track coverage, duplication, and technical debt
+- Generate health reports and trend analysis
+- Correlate SonarCloud findings with local codebase
+</capabilities>
+
+<constraints>
+- Always use environment variables: $SONARCLOUD_TOKEN, $SONARCLOUD_ORG, $SONARCLOUD_PROJECT
+- Load credentials from .env.local if environment variables are not set
+- Never expose tokens in output
+- Validate API responses before processing
+- Handle pagination for large result sets
+</constraints>
+
+<workflow>
+1. Load environment variables (check .env.local if needed: `source .env.local 2>/dev/null || true`)
+2. Verify credentials are available
+3. Determine the analysis scope (project, branch, PR)
+4. Query relevant endpoints
+5. Process and correlate results
+6. Return actionable summary to main context
+</workflow>
+
+# SonarCloud Integration
+
+**Base**: `https://sonarcloud.io/api` | **Auth**: `Bearer $SONARCLOUD_TOKEN`
+
+## Configuration
+
+**Environment Variables**: Required for authentication
+- `SONARCLOUD_TOKEN` - Generate at sonarcloud.io/account/security
+- `SONARCLOUD_ORG` - Your SonarCloud organization key
+- `SONARCLOUD_PROJECT` - Your project key
+
+**Option 1: Use .env.local** (Recommended)
+Add to your project's `.env.local`:
+```bash
+SONARCLOUD_TOKEN=your_token_here
+SONARCLOUD_ORG=your-org
+SONARCLOUD_PROJECT=your-project
+```
+
+Before querying, load environment variables:
+```bash
+# Load .env.local into current environment
+export $(grep -v '^#' .env.local | xargs)
+```
+
+**Option 2: Export directly**
+```bash
+export SONARCLOUD_TOKEN="your_token"
+export SONARCLOUD_ORG="your-org"
+export SONARCLOUD_PROJECT="your-project"
+
+# Common queries
+curl -H "Authorization: Bearer $SONARCLOUD_TOKEN" \
+  "https://sonarcloud.io/api/issues/search?organization=$SONARCLOUD_ORG&componentKeys=$SONARCLOUD_PROJECT&resolved=false"
+curl -H "Authorization: Bearer $SONARCLOUD_TOKEN" \
+  "https://sonarcloud.io/api/measures/component?component=$SONARCLOUD_PROJECT&metricKeys=bugs,coverage"
+curl -H "Authorization: Bearer $SONARCLOUD_TOKEN" \
+  "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$SONARCLOUD_PROJECT"
+```
+
+## Endpoints
+
+| Endpoint                        | Purpose                  | Key Params                               |
+| ------------------------------- | ------------------------ | ---------------------------------------- |
+| `/api/issues/search`            | Bugs, vulnerabilities    | `types`, `severities`, `branch`, `pullRequest` |
+| `/api/measures/component`       | Coverage, complexity     | `metricKeys`, `branch`, `pullRequest`    |
+| `/api/qualitygates/project_status` | Pass/fail status      | `projectKey`, `branch`, `pullRequest`    |
+| `/api/hotspots/search`          | Security hotspots        | `projectKey`, `status`                   |
+| `/api/projects/search`          | List projects            | `organization`, `q`                      |
+| `/api/project_analyses/search`  | Analysis history         | `project`, `from`, `to`                  |
+| `/api/measures/search_history`  | Metrics over time        | `component`, `metrics`, `from`           |
+| `/api/components/tree`          | Files with metrics       | `qualifiers=FIL`, `metricKeys`           |
+| `/api/duplications/show`        | Duplicate code blocks    | `key` (file key), `branch`               |
+| `/api/sources/raw`              | Raw source code          | `key` (file key), `branch`               |
+| `/api/sources/scm`              | SCM blame info           | `key`, `from`, `to`                      |
+| `/api/ce/activity`              | Background tasks         | `component`, `status`, `type`            |
+| `/api/qualityprofiles/search`   | Quality profiles         | `language`, `project`                    |
+| `/api/languages/list`           | Supported languages      | -                                        |
+| `/api/project_branches/list`    | Project branches         | `project`                                |
+| `/api/project_badges/measure`   | SVG badge                | `project`, `metric`, `branch`            |
+| `/api/rules/search`             | Coding rules             | `languages`, `severities`, `types`       |
+
+## Common Filters
+
+**Issues**: `types=BUG,VULNERABILITY,CODE_SMELL` | `severities=BLOCKER,CRITICAL,MAJOR` | `resolved=false` | `inNewCodePeriod=true`
+
+**Metrics**: `bugs,vulnerabilities,code_smells,coverage,duplicated_lines_density,sqale_rating,reliability_rating,security_rating`
+
+**New Code**: `new_bugs,new_vulnerabilities,new_coverage,new_duplicated_lines_density`
+
+## Workflows
+
+### Health Check
+
+```bash
+curl ... "/api/qualitygates/project_status?projectKey=$PROJECT"
+curl ... "/api/measures/component?component=$PROJECT&metricKeys=bugs,vulnerabilities,coverage,sqale_rating"
+curl ... "/api/issues/search?organization=$ORG&componentKeys=$PROJECT&resolved=false&facets=severities,types&ps=1"
+```
+
+### PR Analysis
+
+```bash
+curl ... "/api/qualitygates/project_status?projectKey=$PROJECT&pullRequest=123"
+curl ... "/api/issues/search?organization=$ORG&componentKeys=$PROJECT&pullRequest=123&resolved=false"
+curl ... "/api/measures/component?component=$PROJECT&pullRequest=123&metricKeys=new_bugs,new_coverage"
+```
+
+### Security Audit
+
+```bash
+curl ... "/api/issues/search?organization=$ORG&componentKeys=$PROJECT&types=VULNERABILITY&resolved=false"
+curl ... "/api/hotspots/search?projectKey=$PROJECT&status=TO_REVIEW"
+```
+
+### Duplication Analysis
+
+```bash
+# Get duplication metrics
+curl ... "/api/measures/component?component=$PROJECT&metricKeys=duplicated_lines,duplicated_lines_density,duplicated_blocks,duplicated_files"
+
+# Get files with most duplication
+curl ... "/api/components/tree?component=$PROJECT&qualifiers=FIL&metricKeys=duplicated_lines_density&s=metric&metricSort=duplicated_lines_density&asc=false&ps=20"
+
+# Get duplicate blocks for a specific file (requires file key from above)
+curl ... "/api/duplications/show?key=my-project:src/utils/helpers.ts"
+```
+
+## Response Processing
+
+```bash
+# Count by severity
+curl ... | jq '.issues | group_by(.severity) | map({severity: .[0].severity, count: length})'
+
+# Failed quality gate conditions
+curl ... | jq '.projectStatus.conditions | map(select(.status == "ERROR"))'
+
+# Metrics as key-value
+curl ... | jq '.component.measures | map({(.metric): .value}) | add'
+```
+
+## Detailed Reference
+
+For complete API parameters and response schemas, see [references/api-reference.md](references/api-reference.md).

--- a/.agents/skills/sonarcloud-analysis/evals/README.md
+++ b/.agents/skills/sonarcloud-analysis/evals/README.md
@@ -1,0 +1,27 @@
+# Eval Sets
+
+These eval files use a flat JSON array format targeting `scripts/eval_win.py`:
+
+```json
+[{"query": "...", "should_trigger": true}]
+```
+
+This is **not** compatible with the skill-creator plugin's `run_loop.py` which expects:
+
+```json
+{"skill_name": "...", "evals": [{"id": "...", "prompt": "...", "should_trigger": true}]}
+```
+
+To convert for `run_loop.py`:
+
+```bash
+python3 -c "
+import json, pathlib, uuid
+data = json.loads(pathlib.Path('evals.json').read_text())
+out = {'skill_name': 'SKILL-NAME-HERE', 'evals': [
+    {'id': str(uuid.uuid4()), 'prompt': item['query'], 'should_trigger': item['should_trigger']}
+    for item in data
+]}
+print(json.dumps(out, indent=2))
+" > evals_skill_creator.json
+```

--- a/.agents/skills/sonarcloud-analysis/evals/evals.json
+++ b/.agents/skills/sonarcloud-analysis/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "Why is our quality gate red on this pull request? Break down exactly which conditions failed and by how much.",
+    "should_trigger": true
+  },
+  {
+    "query": "How much technical debt has piled up in the codebase, and which files carry the worst maintainability rating?",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me the coverage and duplication numbers for the develop branch and flag the modules that regressed.",
+    "should_trigger": true
+  },
+  {
+    "query": "List every unresolved BLOCKER and CRITICAL vulnerability SonarCloud found, with file and line, so I know what to fix first.",
+    "should_trigger": true
+  },
+  {
+    "query": "Pull the security hotspots that still need review and summarize the risk for each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Show me how our reliability and security ratings have trended over the last month of analyses.",
+    "should_trigger": true
+  },
+  {
+    "query": "/sonarcloud issues checkout-service --severity BLOCKER",
+    "should_trigger": false
+  },
+  {
+    "query": "Go through all the open PR review threads from Greptile and CodeRabbit, reply to each explaining the fix, and mark them resolved.",
+    "should_trigger": false
+  },
+  {
+    "query": "Run lint, type-check, the test suite, and the security scanner and give me fresh output before I ship this branch.",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix the SQL-injection vulnerability SonarCloud flagged in login.ts and add a regression test.",
+    "should_trigger": false
+  },
+  {
+    "query": "Produce a competitive market report comparing SonarCloud, Snyk, and Codacy for our tooling decision.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/sonarcloud-analysis/references/api-reference.md
+++ b/.agents/skills/sonarcloud-analysis/references/api-reference.md
@@ -1,0 +1,466 @@
+# SonarCloud API Reference
+
+Complete parameter and response documentation for all endpoints.
+
+## Issues (`/api/issues/search`)
+
+### Parameters
+
+| Parameter | Description | Values |
+| --------- | ----------- | ------ |
+| `organization` | Org key | Required |
+| `componentKeys` | Project key(s) | Comma-separated |
+| `types` | Issue types | `BUG`, `VULNERABILITY`, `CODE_SMELL`, `SECURITY_HOTSPOT` |
+| `severities` | Severity | `BLOCKER`, `CRITICAL`, `MAJOR`, `MINOR`, `INFO` |
+| `statuses` | Status | `OPEN`, `CONFIRMED`, `REOPENED`, `RESOLVED`, `CLOSED` |
+| `resolutions` | Resolution | `FALSE-POSITIVE`, `WONTFIX`, `FIXED`, `REMOVED` |
+| `resolved` | Filter | `true`, `false` |
+| `branch` | Branch name | String |
+| `pullRequest` | PR number | String |
+| `createdAfter` | Date filter | `YYYY-MM-DD` |
+| `createdBefore` | Date filter | `YYYY-MM-DD` |
+| `languages` | Languages | `java`, `typescript`, `python`, etc. |
+| `rules` | Rule keys | Comma-separated |
+| `tags` | Issue tags | Comma-separated |
+| `assignees` | Assigned users | Comma-separated |
+| `authors` | Code authors | Comma-separated |
+| `scopes` | Scope | `MAIN`, `TEST` |
+| `inNewCodePeriod` | New code only | `true`, `false` |
+| `facets` | Aggregations | `severities`, `types`, `rules`, `tags` |
+| `p` | Page number | Integer (1-based) |
+| `ps` | Page size | Integer (max 500) |
+| `s` | Sort field | `CREATION_DATE`, `UPDATE_DATE`, `SEVERITY` |
+| `asc` | Sort order | `true`, `false` |
+
+### Response
+
+```json
+{
+  "total": 150,
+  "paging": { "pageIndex": 1, "pageSize": 100, "total": 150 },
+  "issues": [{
+    "key": "AYx...",
+    "rule": "typescript:S1234",
+    "severity": "MAJOR",
+    "component": "my-project:src/file.ts",
+    "line": 42,
+    "message": "Remove this unused variable.",
+    "type": "CODE_SMELL",
+    "status": "OPEN",
+    "effort": "5min",
+    "tags": ["unused"],
+    "creationDate": "2024-01-15T10:30:00+0000"
+  }],
+  "facets": [{ "property": "severities", "values": [{ "val": "MAJOR", "count": 50 }] }]
+}
+```
+
+---
+
+## Metrics (`/api/measures/component`)
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `component` | Project key (required) |
+| `metricKeys` | Metrics (comma-separated) |
+| `branch` | Branch name |
+| `pullRequest` | PR number |
+| `additionalFields` | `metrics`, `periods` |
+
+### All Metric Keys
+
+| Category | Keys |
+| -------- | ---- |
+| Size | `ncloc`, `lines`, `statements`, `functions`, `classes`, `files` |
+| Complexity | `complexity`, `cognitive_complexity` |
+| Coverage | `coverage`, `line_coverage`, `branch_coverage`, `tests`, `test_success_density`, `uncovered_lines`, `uncovered_conditions` |
+| Duplication | `duplicated_lines`, `duplicated_lines_density`, `duplicated_blocks`, `duplicated_files` |
+| Issues | `bugs`, `vulnerabilities`, `code_smells`, `security_hotspots` |
+| Ratings | `sqale_rating`, `reliability_rating`, `security_rating`, `security_review_rating` (1=A to 5=E) |
+| Debt | `sqale_index` (minutes), `sqale_debt_ratio` (%) |
+| Quality Gate | `alert_status`, `quality_gate_details` |
+| New Code | `new_bugs`, `new_vulnerabilities`, `new_code_smells`, `new_coverage`, `new_duplicated_lines_density` |
+
+### Response
+
+```json
+{
+  "component": {
+    "key": "my-project",
+    "name": "My Project",
+    "measures": [
+      { "metric": "bugs", "value": "12" },
+      { "metric": "coverage", "value": "78.5" },
+      { "metric": "sqale_rating", "value": "2.0" }
+    ]
+  }
+}
+```
+
+---
+
+## Quality Gate (`/api/qualitygates/project_status`)
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `projectKey` | Project key (required) |
+| `branch` | Branch name |
+| `pullRequest` | PR number |
+
+### Response
+
+```json
+{
+  "projectStatus": {
+    "status": "ERROR",
+    "conditions": [{
+      "status": "ERROR",
+      "metricKey": "new_coverage",
+      "comparator": "LT",
+      "errorThreshold": "80",
+      "actualValue": "65.3"
+    }],
+    "ignoredConditions": false
+  }
+}
+```
+
+---
+
+## Security Hotspots (`/api/hotspots/search`)
+
+### Parameters
+
+| Parameter | Description | Values |
+| --------- | ----------- | ------ |
+| `projectKey` | Project key | Required |
+| `branch` | Branch name | String |
+| `pullRequest` | PR number | String |
+| `status` | Status | `TO_REVIEW`, `REVIEWED` |
+| `resolution` | Resolution | `FIXED`, `SAFE`, `ACKNOWLEDGED` |
+| `inNewCodePeriod` | New code | `true`, `false` |
+| `p` / `ps` | Pagination | Integer |
+
+### Response
+
+```json
+{
+  "paging": { "total": 5 },
+  "hotspots": [{
+    "key": "...",
+    "component": "my-project:src/auth.ts",
+    "securityCategory": "sql-injection",
+    "vulnerabilityProbability": "HIGH",
+    "status": "TO_REVIEW",
+    "message": "Make sure this SQL query is safe.",
+    "line": 42
+  }]
+}
+```
+
+---
+
+## Projects (`/api/projects/search`)
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `organization` | Org key |
+| `q` | Search query |
+| `qualifiers` | `TRK` (project), `APP` |
+| `p` / `ps` | Pagination |
+
+---
+
+## Analysis History (`/api/project_analyses/search`)
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `project` | Project key |
+| `branch` | Branch name |
+| `from` / `to` | Date range |
+| `p` / `ps` | Pagination |
+
+### Response
+
+```json
+{
+  "analyses": [{
+    "key": "AYx...",
+    "date": "2024-01-15T10:30:00+0000",
+    "projectVersion": "1.2.0",
+    "revision": "abc123def",
+    "events": [{ "category": "VERSION", "name": "1.2.0" }]
+  }]
+}
+```
+
+---
+
+## Metrics History (`/api/measures/search_history`)
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `component` | Project key |
+| `metrics` | Metric keys |
+| `from` / `to` | Date range (`YYYY-MM-DD`) |
+| `branch` | Branch name |
+| `p` / `ps` | Pagination |
+
+---
+
+## Component Tree (`/api/components/tree`)
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `component` | Project key |
+| `branch` | Branch name |
+| `qualifiers` | `FIL` (file), `DIR`, `UTS` (test) |
+| `metricKeys` | Metrics per component |
+| `strategy` | `children`, `leaves`, `all` |
+| `q` | Search query |
+| `s` / `asc` | Sort field / ascending |
+| `metricSort` | Metric to sort by |
+
+---
+
+## Duplications (`/api/duplications/show`)
+
+Get detailed duplicate code blocks for a specific file.
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `key` | File key (required) - format: `project-key:path/to/file.ts` |
+| `branch` | Branch name |
+| `pullRequest` | PR number |
+
+### Response
+
+```json
+{
+  "duplications": [
+    {
+      "blocks": [
+        {
+          "from": 1,
+          "size": 20,
+          "_ref": "1"
+        },
+        {
+          "from": 50,
+          "size": 20,
+          "_ref": "2"
+        }
+      ]
+    }
+  ],
+  "files": {
+    "1": {
+      "key": "my-project:src/utils/helpers.ts",
+      "name": "helpers.ts",
+      "projectName": "My Project"
+    },
+    "2": {
+      "key": "my-project:src/utils/common.ts",
+      "name": "common.ts",
+      "projectName": "My Project"
+    }
+  }
+}
+```
+
+### Workflow: Find All Duplicates
+
+```bash
+# 1. Get files with most duplication
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/components/tree?component=$PROJECT&qualifiers=FIL&metricKeys=duplicated_lines_density&s=metric&metricSort=duplicated_lines_density&asc=false&ps=20"
+
+# 2. For each file, get duplicate blocks
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/duplications/show?key=my-project:src/file.ts"
+```
+
+---
+
+## Rules (`/api/rules/search`)
+
+### Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| `languages` | Filter by language |
+| `severities` | Filter by severity |
+| `types` | Filter by type |
+| `tags` | Filter by tags |
+| `q` | Search query |
+| `p` / `ps` | Pagination |
+
+---
+
+## Sources (`/api/sources/*`)
+
+### Raw Source Code (`/api/sources/raw`)
+
+| Parameter | Description |
+| --------- | ----------- |
+| `key` | File key (required) - format: `project:path/to/file.ts` |
+| `branch` | Branch name |
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/sources/raw?key=my-project:src/utils/helpers.ts"
+```
+
+### SCM Blame (`/api/sources/scm`)
+
+| Parameter | Description |
+| --------- | ----------- |
+| `key` | File key (required) |
+| `from` | Start line |
+| `to` | End line |
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/sources/scm?key=my-project:src/utils/helpers.ts"
+```
+
+**Response**: Returns author, date, and revision for each line.
+
+---
+
+## Compute Engine (`/api/ce/activity`)
+
+Get background task status (analysis jobs).
+
+| Parameter | Description |
+| --------- | ----------- |
+| `component` | Project key |
+| `status` | `SUCCESS`, `FAILED`, `CANCELED`, `PENDING`, `IN_PROGRESS` |
+| `type` | Task type (e.g., `REPORT`) |
+| `minSubmittedAt` | Filter by submission date |
+| `maxExecutedAt` | Filter by execution date |
+| `p` / `ps` | Pagination |
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/ce/activity?component=my-project&status=FAILED"
+```
+
+---
+
+## Quality Profiles (`/api/qualityprofiles/search`)
+
+| Parameter | Description |
+| --------- | ----------- |
+| `language` | Filter by language |
+| `project` | Project key |
+| `qualityProfile` | Profile name |
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/qualityprofiles/search?language=ts"
+```
+
+---
+
+## Languages (`/api/languages/list`)
+
+List all supported languages.
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/languages/list"
+```
+
+**Response**: `{ "languages": [{ "key": "ts", "name": "TypeScript" }, ...] }`
+
+---
+
+## Branches (`/api/project_branches/list`)
+
+| Parameter | Description |
+| --------- | ----------- |
+| `project` | Project key (required) |
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/project_branches/list?project=my-project"
+```
+
+**Response**: `{ "branches": [{ "name": "main", "isMain": true, "type": "LONG", "status": { "qualityGateStatus": "OK" } }] }`
+
+---
+
+## Badges (`/api/project_badges/*`)
+
+### Measure Badge (`/api/project_badges/measure`)
+
+| Parameter | Description |
+| --------- | ----------- |
+| `project` | Project key |
+| `metric` | `bugs`, `coverage`, `code_smells`, `vulnerabilities`, etc. |
+| `branch` | Branch name |
+
+Returns SVG badge image.
+
+```bash
+curl "https://sonarcloud.io/api/project_badges/measure?project=my-project&metric=coverage"
+```
+
+### Quality Gate Badge (`/api/project_badges/quality_gate`)
+
+| Parameter | Description |
+| --------- | ----------- |
+| `project` | Project key |
+| `branch` | Branch name |
+
+```bash
+curl "https://sonarcloud.io/api/project_badges/quality_gate?project=my-project"
+```
+
+---
+
+## Pagination Example
+
+```bash
+PAGE=1
+while true; do
+  R=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    "https://sonarcloud.io/api/issues/search?organization=$ORG&componentKeys=$PROJECT&p=$PAGE&ps=500")
+  echo $R | jq '.issues[]'
+  [ $((PAGE * 500)) -ge $(echo $R | jq '.total') ] && break
+  PAGE=$((PAGE + 1))
+done
+```
+
+---
+
+## Error Codes
+
+| Code | Meaning | Fix |
+| ---- | ------- | --- |
+| 401 | Invalid token | Check `SONARCLOUD_TOKEN` |
+| 403 | No permission | Verify project access |
+| 404 | Not found | Check project/org key |
+| 400 | Bad request | Check parameter values |
+
+---
+
+## References
+
+- [SonarCloud Web API](https://sonarcloud.io/web_api)
+- [SonarCloud Docs](https://docs.sonarsource.com/sonarcloud/)

--- a/.agents/skills/sonarcloud/SKILL.md
+++ b/.agents/skills/sonarcloud/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: sonarcloud
+description: >
+  Query SonarCloud code-quality data via the `/sonarcloud` slash command — the fast in-context
+  lookup for a project, branch, or PR. Handles `issues`, `metrics`, `gate` (pass/fail + failed
+  conditions), `health`, `pr <number>`, `hotspots`, `history`, plus `--branch`, `--severity`,
+  `--type`, `--new-code` filters. Use the moment the user types `/sonarcloud ...` or asks in
+  plain language: "what does SonarCloud say about this PR", "check the SonarCloud quality gate
+  before I ship", "SonarCloud blocker/critical bugs on develop", "new-code SonarCloud issues
+  on PR 214". Only READS/reports — does NOT fix findings or reply-to/resolve PR threads (that
+  is `review`); it is the lightweight command surface, NOT the deep-analysis session
+  correlating findings with local source or history trends (that is `sonarcloud-analysis`).
+  Not for local SAST scans of your own code, nor the Forge issue tracker (`forge issue ...`,
+  "open/ready issues") — here those bare words always mean SonarCloud.
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
+---
+
+# SonarCloud Query Command
+
+Pull code quality data from SonarCloud. Requires `SONARCLOUD_TOKEN` environment variable.
+
+## Arguments
+
+- `$ARGUMENTS` - Query type and parameters
+
+## Query Types
+
+| Query | Description | Example |
+|-------|-------------|---------|
+| `issues <project>` | Get open issues | `/sonarcloud issues my-project` |
+| `metrics <project>` | Get code metrics | `/sonarcloud metrics my-project` |
+| `gate <project>` | Quality gate status | `/sonarcloud gate my-project` |
+| `health <project>` | Full health report | `/sonarcloud health my-project` |
+| `pr <project> <pr#>` | PR analysis | `/sonarcloud pr my-project 123` |
+| `hotspots <project>` | Security hotspots | `/sonarcloud hotspots my-project` |
+| `history <project>` | Analysis history | `/sonarcloud history my-project` |
+
+## Filters (append to query)
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--branch <name>` | Filter by branch | `--branch develop` |
+| `--severity <levels>` | Filter severity | `--severity BLOCKER,CRITICAL` |
+| `--type <types>` | Filter issue type | `--type BUG,VULNERABILITY` |
+| `--new-code` | Only new code issues | `--new-code` |
+
+## Instructions
+
+1. Parse the query from `$ARGUMENTS` to determine:
+   - Query type (issues, metrics, gate, health, pr, hotspots, history)
+   - Project key
+   - Optional filters (branch, severity, type, new-code, etc.)
+2. Check for `SONARCLOUD_TOKEN` environment variable. If not set, inform user.
+3. Check for `SONARCLOUD_ORG` environment variable or ask user for organization key.
+4. Execute the appropriate API call against the SonarCloud REST API (see the API Reference section below for endpoints)
+5. Format and present results clearly:
+   - For issues: Group by severity/type, show file, line, message
+   - For metrics: Show as table with metric name and value
+   - For quality gate: Show pass/fail with failed conditions
+   - For health: Comprehensive summary with all data
+6. Offer follow-up actions:
+   - "Show issues in specific file?"
+   - "Get more details on a specific issue?"
+   - "Compare with another branch?"
+
+## Example Outputs
+
+### Issues Query
+
+```
+📋 Open Issues for my-project (branch: main)
+
+Total: 45 issues
+
+By Severity:
+  🔴 BLOCKER: 2
+  🟠 CRITICAL: 5
+  🟡 MAJOR: 18
+  ⚪ MINOR: 15
+  ⚫ INFO: 5
+
+By Type:
+  🐛 BUG: 8
+  🔓 VULNERABILITY: 3
+  💩 CODE_SMELL: 34
+
+Top Issues:
+1. [CRITICAL] src/auth/login.ts:42 - SQL injection vulnerability
+2. [BLOCKER] src/api/users.ts:156 - Null pointer dereference
+...
+```
+
+### Metrics Query
+
+```
+📊 Metrics for my-project
+
+| Metric | Value |
+|--------|-------|
+| Lines of Code | 51,234 |
+| Coverage | 78.5% |
+| Duplications | 3.2% |
+| Bugs | 8 |
+| Vulnerabilities | 3 |
+| Code Smells | 34 |
+| Technical Debt | 4d 2h |
+| Maintainability | A |
+| Reliability | B |
+| Security | A |
+```
+
+### Quality Gate Query
+
+```
+🚦 Quality Gate: ❌ FAILED
+
+Failed Conditions:
+| Metric | Threshold | Actual |
+|--------|-----------|--------|
+| Coverage on New Code | ≥ 80% | 65.3% |
+| New Bugs | = 0 | 2 |
+
+Passed Conditions:
+| Metric | Threshold | Actual |
+|--------|-----------|--------|
+| New Vulnerabilities | = 0 | 0 |
+| Duplicated Lines | ≤ 3% | 1.2% |
+```
+
+## API Reference
+
+Base URL: `https://sonarcloud.io/api`
+
+### Key Endpoints
+
+```bash
+# Issues
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/issues/search?organization=$ORG&componentKeys=$PROJECT&resolved=false"
+
+# Metrics
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/measures/component?component=$PROJECT&metricKeys=bugs,vulnerabilities,coverage"
+
+# Quality Gate
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/qualitygates/project_status?projectKey=$PROJECT"
+
+# Hotspots
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://sonarcloud.io/api/hotspots/search?projectKey=$PROJECT&status=TO_REVIEW"
+```
+
+## Full Skill Reference
+
+See `skills/sonarcloud-analysis/SKILL.md` for complete API documentation including:
+
+- All endpoints and parameters
+- Response structures
+- Pagination handling
+- Advanced filtering
+- Integration patterns

--- a/.agents/skills/sonarcloud/evals/evals.json
+++ b/.agents/skills/sonarcloud/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "query": "/sonarcloud gate my-project",
+    "should_trigger": true
+  },
+  {
+    "query": "/sonarcloud pr befach-web 214 --new-code",
+    "should_trigger": true
+  },
+  {
+    "query": "What does SonarCloud say about this pull request? Just the quality gate and the blocker issues, quick.",
+    "should_trigger": true
+  },
+  {
+    "query": "Show SonarCloud bugs and vulnerabilities on the develop branch for the api project",
+    "should_trigger": true
+  },
+  {
+    "query": "Any new-code SonarCloud issues on PR 88 before I ship?",
+    "should_trigger": true
+  },
+  {
+    "query": "Pull the SonarCloud coverage and code-smell numbers for my-project so I can eyeball them",
+    "should_trigger": true
+  },
+  {
+    "query": "Open an isolated SonarCloud deep-dive: correlate every flagged vulnerability with the actual source files, walk the analysis history for coverage trends, and hand back a synthesized technical-debt report",
+    "should_trigger": false
+  },
+  {
+    "query": "SonarCloud flagged issues on PR 214 — fix them, reply to each review thread, and mark them resolved",
+    "should_trigger": false
+  },
+  {
+    "query": "Run a SAST security scan over my code and list the vulnerabilities you find",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the open issues that are ready to work on next",
+    "should_trigger": false
+  },
+  {
+    "query": "Run lint and type-check and the test suite before I ship this branch",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: status
+description: >
+  Report where the project stands and what work is in flight -- the Forge status snapshot.
+  Reach for this at session start or whenever the user says "/status", "where am I", "what's
+  in progress", "catch me up", "resume work", or "what changed recently". It surfaces the workflow stage, your active/claimed issues, all issues ranked by
+  composite score with conflict-risk flags, stale already-merged issues (which it closes), and
+  recent commits. Use it to ORIENT and decide the next move -- it reports state; it does not
+  plan, develop, or claim issues. Not for: routing to a stage skill or documenting the full
+  issue-verb surface (kernel); ranking and EXPLAINING a single next-ready or blocked issue to
+  hand off (triage-ready); everyday create/update/list/close/comment/search issue ops
+  (issue-basics); the Hermes harness's token-bounded orient/recap contract (hermes-forge); or
+  the post-merge CI health check that closes issues after a merge lands (verify).
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+Check where you are in the project and what work is in progress.
+
+# Status Check
+
+This skill helps you understand the current state of the project before starting new work.
+
+## Usage
+
+```bash
+/status
+```
+
+## What This Skill Does
+
+## Step 0: Sync team state
+
+```bash
+# Sync team state before showing status
+forge sync || true
+```
+
+### Step 1: Smart Status (ranked issues with conflict detection)
+
+```bash
+bash scripts/smart-status.sh
+```
+This command dynamically computes and displays all issues ranked by composite score (priority, dependency impact, type, staleness, epic proximity). Output includes active sessions, conflict risk annotations, and grouped categories. No manual querying needed.
+
+For full context on any issue: `forge show <id>`
+
+### Step 1b: Reconcile stale in-progress issues
+
+Check if any in-progress issues were already merged but not closed (can happen if `/verify` was skipped or backup was restored from stale snapshot):
+
+```bash
+# Detect default branch dynamically (prefer main over master)
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  if git rev-parse --verify main >/dev/null 2>&1; then DEFAULT_BRANCH="main"
+  elif git rev-parse --verify master >/dev/null 2>&1; then DEFAULT_BRANCH="master"
+  else echo "ERROR: No main or master branch found -- skipping stale reconciliation" >&2; DEFAULT_BRANCH=""; fi
+fi
+
+# For each in_progress issue, check if its PR was already merged
+if [ -n "$DEFAULT_BRANCH" ]; then
+  forge list --status=in_progress --json 2>/dev/null | jq -r '.[].id' | while read id; do
+    # Search git log for the issue ID in commit messages (fixed-strings for literal match)
+    if git log --oneline --first-parent "$DEFAULT_BRANCH" --fixed-strings --grep="$id" | grep -q .; then
+      echo "STALE: $id -- found in git history, likely already merged"
+    fi
+  done
+fi
+```
+
+If stale issues are found, close them:
+```bash
+forge close <id> --force --reason="Already merged -- detected during status reconciliation"
+```
+
+### Step 2: Review Recent Commits
+```bash
+git log --oneline -10
+```
+
+### Step 3: Determine Context
+- **New feature**: No active work, ready to start fresh
+- **Continuing work**: In-progress issues found, resume where left off
+- **Review needed**: Work marked complete, needs review/merge
+
+### Team context
+
+Show current developer's active work and team overview:
+
+```bash
+# Show my active issues
+forge team workload --me 2>&1 || true
+
+# One-line team summary
+forge team dashboard 2>&1 | head -5 || true
+```
+
+## Next Steps
+
+- **If starting new work**: Run `/plan <feature-name>`
+- **If continuing work**: Resume with appropriate phase command
+- **If reviewing**: Run `/review <pr-number>` (the pre-merge doc gate is embedded in `/ship` and `/review`)

--- a/.agents/skills/status/evals/evals.json
+++ b/.agents/skills/status/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "/status",
+    "should_trigger": true
+  },
+  {
+    "query": "where am I on this project right now?",
+    "should_trigger": true
+  },
+  {
+    "query": "catch me up -- what's in progress and what got merged recently?",
+    "should_trigger": true
+  },
+  {
+    "query": "I stepped away for a few days, give me the current state of the work before I dive back in",
+    "should_trigger": true
+  },
+  {
+    "query": "show me my active issues and which stage we're at",
+    "should_trigger": true
+  },
+  {
+    "query": "are there any in-progress issues that were already merged and should be closed?",
+    "should_trigger": true
+  },
+  {
+    "query": "what's the single best next issue to start, and explain why that one?",
+    "should_trigger": false
+  },
+  {
+    "query": "why is issue forge-456 blocked -- what's it waiting on?",
+    "should_trigger": false
+  },
+  {
+    "query": "route me to the correct Forge stage skill for opening a PR",
+    "should_trigger": false
+  },
+  {
+    "query": "create an issue titled 'fix flaky login test' and tag it a bug",
+    "should_trigger": false
+  },
+  {
+    "query": "the PR just merged to master -- confirm CI is green and close the linked issues",
+    "should_trigger": false
+  },
+  {
+    "query": "keep an eye on PR #88 until its checks and review threads settle",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/triage-ready/SKILL.md
+++ b/.agents/skills/triage-ready/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: triage-ready
+description: >
+  Surfaces, ranks, and EXPLAINS the single best next issue in a Forge project — strictly
+  read-only. Recomputes the live ready queue and explains what is blocked via `forge issue
+  ready`/`blocked`/`stats`/`show`, always against the live kernel, never `forge board`.
+  Recommends ONE issue with a one-line reason, then hands off; never claims, comments, closes,
+  or mutates. Use when the user asks "what should I work on", "what's next", "what's ready",
+  "pick/triage my next task", "top of the ready queue", "which issue should I start", "why is
+  this issue blocked", or "what's blocking the most work". NOT for claiming or taking
+  ownership of the pick (use claim-safety), not for everyday issue
+  create/update/list/search/close/comment/dep CRUD (use issue-basics), not for reporting the
+  current workflow stage or "where am I / what's in flight" (use status), not for orienting a
+  whole session or routing to stage skills (use kernel), not for driving an issue to a merged
+  PR (use smith).
+allowed-tools: Read, Bash(forge:*)
+---
+
+# Triage: what should I work on next
+
+A read-only orientation skill. It answers "what is the single best thing to work
+on right now, and *why*?" and hands the pick off to `claim-safety` / `dev` — it
+never mutates the store itself.
+
+Readiness in the Forge kernel is a **derived read model**: an issue is ready only
+when every dependency is satisfied, it is unclaimed (no live lease), it is a
+claimable type (epics and decisions never enter the queue), and no defer window
+holds it back. Because it is derived, **always recompute it** — never trust a
+cached "status == ready". Recompute means: run the query fresh each time.
+
+## Do NOT use `board`
+
+`forge board` reads a legacy snapshot store, not the live kernel, so its readiness
+can be stale or wrong. This skill uses `forge issue ready`, `forge issue blocked`,
+and `forge issue stats` exclusively.
+
+## Procedure
+
+### 1. Take the pulse
+
+```bash
+forge issue stats --json
+```
+
+Returns `data.counts` (`open`/`done`/`cancelled` — keys are present only when
+non-zero, and there is no `in_progress` bucket: claimed work stays in status
+`open` and is surfaced via `active_claims`), `ready_count`, `blocked_count`, and
+`active_claims`. A high `blocked_count` relative to
+`ready_count` is your signal that dependency repair (not new work) is the real
+bottleneck — hand off to `dependency-planning` / `backlog-hygiene`.
+
+### 2. Rank the ready queue
+
+```bash
+forge issue ready --json
+```
+
+`data.issues[]` comes back ordered by `rank` (priority ascending, then id), each
+carrying `id`, `title`, `type`, `priority` (`P0`..`P4`), `rank`, `blocked`,
+`claimed_by`, `parent_id`, `labels[]`, and `dependencies[]`. The top item is your
+default pick. Surface the top few (see Fork points for how many), not the whole
+list.
+
+### 3. Explain WHY the top item is ready
+
+Do not just name it — justify it. Pull its full record:
+
+```bash
+forge issue show <id> --json
+```
+
+State the reason in one sentence, drawn from the record:
+
+- **Priority / rank** — `P0` at `rank` 0 outranks everything below it.
+- **Dependencies satisfied** — every id in `dependencies[]` is closed/done, so
+  nothing gates it (`blocked: false`).
+- **Unclaimed** — `claimed_by` is `null`, so no other agent holds the lease.
+- **Claimable type** — it is a `task`/`feature`/`bug`, not an `epic`/`decision`.
+
+### 4. Explain why the runners-up are NOT ready
+
+```bash
+forge issue blocked --json
+```
+
+For a blocked item, name the specific unmet dependency (from its `dependencies[]`
+cross-referenced against `forge issue show`) — e.g. "blocked by `forge-x` which is
+still `open`". This turns triage into an actionable map: the fastest way to unlock
+the most work is usually to finish the shared blocker.
+
+### 5. Hand off
+
+Recommend ONE issue with its one-line justification, then stop. The caller claims
+it (via `claim-safety`) and executes (via `dev`). Triage does not claim, comment,
+or close — it is strictly read-only.
+
+## Reliability
+
+- **Recompute, never cache.** Readiness is derived; re-run `forge issue ready`
+  every session rather than remembering a prior "ready" verdict.
+- **Respect non-claimable types.** Epics and decisions never appear in `ready`
+  (the queue surfaces only claimable types — `task`/`bug`), so do not hand them
+  off as work. There is no `claimable` field in the CLI JSON; this is behavioral,
+  not a flag you can read.
+- **Check the envelope.** Every `--json` reply carries `ok`; on `ok:false` read
+  `error.message` and retry the query rather than guessing at state.
+- **Read-only.** This skill runs only `stats`/`ready`/`blocked`/`show`. If a fix is
+  needed, hand off — never mutate here.
+
+## Fork points
+
+Editable knobs — change these to carve your own triage policy. This skill is a
+canonical source you fork, not a fixed ladder.
+
+| Knob | Default | How to change |
+|------|---------|---------------|
+| **Readiness query / filters** | `forge issue ready` (whole queue) | Narrow to a slice, e.g. `forge issue list --status open --priority P0 --json` or post-filter `ready` output by `labels[]`/`type` to focus one workstream. |
+| **How many items to surface** | Top 3 by `rank` | Raise for a broad standup view, lower to 1 for a strict "next task only" hand-off. |
+| **Stale threshold** | `forge issue stale --days 14` | Change `--days` to flag idle in-progress work sooner/later; surface stale claims as a caveat before recommending fresh work. |
+| **Priority ordering** | Kernel `rank` (priority, then id) | Re-rank the `ready` list by your own weights — epic proximity (`parent_id`), label, or age — before picking. |
+| **Blocked-explain depth** | One hop (direct unmet deps) | Trace transitively via repeated `forge issue show` when you need the full blocking chain; hand to `graph-forensics` for deep `explain`. |

--- a/.agents/skills/triage-ready/evals/evals.json
+++ b/.agents/skills/triage-ready/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "I just sat down at this repo — what's the highest-priority thing I can actually start right now?",
+    "should_trigger": true
+  },
+  {
+    "query": "Give me the top few off the ready queue and tell me why the first one is unblocked.",
+    "should_trigger": true
+  },
+  {
+    "query": "Why can't I start forge-2agy.2.2 yet? What's holding it up?",
+    "should_trigger": true
+  },
+  {
+    "query": "The backlog feels stuck — is it mostly blocked, and which one dependency would unlock the most work?",
+    "should_trigger": true
+  },
+  {
+    "query": "Pick my next task and justify the choice, don't grab it yet.",
+    "should_trigger": true
+  },
+  {
+    "query": "Claim forge-abc123 for me and confirm I actually hold the lease before I start editing.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a P1 bug titled 'login returns 500' and add a comment linking the repro.",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow right now and what work is in flight?",
+    "should_trigger": false
+  },
+  {
+    "query": "Search every issue mentioning 'oauth' and list the open ones.",
+    "should_trigger": false
+  },
+  {
+    "query": "Take forge-xyz all the way through to a merged PR.",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/validate/SKILL.md
+++ b/.agents/skills/validate/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: validate
+description: >
+  Forge VALIDATE stage — the pre-pull-request quality gate. Rebases the branch onto the
+  current base branch, then runs type-checking, linting, code review, an OWASP Top 10 security
+  review plus dependency scan, and the full test suite, demanding fresh passing output in THIS
+  session before anything ships. Reach for this whenever a branch is code-complete and someone
+  says: validate my changes, run the quality gates, run the pre-PR checks, type-check and lint
+  before the PR, run the security scan, or run the full test suite before opening a PR — and
+  for the literal `/validate` command or `bun run check`. This is the gate that runs AFTER
+  code is written but BEFORE a PR exists, so discriminate carefully: it does not implement
+  features or write tests (that is `/dev`), it does not push the branch or open the PR (that
+  is `/ship`), it does not answer PR review feedback from Greptile / SonarCloud / CodeRabbit
+  (that is `/review`), and it is not the post-merge CI health check (that is `/verify`).
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+> **Note:** Three things share the "validate" name in Forge:
+> - `/validate` (this command): default-template validation command — rebases onto the base branch, then runs type/lint/test/security checks
+> - `forge-preflight` (formerly forge-validate): CLI tool — checks prerequisites before a stage
+> - `bun run check` (scripts/validate.js): Local quality gate — runs type/lint/test/security checks only (does NOT rebase; assumes branch is already current with the base branch)
+
+Run comprehensive validation including type checking, linting, code review, security review, and tests.
+
+# Validate
+
+This skill validates all code before creating a pull request.
+
+## Usage
+
+```bash
+/validate
+```
+
+Or use the validation script (checks only — no rebase):
+
+```bash
+bun run check    # Runs lint/test/security checks only. Does NOT rebase onto the base branch.
+                 # Use /validate for the full workflow (rebase + checks).
+```
+
+```
+<HARD-GATE: /validate entry — rebase onto latest base branch>
+Before running ANY validation checks:
+
+0. Resolve the base branch dynamically (do NOT hardcode master or main):
+   BASE=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
+   if [ -z "$BASE" ] || [ "$BASE" = "(unknown)" ]; then BASE="master"; fi
+
+   This handles repos using main, master, or any other default branch.
+   Falls back to "master" when HEAD is unresolved (detached remote, empty repo).
+
+1. Fetch latest base branch:
+   git fetch origin "$BASE" || { echo "✗ Fetch failed — cannot verify branch freshness"; exit 1; }
+
+   The `|| { ...; exit 1; }` guard ensures fetch failures are never silently skipped.
+
+2. Check if branch is behind:
+   BEHIND=$(git rev-list --count HEAD..origin/"$BASE")
+
+3. If BEHIND > 0:
+   a. Run: git rebase origin/"$BASE" || REBASE_FAILED=1
+   b. If rebase succeeds (REBASE_FAILED unset): print "✓ Rebased onto latest $BASE ($BEHIND commits integrated)"
+   c. If rebase fails (REBASE_FAILED=1 — conflicts or any other error):
+      - Capture conflicting files BEFORE aborting: git diff --name-only --diff-filter=U
+      - Run: git rebase --abort
+      - Print the captured conflicting file list
+      - Print: "✗ Rebase conflict — resolve manually, then re-run /validate"
+      - STOP. Do NOT proceed to any validation checks.
+
+4. If BEHIND = 0:
+   Print "✓ Branch is up-to-date with $BASE" and continue.
+
+Rationale: Without this step, validation checks run against stale code that doesn't
+include recent base branch changes. Integration issues are only caught after the PR is
+created, wasting CI cycles and review time. Rebasing here ensures /validate results
+reflect the true state of what will be merged.
+</HARD-GATE>
+```
+
+## What This Skill Does
+
+**Quick Start**: Run `bun run check` to execute the full validation pipeline (implemented in `scripts/validate.js`). The npm script is named `check`; the workflow command is `/validate`. See individual steps below for details.
+
+### Step 1: Type Check
+```bash
+# Run your project's type check command
+bun run typecheck    # or: npm run typecheck, tsc, etc.
+```
+- Verify all TypeScript types are valid
+- No `any` types allowed
+- Strict mode enforcement
+
+### Step 2: Lint
+```bash
+# Run your project's lint command
+bun run lint    # or: npm run lint, eslint ., etc.
+```
+- Linting rules
+- Code style consistency
+- Best practices compliance
+
+### Step 3: Code Review (if available)
+```bash
+/code-review:code-review
+```
+- Static code analysis
+- Code quality check
+- Potential issues flagged
+
+### Step 4: Security Review
+
+**OWASP Top 10 Checklist**:
+- A01: Broken Access Control
+- A02: Cryptographic Failures
+- A03: Injection
+- A04: Insecure Design
+- A05: Security Misconfiguration
+- A06: Vulnerable Components
+- A07: Authentication Failures
+- A08: Data Integrity Failures
+- A09: Logging & Monitoring Failures
+- A10: Server-Side Request Forgery
+
+**Automated Security Scan**:
+```bash
+# Run your project's security scan
+npm audit    # or: bun audit, snyk test, etc.
+```
+
+**Manual Review**:
+- Review security test scenarios (from design doc — `## Technical Research` section)
+- Verify security mitigations implemented
+- Check for sensitive data exposure
+
+### Step 5: Tests
+```bash
+# Run your project's test command
+bun test    # or: npm run test, jest, vitest, etc.
+```
+- All tests passing
+- Includes security test scenarios
+- TDD tests from /dev phase
+
+> **💭 Plan-Act-Reflect Checkpoint**
+> Before declaring validation complete:
+> - Are all security test scenarios from your design doc actually implemented and passing?
+> - Did you verify OWASP Top 10 mitigations, not just check a box?
+> - Are there edge cases or integration scenarios you haven't tested?
+>
+> **If unsure**: Re-read the `## Technical Research` section in `docs/work/YYYY-MM-DD-<slug>/plan.md`
+
+## On Validation Failure: 4-Phase Debug Mode
+
+> **Iron Law: NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST**
+>
+> Every fix attempt without a diagnosed root cause wastes time and masks the real problem.
+
+### Phase D1: Reproduce
+
+Confirm the failure is deterministic. Capture the exact error.
+
+- Run the failing command fresh — do not rely on cached output
+- Record: exact command, exact error message, exact line number
+- If intermittent: run 3 times, document frequency
+
+### Phase D2: Root-Cause Trace
+
+Trace to the source, not the symptom. **Fix at source, not at symptom.**
+
+- Read the stack trace — where does it originate?
+- Is it a test bug, an implementation bug, or a config bug?
+- What changed recently that could have caused this?
+- Read the actual failing line and surrounding context
+
+### Phase D3: Fix
+
+ONE minimal fix. ONE change at a time.
+
+1. Write the failing test FIRST (if not already a test failure)
+2. Make the smallest possible change to fix the root cause
+3. Do not fix multiple things in one commit
+4. Do not "also improve" unrelated code while fixing
+
+### Phase D4: Verify
+
+Re-run full validation from the beginning.
+
+- Do not declare fixed until you have run the full validate suite
+- Show fresh output — not "it should be fine now"
+- All checks must pass, not just the one that was failing
+
+<HARD-GATE: 3+ fix attempts>
+STOP. Question architecture before Fix #4.
+
+If you have attempted 3+ fixes without resolution:
+1. Step back — is the approach fundamentally wrong?
+2. Read the original spec/design doc
+3. Ask: "Am I fixing symptoms or the real problem?"
+4. Consider: revert all changes and start fresh with better understanding
+
+"Quick fix for now" is not a valid fix strategy.
+</HARD-GATE>
+
+### Red Flags — STOP if you hear yourself saying:
+
+- "Quick fix for now"
+- "It's probably X"
+- "I don't fully understand but this might work"
+- "Should be fixed now"
+- "It was passing earlier"
+- "I'm confident this is right"
+
+**None of these are evidence. Run the command. Show the output.**
+
+### Step 6: Handle Failures
+
+If any check fails:
+```bash
+# Create Forge issue for problems
+forge create "Fix <issue-description>"
+
+# Mark current issue as blocked
+forge update <current-id> --status blocked
+forge comment <current-id> "Blocked by <new-issue-id>"
+
+# Output what needs fixing
+```
+
+If all pass:
+
+```
+<HARD-GATE: /validate exit>
+Do NOT output any variation of "check complete", "ready to ship", or proceed to /ship
+until ALL FOUR show fresh output in this session:
+
+1. Type check: [command run] → [actual output] → exit 0 confirmed
+2. Lint: [command run] → [actual output] → 0 errors, 0 warnings confirmed
+3. Tests: [command run] → [actual output] → N/N passing confirmed
+4. Security scan: [command run] → [actual output] → no critical issues confirmed
+
+"Should pass", "was passing earlier", and "I'm confident" are not evidence.
+Run the commands. Show the output. THEN declare done.
+
+5. Context check: confirm design + acceptance on the Forge issue (`forge issue show <id>`); if the beads-context helper is present, run `bash scripts/beads-context.sh validate <id>` and address any warnings
+6. Stage transition recorded (structured helper when present; kernel-native comment otherwise):
+   if [ -f scripts/beads-context.sh ]; then
+     bash scripts/beads-context.sh stage-transition <id> validate ship \
+       --summary "<all checks pass/fail summary>" \
+       --decisions "<any failures diagnosed and fixed>" \
+       --artifacts "<scripts and commands run>" \
+       --next "<ship readiness notes>"
+   else
+     forge comment <id> "Stage: validate complete → ready for ship
+Summary: <all checks pass/fail summary>
+Decisions: <any failures diagnosed and fixed>
+Artifacts: <scripts and commands run>
+Next: <ship readiness notes>"
+   fi
+</HARD-GATE>
+```
+
+## Example Output (Success)
+
+```
+✓ Type check: Passed
+✓ Lint: Passed
+✓ Code review: No issues
+✓ Security Review:
+  - OWASP Top 10: All mitigations verified
+  - Automated scan: No vulnerabilities
+  - Manual review: Security tests passing
+✓ Tests: 15/15 passing (TDD complete)
+
+Ready for /ship
+```
+
+## Example Output (Failure)
+
+```
+✗ Tests: 2/15 failing
+  - validation.test.ts: Assertion failed
+  - auth.test.ts: Timeout exceeded
+
+✓ Forge issue created: forge-k8m3 "Fix validation test"
+✓ Current issue marked: Blocked by forge-k8m3
+
+Fix issues then re-run /validate
+```
+
+## Integration with Workflow
+
+```
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security (you are here)
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Pre-merge gate: doc updates + CI-green checkpoint embedded in /ship and /review (not a separate stage).
+```
+
+## Tips
+
+- **All checks must pass**: Don't proceed to /ship with failures
+- **Security is mandatory**: OWASP Top 10 review required for all features
+- **Create issues for failures**: Track problems in the Forge issue tracker
+- **TDD helps**: Tests should already pass from /dev phase
+- **Fix before shipping**: Resolve all issues before creating PR

--- a/.agents/skills/validate/evals/evals.json
+++ b/.agents/skills/validate/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Branch is code-complete — run all the pre-PR checks and make sure everything's green before I ship",
+    "should_trigger": true
+  },
+  {
+    "query": "/validate",
+    "should_trigger": true
+  },
+  {
+    "query": "Rebase onto master, then type-check, lint, and run the whole test suite so I know it's clean",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the OWASP security review and full test pass on this branch before we open the PR",
+    "should_trigger": true
+  },
+  {
+    "query": "I'm at the validate stage — take my changes through the quality gates",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement the next task using TDD, red-green-refactor",
+    "should_trigger": false
+  },
+  {
+    "query": "Push this validated branch and open the pull request from the template",
+    "should_trigger": false
+  },
+  {
+    "query": "Go through the Greptile and CodeRabbit comments on my PR and resolve the threads",
+    "should_trigger": false
+  },
+  {
+    "query": "It's merged now — check CI is green on master and close the issue",
+    "should_trigger": false
+  },
+  {
+    "query": "Pull the SonarCloud issues for this PR",
+    "should_trigger": false
+  }
+]

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: verify
+description: >
+  Runs the Forge verify stage — the post-merge health check performed AFTER a PR is merged:
+  switch to master and pull, confirm the merge landed, check CI is green on master, confirm
+  deployments are up, remove the merged worktree, safe-delete the branch, and close the
+  kernel issues the PR resolved. Use when asked to verify a merge went cleanly, confirm
+  post-merge CI health on master, check deployments after merging, clean up a merged branch or
+  worktree, or close the issue now that its PR is merged — and whenever `/verify` is invoked.
+  Strictly the POST-merge stage: use shepherd instead to monitor a still-open PR toward merge,
+  review to fix and resolve PR feedback before merge, ship to push the branch and open the PR,
+  rollback to undo an already-shipped change, status to merely report the current stage
+  without acting, and issue-basics to close an issue unrelated to a just-merged PR.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+Verify that the merge landed correctly and everything is running properly after merge.
+
+# Verify
+
+This skill runs AFTER the user has merged the PR. It checks system health — not documentation (that was handled by the pre-merge gate embedded in `/ship` and `/review`).
+
+## Usage
+
+```bash
+/verify
+```
+
+## What This Skill Does
+
+### Step 1: Switch to Master and Pull
+
+```bash
+git checkout master
+git pull
+```
+
+Confirm the merge actually landed on master. If the PR isn't merged yet, stop and tell the user to merge first.
+
+### Step 2: Confirm PR Is Merged
+
+Detect the PR that produced the current HEAD commit — scope the lookup to that
+commit's SHA so you don't pick up an unrelated newer merge:
+
+```bash
+gh pr list --state merged --base master --search "$(git rev-parse HEAD)" --limit 1 --json number,state,mergedAt,mergedBy
+```
+
+- `state` should be `MERGED`
+- If no PR found: the merge may not have landed yet — stop and tell the user to merge first
+- If the wrong PR appears: user can specify the number directly with `gh pr view <number> --json state,mergedAt,mergedBy`
+
+### Step 3: Check CI on Master After Merge
+
+```bash
+gh run list --branch master --limit 5
+```
+
+Check the most recent workflow runs on `master`:
+- All should be passing or in progress
+- If any failed: identify which workflow and what failed
+- Failed CI on master after merge may need a hotfix PR
+
+### Step 4: Check Deployments (if applicable)
+
+Check if the project has a deployment target:
+
+```bash
+# Check deployment status from latest run
+gh run list --branch master --limit 1
+
+# Check Vercel deployments for the merged PR (use number from Step 2)
+gh pr view <number> --json statusCheckRollup
+```
+
+If deployments exist:
+- Are they showing as successful?
+- Is the production/preview URL responding?
+
+### Step 5: Report Status
+
+**If everything is clean**:
+```
+✅ Merge verified — everything is healthy
+
+  PR: #<number> merged by <user> at <time>
+  CI on master: ✓ All passing
+  Deployments: ✓ Up (if applicable)
+
+  Ready for next feature → run /status
+```
+
+**If issues found**:
+```
+⚠️  Post-merge issues detected
+
+  PR: #<number> merged ✓
+  CI on master: ✗ <workflow-name> failing
+    - Error: <description>
+    - Action needed: <hotfix or investigation>
+
+  Deployments: ✗ <deployment> not responding
+
+  Next: Create hotfix branch or investigate root cause
+```
+
+### Step 6: Clean Up Worktree and Branch
+
+Only run this step after CI is confirmed healthy (Step 3 passed).
+
+Get the merged branch name:
+
+```bash
+gh pr view <number> --json headRefName --jq '.headRefName'
+```
+
+If the branch name cannot be determined (empty output or error), skip cleanup and tell the user to run `git worktree list` and clean up manually.
+
+Find and remove the matching worktree (if it exists):
+
+```bash
+# Get the worktree path for this exact branch
+WORKTREE_PATH=$(git worktree list --porcelain \
+  | awk -v branch="refs/heads/<branch>" '
+      /^worktree / { path=substr($0, 10) }
+      $0 == "branch " branch { print path }
+    ')
+
+if [ -n "$WORKTREE_PATH" ]; then
+  git worktree remove "$WORKTREE_PATH" --force
+  echo "Worktree: removed ✓ ($WORKTREE_PATH)"
+else
+  echo "Worktree: not found (already removed or never created) — skipping"
+fi
+```
+
+If no worktree is found for that branch, skip gracefully with a note: "Worktree: not found (already removed or never created)".
+
+Delete the local branch (safe delete only):
+
+```bash
+git branch -d <branch> 2>/dev/null || echo "Branch: already deleted — skipping"
+```
+
+The `|| echo` fallback handles the case where the branch is already gone (e.g., deleted by a previous run or the remote), so the command never fails the verify step.
+
+Report cleanup in output:
+```
+Worktree: removed ✓
+Branch: <branch-name> deleted ✓
+```
+
+### Step 7: If Issues Found — Create Issue
+
+**Never commit inline.** If something is wrong, create a tracking issue:
+
+```bash
+forge create --title="Post-merge: <description of issue>" --type=bug --priority=1
+```
+
+### Step 8: Close resolved issues (if healthy)
+
+If everything is clean, close all issues referenced in the merged PR.
+
+**Auto-detect issues from PR body and branch name:**
+
+```bash
+# Get PR body and branch name
+PR_BODY=$(gh pr view <number> --json body --jq '.body')
+PR_BRANCH=$(gh pr view <number> --json headRefName --jq '.headRefName')
+
+# Extract issue IDs from PR body
+# Matches short form (e.g. "Closes forge-abc") and kernel UUIDs (e.g. "Closes d71a824b-b0a2-...")
+# Patterns: "Closes <id>", "Fixes <id>", "Resolves <id>"
+SHORT_IDS=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves):?\s+[a-z]+-[a-z0-9]+' | grep -oiE '[a-z]+-[a-z0-9]{3,6}$')
+UUID_IDS=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves):?\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+ISSUE_IDS="$SHORT_IDS $UUID_IDS"
+
+# Validate each ID exists in the kernel
+VALID_IDS=""
+for id in $ISSUE_IDS; do
+  if forge show "$id" >/dev/null 2>&1; then
+    VALID_IDS="$VALID_IDS $id"
+  fi
+done
+ISSUE_IDS="$VALID_IDS"
+
+# Also check branch name for an issue ID — extract segment after last /
+# then validate with forge show to avoid false matches like "pr-templa"
+BRANCH_SLUG=$(echo "$PR_BRANCH" | sed 's|.*/||')
+BRANCH_ID=$(echo "$BRANCH_SLUG" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[a-z]+-[a-z0-9]{3,6}' | head -1)
+if [ -n "$BRANCH_ID" ] && ! forge show "$BRANCH_ID" >/dev/null 2>&1; then
+  BRANCH_ID=""  # Not a valid issue ID — discard
+fi
+```
+
+**Close each matched issue:**
+
+```bash
+# Close issues found in PR body. Track failures — a close that fails must
+# block /verify completion, not be downgraded to a warning.
+close_failed=0
+for id in $ISSUE_IDS; do
+  if ! forge close "$id" --reason="Merged and verified on master (PR #<number>)"; then
+    echo "Warning: could not close $id"
+    close_failed=1
+  fi
+done
+
+# If no issues found in body, try branch name match (skip if already closed above)
+if [ -z "$ISSUE_IDS" ] && [ -n "$BRANCH_ID" ]; then
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" || { echo "Warning: could not close $BRANCH_ID"; close_failed=1; }
+elif [ -n "$BRANCH_ID" ] && ! echo "$ISSUE_IDS" | grep -qw "$BRANCH_ID"; then
+  forge close "$BRANCH_ID" --reason="Merged and verified on master (PR #<number>)" || { echo "Warning: could not close $BRANCH_ID"; close_failed=1; }
+fi
+
+# Any intended close that failed → /verify is NOT complete.
+if [ "$close_failed" -ne 0 ]; then
+  echo "✗ One or more issues failed to close — /verify is NOT complete."
+  exit 1
+fi
+```
+
+**If no issues detected at all**, prompt the user:
+```
+⚠ No issue ID found in PR body or branch name.
+  If this PR closes an issue, run: forge close <id> --reason="Merged and verified on master (PR #<number>)"
+```
+
+```
+<HARD-GATE: /verify exit>
+Do NOT declare /verify complete until:
+1. gh run list --branch master --limit 3 shows actual CI output (not "should be fine")
+2. If healthy: issues extracted from PR body/branch and closed (`forge close` run and confirmed)
+   - If no issue ID found: user was warned and given manual close command
+3. If issues found: tracking issue created for every problem
+4. Worktree removed (or confirmed already gone) — OR Step 6 was intentionally skipped because CI was unhealthy; if skipped, state explicitly: "cleanup deferred, CI was not healthy"
+"It should be fine" is not evidence. Run the command. Show the output.
+</HARD-GATE>
+```
+
+## Rules
+
+- **Never commits code** — this skill may update issue state after post-merge health is verified
+- **Never creates PRs** — if fixes are needed, that's a new /dev cycle
+- **Runs after user confirms merge** — not before
+- **Reports honestly** — if CI is broken on master, say so clearly
+
+## Example Output (Healthy)
+
+```
+✅ Merge verified — everything is healthy
+
+  PR: #89 merged by harshanandak at 2026-02-24T14:30:00Z
+  Branch: feat/auth-refresh deleted ✓
+  CI on master:
+    ✓ Test Suite (ubuntu, node 20): passing
+    ✓ Test Suite (windows, node 22): passing
+    ✓ ESLint: passing
+    ✓ SonarCloud: passing
+    ✓ CodeQL: passing
+  Deployments: N/A (no deployment configured)
+
+  Ready for next feature → run /status
+```
+
+## Example Output (Issues Found)
+
+```
+⚠️  Post-merge issues detected
+
+  PR: #89 merged ✓
+  CI on master:
+    ✓ Test Suite: passing
+    ✗ SonarCloud: quality gate failing
+      - 2 new code smells introduced
+      - Action: investigate or create hotfix
+
+  Created issue: forge-xyz
+  "Post-merge: SonarCloud quality gate failing on master after PR #89"
+
+  Run /status to assess next steps
+```
+
+## Integration with Workflow
+
+```
+Utility: /status  -> Understand current context before starting
+
+Default template:
+  /plan      -> Optional default planner; external planners may satisfy /dev entry
+  /dev       -> Implement each task with subagent-driven TDD
+  /validate  -> Type check, lint, tests, security
+  /ship      -> Push + create PR
+  /review    -> Address PR feedback
+  /verify    -> Post-merge health check
+
+Pre-merge gate: doc updates + CI-green checkpoint embedded in /ship and /review (not a separate stage).
+```

--- a/.agents/skills/verify/evals/evals.json
+++ b/.agents/skills/verify/evals/evals.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "The PR just merged — make sure master is still healthy",
+    "should_trigger": true
+  },
+  {
+    "query": "Confirm the auth-refresh change actually landed on master and CI passed after merge",
+    "should_trigger": true
+  },
+  {
+    "query": "/verify",
+    "should_trigger": true
+  },
+  {
+    "query": "Now that #89 is merged, close the issue it resolved and delete the feature branch",
+    "should_trigger": true
+  },
+  {
+    "query": "Did the deployment go out okay after we merged this?",
+    "should_trigger": true
+  },
+  {
+    "query": "Run the post-merge checks and clean up the merged worktree",
+    "should_trigger": true
+  },
+  {
+    "query": "Watch my open PR and re-run the flaky required check until it can merge",
+    "should_trigger": false
+  },
+  {
+    "query": "Fix and resolve all the Greptile and SonarCloud threads on the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Push this validated branch and open a pull request",
+    "should_trigger": false
+  },
+  {
+    "query": "This merge broke production — revert the PR",
+    "should_trigger": false
+  },
+  {
+    "query": "Where am I in the workflow and what's in progress right now?",
+    "should_trigger": false
+  },
+  {
+    "query": "Close forge-abc, we've decided not to do it",
+    "should_trigger": false
+  }
+]

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,10 @@ skills-lock.json
 
 # Agent skill dirs populated at setup time as real file copies (forge setup /
 # skills-sync populateAgentSkills), not symlinks. Gitignored because they are
-# regenerated locally from canonical skills/; .codex/skills is the committed mirror.
+# regenerated locally from canonical skills/. The committed mirrors are NOT
+# gitignored: .codex/skills (packaging staging mirror) and .agents/skills (Codex's
+# repo-local discovery path — checked in so teammates who clone WITHOUT running
+# `forge setup` still get Forge skills/stages auto-discovered).
 .goose/
 .augment/
 .claude/skills/

--- a/docs/reference/AGENT_SKILL_PARITY.md
+++ b/docs/reference/AGENT_SKILL_PARITY.md
@@ -24,7 +24,7 @@ for Claude Code, Cursor, and Codex; Hermes is modeled in the capability matrix
 
 The shared rule is: keep the skill name, description, and task body canonical, then generate the smallest native wrapper each harness needs.
 
-For Codex, this W0 fixture validates Forge's current repository packaging surface (`.codex/skills`) plus the metadata needed for installed Codex skills. Current Codex docs use `.agents/skills` for direct repo discovery; Forge should migrate the generator before treating that as the renderer target.
+For Codex, this W0 fixture validates Forge's repository packaging surface (`.codex/skills`) plus the metadata needed for installed Codex skills. Codex's documented repo-scope discovery path is `.agents/skills` (scanned cwd → repo root); Forge now generates that mirror at setup and commits it, so a teammate who clones the repo WITHOUT running `forge setup` still gets Forge skills/stages auto-discovered.
 
 Cursor rules are included here because `forge-2si5` explicitly asked for `.cursor/rules/*.mdc` evidence. They are not the final Cursor skill target. The broader parity model must treat Cursor Agent Skills as the primary on-demand workflow surface and Cursor rules as the always-on or scoped-policy surface.
 
@@ -86,7 +86,7 @@ The full Forge extension parity model must cover more than skills:
 | Capability | Canonical Forge source | Claude | Cursor | Codex | Required evidence |
 | --- | --- | --- | --- | --- | --- |
 | Project instructions | structured `AGENTS.md` sections | `CLAUDE.md` shim or generated file | `AGENTS.md` (native) + `.cursor/rules/*.mdc` for scoped policy | `AGENTS.md` | semantic section comparison |
-| Skills/playbooks | agentskills.io-compatible `SKILL.md` | `.claude/skills` | `.cursor/skills` | `.codex/skills` packaging source; `.agents/skills` after generator migration | generated file and trigger metadata |
+| Skills/playbooks | agentskills.io-compatible `SKILL.md` | `.claude/skills` | `.cursor/skills` | `.codex/skills` packaging source (global `$CODEX_HOME` install) + committed `.agents/skills` repo-local discovery | generated file and trigger metadata |
 | Rules/policies | Forge rule manifest (`rules/<name>.md`) | `AGENTS.md` instruction projection (no always-on `.claude/rules/*` policy bloat) | `.cursor/rules/*.mdc` (rendered from `rules/`) | `AGENTS.md` section | rule target and unsupported-surface notes |
 | MCP tools/resources | Forge MCP manifest | Claude MCP config | `.cursor/mcp.json` | Codex MCP config | config render and server probe |
 | Hooks | Forge hook manifest | Claude hook adapter if supported | unsupported unless verified | Codex hook adapter if supported | supported/unsupported matrix |
@@ -96,7 +96,7 @@ The full Forge extension parity model must cover more than skills:
 
 The machine-readable matrix intentionally separates similar-looking surfaces:
 
-- Skills are on-demand workflows: `.claude/skills/<skill>/SKILL.md`, `.cursor/skills/<skill>/SKILL.md`, and Forge's current `.codex/skills/<skill>/SKILL.md` packaging source for Codex. Direct Codex repo discovery should use `.agents/skills/<skill>/SKILL.md` after the Forge generator migrates.
+- Skills are on-demand workflows: `.claude/skills/<skill>/SKILL.md`, `.cursor/skills/<skill>/SKILL.md`, and for Codex both the `.codex/skills/<skill>/SKILL.md` packaging source (global `$CODEX_HOME/skills` install) and the committed `.agents/skills/<skill>/SKILL.md` repo-local discovery mirror (Codex scans it cwd → repo root). Forge now generates `.agents/skills` at setup and commits it.
 - Rules are policy/context projections rendered from one canonical `rules/<name>.md` source: only Cursor has a first-class native rule surface (`.cursor/rules/<rule>.mdc`); Claude, Codex, and Hermes receive the same policy through their `AGENTS.md` instruction projection (adding always-on `.claude/rules/*` policy files would triple-deliver the same context as token bloat).
 - Commands are removed, not shims: the legacy `.claude/commands/` and `.cursor/commands/` surfaces were removed in A0d. The canonical workflow lives in stage skills (`.claude/skills/<stage>`, `.codex/skills/<stage>`); Codex/Hermes fall back to the stage skill, not a command file.
 - MCP is config plumbing: each harness gets native MCP config only when the matrix records a target path and probe evidence.
@@ -111,7 +111,7 @@ The current ecosystem pattern is a canonical payload with native harness rendere
 
 - Claude Code documents skills as `SKILL.md` files whose `description` controls automatic loading, and notes that commands and skills can both expose slash affordances.
 - Cursor documents `.cursor/rules/*.mdc` as persistent scoped context with `description`, `globs`, and `alwaysApply`; Cursor skills are treated by Forge as the on-demand workflow target, while rules remain the policy target.
-- Codex documents skills as reusable workflow packages under `.agents/skills` for repository scope, uses description-based implicit invocation, and uses plugins/marketplaces to distribute reusable skills, MCP servers, hooks, and apps. Forge's current generator still emits `.codex/skills` packages for installation.
+- Codex documents skills as reusable workflow packages under `.agents/skills` for repository scope (checked in for the team, scanned cwd → repo root), uses description-based implicit invocation, and uses plugins/marketplaces to distribute reusable skills, MCP servers, hooks, and apps. Forge emits `.codex/skills` packages for the global `$CODEX_HOME` install and now also generates + commits the repo-local `.agents/skills` mirror at setup.
 - AGENTS.md remains the shared instruction projection for agents that read repository instructions directly.
 
 Forge adopts that pattern by keeping one canonical Forge capability and rendering the smallest verified native wrapper per harness. It does not duplicate every feature blindly into every directory.
@@ -155,7 +155,7 @@ The JSON output includes:
 
 ## Proof Boundary
 
-This fixture proves deterministic metadata-surface parity. It does not launch closed-source agent sessions or claim that a live model selected a skill in a proprietary runtime. For Codex specifically, it validates the current Forge packaging source and metadata, not live auto-invocation or direct `.agents/skills` repo discovery.
+This fixture proves deterministic metadata-surface parity. It does not launch closed-source agent sessions or claim that a live model selected a skill in a proprietary runtime. For Codex specifically, it validates the Forge packaging source and metadata (and the committed `.agents/skills` repo-local discovery mirror), not live auto-invocation inside the Codex runtime.
 
 If a future release needs live invocation proof, add a separate transcript-producing eval for Claude Code, Cursor, and Codex and keep this fixture as the fast CI gate.
 
@@ -170,6 +170,6 @@ Known gaps intentionally left for follow-up. Tier-2 work is tracked under kernel
 - **Hooks (`988ae187`)**: NO harness-native hook file is rendered for ANY harness — all lifecycle enforcement is delivered via Lefthook git hooks. The matrix marks Claude/Codex hooks `contract-only` and Cursor hooks `not-delivered` (Cursor 1.7+ exposes `.cursor/hooks.json`, not yet rendered). Native hook renderers are the deliverable.
 - **Agents/subagents (`802aa4d8`)**: the whole domain is unimplemented — no renderer, manifest, wiring, or tests for any harness. The matrix marks every harness `not-delivered`/`unsupported`. A subagent renderer is the deliverable.
 - **Typed memory (`dce9da46`)**: typed memory is WRITE-ONLY (`insights.js`); no generator projects a memory section into any instruction/rule file. All four typedMemory rows are marked `not-delivered`. A memory-projection renderer is the deliverable.
-- **Codex paths (`55dfeccf`)**: `.codex/skills` is the committed staging mirror; skills install to `$CODEX_HOME/skills`. Direct Codex repo discovery uses `.agents/skills`, which Forge does not yet generate. Codex MCP is global-config-only (`$CODEX_HOME/config.toml`), so `(mcp, codex)` is `not-delivered` at project setup.
+- **Codex paths (`55dfeccf`)**: `.codex/skills` is the committed packaging staging mirror; skills install to the global `$CODEX_HOME/skills`. Codex's repo-local discovery path `.agents/skills` is NOW generated at setup and committed for teammate-clone discovery (this closes the skills/stages half of `55dfeccf`). Codex MCP remains global-config-only (`$CODEX_HOME/config.toml`), so `(mcp, codex)` is still `not-delivered` at project setup.
 - **Safety domains (`1e68255c`)**: Claude permissions, `.cursorignore`, and Codex sandbox/approvals are not yet modeled in the matrix.
 - MCP is now auto-wired project-local for both Claude (`.mcp.json`) and Cursor (`.cursor/mcp.json`) via the tested `lib/mcp-config-renderer.js`. Beads/patch-override state, marketplace trust, and extension packs remain as the matrix records them.

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -69,7 +69,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] lib/protected-path-manifest.js (2)
   - lines: 23 (bd), 33 (bd)
 - [ ] lib/protected-state-surfaces.js (4)
-  - lines: 43 (.beads), 50 (.beads), 51 (bd), 362 (bd)
+  - lines: 43 (.beads), 50 (.beads), 51 (bd), 363 (bd)
 - [ ] lib/runtime-health.js (13)
   - lines: 177 (bd), 218 (.beads), 277 (.beads), 335 (.beads), 507 (bd), 538 (bd), 540 (bd), 543 (bd), 544 (bd), 547 (bd), 552 (bd), 553 (bd), 596 (bd)
 - [ ] lib/status/beads-snapshot.js (1)

--- a/lib/codex-skills.js
+++ b/lib/codex-skills.js
@@ -2,6 +2,18 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const { populateAgentSkills } = require('./skills-sync');
+
+/**
+ * Codex's documented repo-local skill discovery directory, relative to a project
+ * root. Codex scans `.agents/skills/<name>/SKILL.md` from the current working
+ * directory up to the repo root (developers.openai.com/codex/skills). Unlike the
+ * GLOBAL `$CODEX_HOME/skills` install, this surface is committed to the repo, so a
+ * teammate who clones the repo WITHOUT running `forge setup` still gets the Forge
+ * skills/stages auto-discovered.
+ */
+const CODEX_REPO_SKILLS_DIR = '.agents/skills';
+
 function injectForgeAdapter(content, commandName) {
   const adapter = [
     '> Forge stage adapter',
@@ -94,10 +106,44 @@ function buildCodexSkillInstallPlan(sourceRoot, options = {}) {
   }));
 }
 
+/**
+ * Absolute path to a project's repo-local Codex skill discovery dir.
+ *
+ * @param {string} projectRoot - The project/repo root.
+ * @returns {string} `<projectRoot>/.agents/skills`.
+ */
+function resolveCodexRepoSkillsDir(projectRoot) {
+  return path.join(projectRoot, '.agents', 'skills');
+}
+
+/**
+ * Generate the repo-local Codex skill discovery mirror (`.agents/skills`) from
+ * the canonical `skills/` source.
+ *
+ * Content matches the other harness mirrors byte-for-byte (raw canonical — the
+ * `$CODEX_HOME` stage adapter is NOT injected here) so the skills-sync drift gate
+ * can enforce it, and so repo-local discovery reaches parity with the
+ * `.claude/skills` / `.cursor/skills` discovery surfaces.
+ *
+ * @param {object} params
+ * @param {string} params.sourceRoot - Root containing the canonical `skills/` dir.
+ * @param {string} params.projectRoot - Target project/repo root.
+ * @param {boolean} [params.clean=false] - Remove stale canonical-managed dirs first.
+ * @returns {{targetSkillsDir: string, written: string[]}}
+ */
+function populateCodexRepoSkills({ sourceRoot, projectRoot, clean = false }) {
+  const targetSkillsDir = resolveCodexRepoSkillsDir(projectRoot);
+  const { written } = populateAgentSkills({ sourceRoot, targetSkillsDir, clean });
+  return { targetSkillsDir, written };
+}
+
 module.exports = {
+  CODEX_REPO_SKILLS_DIR,
   buildCodexSkillInstallPlan,
   formatCodexSkillsInstallDir,
   listCodexSkillEntries,
+  populateCodexRepoSkills,
   resolveCodexHome,
+  resolveCodexRepoSkillsDir,
   resolveCodexSkillsInstallDir,
 };

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -61,6 +61,8 @@ const {
   buildCodexSkillInstallPlan,
   formatCodexSkillsInstallDir,
   listCodexSkillEntries,
+  populateCodexRepoSkills,
+  CODEX_REPO_SKILLS_DIR,
 } = require('../codex-skills');
 const {
   generateCursorConfig,
@@ -1730,9 +1732,26 @@ function createCodexSkills() {
   CODEX_SETUP_REPORT = {
     installRoot,
     skillCount: installPlan.length,
+    repoSkillsDir: CODEX_REPO_SKILLS_DIR,
+    repoSkillCount: 0,
     status: 'complete',
     message: '',
   };
+
+  // Repo-local discovery mirror: generate `.agents/skills/<name>/SKILL.md` from
+  // the canonical skills/ source. This is Codex's documented repo-scope discovery
+  // path (scanned cwd → repo root) and is committed, so a teammate who clones the
+  // repo WITHOUT running `forge setup` still gets Forge skills/stages discovered.
+  // Independent of the GLOBAL $CODEX_HOME install below (which needs canonical
+  // packaging templates) — so it runs before the install-plan early return.
+  try {
+    const { written } = populateCodexRepoSkills({ sourceRoot: packageDir, projectRoot });
+    CODEX_SETUP_REPORT.repoSkillCount = written.length;
+    console.log(`  Created: ${written.length} repo-local Codex skills in ${CODEX_REPO_SKILLS_DIR}/ (commit for teammate discovery)`);
+  } catch (error) {
+    addSetupNote(`Codex repo-local skill generation failed for ${CODEX_REPO_SKILLS_DIR}: ${error.message}`);
+    console.log(`  Warning: could not generate repo-local Codex skills in ${CODEX_REPO_SKILLS_DIR} (${error.message})`);
+  }
 
   if (installPlan.length === 0) {
     CODEX_SETUP_REPORT.status = 'partial';
@@ -2230,6 +2249,8 @@ function displaySetupSummary(selectedAgents) {
       const skillCount = CODEX_SETUP_REPORT?.skillCount ?? listCodexSkillEntries(packageDir).length;
       const codexRoot = CODEX_SETUP_REPORT?.installRoot || formatCodexSkillsInstallDir({ env: process.env, homeDir: os.homedir() });
       console.log(`  - ${codexRoot}/<stage>/SKILL.md (${skillCount} stage skills)`);
+      const repoSkillCount = CODEX_SETUP_REPORT?.repoSkillCount ?? 0;
+      console.log(`  - ${CODEX_REPO_SKILLS_DIR}/<skill>/SKILL.md (${repoSkillCount} repo-local skills — commit for teammate discovery)`);
     } else if (agent.hasSkill && agent.skillsDir) {
       console.log(`  - ${agent.skillsDir}/<skill>/SKILL.md`);
     }

--- a/lib/harness-capability-matrix.js
+++ b/lib/harness-capability-matrix.js
@@ -28,7 +28,7 @@ const SOURCE_ROWS = [
   ['S2', 'Claude Agent SDK skills', 'https://code.claude.com/docs/en/agent-sdk/skills.md', 'Claude SDK loads project/user/plugin skills and invokes them based on description metadata.'],
   ['S3', 'Cursor rules', 'https://docs.cursor.com/en/context', 'Cursor project rules live in .cursor/rules as .mdc files with description, globs, and alwaysApply metadata.'],
   ['S4', 'Cursor MCP', 'https://docs.cursor.com/context/model-context-protocol', 'Cursor connects external tools and data sources through MCP using stdio, SSE, and streamable HTTP transports.'],
-  ['S5', 'Codex skills', 'https://developers.openai.com/codex/skills', 'Codex skills package instructions, resources, and scripts; Forge currently generates .codex/skills packages for installation, while direct Codex repo discovery uses .agents/skills.'],
+  ['S5', 'Codex skills', 'https://developers.openai.com/codex/skills', 'Codex skills package instructions, resources, and scripts; Codex scans .agents/skills from cwd up to the repo root for repo-scope discovery. Forge generates .codex/skills packages for the global $CODEX_HOME install AND commits the repo-local .agents/skills mirror for teammate-clone discovery.'],
   ['S6', 'Codex MCP', 'https://developers.openai.com/codex/mcp', 'Codex configures MCP servers in config.toml and supports plugin-provided MCP servers.'],
   ['S7', 'Codex hooks', 'https://developers.openai.com/codex/hooks', 'Codex hooks run deterministic scripts during lifecycle events.'],
   ['S8', 'Codex plugins and marketplaces', 'https://developers.openai.com/codex/plugins/build', 'Codex plugins can package skills, apps, MCP servers, hooks, and marketplace metadata.'],
@@ -109,7 +109,7 @@ const CAPABILITY_ROWS = [
   row('skills', 'skills', 'on-demand workflow', [
     ['claude', target('native', '.claude/skills/<skill>/SKILL.md', { activation: 'description match or /skill-name', evidence: ['S1', 'S2'] })],
     ['cursor', target('native', '.cursor/skills/<skill>/SKILL.md', { activation: 'description match or explicit skill invocation', evidence: ['S3', 'S10'] })],
-    ['codex', target('packaged', '$CODEX_HOME/skills/<skill>/SKILL.md', { role: 'installed from the committed .codex/skills staging mirror', activation: 'description match or explicit $skill mention after install', evidence: ['S5'], knownIssue: 'Codex installs to $CODEX_HOME/skills; .codex/skills is the packaging staging mirror, not the install path. Direct repo discovery uses .agents/skills (not yet generated; kernel issue 55dfeccf).' })],
+    ['codex', target('packaged', '$CODEX_HOME/skills/<skill>/SKILL.md', { role: 'installed from the committed .codex/skills staging mirror', activation: 'description match or explicit $skill mention after install', evidence: ['S5'], knownIssue: 'Codex installs to the GLOBAL $CODEX_HOME/skills; .codex/skills is the packaging staging mirror, not the install path. Repo-local discovery uses .agents/skills/<skill>/SKILL.md, now generated at setup and committed for teammate-clone discovery (kernel issue 55dfeccf).' })],
     ['hermes', target('forge-owned', '.hermes/skills/<skill>/SKILL.md', { role: 'Forge-owned skill projection consumed via forge orient/recap', activation: 'forge orient/recap CLI' })],
   ]),
   row('rules', 'rules', null, [
@@ -133,7 +133,7 @@ const CAPABILITY_ROWS = [
   row('commands', 'commands', null, [
     ['claude', target('removed', null, { role: 'legacy .claude/commands/ surface removed in A0d; stage skills live in .claude/skills/<stage>/SKILL.md', evidence: ['S1'] })],
     ['cursor', target('removed', null, { role: 'legacy .cursor/commands/ surface removed in A0d; stage skills live in .cursor/skills/<stage>/SKILL.md', evidence: ['S3'] })],
-    ['codex', target('fallback', '$CODEX_HOME/skills/<stage>/SKILL.md', { role: 'skill fallback (installed from the .codex/skills staging mirror) instead of command authority', activation: 'explicit $skill or description match after install', evidence: ['S5'], knownIssue: 'Direct Codex repo discovery uses .agents/skills (not yet generated; kernel issue 55dfeccf).' })],
+    ['codex', target('fallback', '$CODEX_HOME/skills/<stage>/SKILL.md', { role: 'skill fallback (installed from the .codex/skills staging mirror) instead of command authority', activation: 'explicit $skill or description match after install', evidence: ['S5'], knownIssue: 'Repo-local Codex discovery uses .agents/skills, now generated at setup and committed for teammate-clone discovery (kernel issue 55dfeccf).' })],
     ['hermes', target('cli-consumed', 'forge orient / forge recap', { role: 'CLI command surface instead of command files' })],
   ]),
   row('agents', 'agents', 'subagent role mapping', [
@@ -145,7 +145,7 @@ const CAPABILITY_ROWS = [
   row('stages', 'stage-graph', 'super skill with addressable subskills', [
     ['claude', target('skill-first', '.claude/skills/<stage>/SKILL.md', { evidence: ['S1'] })],
     ['cursor', target('native', '.cursor/skills/<stage>/SKILL.md', { evidence: ['S3', 'S10'] })],
-    ['codex', target('skill-first', '$CODEX_HOME/skills/<stage>/SKILL.md', { role: 'installed from the .codex/skills staging mirror', evidence: ['S5'], knownIssue: 'Direct Codex repo discovery uses .agents/skills (not yet generated; kernel issue 55dfeccf).' })],
+    ['codex', target('skill-first', '$CODEX_HOME/skills/<stage>/SKILL.md', { role: 'installed from the .codex/skills staging mirror', evidence: ['S5'], knownIssue: 'Repo-local Codex discovery uses .agents/skills/<stage>/SKILL.md, now generated at setup and committed for teammate-clone discovery (kernel issue 55dfeccf).' })],
     ['hermes', target('forge-owned', '.hermes/skills/<stage>/SKILL.md', { role: 'Forge-owned stage-skill projection consumed via forge orient/recap' })],
   ]),
   row('beads', 'state-and-memory', 'issue and audit state authority', HARNESS_IDS.map(id => [id, target('forge-owned', 'forge CLI + bd adapter')])),
@@ -226,7 +226,9 @@ function buildSkillsFirstStageGraph() {
       status: 'native',
     },
     codex: {
-      // .codex/skills is the committed staging mirror; skills install to $CODEX_HOME/skills.
+      // .codex/skills is the committed packaging staging mirror; skills install to
+      // the GLOBAL $CODEX_HOME/skills. .agents/skills is the committed repo-local
+      // discovery mirror (generated at setup) that Codex scans cwd → repo root.
       skill: `$CODEX_HOME/skills/${id}/SKILL.md`,
       stagingMirror: `.codex/skills/${id}/SKILL.md`,
       installTarget: '$CODEX_HOME/skills',

--- a/lib/protected-state-surfaces.js
+++ b/lib/protected-state-surfaces.js
@@ -90,6 +90,7 @@ const PROTECTED_SURFACES = [
 		label: 'Generated harness files',
 		matches: filePath =>
 			startsWithAny(filePath, [
+				'.agents/skills',
 				'.claude/skills',
 				'.codex/skills',
 				'.cursor/rules',

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -14,6 +14,7 @@ const FORGE_PACKAGE_ROOT = path.resolve(__dirname, '..');
  * Used to distinguish forge files from user-created files.
  */
 const FORGE_SKILL_DIRS = [
+  '.agents/skills',
   '.claude/skills',
   '.cursor/skills',
   '.codex/skills',

--- a/lib/skills-sync.js
+++ b/lib/skills-sync.js
@@ -5,8 +5,12 @@
  *
  * Canonical source of truth is the committed root `skills/` directory — each
  * `skills/<name>/SKILL.md` (plus any sibling files) is an auto-surfacing skill.
- * Agent harness skill directories (`.claude/skills/`, `.codex/skills/`,
- * `.cursor/skills/`, `.hermes/skills/`) are GENERATED from that canonical source.
+ * Agent harness skill directories (`.agents/skills/`, `.claude/skills/`,
+ * `.codex/skills/`, `.cursor/skills/`, `.hermes/skills/`) are GENERATED from that
+ * canonical source. `.agents/skills` is Codex's documented repo-local discovery
+ * path (scanned from cwd up to the repo root); like `.codex/skills` it is committed
+ * so a teammate who clones the repo WITHOUT running `forge setup` still gets the
+ * Forge skills/stages auto-discovered.
  *
  * This module is the Forge-internal port of the `@forge/skills` CLI sync step.
  * Forge cannot depend on `@forge/skills` at runtime (the `packages/` workspace is
@@ -21,7 +25,7 @@
  *  - Committed-mirror scoped: `checkSkillsSync` only validates agent skill dirs
  *    that already exist on disk. `.claude/skills` / `.cursor/skills` are gitignored
  *    and populated at setup time, so their absence is not drift; `.codex/skills`
- *    is committed and is the mirror the gate enforces.
+ *    and `.agents/skills` are committed and are the mirrors the gate enforces.
  */
 
 const fs = require('node:fs');
@@ -35,6 +39,7 @@ const CANONICAL_SKILLS_DIR = 'skills';
  * Order is stable for deterministic reporting.
  */
 const AGENT_SKILL_DIRS = [
+  '.agents/skills',
   '.claude/skills',
   '.codex/skills',
   '.cursor/skills',
@@ -257,8 +262,8 @@ function diffSkillDir(sourcePath, targetPath) {
  *
  * Only agent skill dirs that already EXIST under `repoRoot` are validated —
  * gitignored, setup-populated dirs (`.claude/skills`, `.cursor/skills`) are
- * absent on a clean checkout and are correctly skipped; `.codex/skills` is the
- * committed mirror the gate enforces.
+ * absent on a clean checkout and are correctly skipped; `.codex/skills` and
+ * `.agents/skills` are the committed mirrors the gate enforces.
  *
  * @param {object} params
  * @param {string} params.repoRoot - Repo root (contains `skills/` + agent dirs).

--- a/test/agents-skills-repo-discovery.test.js
+++ b/test/agents-skills-repo-discovery.test.js
@@ -1,0 +1,90 @@
+const { describe, expect, test } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  AGENT_SKILL_DIRS,
+  listCanonicalSkills,
+  diffSkillDir,
+} = require('../lib/skills-sync');
+const {
+  CODEX_REPO_SKILLS_DIR,
+  resolveCodexRepoSkillsDir,
+  populateCodexRepoSkills,
+} = require('../lib/codex-skills');
+const { STAGE_IDS } = require('../lib/workflow/stages');
+const { UTILITY_SKILL_IDS } = require('../lib/harness-capability-matrix');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// ─── Codex repo-local (.agents/skills) discovery parity ───────────────────────
+//
+// Codex scans `.agents/skills/<name>/SKILL.md` from cwd up to the repo root for
+// repo-scope skill discovery (developers.openai.com/codex/skills — repo skills
+// are "checked into .agents/skills, for your team"). Forge previously installed
+// only to the GLOBAL $CODEX_HOME/skills, leaving a teammate who clones the repo
+// WITHOUT running `forge setup` with zero auto-discovered Forge skills/stages.
+// These tests prove Forge now generates the committed repo-local mirror.
+
+describe('codex repo-local .agents/skills discovery', () => {
+  test('.agents/skills is a drift-enforced agent skill dir', () => {
+    expect(CODEX_REPO_SKILLS_DIR).toBe('.agents/skills');
+    expect(AGENT_SKILL_DIRS).toContain('.agents/skills');
+  });
+
+  test('resolveCodexRepoSkillsDir joins projectRoot with .agents/skills', () => {
+    const projectRoot = path.join('some', 'project');
+    expect(resolveCodexRepoSkillsDir(projectRoot)).toBe(
+      path.join(projectRoot, '.agents', 'skills'),
+    );
+  });
+
+  test('populateCodexRepoSkills writes .agents/skills/<stage>/SKILL.md for every stage', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-agents-skills-'));
+    try {
+      const { targetSkillsDir, written } = populateCodexRepoSkills({
+        sourceRoot: repoRoot,
+        projectRoot: tmp,
+      });
+
+      expect(targetSkillsDir).toBe(path.join(tmp, '.agents', 'skills'));
+
+      // Every workflow stage + utility skill has a repo-local SKILL.md.
+      for (const id of [...STAGE_IDS, ...UTILITY_SKILL_IDS]) {
+        expect(written).toContain(id);
+        const skillFile = path.join(targetSkillsDir, id, 'SKILL.md');
+        expect(fs.existsSync(skillFile)).toBe(true);
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('generated .agents/skills content is byte-identical to canonical skills/', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-agents-skills-'));
+    try {
+      const { targetSkillsDir } = populateCodexRepoSkills({
+        sourceRoot: repoRoot,
+        projectRoot: tmp,
+      });
+      const canonical = listCanonicalSkills(repoRoot);
+      expect(canonical.length).toBeGreaterThan(0);
+      for (const skill of canonical) {
+        const drift = diffSkillDir(skill.sourcePath, path.join(targetSkillsDir, skill.name));
+        expect(drift).toEqual([]);
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('the committed repo .agents/skills mirror is drift-free vs canonical', () => {
+    const committed = resolveCodexRepoSkillsDir(repoRoot);
+    expect(fs.existsSync(committed)).toBe(true);
+    for (const skill of listCanonicalSkills(repoRoot)) {
+      const drift = diffSkillDir(skill.sourcePath, path.join(committed, skill.name));
+      expect(drift).toEqual([]);
+    }
+  });
+});

--- a/test/cleanup/dropped-agent-config.test.js
+++ b/test/cleanup/dropped-agent-config.test.js
@@ -25,11 +25,20 @@ describe('dropped-agent refs in config files', () => {
 
   describe('.gitignore', () => {
     const gitignore = fs.readFileSync(path.join(ROOT, '.gitignore'), 'utf8');
+    // Active ignore rules only — comment lines (which may legitimately MENTION a
+    // path, e.g. the note that `.agents/skills` is a committed mirror) are excluded.
+    const activeEntries = gitignore
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('#'));
 
-    test('does not contain dropped-agent gitignore entries', () => {
+    test('does not actively gitignore dropped-agent dirs (or the committed .agents/skills)', () => {
+      // `.agents/` is now a FORBIDDEN active ignore: `.agents/skills` is Codex's
+      // committed repo-local discovery mirror — gitignoring it would silently break
+      // teammate-clone discovery. The rest are dropped agents.
       const droppedEntries = ['.agents/', '.agent/', '.aider/', '.continue/skills', '.windsurf/skills'];
       for (const entry of droppedEntries) {
-        expect(gitignore).not.toContain(entry);
+        expect(activeEntries.some((line) => line.includes(entry))).toBe(false);
       }
     });
   });

--- a/test/cleanup/dropped-agent-files.test.js
+++ b/test/cleanup/dropped-agent-files.test.js
@@ -12,9 +12,13 @@ describe('dropped-agent files removed', () => {
     'docs/README-v1.3.md',
   ];
 
+  // `.agents` was dropped in 2026-03 as orphaned, gitignored skill cruft with no
+  // plugin referencing it. It is NO LONGER dropped: Codex's documented repo-scope
+  // discovery path is `.agents/skills` (checked in for the team, scanned cwd → repo
+  // root — developers.openai.com/codex/skills), so Forge now generates + commits it
+  // (kernel issue 55dfeccf). Only the singular `.agent` remains dropped cruft.
   const droppedDirs = [
     '.agent',
-    '.agents',
   ];
 
   for (const file of droppedFiles) {

--- a/test/structural/skills-sync-drift.test.js
+++ b/test/structural/skills-sync-drift.test.js
@@ -45,16 +45,19 @@ describe('skills sync drift detection', () => {
 
 // ─── all four harnesses render correctly from source (regenerate-into-temp) ────
 //
-// Only `.codex/skills` is committed as the sentinel mirror. Rather than committing
+// `.codex/skills` and `.agents/skills` are committed as the sentinel mirrors
+// (`.agents/skills` is Codex's repo-local discovery path — checked in so teammates
+// who clone WITHOUT running setup still get discovery). Rather than also committing
 // `.claude/.cursor/.hermes` skill mirrors (which fights the gitignored,
 // setup-populated design and bloats the repo), we prove drift-freedom for ALL
-// FOUR harnesses by regenerating each into a temp dir from the canonical source
+// harness surfaces by regenerating each into a temp dir from the canonical source
 // and asserting a byte-identical render. This guards Claude/Cursor/Hermes from
 // silently rotting even though their dirs are not committed.
 
 describe('all harness skill dirs render from canonical source', () => {
-  test('AGENT_SKILL_DIRS covers all four supported harnesses', () => {
+  test('AGENT_SKILL_DIRS covers every harness surface (incl. Codex repo-local .agents/skills)', () => {
     expect(AGENT_SKILL_DIRS).toEqual([
+      '.agents/skills',
       '.claude/skills',
       '.codex/skills',
       '.cursor/skills',


### PR DESCRIPTION
## What & why

Closes the skills/stages half of kernel issue **55dfeccf**. Codex's documented repo-scope discovery path is `.agents/skills/<name>/SKILL.md` — scanned from cwd up to the repo root, with repo skills "checked into `.agents/skills`, for your team" ([developers.openai.com/codex/skills](https://developers.openai.com/codex/skills)). Forge previously installed skills **only** to the GLOBAL `$CODEX_HOME/skills`, so a teammate who cloned the repo **without** running `forge setup` got **zero** auto-discovered Forge skills/stages in Codex — the only harness lacking a repo-local, teammate-clonable, auto-discovered surface (Claude/Cursor/Hermes all have one).

## What changed

- **Generate at setup**: `forge setup` now writes `.agents/skills/<name>/SKILL.md` for every canonical skill/stage (`lib/codex-skills.js` `populateCodexRepoSkills`, wired into `createCodexSkills` in `lib/commands/setup.js`). Content is **raw canonical** (byte-for-byte with the other mirrors — the `$CODEX_HOME` stage adapter is NOT injected) so the skills-sync drift gate enforces it and repo discovery reaches parity with `.claude`/`.cursor`.
- **Committed, not gitignored** (decision below): added to `AGENT_SKILL_DIRS` (drift-enforced), the `generated_harness` protected surface, and reset `FORGE_SKILL_DIRS`; `.gitignore` documents it as a committed mirror.
- **Reclaims `.agents`** from the 2026-03 dropped-agent cleanup (it was dropped only as orphaned/unreferenced cruft; per current Codex docs + `codex.plugin.json` it is now the real discovery path). Updated the two cleanup tests accordingly.
- **Capability matrix**: codex `skills`/`stages`/`commands` knownIssues now reflect delivery (removed "not yet generated"), preserving the `$CODEX_HOME`-install vs `.agents/skills`-repo-discovery distinction. `STATUS_VOCABULARY` unchanged.
- Regenerated the D20 bd-call-site audit artifact (setup.js line shift).

## Commit vs gitignore decision

**Committed** (mirrors `.codex/skills`). The gap is specifically *teammate-clone-**without**-setup* discovery — only a committed dir survives a clone with no setup step. A gitignored, setup-generated dir (like `.claude`/`.cursor` in this repo) would leave the gap open. Content is drift-enforced against canonical `skills/`.

## Test evidence

- New `test/agents-skills-repo-discovery.test.js` (setup path writes `.agents/skills/<stage>/SKILL.md` for all stages + utility skills; byte-identical to canonical; committed mirror drift-free).
- Updated `skills-sync-drift`, `dropped-agent-files`, `dropped-agent-config` tests.
- Targeted suites green; ESLint `--max-warnings 0` clean; `forge release check --target 0.1.0` = **0 blockers**.
- Full `bun test test/`: 4405 pass / 4 fail — the 4 are pre-existing flaky bash-script/e2e tests (`commitlint.js`, `reverse-sync-cli.mjs`, kernel e2e), unrelated to this change and confirmed flaky (they pass in isolation / vary run-to-run). Pushed via `forge push --quick`.

Kernel issue: 55dfeccf-3095-47ee-8b39-6968276a7fd9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full set of Forge workflow guides for planning, development, validation, review, shipping, verification, triage, rollback, memory, status, and research.
  * Codex now generates and recognizes a repo-local `.agents/skills` mirror during setup.

* **Bug Fixes**
  * Expanded safety checks so generated skill directories are treated consistently across sync, reset, and protected-state handling.

* **Tests**
  * Added coverage for repo-local skill discovery and drift detection.

* **Documentation**
  * Updated reference docs to align skill discovery behavior and workflow expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->