### PR TITLE
feat(kernel-tracking): always-on kernel-tracking rule + toggleable rail.kernel_tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,21 @@ forge merge --auto <pr>        # Opt-in conditional auto-merge — merges only w
 - Run `forge prime` for detailed command reference and session close protocol
 - Use `forge remember` for persistent knowledge and `forge recall` to retrieve it back — do NOT use MEMORY.md files
 
+### Kernel Tracking (nothing discussed goes missing)
+
+**NON-NEGOTIABLE, default-on.** Anything raised in a session — a bug, an idea, a
+design decision, a follow-up, a TODO, a risk noticed in passing — MUST become a
+Forge Kernel issue **immediately** via `forge issue create`, before it can be
+forgotten. Triage it (set a type, link its epic/parent) so it is discoverable.
+When you defer scope, file the follow-up issue and reference it — never leave
+work unfiled. The Kernel is the single source of truth; do NOT substitute
+TodoWrite, markdown TODO lists, or memory notes for a filed issue.
+
+This policy is canonicalized in `rules/kernel-tracking.md` (rendered to every
+port: `.cursor/rules/kernel-tracking.mdc` for Cursor, this projection for
+Claude/Codex/Hermes) and governed by the default-on `rail.kernel_tracking`
+runtime rail. Turn it off only deliberately: `forge gate disable rail.kernel_tracking`.
+
 ## Project Learnings
 
 - **Scope discipline**: Do ONLY what was explicitly asked. Answer a question → stop. Check something → stop. Never auto-continue to next steps or pending work unless told to.

--- a/lib/commands/gate.js
+++ b/lib/commands/gate.js
@@ -36,8 +36,13 @@ function usage() {
   return 'Usage: forge gate <enable|disable|approve|reject|status|check> [<issue-id>] <gate-id> [--reason <text>] [--json]';
 }
 
+// The known-toggle set is gates PLUS unlocked toggleable rails (e.g.
+// rail.kernel_tracking): both are governed through the same `forge gate
+// enable|disable` surface and the resolver's rail-aware workflow.gates loop.
+// The gate.* / rail.* id namespaces are disjoint, so one flat map is unambiguous.
 function knownGates() {
-  return new Map(getDefaultRuntimeGraph().gates.map(gate => [gate.id, gate]));
+  const graph = getDefaultRuntimeGraph();
+  return new Map([...graph.gates, ...graph.rails].map(primitive => [primitive.id, primitive]));
 }
 
 // Kernel deps + env are threaded through the command opts (4th handler arg) so tests
@@ -142,9 +147,10 @@ async function handleCheck(issueId, gateId, projectRoot, opts) {
   const known = validateKnownGate(gateId);
   if (!known.ok) return { success: false, error: known.error };
 
-  // Disabled gate → satisfied without any approval event (read via the shipped resolver).
+  // Disabled gate/rail → satisfied without any approval event (read via the shipped
+  // resolver). Rails share the workflow.gates toggle surface, so check both collections.
   const resolved = getResolvedRuntimeGraph({ projectRoot });
-  const resolvedGate = resolved.gates.find(gate => gate.id === gateId);
+  const resolvedGate = [...resolved.gates, ...resolved.rails].find(gate => gate.id === gateId);
   if (resolvedGate && resolvedGate.enabled === false) {
     return { success: true, output: `gate ${gateId} is disabled — satisfied for ${issueId}` };
   }

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -423,50 +423,20 @@ const RESOLVED_RUNTIME_GRAPH = {
       description: 'Resolved graph can be printed without side effects.',
     }),
   ],
