### PR TITLE
fix(issues): graceful Beads->Kernel fallback instead of dead-ending on 'Beads is not initialized'

### DIFF
--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -484,14 +484,81 @@ function resolveIssueActor(env = {}) {
   return undefined;
 }
 
+// Graceful Beads→Kernel fallback (issue 7f09ae93). When the resolved backend is
+// Beads but Beads is NOT initialized in this project AND a Forge Kernel store
+// already exists at `<gitCommonDir>/forge/kernel.sqlite`, route the operation to
+// the kernel instead of dead-ending on "Beads is not initialized". This unblocks
+// upgraders whose repo predates the kernel default (or whose global `forge` binary
+// is stale and still resolves Beads): the kernel is the correct default and already
+// holds their issues. Returns the resolved kernel paths when the fallback applies,
+// or null to keep the Beads path (so a genuine no-store repo still gets the Beads
+// not-initialized error). Path resolution reuses buildLocalBrokerConfig so the probed
+// location matches exactly what the broker would open. Never throws.
+function resolveBeadsFallbackToKernel(projectRoot, deps = {}) {
+  const checkInit = deps.isBeadsInitialized || isBeadsInitialized;
+  if (checkInit(projectRoot)) {
+    // Beads is initialized — honor the explicit Beads selection, no fallback.
+    return null;
+  }
+
+  let config;
+  try {
+    config = buildLocalBrokerConfig({
+      projectRoot,
+      gitCommonDir: deps.gitCommonDir,
+      databasePath: deps.kernelDatabasePath,
+      execFileSync: deps.execFileSync,
+    });
+  } catch {
+    // No resolvable kernel location (e.g. projectRoot is not a git repo) — there is
+    // no safe fallback target, so let the Beads path report its own error.
+    return null;
+  }
+
+  const fileExists = deps.existsSync || existsSync;
+  if (!fileExists(config.databasePath)) {
+    // No kernel store either — preserve the Beads not-initialized error.
+    return null;
+  }
+
+  return { kernelDatabasePath: config.databasePath, gitCommonDir: config.gitCommonDir };
+}
+
 async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
