### PR TITLE
fix(test): agents-md-convention asserts kernel-native context flow (post-#325)

### DIFF
--- a/test/agents-md-convention.test.js
+++ b/test/agents-md-convention.test.js
@@ -14,8 +14,13 @@ describe('AGENTS.md Descriptive Context Convention section', () => {
     expect(content).toContain('## Descriptive Context Convention');
   });
 
-  test('references beads-context.sh validate command', () => {
-    expect(content).toContain('beads-context.sh validate');
+  test('records stage context through the kernel-native issue comment flow', () => {
+    // #325 replaced the retired stage-transition shell script with the
+    // kernel-native flow: context is recorded as an issue comment and the
+    // check-after-write gate confirms it landed.
+    expect(content).toContain('forge issue comment');
+    expect(content).toContain('gate.issue_verify');
+    expect(content).not.toContain('beads-context.sh');
   });
 
   test('contains Summary field definition', () => {


### PR DESCRIPTION
**HOTFIX — master is red for every code PR.** Kernel issue: `e1dddb77`.

#325 (docs-classified) deliberately removed the retired stage-transition script refs from AGENTS.md, but `test/agents-md-convention.test.js` still asserted the ref exists. Docs PRs skip the full matrix, so the break surfaced on the next code PRs (#326/#327: Full Matrix ×6 + Unit Shard 3 + Coverage all red with this single test).

Fix: assert the kernel-native replacement instead — `forge issue comment` + `gate.issue_verify` present, retired ref **absent**. 6/6 tests green locally.

Recurring classification gap (2nd occurrence after the README-badge incident) filed separately as `a4cec65b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)