### PR TITLE
feat(issue-verify): check-after-write read-back on kernel issue mutations (gate.issue_verify)

### DIFF
--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -7,7 +7,9 @@ const {
   ISSUE_COMMAND_ERROR_SCHEMA_VERSION,
   ISSUE_COMMAND_EXIT_CODES,
   resolveNextCommands,
+  normalizePriority,
 } = require('../kernel/issue-command-contract');
+const { getResolvedRuntimeGraph } = require('../core/runtime-graph');
 
 // The Forge issue command surface. Each subcommand routes through the shared
 // runIssueOperation, which selects the active backend (Kernel by --kernel /
@@ -113,6 +115,199 @@ const SUBCOMMANDS = {
 
 const WRITE_SUBCOMMANDS = new Set(['create', 'update', 'claim', 'release', 'comment', 'close', 'dep']);
 const DEP_ACTIONS = Object.keys(SUBCOMMANDS.dep.actions);
+
+// ---------------------------------------------------------------------------
+// Check-after-write verification (gate.issue_verify, kernel issue 5f928cd0).
+//
+// The kernel has two PROVEN cases where a mutation's ok:true lied about the
+// stored outcome: 145d9ad1 (close --reason/closed_at dropped by the
+// kernel_issues projection) and d71a824b (idempotent claim replay telling a
+// losing agent it won). So after a successful kernel mutation, this boundary
+// re-reads the issue THROUGH THE SAME runner/broker and asserts the intended
+// delta actually landed, emitting `verified: true|false` + `mismatches: []` in
+// the envelope. WARN MODE ONLY: a mismatch prints a warning and the write's
+// success/exit code are never touched; a verification READ error yields
+// `verified: null` (unknown) rather than failing the write. Governed by the
+// default-ON, unlocked `gate.issue_verify` (runtime-graph) — disable via
+// `forge gate disable gate.issue_verify`, which skips the read-back entirely.
+const ISSUE_VERIFY_GATE_ID = 'gate.issue_verify';
+const VERIFIED_SUBCOMMANDS = new Set(['create', 'update', 'close', 'claim', 'comment']);
+
+// Resolve whether gate.issue_verify is enabled for this project. An injected
+// opts.resolveRuntimeGraph wins (tests); an unresolvable config (lint errors)
+// SKIPS verification rather than breaking the write path.
+function isIssueVerifyEnabled(projectRoot, opts = {}) {
+  const resolveGraph = opts.resolveRuntimeGraph || getResolvedRuntimeGraph;
+  try {
+    const graph = resolveGraph({ projectRoot });
+    const gate = (graph.gates || []).find(candidate => candidate.id === ISSUE_VERIFY_GATE_ID);
+    return gate ? gate.enabled !== false : true;
+  } catch {
+    return false;
+  }
+}
+
+// Minimal --flag parser mirroring the broker's parseFlagPairs semantics
+// (--key value and --key=value; last value wins) so the expected delta is
+// derived from the SAME tokens the broker consumed.
+function parseVerifyFlags(args = []) {
+  const flags = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (typeof token !== 'string' || !token.startsWith('--')) continue;
+    const body = token.slice(2);
+    const eq = body.indexOf('=');
+    if (eq !== -1) {
+      flags[body.slice(0, eq)] = body.slice(eq + 1);
+      continue;
+    }
+    const next = args[index + 1];
+    if (typeof next === 'string' && !next.startsWith('--')) {
+      flags[body] = next;
+      index += 1;
+    } else {
+      flags[body] = true;
+    }
+  }
+  return flags;
+}
+
+// The exact-match fields a mutation promised, derived from its flags. Only the
+// REQUESTED fields are asserted (no coupling to backend defaults). Close always
+// asserts the terminal status the broker resolves (explicit --status wins, else
+// 'done' — mirrors the driver's resolveMutationStatus).
+function expectedIssueFields(subcommand, flags) {
+  const expected = {};
+  if (subcommand === 'create' || subcommand === 'update') {
+    if (typeof flags.title === 'string') expected.title = flags.title;
+  }
+  if (subcommand === 'create' && typeof flags.type === 'string') expected.type = flags.type;
+  if (subcommand === 'update') {
+    if (typeof flags.status === 'string') expected.status = flags.status;
+    if (typeof flags.assignee === 'string') expected.assignee = flags.assignee;
+    if (typeof flags.priority === 'string') expected.priority = normalizePriority(flags.priority);
+  }
+  if (subcommand === 'close') {
+    expected.status = typeof flags.status === 'string' ? flags.status : 'done';
+  }
+  return expected;
+}
+
+function collectFieldMismatches(expected, data) {
+  const mismatches = [];
+  for (const [field, value] of Object.entries(expected)) {
+    const stored = data ? data[field] : undefined;
+    if (stored !== value) {
+      mismatches.push(`${field}: expected ${JSON.stringify(value)}, read back ${JSON.stringify(stored ?? null)}`);
+    }
+  }
+  return mismatches;
+}
+
+// Close-specific presence checks — the regression trap for 145d9ad1, where the
+// projection silently dropped closed_at and the --reason text.
+function collectCloseMismatches(flags, data, mismatches) {
+  if (data.closed_at === null || data.closed_at === undefined) {
+    mismatches.push('closed_at: expected a close timestamp, read back null (145d9ad1-class projection drop)');
+  }
+  const reasonRequested = typeof flags.reason === 'string' || typeof flags['close-reason'] === 'string';
+  if (reasonRequested && (data.close_reason === null || data.close_reason === undefined)) {
+    mismatches.push('close_reason: expected the requested reason to persist, read back null (145d9ad1-class projection drop)');
+  }
+}
+
+// Claim verification uses the claim-safety primitive directly: `owns` encodes
+// "does the RESOLVING ACTOR hold the live lease" — exactly the check that
+// catches a d71a824b phantom-claim replay (ok:true for a lease someone else holds).
+async function verifyClaimDelta(runner, issueId, projectRoot, opts) {
+  const readBack = await runner('owns', [issueId, '--json'], projectRoot, opts);
+  if (!readBack || readBack.ok !== true || !readBack.data || typeof readBack.data !== 'object') {
+    return { verified: null };
+  }
+  if (readBack.data.owned === true) {
+    return { verified: true, mismatches: [] };
+  }
+  const heldBy = JSON.stringify(readBack.data.claimed_by ?? null);
+  return {
+    verified: false,
+    mismatches: [
+      `claimed_by: expected the resolved actor to hold the live lease, but owns reports held by ${heldBy} `
+      + '(d71a824b-class phantom-claim replay)',
+    ],
+  };
+}
+
+// Comment verification matches the MINTED comment_id in the re-read comments
+// array (show returns comments with ids), sidestepping the count-increment
+// approach that would need a pre-write read.
+function verifyCommentDelta(result, data) {
+  const commentId = result.data && typeof result.data.comment_id === 'string' ? result.data.comment_id : null;
+  if (!commentId) return { verified: null };
+  const comments = Array.isArray(data.comments) ? data.comments : [];
+  if (comments.some(comment => comment && comment.id === commentId)) {
+    return { verified: true, mismatches: [] };
+  }
+  return {
+    verified: false,
+    mismatches: [`comment: expected comment ${commentId} on the issue, not found in the read-back`],
+  };
+}
+
+// Re-read the mutated issue through the SAME runner and assert the intended
+// delta. Returns { verified: true|false|null, mismatches? }. NEVER throws — a
+// verification failure must never make a successful write report failure.
+async function verifyIssueMutation(subcommand, operationArgs, result, runner, projectRoot, opts) {
+  try {
+    const flags = parseVerifyFlags(operationArgs);
+    const issueId = (result.data && typeof result.data.id === 'string' && result.data.id)
+      ? result.data.id
+      : operationArgs.find(arg => typeof arg === 'string' && !arg.startsWith('-'));
+    if (!issueId) return { verified: null };
+    if (subcommand === 'claim') {
+      return await verifyClaimDelta(runner, issueId, projectRoot, opts);
+    }
+    const readBack = await runner('show', [issueId, '--json'], projectRoot, opts);
+    if (!readBack || readBack.ok !== true || !readBack.data || typeof readBack.data !== 'object') {
+      return { verified: null };
+    }
+    if (subcommand === 'comment') {
+      return verifyCommentDelta(result, readBack.data);
+    }
+    const mismatches = collectFieldMismatches(expectedIssueFields(subcommand, flags), readBack.data);
+    if (subcommand === 'close') {
+      collectCloseMismatches(flags, readBack.data, mismatches);
+    }
+    return { verified: mismatches.length === 0, mismatches };
+  } catch {
+    return { verified: null };
+  }
+}
+
+// Warn-mode reporting: verified:false lists the mismatches; verified:null says
+// the read-back could not confirm. Either way the write stays successful.
+function warnVerifyOutcome(subcommand, issueRef, verification) {
+  if (verification.verified === true) return;
+  const lines = verification.verified === false
+    ? [
+      `[forge verify] WARNING: '${subcommand}' reported ok but the read-back of ${issueRef} does not match the requested change:`,
+      ...verification.mismatches.map(entry => `  - ${entry}`),
+    ]
+    : [`[forge verify] WARNING: '${subcommand}' succeeded but the read-back of ${issueRef} could not confirm the change (verification read failed).`];
+  lines.push('The write itself succeeded (exit 0). Check-after-write is governed by gate.issue_verify (warn mode) — disable via: forge gate disable gate.issue_verify');
+  console.warn(lines.join('\n'));
+}
+
+// Run verification for one successful mutation result and attach the outcome
+// (verified / mismatches) to it, warning on anything but verified:true.
+async function applyIssueVerification(subcommand, operationArgs, result, runner, projectRoot, opts) {
+  const verification = await verifyIssueMutation(subcommand, operationArgs, result, runner, projectRoot, opts);
+  result.verified = verification.verified;
+  if (Array.isArray(verification.mismatches)) {
+    result.mismatches = verification.mismatches;
+  }
+  const issueRef = (result.data && result.data.id) || operationArgs.find(arg => typeof arg === 'string' && !arg.startsWith('-')) || '<issue>';
+  warnVerifyOutcome(subcommand, issueRef, verification);
+}
 
 function normalizeArgs(args = []) {
   return args.filter(arg => arg !== '--');
@@ -256,16 +451,21 @@ function normalizeIssueResult(result, operation, { json = false } = {}) {
   }
 
   if (result.ok === true) {
+    const envelope = {
+      ok: true,
+      schema_version: result.schema_version,
+      command: result.command,
+      data: result.data ?? null,
+      next_commands: result.next_commands ?? [],
+    };
+    // Check-after-write outcome (gate.issue_verify): additive keys, present only
+    // when verification ran (verified may be null when the read-back failed).
+    if (result.verified !== undefined) envelope.verified = result.verified;
+    if (result.mismatches !== undefined) envelope.mismatches = result.mismatches;
     return {
       success: true,
       operation,
-      output: JSON.stringify({
-        ok: true,
-        schema_version: result.schema_version,
-        command: result.command,
-        data: result.data ?? null,
-        next_commands: result.next_commands ?? [],
-      }, null, 2),
+      output: JSON.stringify(envelope, null, 2),
     };
   }
 
@@ -357,7 +557,7 @@ function splitLeadingIds(args = []) {
 // first failure is surfaced as `exitCode` so the bin printer exits with the error
 // class's code. KERNEL PATH ONLY: the Beads passthrough keeps its single
 // `close id1 id2 ...` invocation.
-async function runKernelBatchClose(runner, operation, ids, flags, projectRoot, opts) {
+async function runKernelBatchClose(runner, operation, ids, flags, projectRoot, opts, verifyEnabled = false) {
   const results = [];
   let allSucceeded = true;
   let firstFailureExit;
@@ -368,6 +568,16 @@ async function runKernelBatchClose(runner, operation, ids, flags, projectRoot, o
       const entry = { id, ok: true };
       if (raw.data && Number.isInteger(raw.data.revision)) entry.revision = raw.data.revision;
       if (raw.data && Array.isArray(raw.data.newly_unblocked)) entry.newly_unblocked = raw.data.newly_unblocked;
+      // Per-id check-after-write (gate.issue_verify): the batch path fans out one
+      // close per id, so each id gets its own read-back and verified/mismatches.
+      if (verifyEnabled && raw.ok === true) {
+        const verification = await verifyIssueMutation('close', [id, ...flags], raw, runner, projectRoot, opts);
+        entry.verified = verification.verified;
+        if (Array.isArray(verification.mismatches) && verification.mismatches.length > 0) {
+          entry.mismatches = verification.mismatches;
+        }
+        warnVerifyOutcome('close', id, verification);
+      }
       results.push(entry);
       continue;
     }
@@ -392,6 +602,23 @@ async function runKernelBatchClose(runner, operation, ids, flags, projectRoot, o
     },
     next_commands: resolveNextCommands('issue.close'),
   };
+  // Aggregate the per-id verification into envelope-level verified/mismatches:
+  // false if any closed id mismatched, null if any read-back was inconclusive,
+  // true only when every closed id verified clean.
+  const verifiedEntries = results.filter(entry => entry.ok && entry.verified !== undefined);
+  if (verifiedEntries.length > 0) {
+    if (verifiedEntries.some(entry => entry.verified === false)) {
+      envelope.verified = false;
+      envelope.mismatches = verifiedEntries
+        .filter(entry => Array.isArray(entry.mismatches))
+        .flatMap(entry => entry.mismatches.map(mismatch => `${entry.id}: ${mismatch}`));
+    } else if (verifiedEntries.some(entry => entry.verified === null)) {
+      envelope.verified = null;
+    } else {
+      envelope.verified = true;
+      envelope.mismatches = [];
+    }
+  }
 
   const normalized = {
     success: allSucceeded,
@@ -449,12 +676,18 @@ async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
   const operation = resolveIssueOperation(subcommand, args);
   const operationArgs = resolveOperationArgs(subcommand, args, opts);
 
+  // Check-after-write (gate.issue_verify): resolved ONCE per invocation, kernel
+  // path only. Reads and the Beads path never trigger a read-back.
+  const verifyEnabled = VERIFIED_SUBCOMMANDS.has(subcommand)
+    && shouldUseKernelBroker(opts)
+    && isIssueVerifyEnabled(projectRoot, opts);
+
   // Kernel batch close: >1 leading positional id → one runner call per id,
   // aggregated. A single id falls through to the byte-identical single path.
   if (subcommand === 'close' && shouldUseKernelBroker(opts)) {
     const { ids, flags } = splitLeadingIds(operationArgs);
     if (ids.length > 1) {
-      return runKernelBatchClose(runIssueOperation, operation, ids, flags, projectRoot, opts);
+      return runKernelBatchClose(runIssueOperation, operation, ids, flags, projectRoot, opts, verifyEnabled);
     }
   }
 
@@ -464,6 +697,12 @@ async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
     projectRoot,
     { ...opts, kernelBroker: opts.kernelBroker },
   );
+  // Verify only a SUCCESSFUL kernel-contract mutation (ok:true, not a Beads
+  // {success,output} shape). Warn-only: attaches verified/mismatches, never
+  // changes the result's success or exit code.
+  if (verifyEnabled && result && typeof result === 'object' && result.ok === true && result.success === undefined) {
+    await applyIssueVerification(subcommand, operationArgs, result, runIssueOperation, projectRoot, opts);
+  }
   // `owns` maps the ownership verdict (data.owned) to the process exit code; every
   // other subcommand uses the plain read/mutation normalization.
   if (subcommand === 'owns') {

--- a/lib/commands/claim.js
+++ b/lib/commands/claim.js
@@ -1,21 +1,18 @@
 'use strict';
 
-const { runIssueOperation: defaultRunIssueOperation } = require('../forge-issues');
-const { normalizeArgs, normalizeIssueResult, withResolvedIssueBackend } = require('./_issue');
+const { runIssueSubcommand } = require('./_issue');
 
-// `forge claim <id>` claims an issue. It inlines the shared issue dispatch — resolve
-// the active backend (Kernel via --kernel / --issue-backend kernel /
-// FORGE_ISSUE_BACKEND=kernel, Beads otherwise), route through runIssueOperation, then
-// normalize the Kernel contract into the CLI {success,output} shape. The Beads backend
-// translates claim to `update <id> --claim`; the Kernel backend runs the guarded
-// claim mutation.
+// `forge claim <id>` claims an issue through the SHARED issue dispatch
+// (runIssueSubcommand): backend resolution (Kernel via --kernel /
+// --issue-backend kernel / FORGE_ISSUE_BACKEND=kernel, Beads otherwise; the
+// Beads backend translates claim to `update <id> --claim`), contract
+// normalization, AND the check-after-write verification loop
+// (gate.issue_verify). This command previously inlined its own copy of the
+// dispatch, which silently BYPASSED the boundary verify — the exact surface
+// where the d71a824b phantom-claim replay lied to a losing agent — so it now
+// delegates like create/update/close/comment do.
 async function handler(args, _flags, projectRoot, opts = {}) {
-  const resolved = withResolvedIssueBackend(projectRoot, opts);
-  const runIssueOperation = resolved.runIssueOperation || defaultRunIssueOperation;
-  const normalizedArgs = normalizeArgs(args);
-  const result = await runIssueOperation('claim', normalizedArgs, projectRoot,
-    { ...resolved, kernelBroker: resolved.kernelBroker });
-  return normalizeIssueResult(result, 'claim', { json: normalizedArgs.includes('--json') });
+  return runIssueSubcommand('claim', args, projectRoot, opts);
 }
 
 module.exports = {

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -396,6 +396,22 @@ const RESOLVED_RUNTIME_GRAPH = {
       label: 'Merge approval',
       requires: [],
     }),
+    // gate.issue_verify — check-after-write verification on kernel issue mutations
+    // (create|update|close|claim|comment) at the lib/commands/_issue.js boundary:
+    // after a successful write, re-read through the same broker and confirm the
+    // intended delta landed (verified/mismatches in the envelope; warn-only — the
+    // write's ok is never overturned). Default ON and UNLOCKED, toggled via
+    // `forge gate disable gate.issue_verify` through the same workflow.gates
+    // surface as rail.kernel_tracking. Justified by two proven "ok:true lied"
+    // bugs: 145d9ad1 (close --reason/closed_at dropped in the projection) and
+    // d71a824b (idempotent claim replay telling a losing agent it won). No phase:
+    // it guards the issue-command boundary, not a workflow stage exit.
+    // `requires: []` — the read-back itself, not evidence, is the check.
+    Gate({
+      id: 'gate.issue_verify',
+      label: 'Issue write verification (check-after-write)',
+      requires: [],
+    }),
   ],
   evidence: [
     Evidence({

--- a/lib/release-readiness.js
+++ b/lib/release-readiness.js
@@ -137,9 +137,13 @@ const REQUIRED_CLAIM_RELEASE_COMMANDS = [
   {
     name: 'claim',
     path: 'lib/commands/claim.js',
+    // claim delegates to the SHARED issue dispatch (runIssueSubcommand) so the
+    // check-after-write verify loop (gate.issue_verify) covers it — that
+    // delegation is accepted as kernel evidence alongside a direct
+    // runIssueOperation('claim') dispatch.
     contractPatterns: [
       /forge claim <id>/,
-      /runIssueOperation\(['"]claim['"]|operation:\s*['"]claim['"]/,
+      /runIssueSubcommand\(['"]claim['"]|runIssueOperation\(['"]claim['"]|operation:\s*['"]claim['"]/,
     ],
   },
   {

--- a/test/commands/_issue.test.js
+++ b/test/commands/_issue.test.js
@@ -4,6 +4,14 @@ const { describe, test, expect } = require('bun:test');
 
 const { createIssueSubcommand } = require('../../lib/commands/_issue');
 
+// These tests pin routing/normalization, not the check-after-write loop —
+// gate.issue_verify would add a read-back runner call after each kernel
+// mutation, so it is stubbed OFF here. Verification behavior has its own
+// dedicated suite: test/commands/issue-verify.test.js.
+const VERIFY_OFF = {
+  resolveRuntimeGraph: () => ({ gates: [{ id: 'gate.issue_verify', enabled: false }] }),
+};
+
 // The issue command surface is de-beaded: every subcommand routes through the shared
 // runIssueOperation seam with the subcommand name as the operation (dep fans out to
 // dep.<action>). The backend abstraction (lib/forge-issues.js + the issue adapters)
@@ -165,6 +173,7 @@ describe('issue backend resolution from env/config', () => {
 
     const result = await create.handler(['--title', 'Smoke'], {}, '/repo', {
       env: { FORGE_ISSUE_BACKEND: 'kernel' },
+      ...VERIFY_OFF,
       runIssueOperation: async (operation, args, projectRoot, deps) => {
         calls.push({ operation, args, projectRoot, deps });
         return { ok: true, command: operation, data: { id: 'k1' } };
@@ -375,6 +384,7 @@ describe('kernel batch close (KAP-9)', () => {
 
     const result = await close.handler(['k1', 'k2'], {}, '/repo', {
       issueBackend: 'kernel',
+      ...VERIFY_OFF,
       runIssueOperation: async (operation, args) => {
         calls.push({ operation, args });
         return { ok: true, command: operation, data: { id: args[0], revision: 1 } };
@@ -408,6 +418,7 @@ describe('kernel batch close (KAP-9)', () => {
 
     await close.handler(['k1', 'k2', '--reason', 'done'], {}, '/repo', {
       issueBackend: 'kernel',
+      ...VERIFY_OFF,
       runIssueOperation: async (operation, args) => {
         calls.push({ operation, args });
         return { ok: true, command: operation, data: { id: args[0] } };
@@ -424,6 +435,7 @@ describe('kernel batch close (KAP-9)', () => {
 
     const result = await close.handler(['k1', 'k2'], {}, '/repo', {
       issueBackend: 'kernel',
+      ...VERIFY_OFF,
       runIssueOperation: async (operation, args) => {
         if (args[0] === 'k2') {
           return { ok: false, command: operation, error: { message: 'Issue k2 not found' } };
@@ -451,6 +463,7 @@ describe('kernel batch close (KAP-9)', () => {
 
     const result = await close.handler(['k1'], {}, '/repo', {
       issueBackend: 'kernel',
+      ...VERIFY_OFF,
       runIssueOperation: async (operation, args) => {
         calls.push({ operation, args });
         return {

--- a/test/commands/issue-verify.test.js
+++ b/test/commands/issue-verify.test.js
@@ -1,0 +1,402 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+
+const { runIssueSubcommand } = require('../../lib/commands/_issue');
+const { getDefaultRuntimeGraph, getResolvedRuntimeGraph } = require('../../lib/core/runtime-graph');
+
+// Check-after-write verification at the _issue.js command boundary
+// (kernel issue 5f928cd0, epic 1390e1d1). After a successful kernel mutation the
+// boundary re-reads through the SAME injected runner and asserts the intended
+// delta landed, emitting `verified` + `mismatches` in the envelope. Warn-mode
+// only: a mismatch NEVER turns a successful write into a failure. Justified by
+// two proven "ok:true lied" bugs: 145d9ad1 (close --reason/closed_at dropped in
+// the kernel_issues projection) and d71a824b (idempotent claim replay telling a
+// losing agent it won).
+//
+// Every test injects a fake runIssueOperation (same seam as the response-contract
+// parity tests) so the assertions target the boundary verify loop, not SQLite.
+
+// A recording runner: `handlers` maps operation name -> impl. Calls are recorded
+// so tests can assert whether (and how) the read-back happened.
+function makeRunner(handlers) {
+  const calls = [];
+  const runner = async (operation, args, projectRoot, deps) => {
+    calls.push({ operation, args });
+    const handler = handlers[operation];
+    if (!handler) throw new Error(`unexpected operation: ${operation}`);
+    return handler(operation, args, projectRoot, deps);
+  };
+  return { runner, calls };
+}
+
+function okEnvelope(command, data) {
+  return {
+    ok: true,
+    schema_version: 'forge.issue.v1',
+    command,
+    data,
+    next_commands: [],
+  };
+}
+
+const KERNEL_OPTS = (runIssueOperation) => ({ issueBackend: 'kernel', env: {}, runIssueOperation });
+
+// Silence + capture the boundary's console.warn warnings.
+let warnings;
+const originalWarn = console.warn;
+beforeEach(() => {
+  warnings = [];
+  console.warn = (...args) => { warnings.push(args.join(' ')); };
+});
+afterEach(() => {
+  console.warn = originalWarn;
+});
+
+describe('gate.issue_verify registration (runtime graph)', () => {
+  test('gate.issue_verify is a default-ON, UNLOCKED gate in the default graph', () => {
+    const graph = getDefaultRuntimeGraph();
+    const gate = graph.gates.find(candidate => candidate.id === 'gate.issue_verify');
+    expect(gate).toBeDefined();
+    expect(gate.enabled).toBe(true);
+    expect(gate.locked).toBe(false);
+    expect(gate.requires).toEqual([]);
+  });
+
+  test('workflow.gates["gate.issue_verify"].enabled=false disables it via the resolver (zero new toggle code)', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'forge-issue-verify-'));
+    try {
+      mkdirSync(path.join(root, '.forge'), { recursive: true });
+      writeFileSync(
+        path.join(root, '.forge', 'config.yaml'),
+        'workflow:\n  gates:\n    gate.issue_verify:\n      enabled: false\n',
+      );
+      const graph = getResolvedRuntimeGraph({ projectRoot: root });
+      const gate = graph.gates.find(candidate => candidate.id === 'gate.issue_verify');
+      expect(gate.enabled).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('check-after-write verification (gate.issue_verify, warn mode)', () => {
+  // --- create ---------------------------------------------------------------
+  test('create: read-back confirms requested title/type -> verified:true, mismatches []', async () => {
+    const { runner, calls } = makeRunner({
+      create: () => okEnvelope('issue.create', { id: 'k1', revision: 0 }),
+      show: () => okEnvelope('issue.show', { id: 'k1', title: 'X', type: 'bug', status: 'open' }),
+    });
+
+    const result = await runIssueSubcommand('create', ['--title', 'X', '--type', 'bug', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.verified).toBe(true);
+    expect(envelope.mismatches).toEqual([]);
+    expect(calls.map(call => call.operation)).toEqual(['create', 'show']);
+    expect(calls[1].args[0]).toBe('k1');
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('create: read-back missing the requested title -> verified:false + named mismatch, write still succeeds', async () => {
+    const { runner } = makeRunner({
+      create: () => okEnvelope('issue.create', { id: 'k1', revision: 0 }),
+      show: () => okEnvelope('issue.show', { id: 'k1', title: 'k1', type: 'task' }),
+    });
+
+    const result = await runIssueSubcommand('create', ['--title', 'X', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBeUndefined();
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.verified).toBe(false);
+    expect(envelope.mismatches.some(entry => entry.startsWith('title:'))).toBe(true);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings.join('\n')).toContain('gate.issue_verify');
+  });
+
+  // --- update ---------------------------------------------------------------
+  test('update: requested fields present in the read-back -> verified:true (priority normalized to its P-label)', async () => {
+    const { runner } = makeRunner({
+      update: () => okEnvelope('issue.update', { id: 'k1', revision: 2 }),
+      show: () => okEnvelope('issue.show', { id: 'k1', title: 'T', status: 'in_progress', priority: 'P1' }),
+    });
+
+    const result = await runIssueSubcommand(
+      'update',
+      ['k1', '--status', 'in_progress', '--priority', '1', '--json'],
+      '/repo',
+      KERNEL_OPTS(runner),
+    );
+
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(true);
+    expect(envelope.mismatches).toEqual([]);
+  });
+
+  test('update: a requested field that did not land -> verified:false + named mismatch', async () => {
+    const { runner } = makeRunner({
+      update: () => okEnvelope('issue.update', { id: 'k1', revision: 2 }),
+      show: () => okEnvelope('issue.show', { id: 'k1', status: 'open' }),
+    });
+
+    const result = await runIssueSubcommand('update', ['k1', '--status', 'in_progress', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(false);
+    expect(envelope.mismatches.some(entry => entry.startsWith('status:'))).toBe(true);
+    expect(result.success).toBe(true);
+  });
+
+  // --- close (regression trap for 145d9ad1) ----------------------------------
+  test('close --reason: terminal status + closed_at + close_reason present -> verified:true', async () => {
+    const { runner } = makeRunner({
+      close: () => okEnvelope('issue.close', { id: 'k1', revision: 3 }),
+      show: () => okEnvelope('issue.show', {
+        id: 'k1', status: 'done', closed_at: '2026-07-07T00:00:00Z', close_reason: 'shipped',
+      }),
+    });
+
+    const result = await runIssueSubcommand('close', ['k1', '--reason', 'shipped', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(true);
+    expect(envelope.mismatches).toEqual([]);
+  });
+
+  test('close --reason: projection drops close_reason/closed_at -> verified:false naming both (145d9ad1 trap), exit stays success', async () => {
+    const { runner } = makeRunner({
+      close: () => okEnvelope('issue.close', { id: 'k1', revision: 3 }),
+      show: () => okEnvelope('issue.show', { id: 'k1', status: 'done', closed_at: null, close_reason: null }),
+    });
+
+    const result = await runIssueSubcommand('close', ['k1', '--reason', 'shipped', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBeUndefined();
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.verified).toBe(false);
+    expect(envelope.mismatches.some(entry => entry.startsWith('closed_at:'))).toBe(true);
+    expect(envelope.mismatches.some(entry => entry.startsWith('close_reason:'))).toBe(true);
+    expect(warnings.join('\n')).toContain('close_reason');
+  });
+
+  test('close: non-terminal status in the read-back -> verified:false', async () => {
+    const { runner } = makeRunner({
+      close: () => okEnvelope('issue.close', { id: 'k1', revision: 3 }),
+      show: () => okEnvelope('issue.show', { id: 'k1', status: 'open', closed_at: '2026-07-07T00:00:00Z' }),
+    });
+
+    const result = await runIssueSubcommand('close', ['k1', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(false);
+    expect(envelope.mismatches.some(entry => entry.startsWith('status:'))).toBe(true);
+  });
+
+  // --- claim (regression trap for d71a824b phantom-claim) --------------------
+  test('claim: owns confirms the live lease -> verified:true (read-back via owns, not show)', async () => {
+    const { runner, calls } = makeRunner({
+      claim: () => okEnvelope('claim', { id: 'k1', revision: 0, claim_id: 'lease-1' }),
+      owns: () => okEnvelope('issue.owns', { id: 'k1', owned: true, claimed_by: 'agent-a' }),
+    });
+
+    const result = await runIssueSubcommand('claim', ['k1', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(true);
+    expect(envelope.mismatches).toEqual([]);
+    expect(calls.map(call => call.operation)).toEqual(['claim', 'owns']);
+  });
+
+  test('claim: duplicate-replay ok:true but owns says another actor holds the lease -> verified:false (d71a824b trap)', async () => {
+    const { runner } = makeRunner({
+      claim: () => okEnvelope('claim', { id: 'k1', revision: 0, claim_id: 'lease-1' }),
+      owns: () => okEnvelope('issue.owns', { id: 'k1', owned: false, claimed_by: 'someone-else' }),
+    });
+
+    const result = await runIssueSubcommand('claim', ['k1', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(false);
+    expect(envelope.mismatches.join(' ')).toContain('someone-else');
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  test('top-level `forge claim` routes through the boundary and is verified (no inlined bypass)', async () => {
+    const claimCommand = require('../../lib/commands/claim');
+    const { runner, calls } = makeRunner({
+      claim: () => okEnvelope('claim', { id: 'k1', revision: 0, claim_id: 'lease-1' }),
+      owns: () => okEnvelope('issue.owns', { id: 'k1', owned: true, claimed_by: 'agent-a' }),
+    });
+
+    const result = await claimCommand.handler(['k1', '--json'], {}, '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(true);
+    expect(calls.map(call => call.operation)).toEqual(['claim', 'owns']);
+  });
+
+  // --- comment (clean read path: show returns comments with ids) -------------
+  test('comment: minted comment_id found in the re-read comments -> verified:true', async () => {
+    const { runner } = makeRunner({
+      comment: () => okEnvelope('issue.comment', { id: 'k1', revision: 1, comment_id: 'c9' }),
+      show: () => okEnvelope('issue.show', { id: 'k1', comments: [{ id: 'c9', body: 'note' }] }),
+    });
+
+    const result = await runIssueSubcommand('comment', ['k1', 'note', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(true);
+  });
+
+  test('comment: minted comment_id missing from the re-read -> verified:false', async () => {
+    const { runner } = makeRunner({
+      comment: () => okEnvelope('issue.comment', { id: 'k1', revision: 1, comment_id: 'c9' }),
+      show: () => okEnvelope('issue.show', { id: 'k1', comments: [] }),
+    });
+
+    const result = await runIssueSubcommand('comment', ['k1', 'note', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(false);
+    expect(envelope.mismatches.join(' ')).toContain('c9');
+  });
+
+  // --- kernel batch close: per-id verify -------------------------------------
+  test('multi-id close: each closed id is verified; one projection drop flips the envelope to verified:false', async () => {
+    const { runner } = makeRunner({
+      close: (_operation, args) => okEnvelope('issue.close', { id: args[0], revision: 1 }),
+      show: (_operation, args) => (args[0] === 'k1'
+        ? okEnvelope('issue.show', { id: 'k1', status: 'done', closed_at: '2026-07-07T00:00:00Z', close_reason: 'batch' })
+        : okEnvelope('issue.show', { id: 'k2', status: 'done', closed_at: null, close_reason: null })),
+    });
+
+    const result = await runIssueSubcommand('close', ['k1', 'k2', '--reason', 'batch', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.verified).toBe(false);
+    const k1 = envelope.data.results.find(entry => entry.id === 'k1');
+    const k2 = envelope.data.results.find(entry => entry.id === 'k2');
+    expect(k1.verified).toBe(true);
+    expect(k2.verified).toBe(false);
+    expect(envelope.mismatches.some(entry => entry.startsWith('k2:'))).toBe(true);
+  });
+
+  // --- never break the write path --------------------------------------------
+  test('verify read throws -> write still succeeds with verified:null and a warning, mismatches omitted', async () => {
+    const { runner } = makeRunner({
+      create: () => okEnvelope('issue.create', { id: 'k1', revision: 0 }),
+      show: () => { throw new Error('projection read exploded'); },
+    });
+
+    const result = await runIssueSubcommand('create', ['--title', 'X', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.verified).toBe(null);
+    expect(envelope.mismatches).toBeUndefined();
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  test('verify read returns an error contract -> verified:null, write untouched', async () => {
+    const { runner } = makeRunner({
+      close: () => okEnvelope('issue.close', { id: 'k1', revision: 1 }),
+      show: () => ({
+        ok: false,
+        schema_version: 'forge.issue.error.v1',
+        command: 'issue.show',
+        error: { code: 'FORGE_ISSUE_NOT_FOUND', message: 'gone', exit_code: 3, retryable: false },
+        next_commands: [],
+      }),
+    });
+
+    const result = await runIssueSubcommand('close', ['k1', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(true);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBe(null);
+  });
+
+  test('a FAILED mutation is never verified (no read-back, no verified key)', async () => {
+    const { runner, calls } = makeRunner({
+      close: () => ({
+        ok: false,
+        schema_version: 'forge.issue.error.v1',
+        command: 'issue.close',
+        error: { code: 'FORGE_ISSUE_NOT_FOUND', message: 'Issue nope not found', exit_code: 3, retryable: false },
+        next_commands: [],
+      }),
+    });
+
+    const result = await runIssueSubcommand('close', ['nope', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(3);
+    expect(calls.map(call => call.operation)).toEqual(['close']);
+    const envelope = JSON.parse(result.output);
+    expect(envelope.verified).toBeUndefined();
+  });
+
+  // --- toggle: disabled gate skips the read-back entirely --------------------
+  test('disabled gate.issue_verify -> no read-back, envelope has no verified key', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'forge-issue-verify-off-'));
+    try {
+      mkdirSync(path.join(root, '.forge'), { recursive: true });
+      writeFileSync(
+        path.join(root, '.forge', 'config.yaml'),
+        'workflow:\n  gates:\n    gate.issue_verify:\n      enabled: false\n',
+      );
+      const { runner, calls } = makeRunner({
+        create: () => okEnvelope('issue.create', { id: 'k1', revision: 0 }),
+      });
+
+      const result = await runIssueSubcommand('create', ['--title', 'X', '--json'], root, KERNEL_OPTS(runner));
+
+      expect(result.success).toBe(true);
+      expect(calls.map(call => call.operation)).toEqual(['create']);
+      const envelope = JSON.parse(result.output);
+      expect(envelope.verified).toBeUndefined();
+      expect(envelope.mismatches).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // --- reads and the Beads path stay untouched --------------------------------
+  test('reads (show) are never verified', async () => {
+    const { runner, calls } = makeRunner({
+      show: () => okEnvelope('issue.show', { id: 'k1', title: 'X' }),
+    });
+
+    await runIssueSubcommand('show', ['k1', '--json'], '/repo', KERNEL_OPTS(runner));
+
+    expect(calls.map(call => call.operation)).toEqual(['show']);
+  });
+
+  test('the Beads path passes through byte-identical (no verify, no extra ops)', async () => {
+    const calls = [];
+    const result = await runIssueSubcommand('close', ['forge-abc'], '/repo', {
+      env: {},
+      runIssueOperation: async (operation) => {
+        calls.push(operation);
+        return { success: true, operation };
+      },
+    });
+
+    expect(result).toEqual({ success: true, operation: 'close' });
+    expect(calls).toEqual(['close']);
+  });
+});


### PR DESCRIPTION
## Summary

Check-after-write verification at the `lib/commands/_issue.js` boundary: after a successful kernel issue mutation (`create|update|close|claim|comment`), re-read through the **same broker/runner** and confirm the intended delta actually landed. The envelope gains `verified: true|false|null` + `mismatches: []`. **Warn mode only** — a mismatch prints a clear warning and exits 0; a successful write is never turned into a failure.

Kernel issue: `5f928cd0-6e24-46a7-8e32-d8bc5932027b` (epic `1390e1d1-9b49-43e3-b6f8-2dbf3473a8f2`, lifecycle self-enforcement).

Justified by two proven "ok:true lied" bugs in this repo's history:
- `145d9ad1` — `close --reason`/`closed_at` dropped in the `kernel_issues` projection (data fidelity)
- `d71a824b` — idempotent claim replay telling a losing agent it won (phantom-claim)

## What is verified, per mutation

| Mutation | Read-back | Assertion |
|---|---|---|
| `create` | `show <id> --json` | id exists; requested `--title`/`--type` match |
| `update` | `show <id> --json` | requested `--title`/`--status`/`--assignee`/`--priority` (P-label normalized) match |
| `close` | `show <id> --json` | status is the resolved terminal status (`--status` wins, else `done`); `closed_at` present; `close_reason` present when a reason was requested (**regression trap for 145d9ad1**) |
| `claim` | `owns <id> --json` | the resolving actor holds the live lease — the claim-safety primitive, catching the **d71a824b** phantom-claim replay |
| `comment` | `show <id> --json` | the minted `comment_id` appears in the re-read `comments` array |

The prior builder flagged comment verification as blocked (count-increment needs a pre-write read). It is **unblocked** by matching the minted `comment_id` instead — `show` returns `comments[]` with ids, so no pre-read or count is needed.

Kernel **batch close** fans out per-id, so each closed id gets its own read-back (`results[].verified` / `results[].mismatches`) plus an aggregated envelope-level `verified`/`mismatches`.

## Toggle

`gate.issue_verify` is registered as an ordinary `Gate({...})` in the runtime-graph gates table — **default ON, `locked: false`** — so `forge gate disable gate.issue_verify` turns it off through the existing `workflow.gates` surface with **zero new toggle code** (same mechanism as `rail.kernel_tracking`). When disabled, the read-back is skipped entirely and the envelope carries no `verified` key. Verified live: disable → no read-back; enable → restored.

## Never breaks the write path

- A mismatch → `verified:false` + warning to stderr; `ok`/`success`/exit code untouched.
- A verification **read** error (throw or error contract) → `verified: null`, `mismatches` omitted, warning — never a throw.
- An unresolvable runtime-graph config → verification skipped.
- Failed mutations are never verified (no read-back).
- Beads path and reads are untouched (kernel-contract results only).

## Required companion fix

Top-level `forge claim` (`lib/commands/claim.js`) had **inlined its own copy** of the issue dispatch, bypassing `runIssueSubcommand` — meaning the d71a824b surface would have silently skipped verification. It now delegates to the shared boundary like `create`/`update`/`close`/`comment` (pinned by a regression test).

## Note: the verify loop already catches a live bug

`145d9ad1` is still **open**: a real `forge close <id> --reason x` today leaves `closed_at`/`close_reason` null on the issue row (the reason lives only in the close event payload). With this PR, such closes correctly report `verified:false` with mismatches naming `closed_at`/`close_reason` — warn-only, exit 0. That is the feature working as designed; the projection fix remains `145d9ad1`'s scope.

## Tests

- New: `test/commands/issue-verify.test.js` — 21 tests: happy verify per mutation (create/update/close/claim/comment), simulated projection drop (145d9ad1 trap), phantom-claim (d71a824b trap), batch-close per-id verify, verify-read-throws / error-contract → `verified:null` with write intact, disabled gate → no read-back, failed mutation → no verify, reads and Beads path untouched, gate registration + config-driven disable, top-level claim delegation.
- Updated: `test/commands/_issue.test.js` — 5 routing/normalization tests stub the gate OFF (they pin dispatch shape, not verification).
- Full suite green; `eslint . --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added check-after-write verification for issue actions (create, update, close, claim, comment).
  * Outputs may now include `verified` status and mismatch details when verification is enabled.
* **Bug Fixes**
  * Verification problems are warn-only: they no longer overturn the original write success, and readback failures report `verified: null`.
* **Tests**
  * Added an integration test suite covering verification on/off behavior, per-action projections, batch close aggregation, and warn-mode scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->