-  const createService = deps.createService || (() => {
+  const injectedService = deps.createService;
+  let routeToKernel = shouldUseKernelBroker(deps);
+  let effectiveDeps = deps;
+
+  // Beads→Kernel graceful fallback (7f09ae93). Only considered when a service is not
+  // injected (an injected service owns backend selection), the selection is not
+  // already Kernel, and this is not a help invocation (help must never touch a
+  // backend). When it applies, treat the op as Kernel-routed end-to-end (backend
+  // construction AND the projection-target seam below).
+  if (!injectedService && !routeToKernel && !isHelpInvocation(rawArgs)) {
+    const fallback = resolveBeadsFallbackToKernel(projectRoot, deps);
+    if (fallback) {
+      routeToKernel = true;
+      effectiveDeps = {
+        ...deps,
+        useKernelBroker: true,
+        kernelDatabasePath: fallback.kernelDatabasePath,
+        gitCommonDir: fallback.gitCommonDir,
+      };
+      const notify = deps.warn || ((msg) => process.stderr.write(`${msg}\n`));
+      notify(
+        'Notice: Beads is not initialized, but a Forge Kernel store exists — using the '
+        + 'kernel backend (the default). Run `forge setup` to finish migrating.',
+      );
+    }
+  }
+
+  const createService = injectedService || (() => {
     const context = {
       projectRoot,
-      deps,
+      deps: effectiveDeps,
     };
 
-    if (shouldUseKernelBroker(deps)) {
+    if (routeToKernel) {
       return createIssueService({
         backend: createKernelIssueBackend(context),
       });
@@ -532,7 +599,7 @@ async function runIssueOperation(operation, rawArgs, projectRoot, deps = {}) {
     // here every Kernel-created issue is enqueued as 'beads' and `forge export` — which
     // drains 'jsonl' — finds nothing, silently never emitting git-tracked JSONL. Only
     // the Kernel path uses this seam (`context.projectionTarget`); Beads ignores it.
-    ...(shouldUseKernelBroker(deps) ? { projectionTarget: 'jsonl' } : {}),
+    ...(routeToKernel ? { projectionTarget: 'jsonl' } : {}),
   });
 
   const queueGitHubProjection = deps.enqueueGitHubProjection || deps.queueGitHubProjection;
@@ -569,5 +636,6 @@ module.exports = {
   getBdCommandCandidates,
   getPathEntries,
   resolveIssueActor,
+  resolveBeadsFallbackToKernel,
   resolveWindowsCommandCandidates,
 };

--- a/test/forge-issues.test.js
+++ b/test/forge-issues.test.js
@@ -1079,3 +1079,94 @@ describe('resolveIssueActor precedence', () => {
     expect(resolveIssueActor()).toBeUndefined();
   });
 });
+
+describe('Beads-not-initialized graceful fallback to the kernel (7f09ae93)', () => {
+  test('resolveBeadsFallbackToKernel routes to the kernel when Beads is uninitialized but a kernel store exists', () => {
+    const { resolveBeadsFallbackToKernel } = require('../lib/forge-issues');
+
+    // Derive expectations from the same resolution the broker uses (path.resolve
+    // adds a drive letter on Windows), so the assertion is cross-platform.
+    const expectedGitCommonDir = path.resolve('/repo/.git');
+    const expectedDbPath = path.join(expectedGitCommonDir, 'forge', 'kernel.sqlite');
+
+    const checked = [];
+    const result = resolveBeadsFallbackToKernel('/repo', {
+      isBeadsInitialized: () => false,
+      gitCommonDir: '/repo/.git',
+      existsSync: (p) => {
+        checked.push(p);
+        return true;
+      },
+    });
+
+    expect(result).toEqual({
+      kernelDatabasePath: expectedDbPath,
+      gitCommonDir: expectedGitCommonDir,
+    });
+    // It probed exactly the documented kernel store location.
+    expect(checked).toEqual([expectedDbPath]);
+  });
+
+  test('resolveBeadsFallbackToKernel returns null when Beads IS initialized (honor the explicit selection)', () => {
+    const { resolveBeadsFallbackToKernel } = require('../lib/forge-issues');
+
+    const result = resolveBeadsFallbackToKernel('/repo', {
+      isBeadsInitialized: () => true,
+      gitCommonDir: '/repo/.git',
+      existsSync: () => true,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test('resolveBeadsFallbackToKernel returns null when neither Beads nor a kernel store exists', () => {
+    const { resolveBeadsFallbackToKernel } = require('../lib/forge-issues');
+
+    const result = resolveBeadsFallbackToKernel('/repo', {
+      isBeadsInitialized: () => false,
+      gitCommonDir: '/repo/.git',
+      existsSync: () => false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test('runIssueOperation falls back to the kernel (with a one-line notice) instead of dead-ending', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+
+    const notices = [];
+    const calls = [];
+    const result = await runIssueOperation('list', [], '/repo', {
+      isBeadsInitialized: () => false,
+      gitCommonDir: '/repo/.git',
+      existsSync: () => true,
+      warn: (msg) => notices.push(msg),
+      createKernelBroker: () => ({
+        async runIssueOperation(operation, args) {
+          calls.push({ operation, args });
+          return { ok: true, data: { items: [] } };
+        },
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([{ operation: 'list', args: [] }]);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain('kernel');
+  });
+
+  test('runIssueOperation still returns the Beads not-initialized error when no kernel store exists', async () => {
+    const { runIssueOperation } = require('../lib/forge-issues');
+
+    const result = await runIssueOperation('list', [], '/repo', {
+      isBeadsInitialized: () => false,
+      gitCommonDir: '/repo/.git',
+      existsSync: () => false,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Beads is not initialized in this project. Run forge setup before using forge issues.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the release-critical dead-end where upgraders on an older global `forge`
(predating the kernel default from #298/#305/#306) hit:

> Beads is not initialized in this project. Run forge setup before using forge issues.

when running `forge issue create|ready|list`, even though the kernel is the
correct default (`lib/issue-backend.js` `DEFAULT_BACKEND='kernel'`) and
`.git/forge/kernel.sqlite` already holds their issues. Every upgrader hit a
confusing dead-end and agents couldn't file kernel issues via plain `forge`, so
tracked work went missing.

Kernel issue: **7f09ae93-c4b7-43c9-b1b7-57361f871ce6**

## Fix (approach a — graceful fallback)

Added a Beads→Kernel graceful fallback in `runIssueOperation`
(`lib/forge-issues.js`). When the resolved backend is Beads but Beads is **NOT**
initialized **AND** a kernel store exists at `<gitCommonDir>/forge/kernel.sqlite`,
the operation is routed to the kernel with a one-line **stderr** notice instead
of dead-ending.

Details:
- New pure, never-throwing helper `resolveBeadsFallbackToKernel(projectRoot, deps)`.
  Path resolution reuses `buildLocalBrokerConfig`, so the probed location matches
  exactly what the broker would open.
- The fallback also steers `projectionTarget` to `'jsonl'` (via a single computed
  `routeToKernel` flag) so fallback-created kernel issues still export correctly.
- **Preserved behavior**: when no kernel store exists, the genuine Beads
  not-initialized error still surfaces; help invocations and injected services
  never trigger the fallback; the default (kernel) and explicit-kernel paths are
  byte-identical (the notice fires only on the fallback path).

Fix (b) `forge doctor` stale-binary detection was assessed but skipped: it would
require spawning the potentially-stale global binary and cross-platform version
comparison — not cheap and risk-prone. Fix (a) already makes the plain command
work, which was the priority.

## Testing

- TDD: 5 new tests in `test/forge-issues.test.js` (3 unit for
  `resolveBeadsFallbackToKernel` covering fallback / beads-initialized / no-store,
  2 integration through `runIssueOperation` covering the notice+routing and the
  preserved beads error). Written failing first, then implemented.
- `bun test test/forge-issues.test.js` → 39 pass / 0 fail.
- Related suites (issue-backend, _resolve-command-opts, _issue, issue/issues
  commands, adapters) → 117 pass / 0 fail.
- ESLint `--max-warnings 0` clean on changed files.
- End-to-end: `FORGE_ISSUE_BACKEND=beads node bin/forge.js list` in this repo now
  exits 0, prints the notice on stderr, and returns real kernel issues on clean
  stdout (previously a hard error). Plain `node bin/forge.js list` prints no
  notice (no regression).

## Files changed
- `lib/forge-issues.js`
- `test/forge-issues.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue operations when the selected backend isn’t ready but a local workspace already exists, allowing the app to fall back to the available store instead of failing immediately.
  * Added a clearer warning when this fallback is used, while preserving the original error when no safe fallback is available.
  * Expanded automated coverage for backend fallback behavior and routing to ensure more reliable issue handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->