### PR TITLE
fix(clean): normalize Windows path separators in worktree-branch lookup

### DIFF
--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -64,7 +64,7 @@ function getDefaultBranch(runFile) {
  * @returns {string} Canonical forward-slash key
  */
 function normalizeWorktreeKey(p) {
-  return String(p).replace(/\\/g, '/').replace(/^([a-z]):/, (m, d) => `${d.toUpperCase()}:`);
+  return String(p).replace(/\\/g, '/').replace(/^([a-z]):/, (_m, d) => `${d.toUpperCase()}:`);
 }
 
 /**

--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -63,8 +63,12 @@ function getDefaultBranch(runFile) {
  * @param {string} p - Path in either separator style
  * @returns {string} Canonical forward-slash key
  */
-function normalizeWorktreeKey(p) {
-  return String(p).replace(/\\/g, '/').replace(/^([a-z]):/, (_m, d) => `${d.toUpperCase()}:`);
+function normalizeWorktreeKey(p, platform = process.platform) {
+  const key = String(p).replace(/\\/g, '/').replace(/^([a-z]):/, (_m, d) => `${d.toUpperCase()}:`);
+  // Windows filesystems are case-insensitive, so fold the WHOLE key there —
+  // segment-level case differences between porcelain output and path.resolve
+  // must not miss the lookup. POSIX paths stay case-sensitive.
+  return platform === 'win32' ? key.toLowerCase() : key;
 }
 
 /**

--- a/lib/commands/clean.js
+++ b/lib/commands/clean.js
@@ -55,9 +55,23 @@ function getDefaultBranch(runFile) {
 }
 
 /**
+ * Canonicalize a worktree path for MAP KEYS ONLY (86b04c20): on Windows, git
+ * worktree list --porcelain emits forward-slash paths (C:/...) while
+ * path.resolve emits backslashes (C:\...), so a raw-string lookup never matches
+ * and every merged worktree reads "active". Normalizes separators + drive-letter
+ * case. Real fs/git calls keep the native path form.
+ * @param {string} p - Path in either separator style
+ * @returns {string} Canonical forward-slash key
+ */
+function normalizeWorktreeKey(p) {
+  return String(p).replace(/\\/g, '/').replace(/^([a-z]):/, (m, d) => `${d.toUpperCase()}:`);
+}
+
+/**
  * Parse `git worktree list --porcelain` output into a map of path -> branch.
+ * Keys are canonicalized via normalizeWorktreeKey so lookups match on Windows.
  * @param {string} output - Raw porcelain output
- * @returns {Map<string, string>} Map of worktree path -> branch name
+ * @returns {Map<string, string>} Map of canonical worktree path -> branch name
  */
 function parseWorktreeList(output) {
   const map = new Map();
@@ -76,7 +90,7 @@ function parseWorktreeList(output) {
       }
     }
     if (wtPath && branch) {
-      map.set(wtPath, branch);
+      map.set(normalizeWorktreeKey(wtPath), branch);
     }
   }
   return map;
@@ -256,7 +270,8 @@ async function removeWorktreeRobust(wtPath, runFile, fsApi, opts = {}) {
  */
 async function cleanWorktree(dir, worktreeMap, isMergedFn, worktreesDir, dryRun, runFile, fsApi, opts) {
   const wtPath = path.resolve(worktreesDir, dir);
-  const branch = worktreeMap.get(wtPath) || null;
+  // Lookup by canonical key (86b04c20): porcelain emits C:/ paths, resolve emits C:\.
+  const branch = worktreeMap.get(normalizeWorktreeKey(wtPath)) || null;
 
   if (!branch || !isMergedFn(branch)) {
     return { status: 'active', path: wtPath, branch };
@@ -554,6 +569,7 @@ module.exports = {
   // Exported for unit tests / reuse.
   _internals: {
     getDefaultBranch,
+    normalizeWorktreeKey,
     parseWorktreeList,
     parseMainWorktree,
     getGhMergedRefs,

--- a/test/commands/clean.test.js
+++ b/test/commands/clean.test.js
@@ -362,6 +362,37 @@ describe('forge clean — squash-merge aware detection', () => {
     expect(removed[0]).toBe(wt('wt'));
   });
 
+  test('matches worktree paths across Windows separator styles (git C:/ vs resolve C:\\)', async () => {
+    // Regression for 86b04c20: git worktree list --porcelain emits forward-slash
+    // paths on Windows while path.resolve emits backslashes — the branch lookup
+    // must match regardless, or every merged worktree reads "active".
+    const { _internals } = require('../../lib/commands/clean');
+    expect(_internals.normalizeWorktreeKey('C:\\repo\\.worktrees\\x'))
+      .toBe(_internals.normalizeWorktreeKey('C:/repo/.worktrees/x'));
+    expect(_internals.normalizeWorktreeKey('c:/repo/.worktrees/x'))
+      .toBe(_internals.normalizeWorktreeKey('C:/repo/.worktrees/x'));
+
+    const mod = require('../../lib/commands/clean');
+    const removed = [];
+    // Porcelain reports the worktree with FORWARD slashes even when the lookup
+    // side computes the path natively (backslashes on win32).
+    const porcelainPath = wt('sep').replace(/\\/g, '/');
+    const mockExec = (cmd, args) => {
+      if (cmd === 'gh') return Buffer.from('[]');
+      if (cmd !== 'git') return Buffer.from('');
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('origin/main');
+      if (args[0] === 'branch' && args[1] === '--merged') return Buffer.from('  feat/sep\n  main\n');
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return Buffer.from(`worktree ${porcelainPath}\nbranch refs/heads/feat/sep\n\n`);
+      }
+      if (args[0] === 'worktree' && args[1] === 'remove') { removed.push(args[2]); return Buffer.from(''); }
+      return Buffer.from('');
+    };
+    const result = await mod.handler([], {}, ROOT, { _exec: mockExec, _fs: fsWith(['sep']), _syncMaster: noopSync });
+    expect(result.cleaned).toBe(1);
+    expect(result.active).toBe(0);
+  });
+
   test('_internals.isSquashMerged returns true only when cherry emits a "-" line', () => {
     const { _internals } = require('../../lib/commands/clean');
     const runMerged = (cmd, args) => {

--- a/test/commands/clean.test.js
+++ b/test/commands/clean.test.js
@@ -371,6 +371,12 @@ describe('forge clean — squash-merge aware detection', () => {
       .toBe(_internals.normalizeWorktreeKey('C:/repo/.worktrees/x'));
     expect(_internals.normalizeWorktreeKey('c:/repo/.worktrees/x'))
       .toBe(_internals.normalizeWorktreeKey('C:/repo/.worktrees/x'));
+    // Windows filesystems are case-insensitive beyond the drive letter too:
+    // segment-case differences must fold on win32 but stay significant on POSIX.
+    expect(_internals.normalizeWorktreeKey('C:/Repo/.Worktrees/X', 'win32'))
+      .toBe(_internals.normalizeWorktreeKey('c:/repo/.worktrees/x', 'win32'));
+    expect(_internals.normalizeWorktreeKey('/a/Branch', 'linux'))
+      .not.toBe(_internals.normalizeWorktreeKey('/a/branch', 'linux'));
 
     const mod = require('../../lib/commands/clean');
     const removed = [];


### PR DESCRIPTION
Kernel issue: `86b04c20` (epic `1390e1d1`). Found by dogfooding #319 on Windows.

**Bug:** `git worktree list --porcelain` emits forward-slash paths (`C:/...`) while `path.resolve` emits backslashes, so `worktreeMap.get()` never matched on win32 — every merged worktree read 'active' and `forge clean` removed nothing (reported 0 merged / 42 active despite 14 branches being merged PRs).

**Fix:** canonicalize map keys AND lookups via `normalizeWorktreeKey` (separator + drive-letter-case normalization); native paths still used for real fs/git calls.

**Verified live:** detection went **0 → 14 merged worktrees** on the actual repo, correctly skipping 2 dirty ones. 26/26 tests (incl. cross-separator regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree cleanup on Windows by normalizing path separators and handling case to reliably match worktrees even when path formats differ.
  * Ensured merged/eligible worktrees are correctly identified and removed regardless of whether worktree paths use forward or back slashes.
* **Tests**
  * Added a regression test covering Windows-style worktree path normalization (separator and casing) to prevent future matching issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->