+  // Rails are declared as a data table and mapped through Rail() so each entry
+  // stays a single line (Rail defaults locked: true; kernel_tracking is the one
+  // UNLOCKED, default-ON rail — it ingrains "file every issue/idea/bug/decision
+  // to the kernel immediately; nothing discussed goes missing", and a maintainer
+  // may opt out via `forge gate disable rail.kernel_tracking`, consumed by the
+  // resolver's rail-aware gate loop over workflow.gates.<id>.enabled).
   rails: [
-    Rail({
-      id: 'rail.tdd_intent',
-      key: 'tdd_intent',
-      label: 'TDD intent evidence',
-      description: 'Source changes require test intent and TDD evidence.',
-    }),
-    Rail({
-      id: 'rail.secret_scan',
-      key: 'secret_scan',
-      label: 'Secret scan',
-      description: 'Validation must not knowingly ship secrets.',
-    }),
-    Rail({
-      id: 'rail.branch_protection',
-      key: 'branch_protection',
-      label: 'Branch protection',
-      description: 'Ship through reviewed branches instead of direct protected-branch edits.',
-    }),
-    Rail({
-      id: 'rail.signed_commits',
-      key: 'signed_commits',
-      label: 'Signed commits',
-      description: 'Preserve commit provenance requirements where configured.',
-    }),
-    Rail({
-      id: 'rail.schema_integrity',
-      key: 'schema_integrity',
-      label: 'Schema integrity',
-      description: 'Keep runtime graph and config schemas internally consistent.',
-    }),
-    // Default-ON but UNLOCKED (unlike the L1 safety rails): ingrains "file every
-    // issue/idea/bug/decision to the kernel immediately — nothing discussed goes
-    // missing". Toggled through the existing `forge gate enable|disable` surface
-    // (workflow.gates.<id>.enabled), which the resolver's rail-aware gate loop
-    // consumes. A maintainer may opt out via `forge gate disable rail.kernel_tracking`.
-    Rail({
-      id: 'rail.kernel_tracking',
-      key: 'kernel_tracking',
-      label: 'Kernel issue tracking',
-      description: 'Every issue, idea, bug, and decision discussed is filed to the Forge Kernel.',
-      locked: false,
-    }),
-  ],
+    { key: 'tdd_intent', label: 'TDD intent evidence', description: 'Source changes require test intent and TDD evidence.' },
+    { key: 'secret_scan', label: 'Secret scan', description: 'Validation must not knowingly ship secrets.' },
+    { key: 'branch_protection', label: 'Branch protection', description: 'Ship through reviewed branches instead of direct protected-branch edits.' },
+    { key: 'signed_commits', label: 'Signed commits', description: 'Preserve commit provenance requirements where configured.' },
+    { key: 'schema_integrity', label: 'Schema integrity', description: 'Keep runtime graph and config schemas internally consistent.' },
+    { key: 'kernel_tracking', label: 'Kernel issue tracking', description: 'Every issue, idea, bug, and decision discussed is filed to the Forge Kernel.', locked: false },
+  ].map(def => Rail({ id: `rail.${def.key}`, ...def })),
   adapters: [
     Adapter({
       id: 'adapter.issue',

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -454,6 +454,18 @@ const RESOLVED_RUNTIME_GRAPH = {
       label: 'Schema integrity',
       description: 'Keep runtime graph and config schemas internally consistent.',
     }),
+    // Default-ON but UNLOCKED (unlike the L1 safety rails): ingrains "file every
+    // issue/idea/bug/decision to the kernel immediately — nothing discussed goes
+    // missing". Toggled through the existing `forge gate enable|disable` surface
+    // (workflow.gates.<id>.enabled), which the resolver's rail-aware gate loop
+    // consumes. A maintainer may opt out via `forge gate disable rail.kernel_tracking`.
+    Rail({
+      id: 'rail.kernel_tracking',
+      key: 'kernel_tracking',
+      label: 'Kernel issue tracking',
+      description: 'Every issue, idea, bug, and decision discussed is filed to the Forge Kernel.',
+      locked: false,
+    }),
   ],
   adapters: [
     Adapter({
@@ -627,9 +639,15 @@ function applyWorkflowConfig(graph, config, errors) {
     applyEnabledConfig(graph.phases, id, options, errors, 'stage');
   }
 
+  // The `workflow.gates.<id>.enabled` surface (driven by `forge gate enable|disable`)
+  // governs gates AND unlocked toggleable rails (e.g. rail.kernel_tracking): the id
+  // namespaces are disjoint (gate.* vs rail.*), so a single combined lookup routes each
+  // id to its primitive. applyEnabledConfig still honors each primitive's `locked` flag,
+  // so a locked L1 rail cannot be disabled through this surface either.
   const gates = readConfigSection(workflow, 'gates', errors, 'workflow.gates');
+  const toggleable = [...graph.gates, ...graph.rails];
   for (const [id, options] of Object.entries(gates)) {
-    applyEnabledConfig(graph.gates, id, options, errors, 'gate');
+    applyEnabledConfig(toggleable, id, options, errors, 'gate');
   }
 }
 

--- a/lib/rules-sync.js
+++ b/lib/rules-sync.js
@@ -47,6 +47,7 @@ const CURSOR_RULE_FILES = {
   tdd: 'tdd-enforcement.mdc',
   security: 'security-scanning.mdc',
   documentation: 'documentation.mdc',
+  'kernel-tracking': 'kernel-tracking.mdc',
 };
 
 const CANONICAL_RULE_NAMES = Object.keys(CURSOR_RULE_FILES);

--- a/rules/kernel-tracking.md
+++ b/rules/kernel-tracking.md
@@ -1,0 +1,26 @@
+---
+description: "Always: file every issue, idea, bug, and decision to the Forge Kernel"
+alwaysApply: true
+globs: []
+---
+
+# Kernel Tracking (nothing discussed goes missing)
+
+**NON-NEGOTIABLE.** Anything raised in a session — a bug, an idea, a design
+decision, a follow-up, a TODO, a risk you noticed in passing — MUST become a
+Forge Kernel issue **immediately**, before it can be forgotten. This is a
+structural rule, not a judgment call.
+
+- Found or discussed something trackable? Run `forge issue create` right then —
+  do not wait for "later" or the end of the session.
+- Triage it: set a type and link it to its epic/parent so it is discoverable.
+- Deferring work? File the follow-up issue and reference it — never leave scope
+  cuts unfiled.
+- The Kernel is the single source of truth. Do NOT use TodoWrite, markdown TODO
+  lists, or memory notes as a substitute for a filed issue.
+
+This rule is a **thin pointer** — the authoritative workflow contract lives in
+`AGENTS.md` (see "Forge Issue Tracker") and the stage skills in
+`skills/<stage>/SKILL.md`. It is default-on and governed by the
+`rail.kernel_tracking` runtime rail (`forge gate disable rail.kernel_tracking`
+to turn it off). Do not duplicate policy here.

--- a/test/commands/gate.test.js
+++ b/test/commands/gate.test.js
@@ -9,6 +9,7 @@ const YAML = require('yaml');
 
 const gateCommand = require('../../lib/commands/gate');
 const optionsCommand = require('../../lib/commands/options');
+const { getResolvedRuntimeGraph } = require('../../lib/core/runtime-graph');
 
 const tempRoots = [];
 
@@ -68,5 +69,39 @@ describe('forge gate verb', () => {
     expect((await gateCommand.handler([], {}, root)).success).toBe(false);
     expect((await gateCommand.handler(['toggle', 'gate.plan-exit'], {}, root)).success).toBe(false);
     expect((await gateCommand.handler(['disable'], {}, root)).success).toBe(false);
+  });
+
+  // rail.kernel_tracking is a default-ON, UNLOCKED rail toggled through the same
+  // `forge gate enable|disable` surface as gates (zero new toggle code): the id is
+  // known (validate against knownGates), disable writes workflow.gates.<id>.enabled,
+  // and the shipped resolver flips the rail in the resolved graph.
+  test('disable rail.kernel_tracking is accepted and flips the resolved rail off', async () => {
+    const root = makeProject();
+
+    const result = await gateCommand.handler(['disable', 'rail.kernel_tracking'], {}, root);
+    expect(result.success).toBe(true);
+    expect(readConfig(root).workflow.gates['rail.kernel_tracking'].enabled).toBe(false);
+
+    const rail = getResolvedRuntimeGraph({ projectRoot: root })
+      .rails.find(r => r.id === 'rail.kernel_tracking');
+    expect(rail.enabled).toBe(false);
+  });
+
+  test('enable flips rail.kernel_tracking back on', async () => {
+    const root = makeProject();
+    await gateCommand.handler(['disable', 'rail.kernel_tracking'], {}, root);
+    await gateCommand.handler(['enable', 'rail.kernel_tracking'], {}, root);
+    const rail = getResolvedRuntimeGraph({ projectRoot: root })
+      .rails.find(r => r.id === 'rail.kernel_tracking');
+    expect(rail.enabled).toBe(true);
+  });
+
+  test('forge gate check reflects a disabled rail.kernel_tracking (satisfied)', async () => {
+    const root = makeProject();
+    await gateCommand.handler(['disable', 'rail.kernel_tracking'], {}, root);
+    // A disabled rail is satisfied without any approval event — no kernel needed.
+    const check = await gateCommand.handler(['check', 'issue-1', 'rail.kernel_tracking'], {}, root);
+    expect(check.success).toBe(true);
+    expect(check.output).toMatch(/disabled/);
   });
 });

--- a/test/cursor-config-generation.test.js
+++ b/test/cursor-config-generation.test.js
@@ -122,17 +122,31 @@ describe('Cursor config generation', () => {
     expect(fs.existsSync(rulesDir)).toBeTruthy();
   });
 
-  test('should create all 4 rule files', async () => {
+  test('should create all 5 rule files', async () => {
     await generateCursorConfig(tempDir);
 
     const rulesDir = path.join(tempDir, '.cursor', 'rules');
     const files = await fs.promises.readdir(rulesDir);
 
-    expect(files.length).toBe(4);
+    expect(files.length).toBe(5);
     expect(files.includes('forge-workflow.mdc')).toBeTruthy();
     expect(files.includes('tdd-enforcement.mdc')).toBeTruthy();
     expect(files.includes('security-scanning.mdc')).toBeTruthy();
     expect(files.includes('documentation.mdc')).toBeTruthy();
+    // Always-on kernel-tracking rule: "nothing discussed goes missing — file it".
+    expect(files.includes('kernel-tracking.mdc')).toBeTruthy();
+  });
+
+  test('should create .cursor/rules/kernel-tracking.mdc (always-on, file-it-to-kernel)', async () => {
+    await generateCursorConfig(tempDir);
+
+    const ktPath = path.join(tempDir, '.cursor', 'rules', 'kernel-tracking.mdc');
+    const content = await fs.promises.readFile(ktPath, 'utf-8');
+
+    expect(content.startsWith('---')).toBeTruthy();
+    expect(content.includes('alwaysApply: true')).toBeTruthy();
+    expect(content.includes('forge issue create')).toBeTruthy();
+    expect(/kernel/i.test(content)).toBeTruthy();
   });
 
   test('should not overwrite existing files by default', async () => {

--- a/test/cursor-config-generation.test.js
+++ b/test/cursor-config-generation.test.js
@@ -128,7 +128,7 @@ describe('Cursor config generation', () => {
     const rulesDir = path.join(tempDir, '.cursor', 'rules');
     const files = await fs.promises.readdir(rulesDir);
 
-    expect(files.length).toBe(5);
+    expect(files).toHaveLength(5);
     expect(files.includes('forge-workflow.mdc')).toBeTruthy();
     expect(files.includes('tdd-enforcement.mdc')).toBeTruthy();
     expect(files.includes('security-scanning.mdc')).toBeTruthy();

--- a/test/rules-sync.test.js
+++ b/test/rules-sync.test.js
@@ -34,12 +34,37 @@ describe('rules sync drift detection', () => {
     expect(result.issues).toHaveLength(0);
   });
 
-  test('canonical source defines the four policy rules', () => {
-    expect(CANONICAL_RULE_NAMES).toEqual(['workflow', 'tdd', 'security', 'documentation']);
+  test('canonical source defines the five policy rules', () => {
+    expect(CANONICAL_RULE_NAMES).toEqual([
+      'workflow', 'tdd', 'security', 'documentation', 'kernel-tracking',
+    ]);
     const rules = listCanonicalRules(repoRoot);
     expect(rules.map((r) => r.name).sort()).toEqual(
-      ['documentation', 'security', 'tdd', 'workflow'],
+      ['documentation', 'kernel-tracking', 'security', 'tdd', 'workflow'],
     );
+  });
+
+  // The always-on kernel-tracking rule must render to EVERY port: a native
+  // `.cursor/rules/kernel-tracking.mdc` for Cursor, and the AGENTS.md projection
+  // for Claude/Codex/Hermes. It ingrains "nothing discussed goes missing —
+  // file it to the kernel immediately" as a structural, default-on rule.
+  test('kernel-tracking renders to the Cursor native surface (always-on, file-it pointer)', () => {
+    expect(CURSOR_RULE_FILES['kernel-tracking']).toBe('kernel-tracking.mdc');
+    const [rule] = listCanonicalRules(repoRoot, { only: ['kernel-tracking'] });
+    expect(rule.alwaysApply).toBe('true');
+    const cursor = renderCursorRule(rule);
+    expect(cursor.includes('alwaysApply: true')).toBe(true);
+    expect(/forge issue create/.test(cursor)).toBe(true);
+    expect(/kernel/i.test(cursor)).toBe(true);
+    // Thin pointer: defers to the authoritative AGENTS.md / skill source.
+    expect(/AGENTS\.md|skill/i.test(cursor)).toBe(true);
+  });
+
+  test('kernel-tracking policy is projected into AGENTS.md for Claude/Codex/Hermes', () => {
+    const agents = fs.readFileSync(path.join(repoRoot, 'AGENTS.md'), 'utf-8');
+    expect(/kernel[- ]tracking/i.test(agents)).toBe(true);
+    expect(/nothing discussed goes missing/i.test(agents)).toBe(true);
+    expect(agents.includes('rail.kernel_tracking')).toBe(true);
   });
 
   test('regenerate-into-temp is byte-identical across runs (drift-free)', () => {
@@ -84,7 +109,7 @@ describe('rules sync drift detection', () => {
   });
 
   test('Claude does NOT get always-on policy rule files (no token bloat)', () => {
-    for (const name of ['workflow', 'tdd', 'security', 'documentation']) {
+    for (const name of ['workflow', 'tdd', 'security', 'documentation', 'kernel-tracking']) {
       expect(fs.existsSync(path.join(repoRoot, '.claude/rules', `${name}.md`))).toBe(false);
     }
   });

--- a/test/runtime-graph.test.js
+++ b/test/runtime-graph.test.js
@@ -49,6 +49,18 @@ describe('runtime graph contract', () => {
       .toBe('bun run typecheck; bun run lint; bun test; bun audit');
   });
 
+  // rail.kernel_tracking ingrains "file every issue/idea/bug/decision to the
+  // kernel" as a structural, default-ON rail. Unlike the L1 safety rails it is
+  // NOT locked — a maintainer may opt out via `forge gate disable rail.kernel_tracking`.
+  test('registers the default-ON, unlocked kernel_tracking rail', () => {
+    const graph = getResolvedRuntimeGraph();
+    const rail = graph.rails.find(candidate => candidate.id === 'rail.kernel_tracking');
+    expect(rail).toBeDefined();
+    expect(rail.key).toBe('kernel_tracking');
+    expect(rail.enabled).toBe(true);
+    expect(rail.locked).toBe(false);
+  });
+
   test('represents the current plan to ship command flow as a resolved graph', () => {
     const graph = getResolvedRuntimeGraph();
     const phaseIds = graph.phases.map(phase => phase.id);


### PR DESCRIPTION
## Summary

Ingrains "**nothing discussed goes missing** — file every issue/idea/bug/decision to the kernel immediately" as a structural, default-on Forge mechanism.

Kernel issue: `2b9baff3-5b64-4081-81cf-915ec4a240b1` (epic `1390e1d1`).

## What landed

### Part 1 — Canonical always-on rule
- New `rules/kernel-tracking.md` (thin pointer, `alwaysApply: true`): instructs agents to `forge issue create` + triage anything discussed, and never leave deferred scope unfiled. The Kernel is the single source of truth (no TodoWrite/markdown substitutes).
- Wired into `lib/rules-sync.js` (`CURSOR_RULE_FILES`) so it renders to **every port**: `.cursor/rules/kernel-tracking.mdc` (Cursor native surface) and the **AGENTS.md projection** for Claude/Codex/Hermes (new "Kernel Tracking" subsection).

### Part 2 — Default-ON, toggleable rail
- Registered `rail.kernel_tracking` (`locked: false`) in `lib/core/runtime-graph.js` — default ON, **not** locked (unlike the L1 safety rails).
- Made the existing `workflow.gates.<id>.enabled` toggle surface rail-aware so `forge gate disable rail.kernel_tracking` turns it off and `forge gate check` reflects it — **zero new toggle code**: `knownGates()`, the resolver's gate loop, and `handleCheck` now span gates + rails. The `gate.*` / `rail.*` id namespaces are disjoint, and locked rails stay protected (a locked rail still can't be disabled through this surface).

### Part 3 — DEFERRED (filed, not dropped)
Check-after-write verify at the `_issue.js` command boundary (`gate.issue_verify`) is deferred: it touches the hottest shared command boundary and **comment-count verification has no clean read path** today (no list-comments read; unclear if kernel `show --json` returns a comment count). Filed as follow-up **`5f928cd0-6e24-46a7-8e32-d8bc5932027b`** with a full spec + blocker analysis — dogfooding this very mechanism (nothing discussed goes missing).

## How tested (TDD)
- `test/rules-sync.test.js` — five canonical rules; kernel-tracking renders to Cursor + is projected into AGENTS.md.
- `test/cursor-config-generation.test.js` — now expects 5 `.mdc` files incl. `kernel-tracking.mdc`.
- `test/runtime-graph.test.js` — `rail.kernel_tracking` present, `enabled: true`, `locked: false`.
- `test/commands/gate.test.js` — `forge gate disable/enable/check rail.kernel_tracking` flips the resolved rail and reflects disabled state.
- Full suite green in normal state (only the pre-existing cursor-count assertion needed updating); `bun run lint` clean.

> Pushed with `forge push --quick` (lint-only): the pre-push fixture tests that shell out to `git init`/`git add`/`git clone` fail only under actual-push git-lock state (documented AGENTS.md learning) — all verified green in normal state. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an always-on Kernel Tracking policy requiring session-raised items (bugs, ideas, decisions, risks, and follow-ups) to be immediately recorded as tracked issues.
  * Introduced a toggleable runtime rail so this policy can be enabled/disabled through existing gate controls.
* **Bug Fixes**
  * Improved “gate check” handling so disabled rails are treated consistently with disabled gates.
  * Ensured the Kernel Tracking rule is included in generated/projection rule surfaces.
* **Documentation**
  * Added Kernel Tracking policy content to the agent guidance and canonical rules set.
* **Tests**
  * Expanded tests to cover rail default/locked behavior, enable/disable flows, and rule generation/projection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->