### PR TITLE
fix(clean): squash-merge-aware worktree cleanup + post-merge master fast-forward

### DIFF
--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -488,7 +488,10 @@ async function cleanWorktrees(worktreesDir, runFile, fsApi, dryRun, opts) {
   let mergedBranches = [];
   const mergedOut = tryRun(runFile, 'git', ['branch', '--merged', defaultBranch]);
   if (mergedOut) {
-    mergedBranches = mergedOut.split('\n').map(b => b.trim().replace(/^\*\s*/, '')).filter(Boolean);
+    // Strip the current-branch `*` and the linked-worktree `+` prefixes that
+    // `git branch --merged` emits, so worktree-checked-out branches still hit the
+    // ancestry fast path instead of falling through to the slower squash tier.
+    mergedBranches = mergedOut.split('\n').map(b => b.trim().replace(/^[*+]\s*/, '')).filter(Boolean);
   }
   const ghMergedRefs = getGhMergedRefs(runFile);
   const ctx = { defaultBranch, mergedBranches, ghMergedRefs, runFile };

--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -103,17 +103,23 @@ function parseMainWorktree(output) {
  * GitHub tier: collect head refs of merged PRs (one memoized call).
  * Returns an empty Set when gh is unavailable or errors — a safe no-signal.
  * @param {Function} runFile - execFileSync-compatible function
- * @returns {Set<string>} Set of merged PR head branch names
+ * @returns {Map<string, string>} Map of merged PR head branch name -> head commit OID
  */
 function getGhMergedRefs(runFile) {
-  const out = tryRun(runFile, 'gh', ['pr', 'list', '--state', 'merged', '--json', 'headRefName', '--limit', '200']);
-  if (!out) return new Set();
+  const out = tryRun(runFile, 'gh', ['pr', 'list', '--state', 'merged', '--json', 'headRefName,headRefOid', '--limit', '200']);
+  if (!out) return new Map();
   try {
     const arr = JSON.parse(out);
-    if (!Array.isArray(arr)) return new Set();
-    return new Set(arr.map(p => p && p.headRefName).filter(Boolean));
+    if (!Array.isArray(arr)) return new Map();
+    const map = new Map();
+    // Record the head OID too: a reused/advanced branch name must NOT be treated as
+    // merged unless its current tip still matches the OID GitHub merged.
+    for (const p of arr) {
+      if (p && p.headRefName && p.headRefOid) map.set(p.headRefName, p.headRefOid);
+    }
+    return map;
   } catch (_e) { /* intentional: malformed gh output → no signal */ // NOSONAR S2486
-    return new Set();
+    return new Map();
   }
 }
 
@@ -150,13 +156,22 @@ function isSquashMerged(branch, defaultBranch, runFile) {
  * @param {object} ctx - Detection context
  * @param {string} ctx.defaultBranch - Default branch name
  * @param {string[]} ctx.mergedBranches - Ancestry-merged branch names
- * @param {Set<string>} ctx.ghMergedRefs - Merged PR head refs
+ * @param {Map<string, string>} ctx.ghMergedRefs - Merged PR head branch -> head OID
  * @param {Function} ctx.runFile - execFileSync-compatible function
  * @returns {boolean} True iff the branch is merged (any tier)
  */
 function detectMerged(branch, ctx) {
   if (ctx.mergedBranches.includes(branch)) return true;
-  if (ctx.ghMergedRefs && ctx.ghMergedRefs.has(branch)) return true;
+  if (ctx.ghMergedRefs) {
+    const mergedOid = ctx.ghMergedRefs.get(branch);
+    // Only trust the gh "merged" signal when the merged PR's head OID still matches
+    // the branch tip; a reused/advanced branch name with new commits falls through
+    // to the squash patch-equivalence check (never remove on doubt).
+    if (mergedOid) {
+      const tip = tryRun(ctx.runFile, 'git', ['rev-parse', branch]);
+      if (tip && tip === mergedOid) return true;
+    }
+  }
   return isSquashMerged(branch, ctx.defaultBranch, ctx.runFile);
 }
 
@@ -172,8 +187,8 @@ function isWorktreeDirty(wtPath, runFile) {
   try {
     const out = runFile('git', ['-C', wtPath, 'status', '--porcelain'], { stdio: 'pipe' }).toString().trim();
     return out.length > 0;
-  } catch (_e) { /* intentional: unknowable → let git's own guard decide */ // NOSONAR S2486
-    return false;
+  } catch (_e) { /* status unknowable → treat as UNSAFE (dirty) so we never remove on doubt */ // NOSONAR S2486
+    return true;
   }
 }
 
@@ -247,13 +262,14 @@ async function cleanWorktree(dir, worktreeMap, isMergedFn, worktreesDir, dryRun,
     return { status: 'active', path: wtPath, branch };
   }
 
-  if (dryRun) {
-    return { status: 'cleaned', path: wtPath, branch };
-  }
-
-  // Merged, but never blow away uncommitted local edits.
+  // Merged, but never blow away uncommitted local edits. Checked BEFORE the dry-run
+  // branch so a dry run reports the same "dirty" skip the real run would take.
   if (isWorktreeDirty(wtPath, runFile)) {
     return { status: 'dirty', path: wtPath, branch };
+  }
+
+  if (dryRun) {
+    return { status: 'cleaned', path: wtPath, branch };
   }
 
   const outcome = await removeWorktreeRobust(wtPath, runFile, fsApi, opts);
@@ -307,12 +323,15 @@ function backupUntracked(fsApi, mainPath, stderr, opts) {
 }
 
 /**
- * Count revisions in a range (e.g. `main..origin/main`); 0 on any error.
+ * Count revisions in a range (e.g. `main..origin/main`). Returns null on error/no
+ * signal so callers can distinguish "verified 0 commits" from "could not verify"
+ * (a successful rev-list --count always prints at least "0").
  */
 function countRevs(runFile, cwd, range) {
   const out = tryRun(runFile, 'git', ['-C', cwd, 'rev-list', '--count', range]);
+  if (out === '') return null;
   const n = parseInt(out, 10);
-  return Number.isFinite(n) ? n : 0;
+  return Number.isFinite(n) ? n : null;
 }
 
 /**
@@ -355,11 +374,20 @@ async function syncMasterBranch(runFile, fsApi, opts = {}) {
     const defaultBranch = getDefaultBranch(runFile);
     result.defaultBranch = defaultBranch;
 
-    // Refresh origin/<default> without touching the working tree.
-    tryRun(runFile, 'git', ['-C', main.path, 'fetch', 'origin', defaultBranch]);
+    // Refresh origin/<default> without touching the working tree. A fetch failure is
+    // surfaced (not swallowed into a misleading "up-to-date").
+    try {
+      runFile('git', ['-C', main.path, 'fetch', 'origin', defaultBranch], { stdio: 'pipe' });
+    } catch (err) {
+      result.reason = 'fetch-failed';
+      result.error = err && err.message;
+      return result;
+    }
 
     const behind = countRevs(runFile, main.path, `${defaultBranch}..origin/${defaultBranch}`);
     const ahead = countRevs(runFile, main.path, `origin/${defaultBranch}..${defaultBranch}`);
+    // null = rev-list could not verify the range; do NOT claim up-to-date on doubt.
+    if (behind === null || ahead === null) { result.reason = 'rev-list-failed'; return result; }
     result.behind = behind;
     result.ahead = ahead;
 
@@ -388,6 +416,34 @@ async function syncMasterBranch(runFile, fsApi, opts = {}) {
   }
 }
 
+/** Append the dirty-worktree lines (extracted to keep formatOutput simple). */
+function renderDirty(dirty, lines) {
+  if (!dirty || dirty.length === 0) return;
+  lines.push(`Skipped ${dirty.length} dirty worktree(s) with uncommitted changes:`);
+  for (const p of dirty) lines.push(`  - ${p}`);
+}
+
+/** Append the survivor warning lines. */
+function renderSurvivors(survivors, lines) {
+  if (!survivors || survivors.length === 0) return;
+  lines.push(`WARNING: ${survivors.length} merged worktree(s) could not be removed (manual cleanup needed):`);
+  for (const s of survivors) lines.push(`  - ${s.path}${s.error ? ` (${s.error})` : ''}`);
+}
+
+/** Append the master-sync outcome line(s). */
+function renderMasterSync(masterSync, lines) {
+  if (!masterSync || !masterSync.attempted) return;
+  const ms = masterSync;
+  if (ms.synced) {
+    lines.push(`Fast-forwarded ${ms.defaultBranch} (${ms.behind} commit(s) behind, method: ${ms.method}).`);
+    if (ms.backedUp && ms.backedUp.length > 0) {
+      lines.push(`  Backed up ${ms.backedUp.length} untracked file(s) before fast-forward.`);
+    }
+  } else if (ms.reason && ms.reason !== 'up-to-date' && ms.reason !== 'no-main-worktree') {
+    lines.push(`Master sync skipped (${ms.reason}${ms.error ? `: ${ms.error}` : ''}).`);
+  }
+}
+
 /**
  * Build the user-facing report line(s) for the clean run.
  */
@@ -395,25 +451,9 @@ function formatOutput(summary) {
   const lines = [];
   const verb = summary.dryRun ? 'Would remove' : 'Removed';
   lines.push(`${verb} ${summary.cleaned} merged worktree(s); ${summary.active} active kept.`);
-  if (summary.dirty.length > 0) {
-    lines.push(`Skipped ${summary.dirty.length} dirty worktree(s) with uncommitted changes:`);
-    for (const p of summary.dirty) lines.push(`  - ${p}`);
-  }
-  if (summary.survivors.length > 0) {
-    lines.push(`WARNING: ${summary.survivors.length} merged worktree(s) could not be removed (manual cleanup needed):`);
-    for (const s of summary.survivors) lines.push(`  - ${s.path}${s.error ? ` (${s.error})` : ''}`);
-  }
-  if (summary.masterSync && summary.masterSync.attempted) {
-    const ms = summary.masterSync;
-    if (ms.synced) {
-      lines.push(`Fast-forwarded ${ms.defaultBranch} (${ms.behind} commit(s) behind, method: ${ms.method}).`);
-      if (ms.backedUp && ms.backedUp.length > 0) {
-        lines.push(`  Backed up ${ms.backedUp.length} untracked file(s) before fast-forward.`);
-      }
-    } else if (ms.reason && ms.reason !== 'up-to-date' && ms.reason !== 'no-main-worktree') {
-      lines.push(`Master sync skipped (${ms.reason}${ms.error ? `: ${ms.error}` : ''}).`);
-    }
-  }
+  renderDirty(summary.dirty, lines);
+  renderSurvivors(summary.survivors, lines);
+  renderMasterSync(summary.masterSync, lines);
   return lines.join('\n');
 }
 
@@ -429,53 +469,57 @@ function formatOutput(summary) {
  * @param {Function} [opts._syncMaster] - Override master sync (testing)
  * @returns {Promise<object>} Structured result
  */
+/**
+ * Scan .worktrees/ and remove the merged ones (squash-aware). Returns the tallies;
+ * a no-op ({0,0,[],[]}) when .worktrees/ is absent or empty. Extracted from handler
+ * so the top-level orchestration stays under the complexity gate.
+ * @returns {Promise<{ cleaned: number, active: number, survivors: object[], dirty: string[] }>}
+ */
+async function cleanWorktrees(worktreesDir, runFile, fsApi, dryRun, opts) {
+  const acc = { cleaned: 0, active: 0, survivors: [], dirty: [] };
+  if (!fsApi.existsSync(worktreesDir)) return acc;
+
+  const entries = fsApi.readdirSync(worktreesDir, { withFileTypes: true });
+  const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+  if (dirs.length === 0) return acc;
+
+  // Detection context: ancestry list + gh merged refs + squash fallback.
+  const defaultBranch = getDefaultBranch(runFile);
+  let mergedBranches = [];
+  const mergedOut = tryRun(runFile, 'git', ['branch', '--merged', defaultBranch]);
+  if (mergedOut) {
+    mergedBranches = mergedOut.split('\n').map(b => b.trim().replace(/^\*\s*/, '')).filter(Boolean);
+  }
+  const ghMergedRefs = getGhMergedRefs(runFile);
+  const ctx = { defaultBranch, mergedBranches, ghMergedRefs, runFile };
+  const isMergedFn = opts._isMerged || (branch => detectMerged(branch, ctx));
+
+  const listOutput = tryRun(runFile, 'git', ['worktree', 'list', '--porcelain']);
+  const worktreeMap = listOutput ? parseWorktreeList(listOutput) : new Map();
+
+  for (const dir of dirs) {
+    const res = await cleanWorktree(dir, worktreeMap, isMergedFn, worktreesDir, dryRun, runFile, fsApi, opts);
+    if (res.status === 'cleaned') acc.cleaned++;
+    else if (res.status === 'survivor') acc.survivors.push(res);
+    else if (res.status === 'dirty') acc.dirty.push(res.path);
+    else acc.active++;
+  }
+
+  if (!dryRun && acc.cleaned > 0) {
+    tryRun(runFile, 'git', ['worktree', 'prune']);
+  }
+  return acc;
+}
+
 async function handler(_args, flags, projectRoot, opts = {}) {
   const runFile = opts._exec || execFileSync;
   const fsApi = opts._fs || fs;
   const dryRun = !!(flags['--dry-run'] || flags.dryRun);
   const masterSyncEnabled = !(flags['--no-master-sync'] || flags.noMasterSync);
-
   const worktreesDir = path.resolve(projectRoot, '.worktrees');
 
-  let cleaned = 0;
-  let active = 0;
-  const survivors = [];
-  const dirty = [];
-
-  // Worktree cleanup runs only when .worktrees/ has directories; master
-  // auto-update below is independent of it (post-merge sync always applies).
-  if (fsApi.existsSync(worktreesDir)) {
-    const entries = fsApi.readdirSync(worktreesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
-
-    if (dirs.length > 0) {
-      // Detection context: ancestry list + gh merged refs + squash fallback.
-      const defaultBranch = getDefaultBranch(runFile);
-      let mergedBranches = [];
-      const mergedOut = tryRun(runFile, 'git', ['branch', '--merged', defaultBranch]);
-      if (mergedOut) {
-        mergedBranches = mergedOut.split('\n').map(b => b.trim().replace(/^\*\s*/, '')).filter(Boolean);
-      }
-      const ghMergedRefs = getGhMergedRefs(runFile);
-      const ctx = { defaultBranch, mergedBranches, ghMergedRefs, runFile };
-      const isMergedFn = opts._isMerged || (branch => detectMerged(branch, ctx));
-
-      const listOutput = tryRun(runFile, 'git', ['worktree', 'list', '--porcelain']);
-      const worktreeMap = listOutput ? parseWorktreeList(listOutput) : new Map();
-
-      for (const dir of dirs) {
-        const res = await cleanWorktree(dir, worktreeMap, isMergedFn, worktreesDir, dryRun, runFile, fsApi, opts);
-        if (res.status === 'cleaned') cleaned++;
-        else if (res.status === 'survivor') survivors.push(res);
-        else if (res.status === 'dirty') dirty.push(res.path);
-        else active++;
-      }
-
-      if (!dryRun && cleaned > 0) {
-        tryRun(runFile, 'git', ['worktree', 'prune']);
-      }
-    }
-  }
+  // Worktree cleanup (no-op when .worktrees/ absent); master auto-update is independent.
+  const { cleaned, active, survivors, dirty } = await cleanWorktrees(worktreesDir, runFile, fsApi, dryRun, opts);
 
   // Post-merge master auto-update (default-on; skipped in dry-run).
   let masterSync = null;
@@ -515,6 +559,7 @@ module.exports = {
     isWorktreeDirty,
     removeWorktreeRobust,
     cleanWorktree,
+    cleanWorktrees,
     parseUntrackedOverwrites,
     backupUntracked,
     syncMasterBranch,

--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -6,7 +6,9 @@ const path = require('node:path');
 
 /**
  * Forge Clean Command
- * Remove worktrees for merged branches.
+ * Remove worktrees for merged branches (squash-merge aware) and optionally
+ * fast-forward the main checkout's default branch after merges.
+ *
  * Uses execFileSync (not execSync) to prevent command injection (OWASP A03).
  *
  * The Kernel issue store lives in the shared git common dir, so there is no
@@ -14,6 +16,22 @@ const path = require('node:path');
  *
  * @module commands/clean
  */
+
+/**
+ * Run a git/gh command through the injected runner, returning trimmed stdout.
+ * Returns '' on any failure (callers treat empty as "no signal").
+ * @param {Function} runFile - execFileSync-compatible function
+ * @param {string} cmd - Executable (e.g. 'git', 'gh')
+ * @param {string[]} args - Arguments
+ * @returns {string} Trimmed stdout, or '' on error
+ */
+function tryRun(runFile, cmd, args) {
+  try {
+    return runFile(cmd, args, { stdio: 'pipe' }).toString().trim();
+  } catch (_e) { /* intentional: caller treats '' as no-signal */ // NOSONAR S2486
+    return '';
+  }
+}
 
 /**
  * Detect the default branch (main, master, develop, trunk).
@@ -65,30 +83,338 @@ function parseWorktreeList(output) {
 }
 
 /**
- * Clean a single worktree directory if its branch is merged.
+ * Return the first worktree block from `git worktree list --porcelain` — the
+ * main working tree — as { path, branch } (branch is null when detached).
+ * @param {string} output - Raw porcelain output
+ * @returns {{ path: string, branch: string|null }|null}
+ */
+function parseMainWorktree(output) {
+  const firstBlock = output.split('\n\n')[0] || '';
+  let wtPath = null;
+  let branch = null;
+  for (const line of firstBlock.trim().split('\n')) {
+    if (line.startsWith('worktree ')) wtPath = line.slice('worktree '.length);
+    if (line.startsWith('branch ')) branch = line.slice('branch refs/heads/'.length);
+  }
+  return wtPath ? { path: wtPath, branch } : null;
+}
+
+/**
+ * GitHub tier: collect head refs of merged PRs (one memoized call).
+ * Returns an empty Set when gh is unavailable or errors — a safe no-signal.
+ * @param {Function} runFile - execFileSync-compatible function
+ * @returns {Set<string>} Set of merged PR head branch names
+ */
+function getGhMergedRefs(runFile) {
+  const out = tryRun(runFile, 'gh', ['pr', 'list', '--state', 'merged', '--json', 'headRefName', '--limit', '200']);
+  if (!out) return new Set();
+  try {
+    const arr = JSON.parse(out);
+    if (!Array.isArray(arr)) return new Set();
+    return new Set(arr.map(p => p && p.headRefName).filter(Boolean));
+  } catch (_e) { /* intentional: malformed gh output → no signal */ // NOSONAR S2486
+    return new Set();
+  }
+}
+
+/**
+ * Squash-merge tier (git-only, deterministic). A squash-merged branch tip is
+ * NOT an ancestor of the default branch, so `git branch --merged` misses it.
+ * Instead, synthesize a single commit from the branch's tree onto the
+ * merge-base and ask `git cherry` whether the default branch already contains a
+ * patch-equivalent commit. `git cherry` prints `- <sha>` when an equivalent
+ * exists (i.e. the branch was squash-merged) and `+ <sha>` otherwise.
+ * Empty output / any error → treated as NOT merged (never remove on doubt).
+ * @param {string} branch - Branch under test
+ * @param {string} defaultBranch - Default branch name
+ * @param {Function} runFile - execFileSync-compatible function
+ * @returns {boolean} True iff the branch is patch-equivalent-merged into default
+ */
+function isSquashMerged(branch, defaultBranch, runFile) {
+  const mergeBase = tryRun(runFile, 'git', ['merge-base', defaultBranch, branch]);
+  if (!mergeBase) return false;
+  const tree = tryRun(runFile, 'git', ['rev-parse', `${branch}^{tree}`]);
+  if (!tree) return false;
+  const synthetic = tryRun(runFile, 'git', ['commit-tree', tree, '-p', mergeBase, '-m', '_']);
+  if (!synthetic) return false;
+  const cherry = tryRun(runFile, 'git', ['cherry', defaultBranch, synthetic]);
+  // A single `- <sha>` line means the combined diff is already in `default`.
+  return cherry.startsWith('-');
+}
+
+/**
+ * Squash-aware merged detection over three short-circuiting tiers:
+ *   (a) ancestry list (`git branch --merged`), (b) merged-PR head refs (gh),
+ *   (c) git-only squash patch-equivalence. A branch confirmed by none stays.
+ * @param {string} branch - Branch name
+ * @param {object} ctx - Detection context
+ * @param {string} ctx.defaultBranch - Default branch name
+ * @param {string[]} ctx.mergedBranches - Ancestry-merged branch names
+ * @param {Set<string>} ctx.ghMergedRefs - Merged PR head refs
+ * @param {Function} ctx.runFile - execFileSync-compatible function
+ * @returns {boolean} True iff the branch is merged (any tier)
+ */
+function detectMerged(branch, ctx) {
+  if (ctx.mergedBranches.includes(branch)) return true;
+  if (ctx.ghMergedRefs && ctx.ghMergedRefs.has(branch)) return true;
+  return isSquashMerged(branch, ctx.defaultBranch, ctx.runFile);
+}
+
+/**
+ * Whether a worktree has uncommitted (staged or unstaged) changes.
+ * Merged branches have their commits in the default branch already, so the only
+ * loss risk is uncommitted working-tree edits — those block removal.
+ * @param {string} wtPath - Absolute worktree path
+ * @param {Function} runFile - execFileSync-compatible function
+ * @returns {boolean} True iff dirty
+ */
+function isWorktreeDirty(wtPath, runFile) {
+  try {
+    const out = runFile('git', ['-C', wtPath, 'status', '--porcelain'], { stdio: 'pipe' }).toString().trim();
+    return out.length > 0;
+  } catch (_e) { /* intentional: unknowable → let git's own guard decide */ // NOSONAR S2486
+    return false;
+  }
+}
+
+const DEFAULT_MAX_TRIES = 3;
+
+/**
+ * Windows-robust worktree removal. FS locks on Windows frequently fail
+ * `git worktree remove` with "Directory not empty" / "Permission denied", so:
+ *   1. retry plain remove with backoff,
+ *   2. fall back to `--force`,
+ *   3. `git worktree prune` + manual recursive dir removal.
+ * Never throws — returns a structured outcome so survivors can be reported.
+ * @param {string} wtPath - Absolute worktree path
+ * @param {Function} runFile - execFileSync-compatible function
+ * @param {object} fsApi - fs-compatible module
+ * @param {object} opts - Injection: _sleep, _maxTries
+ * @returns {Promise<{ removed: boolean, method?: string, error?: string }>}
+ */
+async function removeWorktreeRobust(wtPath, runFile, fsApi, opts = {}) {
+  const sleep = opts._sleep || (ms => new Promise(resolve => setTimeout(resolve, ms)));
+  const maxTries = Number.isInteger(opts._maxTries) ? opts._maxTries : DEFAULT_MAX_TRIES;
+  const errors = [];
+
+  for (let attempt = 0; attempt < maxTries; attempt++) {
+    try {
+      runFile('git', ['worktree', 'remove', wtPath], { stdio: 'pipe' });
+      return { removed: true, method: 'remove' };
+    } catch (err) {
+      errors.push(err.message);
+      if (attempt < maxTries - 1) await sleep(200 * (attempt + 1));
+    }
+  }
+
+  try {
+    runFile('git', ['worktree', 'remove', '--force', wtPath], { stdio: 'pipe' });
+    return { removed: true, method: 'force' };
+  } catch (err) { errors.push(err.message); }
+
+  // Last resort: prune the ref, then manually remove the directory.
+  try {
+    runFile('git', ['worktree', 'prune'], { stdio: 'pipe' });
+    if (fsApi.existsSync(wtPath)) {
+      fsApi.rmSync(wtPath, { recursive: true, force: true });
+    }
+    if (!fsApi.existsSync(wtPath)) {
+      runFile('git', ['worktree', 'prune'], { stdio: 'pipe' });
+      return { removed: true, method: 'prune+rm' };
+    }
+  } catch (err) { errors.push(err.message); }
+
+  return { removed: false, error: errors[errors.length - 1] || 'unknown removal failure' };
+}
+
+/**
+ * Categorize + (optionally) remove a single worktree directory.
  * @param {string} dir - Directory name within .worktrees/
  * @param {Map<string, string>} worktreeMap - Path-to-branch mapping
- * @param {string[]} mergedBranches - List of merged branch names
+ * @param {Function} isMergedFn - (branch) => boolean squash-aware detector
  * @param {string} worktreesDir - Absolute path to .worktrees/
  * @param {boolean} dryRun - If true, skip actual removal
  * @param {Function} runFile - execFileSync-compatible function
- * @returns {Promise<boolean>} True if the worktree was cleaned (or would be in dry-run)
+ * @param {object} fsApi - fs-compatible module
+ * @param {object} opts - Removal injection options
+ * @returns {Promise<{ status: string, path: string, branch: string|null, error?: string }>}
  */
-async function cleanWorktree(dir, worktreeMap, mergedBranches, worktreesDir, dryRun, runFile) {
+async function cleanWorktree(dir, worktreeMap, isMergedFn, worktreesDir, dryRun, runFile, fsApi, opts) {
   const wtPath = path.resolve(worktreesDir, dir);
-  const branch = worktreeMap.get(wtPath);
+  const branch = worktreeMap.get(wtPath) || null;
 
-  if (branch && mergedBranches.includes(branch)) {
-    if (!dryRun) {
+  if (!branch || !isMergedFn(branch)) {
+    return { status: 'active', path: wtPath, branch };
+  }
+
+  if (dryRun) {
+    return { status: 'cleaned', path: wtPath, branch };
+  }
+
+  // Merged, but never blow away uncommitted local edits.
+  if (isWorktreeDirty(wtPath, runFile)) {
+    return { status: 'dirty', path: wtPath, branch };
+  }
+
+  const outcome = await removeWorktreeRobust(wtPath, runFile, fsApi, opts);
+  if (outcome.removed) {
+    return { status: 'cleaned', path: wtPath, branch, method: outcome.method };
+  }
+  return { status: 'survivor', path: wtPath, branch, error: outcome.error };
+}
+
+/**
+ * Parse the file list from git's "untracked working tree files would be
+ * overwritten by merge" error text.
+ * @param {string} stderr - Combined stderr text from the failed merge
+ * @returns {string[]} Repo-relative file paths
+ */
+function parseUntrackedOverwrites(stderr) {
+  const files = [];
+  let collecting = false;
+  for (const raw of stderr.split('\n')) {
+    const line = raw.replace(/\r$/, '');
+    if (/would be overwritten by merge:/i.test(line)) { collecting = true; continue; }
+    if (/^please move or remove them|^aborting/i.test(line.trim())) { collecting = false; continue; }
+    if (collecting) {
+      const f = line.trim();
+      if (f) files.push(f);
+    }
+  }
+  return files;
+}
+
+/**
+ * Move would-be-overwritten untracked files into a timestamped backup dir so a
+ * fast-forward can proceed without losing local work.
+ * @returns {string[]} Relative paths that were backed up
+ */
+function backupUntracked(fsApi, mainPath, stderr, opts) {
+  const files = parseUntrackedOverwrites(stderr);
+  if (files.length === 0) return [];
+  const stamp = opts && opts._now ? opts._now() : Date.now();
+  const backupDir = path.join(mainPath, '.forge', `clean-backup-${stamp}`);
+  const moved = [];
+  for (const rel of files) {
+    try {
+      const dest = path.join(backupDir, rel);
+      fsApi.mkdirSync(path.dirname(dest), { recursive: true });
+      fsApi.renameSync(path.join(mainPath, rel), dest);
+      moved.push(rel);
+    } catch (_e) { /* intentional: best-effort per-file backup */ } // NOSONAR S2486
+  }
+  return moved;
+}
+
+/**
+ * Count revisions in a range (e.g. `main..origin/main`); 0 on any error.
+ */
+function countRevs(runFile, cwd, range) {
+  const out = tryRun(runFile, 'git', ['-C', cwd, 'rev-list', '--count', range]);
+  const n = parseInt(out, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Fast-forward the checked-out default branch to origin, backing up any
+ * untracked files that would block the merge.
+ */
+function fastForwardCheckedOut(runFile, fsApi, mainPath, defaultBranch, opts) {
+  try {
+    runFile('git', ['-C', mainPath, 'merge', '--ff-only', `origin/${defaultBranch}`], { stdio: 'pipe' });
+    return { synced: true, method: 'ff' };
+  } catch (err) {
+    const stderr = err && err.stderr ? err.stderr.toString() : (err && err.message) || '';
+    if (/untracked working tree files would be overwritten/i.test(stderr)) {
+      const backedUp = backupUntracked(fsApi, mainPath, stderr, opts);
       try {
-        runFile('git', ['worktree', 'remove', wtPath], { stdio: 'pipe' });
-      } catch (_removeErr) { /* intentional: worktree has uncommitted changes, skip */ // NOSONAR S2486
-        return false;
+        runFile('git', ['-C', mainPath, 'merge', '--ff-only', `origin/${defaultBranch}`], { stdio: 'pipe' });
+        return { synced: true, method: 'ff-after-backup', backedUp };
+      } catch (err2) {
+        return { synced: false, reason: 'ff-failed-after-backup', error: err2.message, backedUp };
       }
     }
-    return true;
+    return { synced: false, reason: 'ff-failed', error: err && err.message };
   }
-  return false;
+}
+
+/**
+ * Post-merge master auto-update: fetch origin and fast-forward the MAIN
+ * checkout's default branch when it is strictly behind (never on divergence).
+ * Untracked local files are preserved (backed up if they would block the FF).
+ * Default-on; opt out with `--no-master-sync`. Never throws.
+ * @returns {Promise<object>} Structured outcome for reporting
+ */
+async function syncMasterBranch(runFile, fsApi, opts = {}) {
+  const result = { attempted: true, synced: false };
+  try {
+    const listOut = tryRun(runFile, 'git', ['worktree', 'list', '--porcelain']);
+    const main = parseMainWorktree(listOut);
+    if (!main) { result.reason = 'no-main-worktree'; return result; }
+
+    const defaultBranch = getDefaultBranch(runFile);
+    result.defaultBranch = defaultBranch;
+
+    // Refresh origin/<default> without touching the working tree.
+    tryRun(runFile, 'git', ['-C', main.path, 'fetch', 'origin', defaultBranch]);
+
+    const behind = countRevs(runFile, main.path, `${defaultBranch}..origin/${defaultBranch}`);
+    const ahead = countRevs(runFile, main.path, `origin/${defaultBranch}..${defaultBranch}`);
+    result.behind = behind;
+    result.ahead = ahead;
+
+    if (behind === 0) { result.reason = 'up-to-date'; return result; }
+    if (ahead > 0) { result.reason = 'diverged'; return result; } // not a fast-forward — leave it
+
+    if (main.branch === defaultBranch) {
+      Object.assign(result, fastForwardCheckedOut(runFile, fsApi, main.path, defaultBranch, opts));
+      return result;
+    }
+
+    // Main checkout is on a feature branch: fast-forward the local ref without checkout.
+    try {
+      runFile('git', ['-C', main.path, 'fetch', 'origin', `${defaultBranch}:${defaultBranch}`], { stdio: 'pipe' });
+      result.synced = true;
+      result.method = 'ref-update';
+    } catch (err) {
+      result.reason = 'ref-update-failed';
+      result.error = err && err.message;
+    }
+    return result;
+  } catch (err) {
+    result.reason = 'error';
+    result.error = err && err.message;
+    return result;
+  }
+}
+
+/**
+ * Build the user-facing report line(s) for the clean run.
+ */
+function formatOutput(summary) {
+  const lines = [];
+  const verb = summary.dryRun ? 'Would remove' : 'Removed';
+  lines.push(`${verb} ${summary.cleaned} merged worktree(s); ${summary.active} active kept.`);
+  if (summary.dirty.length > 0) {
+    lines.push(`Skipped ${summary.dirty.length} dirty worktree(s) with uncommitted changes:`);
+    for (const p of summary.dirty) lines.push(`  - ${p}`);
+  }
+  if (summary.survivors.length > 0) {
+    lines.push(`WARNING: ${summary.survivors.length} merged worktree(s) could not be removed (manual cleanup needed):`);
+    for (const s of summary.survivors) lines.push(`  - ${s.path}${s.error ? ` (${s.error})` : ''}`);
+  }
+  if (summary.masterSync && summary.masterSync.attempted) {
+    const ms = summary.masterSync;
+    if (ms.synced) {
+      lines.push(`Fast-forwarded ${ms.defaultBranch} (${ms.behind} commit(s) behind, method: ${ms.method}).`);
+      if (ms.backedUp && ms.backedUp.length > 0) {
+        lines.push(`  Backed up ${ms.backedUp.length} untracked file(s) before fast-forward.`);
+      }
+    } else if (ms.reason && ms.reason !== 'up-to-date' && ms.reason !== 'no-main-worktree') {
+      lines.push(`Master sync skipped (${ms.reason}${ms.error ? `: ${ms.error}` : ''}).`);
+    }
+  }
+  return lines.join('\n');
 }
 
 /**
@@ -99,80 +425,99 @@ async function cleanWorktree(dir, worktreeMap, mergedBranches, worktreesDir, dry
  * @param {object} [opts] - Options for dependency injection
  * @param {Function} [opts._exec] - Override for execFileSync (testing)
  * @param {object} [opts._fs] - Override for fs module (testing)
- * @returns {Promise<{ success: boolean, cleaned: number, active: number, dryRun: boolean }>}
+ * @param {Function} [opts._isMerged] - Override merged detection (testing)
+ * @param {Function} [opts._syncMaster] - Override master sync (testing)
+ * @returns {Promise<object>} Structured result
  */
 async function handler(_args, flags, projectRoot, opts = {}) {
   const runFile = opts._exec || execFileSync;
   const fsApi = opts._fs || fs;
   const dryRun = !!(flags['--dry-run'] || flags.dryRun);
+  const masterSyncEnabled = !(flags['--no-master-sync'] || flags.noMasterSync);
 
   const worktreesDir = path.resolve(projectRoot, '.worktrees');
 
-  // If .worktrees/ doesn't exist, nothing to clean
-  if (!fsApi.existsSync(worktreesDir)) {
-    return { success: true, cleaned: 0, active: 0, dryRun };
-  }
-
-  // 1. List dirs in .worktrees/
-  const entries = fsApi.readdirSync(worktreesDir, { withFileTypes: true });
-  const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
-
-  if (dirs.length === 0) {
-    return { success: true, cleaned: 0, active: 0, dryRun };
-  }
-
-  // 2. Detect default branch, then get merged branches
-  const defaultBranch = getDefaultBranch(runFile);
-  let mergedBranches;
-  try {
-    const mergedOutput = runFile('git', ['branch', '--merged', defaultBranch], { stdio: 'pipe' });
-    mergedBranches = mergedOutput
-      .toString()
-      .split('\n')
-      .map(b => b.trim().replace(/^\*\s*/, ''))
-      .filter(b => b.length > 0);
-  } catch (_e) { /* intentional: fallback to empty list */ // NOSONAR S2486
-    mergedBranches = [];
-  }
-
-  // 3. Get worktree -> branch mapping from git
-  let worktreeMap;
-  try {
-    const listOutput = runFile('git', ['worktree', 'list', '--porcelain'], { stdio: 'pipe' });
-    worktreeMap = parseWorktreeList(listOutput.toString());
-  } catch (_e) { /* intentional: fallback to empty map */ // NOSONAR S2486
-    worktreeMap = new Map();
-  }
-
-  // 4. For each worktree dir, check if its branch is merged
   let cleaned = 0;
   let active = 0;
+  const survivors = [];
+  const dirty = [];
 
-  for (const dir of dirs) {
-    const wasCleaned = await cleanWorktree(dir, worktreeMap, mergedBranches, worktreesDir, dryRun, runFile);
-    if (wasCleaned) {
-      cleaned++;
-    } else {
-      active++;
+  // Worktree cleanup runs only when .worktrees/ has directories; master
+  // auto-update below is independent of it (post-merge sync always applies).
+  if (fsApi.existsSync(worktreesDir)) {
+    const entries = fsApi.readdirSync(worktreesDir, { withFileTypes: true });
+    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+
+    if (dirs.length > 0) {
+      // Detection context: ancestry list + gh merged refs + squash fallback.
+      const defaultBranch = getDefaultBranch(runFile);
+      let mergedBranches = [];
+      const mergedOut = tryRun(runFile, 'git', ['branch', '--merged', defaultBranch]);
+      if (mergedOut) {
+        mergedBranches = mergedOut.split('\n').map(b => b.trim().replace(/^\*\s*/, '')).filter(Boolean);
+      }
+      const ghMergedRefs = getGhMergedRefs(runFile);
+      const ctx = { defaultBranch, mergedBranches, ghMergedRefs, runFile };
+      const isMergedFn = opts._isMerged || (branch => detectMerged(branch, ctx));
+
+      const listOutput = tryRun(runFile, 'git', ['worktree', 'list', '--porcelain']);
+      const worktreeMap = listOutput ? parseWorktreeList(listOutput) : new Map();
+
+      for (const dir of dirs) {
+        const res = await cleanWorktree(dir, worktreeMap, isMergedFn, worktreesDir, dryRun, runFile, fsApi, opts);
+        if (res.status === 'cleaned') cleaned++;
+        else if (res.status === 'survivor') survivors.push(res);
+        else if (res.status === 'dirty') dirty.push(res.path);
+        else active++;
+      }
+
+      if (!dryRun && cleaned > 0) {
+        tryRun(runFile, 'git', ['worktree', 'prune']);
+      }
     }
   }
 
-  // Prune stale worktree refs to prevent bare repo state
-  if (!dryRun && cleaned > 0) {
-    try {
-      runFile('git', ['worktree', 'prune'], { stdio: 'pipe' });
-    } catch (_e) { /* intentional: prune is best-effort cleanup */ } // NOSONAR S2486
+  // Post-merge master auto-update (default-on; skipped in dry-run).
+  let masterSync = null;
+  if (masterSyncEnabled && !dryRun) {
+    const doSync = opts._syncMaster || (() => syncMasterBranch(runFile, fsApi, opts));
+    masterSync = await doSync();
   }
 
-  return { success: true, cleaned, active, dryRun };
+  return finalize({ success: true, cleaned, active, dryRun, survivors, dirty }, masterSync);
+}
+
+/**
+ * Attach the master-sync outcome + a rendered report to the result.
+ */
+function finalize(summary, masterSync) {
+  const withSync = { ...summary, masterSync };
+  return { ...withSync, output: formatOutput(withSync) };
 }
 
 module.exports = {
   name: 'clean',
-  description: 'Remove worktrees for merged branches',
-  usage: 'forge clean [--dry-run]',
+  description: 'Remove worktrees for merged branches (squash-aware) and fast-forward the default branch',
+  usage: 'forge clean [--dry-run] [--no-master-sync]',
   flags: {
     '--dry-run': 'Show what would be cleaned without removing',
+    '--no-master-sync': 'Do not fast-forward the main checkout default branch after cleaning',
   },
   handler,
+  // Exported for unit tests / reuse.
+  _internals: {
+    getDefaultBranch,
+    parseWorktreeList,
+    parseMainWorktree,
+    getGhMergedRefs,
+    isSquashMerged,
+    detectMerged,
+    isWorktreeDirty,
+    removeWorktreeRobust,
+    cleanWorktree,
+    parseUntrackedOverwrites,
+    backupUntracked,
+    syncMasterBranch,
+    formatOutput,
+  },
 };

--- a/test/commands/clean.test.js
+++ b/test/commands/clean.test.js
@@ -342,6 +342,26 @@ describe('forge clean — squash-merge aware detection', () => {
     expect(removed.length).toBe(0);
   });
 
+  test('detects a merged branch that git prefixes with "+" (checked out in a linked worktree)', async () => {
+    const mod = require('../../lib/commands/clean');
+    const removed = [];
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      // git prefixes a branch checked out in a linked worktree with "+".
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('+ feat/wt\n  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('wt')}\nbranch refs/heads/feat/wt\n\n`);
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove') { removed.push(args[2]); return Buffer.from(''); }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['wt']), _syncMaster: noopSync });
+    expect(result.cleaned).toBe(1); // matched via ancestry fast path after stripping "+"
+    expect(removed[0]).toBe(wt('wt'));
+  });
+
   test('_internals.isSquashMerged returns true only when cherry emits a "-" line', () => {
     const { _internals } = require('../../lib/commands/clean');
     const runMerged = (cmd, args) => {

--- a/test/commands/clean.test.js
+++ b/test/commands/clean.test.js
@@ -223,3 +223,274 @@ describe('forge clean command', () => {
     expect(result.active).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Squash-merge awareness + Windows-robust removal + master auto-update
+// ---------------------------------------------------------------------------
+
+const ROOT = '/fake/root';
+const wt = (name) => path.resolve(ROOT, '.worktrees', name);
+const noopSync = async () => ({ attempted: false });
+
+/** fs mock exposing a single .worktrees dir listing. */
+function fsWith(names, over = {}) {
+  return {
+    existsSync: () => true,
+    readdirSync: (_p, opts) =>
+      (opts && opts.withFileTypes) ? names.map(n => ({ name: n, isDirectory: () => true })) : [],
+    readFileSync: () => '',
+    ...over,
+  };
+}
+
+describe('forge clean — squash-merge aware detection', () => {
+  test('removes a squash-merged worktree missed by git branch --merged', async () => {
+    const mod = require('../../lib/commands/clean');
+    const removed = [];
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]'); // no PR signal
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      // Ancestry check does NOT list the squash-merged branch (only main).
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('sq')}\nbranch refs/heads/feat/sq\n\n`);
+      }
+      // Squash patch-equivalence path.
+      if (args[0] === 'merge-base') return Buffer.from('basesha\n');
+      if (args[0] === 'rev-parse' && String(args[1]).endsWith('^{tree}')) return Buffer.from('treesha\n');
+      if (args[0] === 'commit-tree') return Buffer.from('synthsha\n');
+      if (args[0] === 'cherry') return Buffer.from('- 1234567 squashed change\n'); // equivalent exists
+      if (args[0] === 'worktree' && args[1] === 'remove') { removed.push(args[2]); return Buffer.from(''); }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['sq']), _syncMaster: noopSync });
+    expect(result.cleaned).toBe(1);
+    expect(result.active).toBe(0);
+    expect(removed[0]).toBe(wt('sq'));
+  });
+
+  test('keeps an unmerged branch (cherry shows a new commit)', async () => {
+    const mod = require('../../lib/commands/clean');
+    const removed = [];
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('wip')}\nbranch refs/heads/feat/wip\n\n`);
+      }
+      if (args[0] === 'merge-base') return Buffer.from('basesha\n');
+      if (args[0] === 'rev-parse' && String(args[1]).endsWith('^{tree}')) return Buffer.from('treesha\n');
+      if (args[0] === 'commit-tree') return Buffer.from('synthsha\n');
+      if (args[0] === 'cherry') return Buffer.from('+ 89abcde new work\n'); // NOT merged
+      if (args[0] === 'worktree' && args[1] === 'remove') { removed.push(args[2]); return Buffer.from(''); }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['wip']), _syncMaster: noopSync });
+    expect(result.cleaned).toBe(0);
+    expect(result.active).toBe(1);
+    expect(removed.length).toBe(0);
+  });
+
+  test('removes a branch reported merged by gh even without ancestry/cherry signal', async () => {
+    const mod = require('../../lib/commands/clean');
+    const removed = [];
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from(JSON.stringify([{ headRefName: 'feat/pr' }]));
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('pr')}\nbranch refs/heads/feat/pr\n\n`);
+      }
+      if (args[0] === 'merge-base') return Buffer.from(''); // no squash signal
+      if (args[0] === 'worktree' && args[1] === 'remove') { removed.push(args[2]); return Buffer.from(''); }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['pr']), _syncMaster: noopSync });
+    expect(result.cleaned).toBe(1);
+    expect(removed[0]).toBe(wt('pr'));
+  });
+
+  test('_internals.isSquashMerged returns true only when cherry emits a "-" line', () => {
+    const { _internals } = require('../../lib/commands/clean');
+    const runMerged = (cmd, args) => {
+      if (args[0] === 'merge-base') return Buffer.from('base');
+      if (args[0] === 'rev-parse') return Buffer.from('tree');
+      if (args[0] === 'commit-tree') return Buffer.from('synth');
+      if (args[0] === 'cherry') return Buffer.from('- deadbee equiv');
+      return Buffer.from('');
+    };
+    const runNot = (cmd, args) => (args[0] === 'cherry' ? Buffer.from('+ deadbee new') : runMerged(cmd, args));
+    expect(_internals.isSquashMerged('feat/x', 'main', runMerged)).toBe(true);
+    expect(_internals.isSquashMerged('feat/x', 'main', runNot)).toBe(false);
+  });
+});
+
+describe('forge clean — Windows-robust removal', () => {
+  test('falls back to --force after plain remove fails, still counts as cleaned', async () => {
+    const mod = require('../../lib/commands/clean');
+    let plainTries = 0;
+    let forced = false;
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  feat/done\n  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('done')}\nbranch refs/heads/feat/done\n\n`);
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove') {
+        if (args[2] === '--force') { forced = true; return Buffer.from(''); }
+        plainTries++;
+        const e = new Error('fatal: cannot remove: Directory not empty');
+        throw e;
+      }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, {
+      _exec: mockExec, _fs: fsWith(['done']), _syncMaster: noopSync,
+      _sleep: async () => {}, _maxTries: 2,
+    });
+    expect(plainTries).toBe(2);      // retried up to maxTries
+    expect(forced).toBe(true);       // then forced
+    expect(result.cleaned).toBe(1);
+    expect(result.survivors.length).toBe(0);
+  });
+
+  test('reports survivors (never silently) when even force + prune fail', async () => {
+    const mod = require('../../lib/commands/clean');
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  feat/stuck\n  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('stuck')}\nbranch refs/heads/feat/stuck\n\n`);
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove') { throw new Error('EPERM: operation not permitted'); }
+      return Buffer.from('');
+    };
+    // existsSync stays true → manual rm cannot confirm removal.
+    const fsMock = fsWith(['stuck'], { rmSync: () => { /* locked, no-op */ } });
+    const result = await mod.handler([], {}, ROOT, {
+      _exec: mockExec, _fs: fsMock, _syncMaster: noopSync, _sleep: async () => {}, _maxTries: 1,
+    });
+    expect(result.cleaned).toBe(0);
+    expect(result.survivors.length).toBe(1);
+    expect(result.survivors[0].path).toBe(wt('stuck'));
+    expect(result.output).toContain('WARNING');
+  });
+
+  test('skips a dirty merged worktree instead of destroying uncommitted work', async () => {
+    const mod = require('../../lib/commands/clean');
+    const removed = [];
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  feat/dirty\n  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('dirty')}\nbranch refs/heads/feat/dirty\n\n`);
+      }
+      if (args[0] === '-C' && args[2] === 'status') return Buffer.from(' M lib/thing.js\n'); // dirty
+      if (args[0] === 'worktree' && args[1] === 'remove') { removed.push(args[2]); return Buffer.from(''); }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['dirty']), _syncMaster: noopSync });
+    expect(removed.length).toBe(0);
+    expect(result.cleaned).toBe(0);
+    expect(result.dirty.length).toBe(1);
+    expect(result.output.toLowerCase()).toContain('dirty');
+  });
+});
+
+describe('forge clean — master auto-update', () => {
+  function syncExec(behindCount, aheadCount, mainBranch, extra = {}) {
+    return (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(
+          `worktree /main\nHEAD abc\nbranch refs/heads/${mainBranch}\n\n` +
+          `worktree ${wt('done')}\nbranch refs/heads/feat/done\n\n`
+        );
+      }
+      if (args[0] === '-C' && args[2] === 'rev-list') {
+        const range = args[4];
+        if (range === 'main..origin/main') return Buffer.from(String(behindCount));
+        if (range === 'origin/main..main') return Buffer.from(String(aheadCount));
+        return Buffer.from('0');
+      }
+      if (extra.onExec) extra.onExec(cmd, args);
+      return Buffer.from('');
+    };
+  }
+
+  test('fast-forwards the checked-out default branch when behind', async () => {
+    const mod = require('../../lib/commands/clean');
+    let ffCalled = false;
+    const exec = syncExec(3, 0, 'main', {
+      onExec: (cmd, args) => {
+        if (args[0] === '-C' && args[2] === 'merge' && args[3] === '--ff-only') ffCalled = true;
+      },
+    });
+    const result = await mod.handler([], {}, ROOT, { _exec: exec, _fs: fsWith([]) });
+    expect(ffCalled).toBe(true);
+    expect(result.masterSync.synced).toBe(true);
+    expect(result.masterSync.behind).toBe(3);
+    expect(result.output).toContain('Fast-forwarded');
+  });
+
+  test('does NOT touch a diverged default branch (behind AND ahead)', async () => {
+    const mod = require('../../lib/commands/clean');
+    let ffCalled = false;
+    const exec = syncExec(3, 2, 'main', {
+      onExec: (cmd, args) => {
+        if (args[0] === '-C' && args[3] === 'merge') ffCalled = true;
+      },
+    });
+    const result = await mod.handler([], {}, ROOT, { _exec: exec, _fs: fsWith([]) });
+    expect(ffCalled).toBe(false);
+    expect(result.masterSync.synced).toBe(false);
+    expect(result.masterSync.reason).toBe('diverged');
+  });
+
+  test('--no-master-sync disables the fast-forward step', async () => {
+    const mod = require('../../lib/commands/clean');
+    let ffCalled = false;
+    const exec = syncExec(3, 0, 'main', {
+      onExec: (cmd, args) => { if (args[0] === '-C' && args[2] === 'merge') ffCalled = true; },
+    });
+    const result = await mod.handler([], { '--no-master-sync': true }, ROOT, { _exec: exec, _fs: fsWith([]) });
+    expect(ffCalled).toBe(false);
+    expect(result.masterSync).toBeNull();
+  });
+
+  test('dry-run performs no master sync', async () => {
+    const mod = require('../../lib/commands/clean');
+    let ffCalled = false;
+    const exec = syncExec(3, 0, 'main', {
+      onExec: (cmd, args) => { if (args[0] === '-C' && args[2] === 'merge') ffCalled = true; },
+    });
+    const result = await mod.handler([], { '--dry-run': true }, ROOT, { _exec: exec, _fs: fsWith([]) });
+    expect(ffCalled).toBe(false);
+    expect(result.masterSync).toBeNull();
+  });
+
+  test('_internals.parseUntrackedOverwrites extracts the blocked files', () => {
+    const { _internals } = require('../../lib/commands/clean');
+    const stderr = [
+      'error: The following untracked working tree files would be overwritten by merge:',
+      '\tdocs/new.md',
+      '\tlib/added.js',
+      'Please move or remove them before you merge.',
+      'Aborting',
+    ].join('\n');
+    expect(_internals.parseUntrackedOverwrites(stderr)).toEqual(['docs/new.md', 'lib/added.js']);
+  });
+});

--- a/test/commands/clean.test.js
+++ b/test/commands/clean.test.js
@@ -298,9 +298,10 @@ describe('forge clean — squash-merge aware detection', () => {
     const mod = require('../../lib/commands/clean');
     const removed = [];
     const mockExec = (cmd, args) => {
-      if (cmd === 'gh') return Buffer.from(JSON.stringify([{ headRefName: 'feat/pr' }]));
+      if (cmd === 'gh') return Buffer.from(JSON.stringify([{ headRefName: 'feat/pr', headRefOid: 'prsha' }]));
       if (cmd !== 'git') return Buffer.from('');
       if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'rev-parse' && args[1] === 'feat/pr') return Buffer.from('prsha\n'); // tip matches merged PR head
       if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  main\n');
       if (args[0] === 'worktree' && args[1] === 'list') {
         return Buffer.from(`worktree ${wt('pr')}\nbranch refs/heads/feat/pr\n\n`);
@@ -312,6 +313,33 @@ describe('forge clean — squash-merge aware detection', () => {
     const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['pr']), _syncMaster: noopSync });
     expect(result.cleaned).toBe(1);
     expect(removed[0]).toBe(wt('pr'));
+  });
+
+  test('does NOT trust a gh-merged ref whose tip advanced past the merged OID', async () => {
+    const mod = require('../../lib/commands/clean');
+    const removed = [];
+    const mockExec = (cmd, args) => {
+      // gh says feat/reuse was merged at oldsha, but the branch tip is now newsha.
+      if (cmd === 'gh') return Buffer.from(JSON.stringify([{ headRefName: 'feat/reuse', headRefOid: 'oldsha' }]));
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'rev-parse' && args[1] === 'feat/reuse') return Buffer.from('newsha\n'); // advanced
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('reuse')}\nbranch refs/heads/feat/reuse\n\n`);
+      }
+      // Squash tier finds NO patch-equivalent → must be kept.
+      if (args[0] === 'merge-base') return Buffer.from('basesha\n');
+      if (args[0] === 'rev-parse' && String(args[1]).endsWith('^{tree}')) return Buffer.from('treesha\n');
+      if (args[0] === 'commit-tree') return Buffer.from('synthsha\n');
+      if (args[0] === 'cherry') return Buffer.from('+ 89abcde new work\n'); // NOT merged
+      if (args[0] === 'worktree' && args[1] === 'remove') { removed.push(args[2]); return Buffer.from(''); }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['reuse']), _syncMaster: noopSync });
+    expect(result.cleaned).toBe(0);
+    expect(result.active).toBe(1);
+    expect(removed.length).toBe(0);
   });
 
   test('_internals.isSquashMerged returns true only when cherry emits a "-" line', () => {
@@ -405,6 +433,34 @@ describe('forge clean — Windows-robust removal', () => {
     expect(result.dirty.length).toBe(1);
     expect(result.output.toLowerCase()).toContain('dirty');
   });
+
+  test('treats an unknowable dirty state (git status throws) as UNSAFE — never removes', () => {
+    const { _internals } = require('../../lib/commands/clean');
+    const throwingRun = (_cmd, args) => {
+      if (args[0] === '-C' && args[2] === 'status') throw new Error('fatal: not a git repository (transient)');
+      return Buffer.from('');
+    };
+    // Unknown → dirty (true) so the caller skips removal rather than force-deleting.
+    expect(_internals.isWorktreeDirty('/wt/x', throwingRun)).toBe(true);
+  });
+
+  test('dry-run reflects dirty-worktree protection (reports skip, not "Would remove")', async () => {
+    const mod = require('../../lib/commands/clean');
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  feat/dirty\n  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${wt('dirty')}\nbranch refs/heads/feat/dirty\n\n`);
+      }
+      if (args[0] === '-C' && args[2] === 'status') return Buffer.from(' M lib/thing.js\n'); // dirty
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], { '--dry-run': true }, ROOT, { _exec: mockExec, _fs: fsWith(['dirty']), _syncMaster: noopSync });
+    expect(result.cleaned).toBe(0);
+    expect(result.dirty.length).toBe(1);
+  });
 });
 
 describe('forge clean — master auto-update', () => {
@@ -435,7 +491,7 @@ describe('forge clean — master auto-update', () => {
     const mod = require('../../lib/commands/clean');
     let ffCalled = false;
     const exec = syncExec(3, 0, 'main', {
-      onExec: (cmd, args) => {
+      onExec: (_cmd, args) => {
         if (args[0] === '-C' && args[2] === 'merge' && args[3] === '--ff-only') ffCalled = true;
       },
     });
@@ -450,7 +506,7 @@ describe('forge clean — master auto-update', () => {
     const mod = require('../../lib/commands/clean');
     let ffCalled = false;
     const exec = syncExec(3, 2, 'main', {
-      onExec: (cmd, args) => {
+      onExec: (_cmd, args) => {
         if (args[0] === '-C' && args[3] === 'merge') ffCalled = true;
       },
     });
@@ -464,7 +520,7 @@ describe('forge clean — master auto-update', () => {
     const mod = require('../../lib/commands/clean');
     let ffCalled = false;
     const exec = syncExec(3, 0, 'main', {
-      onExec: (cmd, args) => { if (args[0] === '-C' && args[2] === 'merge') ffCalled = true; },
+      onExec: (_cmd, args) => { if (args[0] === '-C' && args[2] === 'merge') ffCalled = true; },
     });
     const result = await mod.handler([], { '--no-master-sync': true }, ROOT, { _exec: exec, _fs: fsWith([]) });
     expect(ffCalled).toBe(false);
@@ -475,11 +531,28 @@ describe('forge clean — master auto-update', () => {
     const mod = require('../../lib/commands/clean');
     let ffCalled = false;
     const exec = syncExec(3, 0, 'main', {
-      onExec: (cmd, args) => { if (args[0] === '-C' && args[2] === 'merge') ffCalled = true; },
+      onExec: (_cmd, args) => { if (args[0] === '-C' && args[2] === 'merge') ffCalled = true; },
     });
     const result = await mod.handler([], { '--dry-run': true }, ROOT, { _exec: exec, _fs: fsWith([]) });
     expect(ffCalled).toBe(false);
     expect(result.masterSync).toBeNull();
+  });
+
+  test('surfaces a fetch failure instead of masquerading as up-to-date', async () => {
+    const mod = require('../../lib/commands/clean');
+    const exec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from('worktree /main\nHEAD abc\nbranch refs/heads/main\n\n');
+      }
+      if (args[0] === '-C' && args[2] === 'fetch') throw new Error('fatal: unable to access origin');
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: exec, _fs: fsWith([]) });
+    expect(result.masterSync.synced).toBe(false);
+    expect(result.masterSync.reason).toBe('fetch-failed');
   });
 
   test('_internals.parseUntrackedOverwrites extracts the blocked files', () => {


### PR DESCRIPTION
Kernel issues: `32b3c3ef` + `2e264865` (epic `1390e1d1`).

**Problem:** `forge clean` missed squash-merged branches (a squash-merged tip isn't an ancestor of master, so `git branch --merged` misses it) → merged worktrees piled up (~26). Master also drifted behind after merges.

**Fix:** 3-tier squash-aware merged detection that short-circuits — (a) ancestry (`git branch --merged`), (b) merged-PR head refs (`gh pr list --state merged`), (c) git-only patch-equivalence (`git cherry` `- <sha>`). Never removes on doubt; guards dirty worktrees. Adds a post-merge fast-forward of the main checkout's default branch. Runner is injected for deterministic tests.

**Tests:** test/commands/clean.test.js — 20/20 pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `forge clean` is now squash-merge-aware and improves merged-branch detection.
  * Optionally fast-forwards the default branch after cleanup (disable with `--no-master-sync`).
* **Bug Fixes**
  * More robust worktree removal across platforms, with safer behavior when removals fail.
  * Dirty worktrees are skipped; untracked-file fast-forward conflicts are backed up and retried.
  * Sync is blocked or reported correctly when fetch/fast-forward cannot proceed.
* **Documentation**
  * Updated command description, usage, and expanded the cleanup report.
* **Tests**
  * Added coverage for squash-merge detection, Windows-safe removal, dirty-worktree protection, and default-branch sync scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->