### PR TITLE
chore(release): public-safe codex approval_policy + kernel-native AGENTS.md context flow

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,7 +5,10 @@
 #   untrusted   = require approval for all state-changing commands
 #   on-request  = agent decides when to ask (recommended for interactive dev)
 #   never       = no prompts (for CI / fully automated runs)
-approval_policy = "never"
+# Public-safe default: the agent asks before risky state changes. Flip to
+# "never" locally if you run fully automated (this file is a template — your
+# global $CODEX_HOME/config.toml trust settings still apply).
+approval_policy = "on-request"
 
 # Restrict file access to project workspace only (prevents access outside project root)
 sandbox_mode = "workspace-write"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Task 2: Validation logic
 
 ```json
 {
-  "id": "forge-x7y2",
+  "id": "9f2c41d7-3a8e-4b6f-9c21-5e7d0a184c3b",
   "type": "critical",
   "currentStage": "dev",
   "completedStages": ["plan"],
@@ -251,15 +251,22 @@ Every stage transition should carry structured context so the next stage (or a n
 | /review    | All feedback addressed | Comment resolutions | Fixed files, commit SHAs | Doc update needs |
 | pre-merge gate | Docs updated, CI green | N/A | Updated doc files | Merge instructions |
 
-### Validation Command
+### Recording Stage Context
 
-Run at each stage exit to check for missing context:
+Record the stage-exit context as a kernel issue comment so the next stage (or a
+fresh session) can resume from the issue record itself:
 
 ```bash
-bash scripts/beads-context.sh validate <beads-issue-id>
+forge issue comment <issue-id> "stage: dev -> validate
+summary: All 5 tasks done, 1 decision gate fired
+decisions: Used streaming parser over DOM for memory efficiency
+artifacts: lib/parser.js test/parser.test.js
+next: Run lint first — streaming approach may trigger no-await rule"
 ```
 
-This checks: (1) issue has a description, (2) at least one stage transition exists, (3) most recent transition has a summary, (4) design metadata is set if past the plan stage. Exits 0 when context checks run (even if warnings are found); exits 1 only if the issue cannot be retrieved.
+Check-after-write verification (`gate.issue_verify`, default-on) confirms the
+comment actually landed. Read context back with `forge show <issue-id>` (or
+`forge recap <issue-id>` for the bounded orientation envelope).
 
 ### Field Definitions
 
@@ -268,23 +275,10 @@ This checks: (1) issue has a description, (2) at least one stage transition exis
 - **Artifacts**: File paths or URLs produced by this stage. Example: `--artifacts "lib/parser.js test/parser.test.js docs/work/2026-03-26-parser/plan.md"`
 - **Next**: Guidance for the next stage on what to focus on. Example: `--next "Run lint first — streaming approach may trigger no-await rule"`
 
-### Usage in Stage Transitions
-
-```bash
-# Basic (backward compatible)
-bash scripts/beads-context.sh stage-transition <id> dev validate
-
-# With context fields (recommended)
-bash scripts/beads-context.sh stage-transition <id> dev validate \
-  --summary "All 5 tasks done, 0 gates fired" \
-  --decisions "Used approach A per design doc" \
-  --artifacts "lib/foo.js test/foo.test.js" \
-  --next "Run type check and lint"
-```
-
 ### Enforcement Level
 
-This convention is **advisory only**. The `validate` subcommand prints warnings but always exits 0. It does not block any stage transition. The goal is to build good habits, not to create friction.
+This convention is **advisory only** — missing fields never block a stage
+transition. The goal is to build good habits, not to create friction.
 
 ## Forge Issue Tracker
 


### PR DESCRIPTION
Kernel issue: `3562d4d3` (0.1.0 critical path; epic `1390e1d1`). Two maintainer-decided release-hygiene items:

1. **`.codex/config.toml`: `approval_policy` `never` → `on-request`** — the public-safe template default (maintainer decision 2026-07-07); a comment documents flipping to `never` for fully-automated local use.
2. **AGENTS.md de-Beads completion** — the Descriptive Context Convention section still taught the retired stage-transition shell script (3 refs) inside the file that declares kernel authority (Fable A5-F1). Replaced with the kernel-native `forge issue comment` context flow (+ a `gate.issue_verify` note), and modernized the State Management example id (A5-F2).

**Tests:** docs-consistency + release-readiness: 81 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The agent will now ask for confirmation before performing risky state-changing actions.
* **Documentation**
  * Updated workflow guidance for recording and verifying stage-exit context.
  * Clarified that some convention fields are advisory and won’t block progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->