### PR TITLE
chore(release): 0.1.0-beta.1 + guarded npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,9 +43,33 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: bun install
+      # Guard 1 (kernel 3f83ca6c): the release tag MUST match package.json version, so a
+      # release created without bumping package.json can never publish the wrong version.
+      - name: Guard — release tag matches package.json version
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "package.json=$PKG  release tag=$TAG"
+          if [ "$PKG" != "$TAG" ]; then
+            echo "::error::Release tag ($TAG) != package.json version ($PKG). Bump package.json before releasing."
+            exit 1
+          fi
+      # Guard 2: the release-readiness gate must pass before we publish.
+      - name: Release-readiness gate
+        run: node bin/forge.js release check --target "$(node -p "require('./package.json').version")"
       # Verify package contents before publishing (no build needed - pure JS package)
       - name: Verify package contents
         run: npm pack --dry-run
-      - run: npm publish --provenance
+      # Publish. A prerelease version (contains a hyphen, e.g. 0.1.0-beta.1) goes under the
+      # `beta` dist-tag so `npm install forge-workflow` keeps resolving the latest STABLE.
+      - name: Publish to npm
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if echo "$VERSION" | grep -q '-'; then
+            echo "Prerelease $VERSION → publishing under the 'beta' dist-tag"
+            npm publish --provenance --tag beta
+          else
+            npm publish --provenance
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-07-08
+## [0.1.0-beta.1] - 2026-07-09
 
-First public release. The default issue backend changed from Beads to the built-in Kernel store, the Kernel's git-tracked JSONL portability loop now works end to end, and a pre-beta audit hardened the CLI surface, docs, and npm packaging.
+First public release (beta). Published under the npm `beta` dist-tag. The default issue backend changed from Beads to the built-in Kernel store, the Kernel's git-tracked JSONL portability loop now works end to end, and a pre-beta audit hardened the CLI surface, docs, and npm packaging.
 
 ### Changed
 

--- a/lib/release-readiness.js
+++ b/lib/release-readiness.js
@@ -1885,14 +1885,17 @@ function buildBlockers(projectRoot, audit) {
 
 function buildReadinessReport(projectRoot, options = {}) {
   const target = options.target || SUPPORTED_TARGET;
-  if (target !== SUPPORTED_TARGET) {
+  // Accept prerelease variants (0.1.0-beta.1, 0.1.0-rc.1, …) against their base version's
+  // readiness profile — a beta's readiness content is identical to its release.
+  const baseTarget = String(target).split('-')[0];
+  if (baseTarget !== SUPPORTED_TARGET) {
     return {
       success: false,
       target,
       blockers: [{
         id: 'unsupported-target',
         title: 'unsupported release readiness target',
-        detail: `Unsupported release readiness target: ${target}. Supported target: ${SUPPORTED_TARGET}.`,
+        detail: `Unsupported release readiness target: ${target}. Supported target: ${SUPPORTED_TARGET} (prerelease suffixes like -beta.1 are accepted).`,
         evidence: [],
       }],
       audit: auditBdCallSites(projectRoot, options),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-workflow",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.1",
   "description": "Local runtime control plane for AI-assisted engineering workflows, gates, evidence, and all AI agents",
   "bin": {
     "forge": "bin/forge.js",

--- a/test/release-readiness.test.js
+++ b/test/release-readiness.test.js
@@ -2274,3 +2274,22 @@ test('fresh clone placeholder', async () => {
     expect(blocker.detail).toContain('missing acceptance coverage');
   });
 });
+
+describe('release readiness target — prerelease acceptance (3f83ca6c)', () => {
+  test('accepts a prerelease target (0.1.0-beta.1) against the base version profile', () => {
+    const root = makeRepo();
+    writeRepoAgentPluginManifests(root);
+    const beta = buildReadinessReport(root, { target: '0.1.0-beta.1' });
+    const base = buildReadinessReport(root, { target: '0.1.0' });
+    expect(beta.blockers.find(blocker => blocker.id === 'unsupported-target')).toBeUndefined();
+    expect(beta.success).toBe(base.success); // identical readiness profile
+  });
+
+  test('still rejects an unrelated target version', () => {
+    const root = makeRepo();
+    writeRepoAgentPluginManifests(root);
+    const report = buildReadinessReport(root, { target: '9.9.9' });
+    expect(report.success).toBe(false);
+    expect(report.blockers.find(blocker => blocker.id === 'unsupported-target')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Release cut: 0.1.0-beta.1 (public beta) + guarded publish

Stages the first public beta. Version bump + a guarded npm-publish workflow. **This PR does not publish** — publishing is triggered separately by creating the `0.1.0-beta.1` GitHub release.

### Changes
- **Version → `0.1.0-beta.1`** (`package.json`); CHANGELOG heading → `[0.1.0-beta.1]`.
- **`.github/workflows/npm-publish.yml` guards** (kernel `3f83ca6c`):
  1. Assert the release **tag == `package.json` version** — fail loud on mismatch (can't publish the wrong version).
  2. Run **`forge release check`** as a publish precondition.
  3. A **prerelease** version (contains a hyphen) publishes under the **`beta` dist-tag**, so `npm install forge-workflow` keeps resolving the latest *stable* — only `@beta` opt-in users get this.
- **`release-readiness`** now accepts prerelease targets (`0.1.0-beta.1`) against the base version's profile; base + unrelated targets behave exactly as before. Regression tests added.

### Verification
- `forge release check --target 0.1.0-beta.1` → PASS; `--target 0.1.0` → PASS; `--target 9.9.9` → still rejected.
- `forge --version` → `Forge v0.1.0-beta.1`; `npm pack --dry-run` → `forge-workflow-0.1.0-beta.1.tgz`, 425 files.
- 57 release-readiness tests + lint green; workflow YAML valid.

### To publish (maintainer, after merge)
Create a GitHub release tagged `0.1.0-beta.1` → the workflow runs the guards and `npm publish --provenance --tag beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
