### PR TITLE
fix: Windows fresh-user audit trio — win32 spawns, remember/recall flag leak, stale skills hint

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -38,7 +38,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const readline = require('node:readline');
-const { execSync, execFileSync, spawnSync } = require('node:child_process');
+const { execSync } = require('node:child_process');
 
 // Get version from package.json (single source of truth)
 const packageDir = path.dirname(__dirname);
@@ -100,37 +100,10 @@ let actionLog = new SetupActionLog();
 // Detected package manager
 let PKG_MANAGER = 'npm';
 
-/**
- * Securely execute a command with PATH validation
- * Mitigates SonarCloud S4036: Ensures executables are from trusted locations
- * @param {string} command - The command to execute
- * @param {string[]} args - Command arguments
- * @param {object} options - execFileSync options
- */
-function secureExecFileSync(command, args = [], options = {}) {
-  try {
-    // Resolve command's full path to validate it's in a trusted location
-    const isWindows = process.platform === 'win32';
-    const pathResolver = isWindows ? 'where.exe' : 'which';
-
-    const result = spawnSync(pathResolver, [command], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore']
-    });
-
-    if (result.status === 0 && result.stdout) {
-      // Command found - use resolved path for execution
-      // Handle both CRLF (Windows) and LF (Unix) line endings
-      const resolvedPath = result.stdout.trim().split(/\r?\n/)[0].trim();
-      return execFileSync(resolvedPath, args, options);
-    }
-  } catch (_err) { // NOSONAR - S2486: Intentionally ignored; falls back to direct command execution below
-  }
-
-  // Fallback: execute with command name (maintains compatibility)
-  // This is safe for our use case as we only execute known, hardcoded commands
-  return execFileSync(command, args, options);
-}
+// Securely execute a command with PATH validation (SonarCloud S4036).
+// Delegates to the shared helper, which also handles Windows npm/npx/lefthook
+// cmd shims that cannot be spawned directly (kernel issue 9997d516).
+const { secureExecFileSync } = require('../lib/shell-utils');
 
 /**
  * Load agent definitions from plugin architecture
@@ -2775,8 +2748,8 @@ function installGitHooks() {
       } catch (error_) {
         // Fallback to global lefthook
         console.warn('npx lefthook failed, trying global:', error_.message);
-        execFileSync('lefthook', ['version'], { stdio: 'ignore' });
-        execFileSync('lefthook', ['install'], { stdio: 'inherit', cwd: projectRoot });
+        secureExecFileSync('lefthook', ['version'], { stdio: 'ignore' });
+        secureExecFileSync('lefthook', ['install'], { stdio: 'inherit', cwd: projectRoot });
         console.log('  ✓ Lefthook hooks installed (global)');
       }
     } catch (err) {
@@ -3336,11 +3309,10 @@ function autoSetupToolsInQuickMode() {
     console.log('📦 Initializing Skills...');
     initializeSkills(skillsStatus);
     console.log('');
-  } else if (!skillsStatus) {
-    const installCmd = PKG_MANAGER === 'bun' ? 'bun add -g' : 'npm install -g';
-    console.log(`  ℹ Skills not found — install with: ${installCmd} @forge/skills`);
-    console.log('');
   }
+  // No hint when the optional Skills CLI is absent: setup bundles and renders
+  // Forge's skills itself, and the previously advertised "@forge/skills"
+  // package does not exist on npm (kernel issue 6e554b41).
 }
 
 // Helper: Configure default external services in quick mode - extracted to reduce cognitive complexity

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -16,7 +16,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 ## command
 
 - [ ] bin/forge.js (26)
-  - lines: 2211 (bd), 2213 (bd), 2369 (bd), 2812 (bd), 2821 (bd), 2834 (bd), 2847 (.beads), 2867 (bd), 2869 (bd), 2871 (bd), 2906 (bd), 2930 (bd), 3016 (bd), 3060 (bd), 3084 (bd), 3090 (bd), 3094 (bd), 3099 (bd), 3105 (bd), 3115 (bd), 3247 (bd), 3252 (bd), 3263 (bd), 3330 (bd), 4036 (bd), 4534 (bd)
+  - lines: 2184 (bd), 2186 (bd), 2342 (bd), 2785 (bd), 2794 (bd), 2807 (bd), 2820 (.beads), 2840 (bd), 2842 (bd), 2844 (bd), 2879 (bd), 2903 (bd), 2989 (bd), 3033 (bd), 3057 (bd), 3063 (bd), 3067 (bd), 3072 (bd), 3078 (bd), 3088 (bd), 3220 (bd), 3225 (bd), 3236 (bd), 3303 (bd), 4008 (bd), 4506 (bd)
 - [ ] lib/commands/_resolve-command-opts.js (2)
   - lines: 8 (bd), 10 (bd)
 - [ ] lib/commands/dev.js (1)
@@ -30,7 +30,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] lib/commands/test.js (5)
   - lines: 8 (dolt), 60 (bd), 63 (bd), 67 (bd), 70 (bd)
 - [ ] lib/commands/validate.js (1)
-  - lines: 25 (.beads)
+  - lines: 26 (.beads)
 
 ## runtime
 

--- a/lib/commands/recall.js
+++ b/lib/commands/recall.js
@@ -1,16 +1,20 @@
 'use strict';
 
 const memoryRouter = require('../memory/router');
+const { stripGlobalFlags } = require('../global-flags');
 
 const usage = 'Usage: forge recall [query] [--limit N] [--json]';
 
 /**
  * Separate the optional positional query from `--limit N` and `--json`.
+ * Global flags (e.g. `-p <dir>`) are stripped first so they never corrupt
+ * the search query (kernel issue c1e090ff).
  *
- * @param {string[]} args - Raw command arguments.
+ * @param {string[]} rawArgs - Raw command arguments.
  * @returns {{ query: string, limit: (number|undefined), json: boolean }}
  */
