### PR TITLE
fix(kernel): session-scope claim identity so same-actor agents don't silently double-work (d71a824b)

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -590,8 +590,20 @@ function buildDependencyMutationEvent(operation, flags, actor, origin, context, 
 
 // Build the kernel event for a claim / release op. The event is scoped on the
 // 'claim' entity stream (entity_id = claim lease id). The default idempotency key
-// is keyed on issue_id + actor so a same-actor retry replays as a duplicate while a
-// different actor produces a distinct key that reaches the lease-conflict path.
+// is keyed on issue_id + actor + session so a same-SESSION retry replays as a
+// duplicate while a different session (or actor) produces a distinct key that reaches
+// the lease-conflict path.
+//
+// SESSION-SCOPED KEY (kernel d71a824b): keying on `actor` alone was a correctness
+// hole — `actor` defaults to a shared 'forge' and two concurrent agents acting as the
+// SAME human actor on the SAME issue collided on ONE key, so the loser's claim
+// collapsed to an idempotent duplicate-replay (ok:true) instead of reaching the
+// claim_conflict lease guard, and BOTH agents then passed owns() → silent double-work.
+// Appending the per-agent session-id gives distinct sessions distinct keys, so exactly
+// one wins the partial-UNIQUE active lease and the other is correctly quarantined. A
+// session-less caller (sessionId null) keeps the historical
+// `${eventType}:${issueId}:${actor}` key BYTE-FOR-BYTE, so single-agent same-key
+// retries still replay as duplicates and existing callers/tests are unaffected.
 //
 // The DOCUMENTED CLI is positional — `forge claim <id>` / `forge release <id>` —
 // so the issue id is the first positional, matching update/close/dep. The --issue
@@ -603,7 +615,11 @@ function buildClaimMutationEvent(operation, flags, actor, origin, context, args 
 	const issueId = typeof flags.issue === 'string' ? flags.issue : firstPositionalArg(args);
 	const claimId = context.claimId || randomUUID();
 	const eventType = ISSUE_MUTATION_EVENT_TYPES[operation];
-	const idempotencyKey = context.idempotencyKey || `${eventType}:${issueId}:${actor}`;
+	const sessionId = context.sessionId ?? null;
+	const idempotencyKey = context.idempotencyKey
+		|| (sessionId
+			? `${eventType}:${issueId}:${actor}:${sessionId}`
+			: `${eventType}:${issueId}:${actor}`);
 	const payload = { issue_id: issueId };
 	if (typeof flags.expires === 'string') payload.expires_at = flags.expires;
 	return {
@@ -614,7 +630,7 @@ function buildClaimMutationEvent(operation, flags, actor, origin, context, args 
 		expected_revision: 0,
 		actor,
 		origin,
-		session_id: context.sessionId ?? null,
+		session_id: sessionId,
 		worktree_id: context.worktreeId ?? null,
 		payload,
 	};

--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -615,7 +615,13 @@ function buildClaimMutationEvent(operation, flags, actor, origin, context, args 
 	const issueId = typeof flags.issue === 'string' ? flags.issue : firstPositionalArg(args);
 	const claimId = context.claimId || randomUUID();
 	const eventType = ISSUE_MUTATION_EVENT_TYPES[operation];
-	const sessionId = context.sessionId ?? null;
+	// Treat an empty/whitespace-only session-id as session-LESS: it must never append to
+	// the idempotency key and never be stored as a non-null session_id. This uses the
+	// SAME trim-truthy emptiness test as the owns() read (lib/kernel/sqlite-driver.js), so
+	// '' can never count as "present" at the write site and "absent" at the read site.
+	const sessionId = typeof context.sessionId === 'string' && context.sessionId.trim() !== ''
+		? context.sessionId
+		: null;
 	const idempotencyKey = context.idempotencyKey
 		|| (sessionId
 			? `${eventType}:${issueId}:${actor}:${sessionId}`

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -527,11 +527,13 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 		// OWNED for a lease only one of them holds. When BOTH the caller and the live
 		// lease carry a session-id they must match; if either side is session-less (a
 		// no-env caller, or a pre-session claim) we fall back to actor-only ownership so
-		// historical behavior is preserved byte-for-byte.
-		const contextSession = typeof context.sessionId === 'string' && context.sessionId
-			? context.sessionId
-			: null;
-		const claimSession = claim ? (claim.session_id ?? null) : null;
+		// historical behavior is preserved byte-for-byte. An empty/whitespace-only
+		// session-id counts as session-LESS on BOTH sides — the SAME trim-truthy test the
+		// claim-key write uses (buildClaimMutationEvent in lib/kernel/broker.js) — so ''
+		// can never count as "present" here and "absent" there.
+		const normalizeSession = value => (typeof value === 'string' && value.trim() !== '' ? value : null);
+		const contextSession = normalizeSession(context.sessionId);
+		const claimSession = claim ? normalizeSession(claim.session_id) : null;
 		const sessionMismatch = contextSession !== null
 			&& claimSession !== null
 			&& contextSession !== claimSession;

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -522,7 +522,20 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 		const claim = loadActiveKernelClaimRow(runtime, db, id);
 		const claimedBy = claim ? (claim.actor ?? null) : null;
 		const expired = claim ? isLeaseExpired(claim, now) : false;
-		const owned = Boolean(claim) && !expired && claimedBy === actor;
+		// Ownership is per-SESSION, not just per-actor (kernel d71a824b): two agents
+		// sharing one human actor but running as DIFFERENT sessions must not both read
+		// OWNED for a lease only one of them holds. When BOTH the caller and the live
+		// lease carry a session-id they must match; if either side is session-less (a
+		// no-env caller, or a pre-session claim) we fall back to actor-only ownership so
+		// historical behavior is preserved byte-for-byte.
+		const contextSession = typeof context.sessionId === 'string' && context.sessionId
+			? context.sessionId
+			: null;
+		const claimSession = claim ? (claim.session_id ?? null) : null;
+		const sessionMismatch = contextSession !== null
+			&& claimSession !== null
+			&& contextSession !== claimSession;
+		const owned = Boolean(claim) && !expired && claimedBy === actor && !sessionMismatch;
 		return okIssueResponse('issue.owns', {
 			id,
 			actor,

--- a/test/kernel/claim-session-identity.test.js
+++ b/test/kernel/claim-session-identity.test.js
@@ -106,4 +106,56 @@ describe('claim session identity — same actor, different sessions (d71a824b)',
     expect(owns.data.owned).toBe(true);
     expect(owns.data.claimed_by).toBe('forge-a');
   });
+
+  test('same actor + same session claiming the SAME issue twice: idempotent duplicate replay — one lease, no conflict', async () => {
+    // The central POSITIVE guarantee: identical (actor, session) on the same issue
+    // yields an IDENTICAL idempotency key, so the retry replays as a duplicate (ok:true)
+    // rather than minting a second lease or tripping claim_conflict. This guards against
+    // a regression that changed the key format for same-session retries (which would
+    // otherwise stay green — the distinct-sessions test alone would not catch it).
+    await createIssue('sess-4', 'Retry');
+
+    const first = await claim('sess-4', 'alice', 'sess-A', now);
+    const second = await claim('sess-4', 'alice', 'sess-A', '2026-06-20T00:00:01.000Z');
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    // ok:true means NOT a claim conflict (a conflict is ok:false with an error).
+    expect(second.error).toBeUndefined();
+
+    // Exactly ONE active lease exists — the retry did not create a second.
+    const stats = await driver.issueOperation('stats', [], { now }, config);
+    expect(stats.data.active_claims).toBe(1);
+
+    // And the single session still holds it.
+    const owns = await driver.issueOperation(
+      'owns', ['sess-4'], { now, actor: 'alice', sessionId: 'sess-A' }, config,
+    );
+    expect(owns.data.owned).toBe(true);
+  });
+
+  test('empty-string session-id is treated as session-LESS symmetrically (key + owns)', async () => {
+    // '' must behave identically at the write site (no trailing ':' appended to the key,
+    // session_id stored null) and the owns read (actor-only fallback), never as "present"
+    // at one and "absent" at the other.
+    await createIssue('sess-5', 'Blank');
+
+    // Claim with an EMPTY session, then re-claim with an actual session-less caller: both
+    // resolve to the SAME `claim.create:sess-5:alice` key, so the second is a duplicate
+    // replay (ok:true) — proving '' did not append to the key.
+    const empty = await claim('sess-5', 'alice', '', now);
+    const sessionless = await claim('sess-5', 'alice', undefined, '2026-06-20T00:00:01.000Z');
+    expect(empty.ok).toBe(true);
+    expect(sessionless.ok).toBe(true);
+
+    const stats = await driver.issueOperation('stats', [], { now }, config);
+    expect(stats.data.active_claims).toBe(1);
+
+    // owns with an empty session falls back to actor-only ownership (stored session is null).
+    const owns = await driver.issueOperation(
+      'owns', ['sess-5'], { now, actor: 'alice', sessionId: '' }, config,
+    );
+    expect(owns.data.owned).toBe(true);
+    expect(owns.data.claimed_by).toBe('alice');
+  });
 });

--- a/test/kernel/claim-session-identity.test.js
+++ b/test/kernel/claim-session-identity.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Session-scoped claim identity (kernel d71a824b). The claim idempotency key was
+// `claim.create:<issue_id>:<actor>` with `actor` defaulting to a shared 'forge'. Two
+// concurrent AGENTS acting as the SAME human actor on the SAME issue produced the SAME
+// key, so the loser's claim collapsed to an idempotent duplicate-replay (ok:true)
+// instead of reaching the claim_conflict lease guard — and, because owns() compared by
+// actor only, BOTH agents read OWNED. That is silent double-work (a correctness hole,
+// not just provenance). The fix threads the per-agent SESSION-ID into (a) the claim
+// idempotency key and (b) the owns() lease-ownership check, so exactly one session wins
+// the lease and the other is correctly rejected.
+describe('claim session identity — same actor, different sessions (d71a824b)', () => {
+  let tmpDir;
+  let driver;
+  let broker;
+  let config;
+  const now = '2026-06-20T00:00:00.000Z';
+
+  async function createIssue(id, title = id) {
+    return broker.runIssueOperation(
+      'create',
+      ['--id', id, '--title', title, '--type', 'task'],
+      { now, actor: 'tester' },
+    );
+  }
+
+  async function claim(id, actor, sessionId, at = now) {
+    return broker.runIssueOperation('claim', ['--issue', id], { now: at, actor, sessionId });
+  }
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claim-session-'));
+    const dbPath = path.join(tmpDir, 'kernel.sqlite');
+    config = { databasePath: dbPath };
+    driver = createBuiltinSQLiteDriver({});
+    broker = createLocalBroker({
+      projectRoot: tmpDir,
+      execFileSync: () => path.join(tmpDir, '.git'),
+      databasePath: dbPath,
+      driver,
+    });
+    await broker.initialize();
+  });
+
+  afterEach(() => {
+    if (driver) driver.close();
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('two claims, one human actor, distinct session-ids: exactly one wins, the other is a claim conflict', async () => {
+    await createIssue('sess-1', 'Contended');
+
+    // Same human actor ('alice'), two different per-agent sessions.
+    const a = await claim('sess-1', 'alice', 'sess-A', now);
+    const b = await claim('sess-1', 'alice', 'sess-B', '2026-06-20T00:00:01.000Z');
+
+    // Before the fix both keys are `claim.create:sess-1:alice`, so B replays as an
+    // idempotent duplicate (ok:true) and BOTH report success. After the fix B reaches
+    // the lease guard and is quarantined as a claim conflict.
+    const wins = [a, b].filter(r => r.ok === true);
+    const conflicts = [a, b].filter(r => r.ok === false);
+    expect(wins.length).toBe(1);
+    expect(conflicts.length).toBe(1);
+
+    // A claimed first, so A holds the lease and B is the loser.
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(false);
+    expect(b.error.code).toBe('FORGE_ISSUE_CLAIM_CONFLICT');
+  });
+
+  test('owns() is session-scoped: the winning session OWNS, a same-actor other session does NOT', async () => {
+    await createIssue('sess-2', 'Contended');
+    await claim('sess-2', 'alice', 'sess-A', now);
+
+    const ownsWinner = await driver.issueOperation(
+      'owns', ['sess-2'], { now, actor: 'alice', sessionId: 'sess-A' }, config,
+    );
+    expect(ownsWinner.data.owned).toBe(true);
+    expect(ownsWinner.data.claimed_by).toBe('alice');
+
+    // Same human actor, DIFFERENT session — must NOT be reported as the lease holder,
+    // even though claimed_by === actor. Before the fix owns compared actor only and
+    // wrongly returned owned:true.
+    const ownsOther = await driver.issueOperation(
+      'owns', ['sess-2'], { now, actor: 'alice', sessionId: 'sess-B' }, config,
+    );
+    expect(ownsOther.data.owned).toBe(false);
+  });
+
+  test('backward compatible: a session-less caller still owns its own session-less claim', async () => {
+    await createIssue('sess-3', 'Legacy');
+    // No sessionId anywhere — historical actor-only behavior must be preserved.
+    await claim('sess-3', 'forge-a', undefined, now);
+
+    const owns = await driver.issueOperation(
+      'owns', ['sess-3'], { now, actor: 'forge-a' }, config,
+    );
+    expect(owns.data.owned).toBe(true);
+    expect(owns.data.claimed_by).toBe('forge-a');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **C1** correctness hole (`d71a824b`): the claim idempotency key was `claim.create:${issueId}:${actor}` with `actor` defaulting to `'forge'`, so two concurrent **agents** acting as the same human actor on the same issue produced the **same key** → the second deduped to `ok:true` and **both** passed `owns()` → silent double-work.

## Fix

- **Claim key** (`broker.js`): thread the per-agent `session-id` into the idempotency key when present, so two agents/sessions get **distinct keys** and the partial-UNIQUE active-lease index lets exactly one win (the other correctly gets `claim_conflict`). Session-less callers keep the **byte-identical** historical key.
- **`owns()`** (`sqlite-driver.js`): ownership now also requires a **session match** when both sides carry a session; either side session-less falls back to actor-only (backward-compatible).
- Reuses existing plumbing (`FORGE_SESSION_ID` → mutation context → `claims` table). **No schema/migration change.**

## Tightenings (from adversarial verify panel)

- Shared trim-truthy session normalization at **both** the write (key) and read (`owns`) sites — `''`/whitespace is uniformly session-less (closes a write/read asymmetry).
- Tests: distinct-sessions → exactly one wins; `owns()` session-scoped; **same-session idempotent retry** → one key / one lease / no conflict; empty-string symmetry; backward-compat.

## Tests

`test/kernel/claim-session-identity.test.js`: **5 pass, 0 fail**. Full kernel suite green pre-tightening (477 pass); CI runs the full suite on this PR.

## Follow-ups (tracked, intentionally out of scope)

- `56b080c9` (P2) — `owns()` can report `owned=true` after an expiry+reclaim by a session-less same-actor agent during the rollout window. **Pre-existing, not a regression**; the proper fix is a design decision that conflicts with legacy-claim back-compat.
- `bd3ea7c9` (P3) — escape/length-prefix the composite idempotency-key delimiter.

Issue: `d71a824b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