-function parseArgs(args) {
+function parseArgs(rawArgs) {
+  const args = stripGlobalFlags(rawArgs);
   const words = [];
   let limit;
   let json = false;

--- a/lib/commands/remember.js
+++ b/lib/commands/remember.js
@@ -1,16 +1,20 @@
 'use strict';
 
 const memoryRouter = require('../memory/router');
+const { stripGlobalFlags } = require('../global-flags');
 
 const usage = 'Usage: forge remember <note> [--tag <label>]... [--json]';
 
 /**
  * Split positional note words from `--tag <label>` pairs and the `--json` flag.
+ * Global flags (e.g. `-p <dir>`) are stripped first so they never leak into
+ * the stored note content (kernel issue c1e090ff).
  *
- * @param {string[]} args - Raw command arguments.
+ * @param {string[]} rawArgs - Raw command arguments.
  * @returns {{ note: string, tags: string[], json: boolean }}
  */
-function parseArgs(args) {
+function parseArgs(rawArgs) {
+  const args = stripGlobalFlags(rawArgs);
   const words = [];
   const tags = [];
   let json = false;

--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -13,7 +13,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const readline = require('node:readline');
-const { execSync, execFileSync } = require('node:child_process');
+const { execSync } = require('node:child_process');
 
 // Compute packageDir relative to this file (lib/commands/setup.js -> project root)
 const packageDir = path.resolve(__dirname, '..', '..');
@@ -2675,8 +2675,8 @@ function installGitHooks() { // NOSONAR — Extracted as-is from bin/forge.js; c
       } catch (error_) {
         // Fallback to global lefthook
         console.warn('npx lefthook failed, trying global:', error_.message);
-        execFileSync('lefthook', ['version'], { stdio: 'ignore' });
-        execFileSync('lefthook', ['install'], { stdio: 'inherit', cwd: projectRoot });
+        secureExecFileSync('lefthook', ['version'], { stdio: 'ignore' });
+        secureExecFileSync('lefthook', ['install'], { stdio: 'inherit', cwd: projectRoot });
         console.log('  ✓ Lefthook hooks installed (global)');
       }
   } catch (err) {
@@ -3059,11 +3059,10 @@ async function autoSetupToolsInQuickMode() {
     console.log('📦 Initializing Skills...');
     initializeSkills(skillsStatus);
     console.log('');
-  } else if (!skillsStatus) {
-    const installCmd = PKG_MANAGER === 'bun' ? 'bun add -g' : 'npm install -g';
-    console.log(`  ℹ Skills not found — install with: ${installCmd} @forge/skills`);
-    console.log('');
   }
+  // No hint when the optional Skills CLI is absent: setup bundles and renders
+  // Forge's skills itself, and the previously advertised "@forge/skills"
+  // package does not exist on npm (kernel issue 6e554b41).
 }
 
 // Helper: Configure default external services in quick mode - extracted to reduce cognitive complexity

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -11,6 +11,7 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { secureExecFileSync } = require('../shell-utils');
 
 // Constants
 const CHECK_TYPES = {
@@ -462,7 +463,7 @@ async function runSecurityScan() { // NOSONAR S3776
 		try {
 			let npmRawOutput = null;
 			try {
-				npmRawOutput = execFileSync('npm', ['audit', '--json', '--production'], getExecOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
+				npmRawOutput = secureExecFileSync('npm', ['audit', '--json', '--production'], getExecOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
 			} catch (npmExitError) {
 				if (npmExitError.killed && npmExitError.signal === 'SIGTERM') {
 					return {

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -78,7 +78,14 @@ function runInstall(worktreePath, projectRoot, spawnFn, fsApi) {
   const pkgManager = detectPackageManager(projectRoot, fsApi);
   if (!pkgManager) return { linked: false, installed: false };
 
-  const result = spawnFn(pkgManager, ['install'], { cwd: worktreePath, stdio: 'pipe' });
+  // shell:true on Windows: npm/pnpm/yarn are .cmd shims that cannot be spawned
+  // directly (ENOENT / EINVAL). pkgManager comes from lockfile detection (fixed
+  // set) and args are hardcoded, so no user input reaches the shell.
+  const result = spawnFn(pkgManager, ['install'], {
+    cwd: worktreePath,
+    stdio: 'pipe',
+    shell: process.platform === 'win32',
+  });
   if (result && result.error) {
     throw new Error(`Dependency install failed: could not run '${pkgManager} install' in ${worktreePath}: ${result.error.message}`);
   }

--- a/lib/global-flags.js
+++ b/lib/global-flags.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Global CLI flags recognized by bin/forge.js parseGlobalFlags().
+ *
+ * bin/forge.js parses these into the `flags` object but leaves them inside the
+ * positional `args` array it hands to command handlers. Free-text commands
+ * (remember, recall) that join positionals into content must strip them first,
+ * or `forge remember "note" -p <dir>` stores the literal `note -p <dir>`
+ * (kernel issue c1e090ff).
+ *
+ * Keep these sets in sync with parseGlobalFlags() in bin/forge.js.
+ * @module lib/global-flags
+ */
+
+// Flags that consume a following value token (also accepted as --flag=value).
+const GLOBAL_VALUE_FLAGS = new Set([
+  '--path', '-p',
+  '--agents',
+  '--merge',
+  '--type',
+  '--budget',
+]);
+
+const GLOBAL_VALUE_FLAG_PREFIXES = ['--path=', '--agents=', '--merge=', '--type=', '--budget='];
+
+// Boolean flags that take no value.
+const GLOBAL_BOOLEAN_FLAGS = new Set([
+  '--quick', '-q',
+  '--skip-external', '--skip-services',
+  '--all',
+  '--help', '-h',
+  '--version', '-V',
+  '--yes', '-y',
+  '--non-interactive',
+  '--force',
+  '--verbose',
+  '--dry-run',
+  '--symlink',
+  '--sync',
+  '--interview',
+]);
+
+/**
+ * Remove recognized global flags (and their values) from a positional args
+ * array. Plain words that merely resemble flag names (no leading dash) are
+ * always kept.
+ *
+ * @param {string[]} args - Raw command arguments.
+ * @returns {string[]} Arguments with global flags stripped.
+ */
+function stripGlobalFlags(args) {
+  const kept = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (GLOBAL_BOOLEAN_FLAGS.has(arg)) continue;
+    if (GLOBAL_VALUE_FLAG_PREFIXES.some((prefix) => arg.startsWith(prefix))) continue;
+    if (GLOBAL_VALUE_FLAGS.has(arg)) {
+      const next = args[index + 1];
+      // Mirror parsePathFlag() in bin/forge.js: the value is consumed only
+      // when it exists and is not itself a flag.
+      if (next !== undefined && !next.startsWith('-')) index += 1;
+      continue;
+    }
+    kept.push(arg);
+  }
+  return kept;
+}
+
+module.exports = {
+  GLOBAL_BOOLEAN_FLAGS,
+  GLOBAL_VALUE_FLAGS,
+  stripGlobalFlags,
+};

--- a/lib/shell-utils.js
+++ b/lib/shell-utils.js
@@ -36,16 +36,18 @@ function assertShellSafeTokens(command, args) {
 
 /**
  * Decide how to spawn a command on Windows from `where.exe` candidates.
- * Prefers a directly spawnable .exe/.com; otherwise runs the BARE command name
- * through cmd.exe (shell:true), which resolves npm.cmd/npx.cmd/lefthook.cmd
- * via PATH/PATHEXT — so paths with spaces never hit shell parsing.
+ * Prefers a directly spawnable .exe/.com — including when the caller already
+ * passed an absolute .exe/.com path (which `where.exe` may not re-enumerate);
+ * otherwise runs the BARE command name through cmd.exe (shell:true), which
+ * resolves npm.cmd/npx.cmd/lefthook.cmd via PATH/PATHEXT — so paths with spaces
+ * never hit shell parsing or the shell-safe token allowlist.
  *
- * @param {string} command - Original command name
+ * @param {string} command - Original command name or absolute path
  * @param {string[]} candidates - Resolved paths from `where.exe`, best first
  * @returns {{ file: string, shell: boolean }}
  */
 function resolveWindowsSpawnSpec(command, candidates) {
-  const direct = candidates.find(
+  const direct = [command, ...candidates].find(
     (candidate) => WINDOWS_DIRECT_SPAWN_EXTS.has(path.extname(candidate).toLowerCase())
   );
   if (direct) {

--- a/lib/shell-utils.js
+++ b/lib/shell-utils.js
@@ -5,10 +5,60 @@
  */
 
 const { execFileSync, spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+// Extensions Windows can spawn directly via CreateProcess. Anything else that
+// `where.exe` returns — the extensionless POSIX shim (`npm`) or the batch shim
+// (`npm.cmd`) — cannot be handed to execFileSync: the former is a bash script
+// (spawnSync ENOENT, kernel issue 9997d516) and patched Node refuses .cmd/.bat
+// without shell:true (CVE-2024-27980).
+const WINDOWS_DIRECT_SPAWN_EXTS = new Set(['.exe', '.com']);
+
+// Conservative allowlist for tokens executed through cmd.exe. Blocks every cmd
+// metacharacter (& | < > ^ % ! " ' ` ( ) ; and whitespace) so shell execution
+// cannot be turned into injection even if a caller ever passes dynamic input.
+const SAFE_SHELL_TOKEN = /^[A-Za-z0-9@_+=:,./\\-]+$/;
+
+/**
+ * Throw when any token is unsafe to pass through cmd.exe.
+ * @param {string} command - The command name
+ * @param {string[]} args - Command arguments
+ */
+function assertShellSafeTokens(command, args) {
+  for (const token of [command, ...args]) {
+    if (typeof token !== 'string' || !SAFE_SHELL_TOKEN.test(token)) {
+      throw new Error(
+        `Refusing to run "${command}" via shell: unsafe token ${JSON.stringify(token)}`
+      );
+    }
+  }
+}
+
+/**
+ * Decide how to spawn a command on Windows from `where.exe` candidates.
+ * Prefers a directly spawnable .exe/.com; otherwise runs the BARE command name
+ * through cmd.exe (shell:true), which resolves npm.cmd/npx.cmd/lefthook.cmd
+ * via PATH/PATHEXT — so paths with spaces never hit shell parsing.
+ *
+ * @param {string} command - Original command name
+ * @param {string[]} candidates - Resolved paths from `where.exe`, best first
+ * @returns {{ file: string, shell: boolean }}
+ */
+function resolveWindowsSpawnSpec(command, candidates) {
+  const direct = candidates.find(
+    (candidate) => WINDOWS_DIRECT_SPAWN_EXTS.has(path.extname(candidate).toLowerCase())
+  );
+  if (direct) {
+    return { file: direct, shell: false };
+  }
+  return { file: command, shell: true };
+}
 
 /**
  * Securely execute a command with PATH validation.
  * Mitigates SonarCloud S4036: Ensures executables are from trusted locations.
+ * On Windows, handles npm/npx/lefthook-style cmd shims that cannot be spawned
+ * directly (see resolveWindowsSpawnSpec).
  * @param {string} command - The command to execute
  * @param {string[]} [args=[]] - Command arguments
  * @param {object} [options={}] - execFileSync options
@@ -18,16 +68,16 @@ function secureExecFileSync(command, args = [], options = {}) {
   const {
     _execFileSync = execFileSync,
     _spawnSync = spawnSync,
+    _platform = process.platform,
     ...execOptions
   } = options;
 
-  let resolvedPath = null;
+  const isWindows = _platform === 'win32';
+  const pathResolver = isWindows ? 'where.exe' : 'which';
 
+  let candidates = [];
   try {
     // Resolve command's full path to validate it's in a trusted location
-    const isWindows = process.platform === 'win32';
-    const pathResolver = isWindows ? 'where.exe' : 'which';
-
     const result = _spawnSync(pathResolver, [command], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore']
@@ -35,14 +85,27 @@ function secureExecFileSync(command, args = [], options = {}) {
 
     if (result.status === 0 && result.stdout) {
       // Handle both CRLF (Windows) and LF (Unix) line endings
-      resolvedPath = result.stdout.trim().split(/\r?\n/)[0].trim();
+      candidates = result.stdout
+        .trim()
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
     }
   } catch (_err) { // NOSONAR - S2486: Intentionally ignored; falls back to direct command execution below
   }
 
+  if (isWindows) {
+    const spec = resolveWindowsSpawnSpec(command, candidates);
+    if (spec.shell) {
+      assertShellSafeTokens(command, args);
+      return _execFileSync(command, args, { ...execOptions, shell: true });
+    }
+    return _execFileSync(spec.file, args, execOptions);
+  }
+
   // Fall back only when resolution failed. If execution of the resolved binary
   // throws, propagate that error instead of retrying with the unresolved name.
-  return _execFileSync(resolvedPath || command, args, execOptions);
+  return _execFileSync(candidates[0] || command, args, execOptions);
 }
 
 module.exports = {

--- a/test/commands/recall.test.js
+++ b/test/commands/recall.test.js
@@ -90,4 +90,19 @@ describe('forge recall command', () => {
     const parsed = JSON.parse(result.output);
     expect(parsed).toHaveLength(2);
   });
+
+  test('does not treat the -p global flag as part of the query (kernel c1e090ff)', async () => {
+    const projectRoot = makeProjectRoot();
+    memoryStore.append(projectRoot, 'ship the fix');
+
+    const result = await recall.handler(
+      ['ship the fix', '-p', 'C:\\some\\project'],
+      { path: 'C:\\some\\project' },
+      projectRoot
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('ship the fix');
+    expect(result.output).not.toContain('No notes match');
+  });
 });

--- a/test/commands/remember.test.js
+++ b/test/commands/remember.test.js
@@ -78,4 +78,30 @@ describe('forge remember command', () => {
     const parsed = JSON.parse(result.output);
     expect(parsed.note).toBe('json note');
   });
+
+  test('does not store the -p global flag and its value in the note (kernel c1e090ff)', async () => {
+    const projectRoot = makeProjectRoot();
+    const result = await remember.handler(
+      ['ship the fix', '-p', 'C:\\some\\project'],
+      { path: 'C:\\some\\project' },
+      projectRoot
+    );
+
+    expect(result.success).toBe(true);
+    const [entry] = memoryStore.list(projectRoot);
+    expect(entry.note).toBe('ship the fix');
+  });
+
+  test('strips --path= and other global flags from the note content', async () => {
+    const projectRoot = makeProjectRoot();
+    const result = await remember.handler(
+      ['multi', 'word', 'note', '--path=/tmp/project', '--verbose'],
+      {},
+      projectRoot
+    );
+
+    expect(result.success).toBe(true);
+    const [entry] = memoryStore.list(projectRoot);
+    expect(entry.note).toBe('multi word note');
+  });
 });

--- a/test/global-flags.test.js
+++ b/test/global-flags.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const { stripGlobalFlags } = require('../lib/global-flags');
+
+describe('stripGlobalFlags', () => {
+  test('strips -p and its value (kernel c1e090ff regression)', () => {
+    expect(stripGlobalFlags(['remember this', '-p', 'C:\\some\\dir']))
+      .toEqual(['remember this']);
+  });
+
+  test('strips --path with a separate value', () => {
+    expect(stripGlobalFlags(['note', 'text', '--path', '/tmp/project']))
+      .toEqual(['note', 'text']);
+  });
+
+  test('strips the --path=<dir> form', () => {
+    expect(stripGlobalFlags(['note', '--path=/tmp/project'])).toEqual(['note']);
+  });
+
+  test('strips boolean global flags without eating following words', () => {
+    expect(stripGlobalFlags(['--verbose', 'keep', '--dry-run', 'these', '-y']))
+      .toEqual(['keep', 'these']);
+  });
+
+  test('strips other value-taking global flags with their values', () => {
+    expect(stripGlobalFlags(['note', '--agents', 'claude', '--type', 'bug']))
+      .toEqual(['note']);
+  });
+
+  test('does not consume a following flag as a value', () => {
+    expect(stripGlobalFlags(['note', '-p', '--verbose'])).toEqual(['note']);
+  });
+
+  test('leaves non-global flags (e.g. --tag) untouched', () => {
+    expect(stripGlobalFlags(['note', '--tag', 'infra', '--json']))
+      .toEqual(['note', '--tag', 'infra', '--json']);
+  });
+
+  test('leaves plain words that resemble flag names untouched', () => {
+    expect(stripGlobalFlags(['force', 'sync', 'path'])).toEqual(['force', 'sync', 'path']);
+  });
+});

--- a/test/shell-utils.test.js
+++ b/test/shell-utils.test.js
@@ -6,6 +6,7 @@ describe('secureExecFileSync', () => {
   test('falls back to the original command when path resolution fails', () => {
     const execCalls = [];
     const result = secureExecFileSync('bd', ['version'], {
+      _platform: 'linux',
       _spawnSync: () => ({ status: 1, stdout: '' }),
       _execFileSync: (command, args) => {
         execCalls.push({ command, args });
@@ -20,6 +21,7 @@ describe('secureExecFileSync', () => {
   test('uses the resolved executable path when lookup succeeds', () => {
     const execCalls = [];
     secureExecFileSync('bd', ['version'], {
+      _platform: 'linux',
       _spawnSync: () => ({ status: 0, stdout: '/usr/bin/bd\n' }),
       _execFileSync: (command, args) => {
         execCalls.push({ command, args });
@@ -34,6 +36,7 @@ describe('secureExecFileSync', () => {
     const execCalls = [];
 
     expect(() => secureExecFileSync('bd', ['version'], {
+      _platform: 'linux',
       _spawnSync: () => ({ status: 0, stdout: '/usr/bin/bd\n' }),
       _execFileSync: (command) => {
         execCalls.push(command);
@@ -42,5 +45,95 @@ describe('secureExecFileSync', () => {
     })).toThrow('boom: /usr/bin/bd');
 
     expect(execCalls).toEqual(['/usr/bin/bd']);
+  });
+
+  describe('on win32 (regression: spawnSync npm ENOENT — kernel 9997d516)', () => {
+    test('runs cmd-shim binaries (npm.cmd) via shell with the bare command name', () => {
+      const execCalls = [];
+      // where.exe lists the extensionless shim FIRST — the old code picked it
+      // and execFileSync failed with ENOENT (it is a bash script, not a PE).
+      secureExecFileSync('npm', ['install', '--save-dev', 'lefthook'], {
+        _platform: 'win32',
+        _spawnSync: () => ({
+          status: 0,
+          stdout: 'C:\\Program Files\\nodejs\\npm\r\nC:\\Program Files\\nodejs\\npm.cmd\r\n',
+        }),
+        _execFileSync: (command, args, options) => {
+          execCalls.push({ command, args, shell: options.shell });
+          return '';
+        },
+      });
+
+      expect(execCalls).toEqual([{
+        command: 'npm',
+        args: ['install', '--save-dev', 'lefthook'],
+        shell: true,
+      }]);
+    });
+
+    test('spawns a resolved .exe directly without a shell', () => {
+      const execCalls = [];
+      secureExecFileSync('bd', ['version'], {
+        _platform: 'win32',
+        _spawnSync: () => ({ status: 0, stdout: 'C:\\tools\\bd.exe\r\n' }),
+        _execFileSync: (command, args, options) => {
+          execCalls.push({ command, args, shell: options.shell });
+          return '';
+        },
+      });
+
+      expect(execCalls).toEqual([{
+        command: 'C:\\tools\\bd.exe',
+        args: ['version'],
+        shell: undefined,
+      }]);
+    });
+
+    test('prefers a .exe even when where.exe lists a shim first', () => {
+      const execCalls = [];
+      secureExecFileSync('lefthook', ['install'], {
+        _platform: 'win32',
+        _spawnSync: () => ({
+          status: 0,
+          stdout: 'C:\\repo\\node_modules\\.bin\\lefthook\r\nC:\\repo\\node_modules\\.bin\\lefthook.exe\r\n',
+        }),
+        _execFileSync: (command, args, options) => {
+          execCalls.push({ command, args, shell: options.shell });
+          return '';
+        },
+      });
+
+      expect(execCalls).toEqual([{
+        command: 'C:\\repo\\node_modules\\.bin\\lefthook.exe',
+        args: ['install'],
+        shell: undefined,
+      }]);
+    });
+
+    test('falls back to shell execution when resolution fails entirely', () => {
+      const execCalls = [];
+      secureExecFileSync('npx', ['lefthook', 'install'], {
+        _platform: 'win32',
+        _spawnSync: () => ({ status: 1, stdout: '' }),
+        _execFileSync: (command, args, options) => {
+          execCalls.push({ command, args, shell: options.shell });
+          return '';
+        },
+      });
+
+      expect(execCalls).toEqual([{
+        command: 'npx',
+        args: ['lefthook', 'install'],
+        shell: true,
+      }]);
+    });
+
+    test('refuses shell execution when a token contains cmd metacharacters', () => {
+      expect(() => secureExecFileSync('npm', ['install', 'x && del C:\\'], {
+        _platform: 'win32',
+        _spawnSync: () => ({ status: 0, stdout: 'C:\\nodejs\\npm.cmd\r\n' }),
+        _execFileSync: () => '',
+      })).toThrow(/unsafe token/);
+    });
   });
 });

--- a/test/shell-utils.test.js
+++ b/test/shell-utils.test.js
@@ -135,5 +135,29 @@ describe('secureExecFileSync', () => {
         _execFileSync: () => '',
       })).toThrow(/unsafe token/);
     });
+
+    test('spawns an absolute .exe command directly even when where.exe finds nothing', () => {
+      // Regression (kernel 9997d516): callers may pass an already-resolved
+      // absolute path (e.g. "C:\\Program Files\\Git\\bin\\git.exe"). where.exe
+      // may not re-enumerate it, leaving no candidates. It must still spawn
+      // directly (shell:false) — never fall to shell:true, where the space in
+      // "Program Files" trips the shell-safe token allowlist.
+      const execCalls = [];
+      const gitExe = 'C:\\Program Files\\Git\\bin\\git.exe';
+      secureExecFileSync(gitExe, ['rev-parse', 'HEAD'], {
+        _platform: 'win32',
+        _spawnSync: () => ({ status: 1, stdout: '' }),
+        _execFileSync: (command, args, options) => {
+          execCalls.push({ command, args, shell: options.shell });
+          return '';
+        },
+      });
+
+      expect(execCalls).toEqual([{
+        command: gitExe,
+        args: ['rev-parse', 'HEAD'],
+        shell: undefined,
+      }]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes three findings from the adversarial Windows fresh-user audit (one PR, TDD each):

### P0 — Windows spawn ENOENT breaks lefthook/hook install (kernel `9997d516-455c-4f32-a170-a6dbd90a2d12`)

Root cause: `secureExecFileSync` (lib/shell-utils.js, plus a drifted local duplicate in bin/forge.js) took the **first** line of `where.exe` output. For npm that is the extensionless bash shim `C:\Program Files\nodejs\npm`, which `execFileSync` cannot spawn — exactly the audit's `spawnSync C:\Program Files\nodejs\npm ENOENT`. Resolving to `npm.cmd` alone is not enough either: patched Node refuses `.cmd`/`.bat` without `shell:true` (CVE-2024-27980).

Fix (one approach, applied consistently):
- `secureExecFileSync` on win32 now prefers a directly spawnable `.exe`/`.com` candidate; otherwise it runs the **bare command name** through `cmd.exe` (`shell:true`), which resolves cmd shims via PATH/PATHEXT — so paths with spaces never hit shell parsing.
- Security: shell execution is gated by a strict token allowlist (`assertShellSafeTokens`) that rejects every cmd metacharacter, so no user-controlled string can reach the shell.
- bin/forge.js's buggy local duplicate of `secureExecFileSync` was deleted and now delegates to the shared helper.
- Same-class sweep of lib/: global-lefthook fallback in lib/commands/setup.js and bin/forge.js (`execFileSync('lefthook', …)` → `secureExecFileSync`), `npm audit` in lib/commands/validate.js, and worktree dependency install in lib/commands/worktree.js (`shell: process.platform === 'win32'`, matching the existing pattern in push.js/test.js).

### P1 — `forge remember/recall` store/query the literal `-p <dir>` (kernel `c1e090ff-66ff-4404-b234-05cc91348cfc`)

bin/forge.js parses global flags but leaves them inside the positional `args` it hands to handlers; remember/recall joined ALL positionals. New `lib/global-flags.js` (`stripGlobalFlags`) strips the full bin/forge.js global-flag set — value flags (`--path/-p`, `--agents`, `--merge`, `--type`, `--budget`, incl. `=` forms, flag AND value) and boolean flags — before joining free-text content. Sweep of `join(' ')` sites in lib/commands/ found no other command with the same defect (hooks.js joins already-parsed unknowns; ship.js joins a slug).

### P2 — Stale `@forge/skills` install hint (kernel `6e554b41-1f3b-468b-8dd9-4ff345bf1d55`)

Setup printed `Skills not found — install with: npm install -g @forge/skills` (a package that does not exist on npm) right before rendering the 20 bundled skills. Hint removed in both lib/commands/setup.js and the bin/forge.js duplicate — skills are bundled and rendered by setup itself.

## Live Windows confirmation (this machine, Windows 11)

Fresh toy repo (`git init` + minimal package.json under `os.tmpdir()`), then
`node bin/forge.js setup --agents claude --quick --yes -p <toy>`:

```
exit=0
📦 Installing lefthook for git hooks...
  ✓ Lefthook installed
  ✓ Lefthook hooks installed (local)
==HOOKS==
prepare-commit-msg
```

No ENOENT anywhere in the log; `npm install --save-dev lefthook` and `npx lefthook install` both actually execute now (before the fix they died at spawn). Two pre-existing, cross-platform issues surfaced by this live run were filed as follow-ups rather than expanded into this PR:
- `e452422c` — lefthook's npm postinstall creates its example lefthook.yml first, so setup skips copying Forge's TDD config on fresh projects (only `prepare-commit-msg` gets synced).
- `22e33dbf` — with no package.json in the target project, npm walks up to an ancestor package.json (observed ERESOLVE against a stray user-profile package.json).

## Tests

- `test/shell-utils.test.js` — win32 regression cases (extensionless-shim-first → shell with bare name; `.exe` preferred without shell; resolution failure fallback; unsafe-token rejection) + existing POSIX cases pinned with `_platform`.
- `test/global-flags.test.js` — new suite for `stripGlobalFlags`.
- `test/commands/remember.test.js`, `test/commands/recall.test.js` — `-p`/`--path=`/boolean-flag stripping regressions.
- Targeted run: shell-utils, global-flags, remember, recall, setup-lefthook-repair, setup-hooks-config, validate, worktree, push, memory — **152 pass / 0 fail** (13 skip). `bun run lint` green (`--max-warnings 0`).

Kernel issues: `9997d516-455c-4f32-a170-a6dbd90a2d12`, `c1e090ff-66ff-4404-b234-05cc91348cfc`, `6e554b41-1f3b-468b-8dd9-4ff345bf1d55`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now strip recognized global flags from user input when searching recall and saving notes, preventing flag tokens from being saved or treated as part of the query.
* **Bug Fixes**
  * Improved Windows command execution for installs and shell invocations, with safer execution logic and more reliable package-manager setup.
  * Security scan fallback now uses the hardened execution path.
* **Other**
  * Quick-mode setup no longer prints an informational install hint when an optional external tool is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->