### PR TITLE
fix(release): audit only git-tracked files so the bd census is deterministic (1d4077d8)

### DIFF
--- a/lib/release-readiness.js
+++ b/lib/release-readiness.js
@@ -494,21 +494,30 @@ function addCallSites(groups, group, relativePath, lineEntries) {
 // makes the census deterministic under a dirty/parallel working tree: an untracked temp
 // file a concurrent test drops under a scan root no longer perturbs it (issue 1d4077d8).
 function trackedRepoFiles(projectRoot) {
+  let output;
   try {
-    const output = execFileSync('git', ['-C', projectRoot, 'ls-files', '-z'], {
+    // NOSONAR S4036 — `git` is resolved from PATH by design (cross-platform CLI; the repo
+    // spawns git this way throughout and cannot hardcode a portable absolute path).
+    output = execFileSync('git', ['-C', projectRoot, 'ls-files', '-z'], {
       encoding: 'utf8',
       maxBuffer: 64 * 1024 * 1024,
     });
-    const tracked = new Set();
-    for (const entry of output.split('\0')) {
-      if (entry) {
-        tracked.add(normalizeRepoPath(entry));
-      }
+  } catch (error) {
+    // Fall back to the raw walk ONLY for a genuine non-git tree (which legitimately has no
+    // tracked set). Any OTHER git/exec failure must NOT silently reintroduce the untracked-
+    // scan nondeterminism this fix removes — surface it instead of masking it.
+    if (/not a git repository/i.test(String(error && error.stderr))) {
+      return null;
     }
-    return tracked;
-  } catch (_error) {
-    return null;
+    throw error;
   }
+  const tracked = new Set();
+  for (const entry of output.split('\0')) {
+    if (entry) {
+      tracked.add(normalizeRepoPath(entry));
+    }
+  }
+  return tracked;
 }
 
 function auditBdCallSites(projectRoot, options = {}) {

--- a/lib/release-readiness.js
+++ b/lib/release-readiness.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const babelParser = require('@babel/parser');
 
 const SUPPORTED_TARGET = '0.1.0';
@@ -488,9 +489,35 @@ function addCallSites(groups, group, relativePath, lineEntries) {
   });
 }
 
+// Git-tracked repo files (repo-relative, forward-slash), or null when this isn't a git
+// repo (then callers fall back to the raw walk). Restricting the bd-audit to tracked files
+// makes the census deterministic under a dirty/parallel working tree: an untracked temp
+// file a concurrent test drops under a scan root no longer perturbs it (issue 1d4077d8).
+function trackedRepoFiles(projectRoot) {
+  try {
+    const output = execFileSync('git', ['-C', projectRoot, 'ls-files', '-z'], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const tracked = new Set();
+    for (const entry of output.split('\0')) {
+      if (entry) {
+        tracked.add(normalizeRepoPath(entry));
+      }
+    }
+    return tracked;
+  } catch (_error) {
+    return null;
+  }
+}
+
 function auditBdCallSites(projectRoot, options = {}) {
   const roots = getScanRoots(projectRoot, options);
+  // Only audit git-tracked files, so untracked working-tree pollution (e.g. a concurrent
+  // test's temp files under a scan root) can't perturb the census (issue 1d4077d8).
+  const tracked = trackedRepoFiles(projectRoot);
   const files = [...new Set(roots.flatMap(root => walkFiles(projectRoot, root)))]
+    .filter(relativePath => !tracked || tracked.has(normalizeRepoPath(relativePath)))
     .sort((left, right) => left.localeCompare(right));
   const groups = newGroupedAudit();
 

--- a/test/release-readiness-tracked.test.js
+++ b/test/release-readiness-tracked.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { afterEach, describe, test, expect } = require('bun:test');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { auditBdCallSites } = require('../lib/release-readiness');
+
+const tempDirs = [];
+
+// A throwaway git repo with one committed, bd-referencing file under `docs/`.
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-bd-audit-'));
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'docs', 'tracked.md'), 'legacy note: run `bd list` to see issues\n');
+  execFileSync('git', ['add', '.'], { cwd: dir });
+  execFileSync(
+    'git',
+    ['-c', 'user.email=t@example.com', '-c', 'user.name=Test', 'commit', '-qm', 'seed'],
+    { cwd: dir },
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+});
+
+describe('auditBdCallSites is deterministic under working-tree pollution (1d4077d8)', () => {
+  test('ignores untracked files dropped under a scan root', () => {
+    const repo = makeRepo();
+
+    const clean = auditBdCallSites(repo, { scanRoots: ['docs'] });
+    expect(clean.totalCount).toBeGreaterThan(0); // the committed file IS audited
+
+    // Simulate a concurrent test dropping an untracked, bd-referencing file under the same
+    // scan root. Pre-fix the raw fs walk counted it (census drifts → flaky "stale artifact");
+    // the tracked-only audit must ignore it.
+    fs.writeFileSync(path.join(repo, 'docs', 'pollution.md'), 'stray `bd create` call site\n');
+    const polluted = auditBdCallSites(repo, { scanRoots: ['docs'] });
+
+    expect(polluted.totalCount).toBe(clean.totalCount);
+    expect(polluted.totalFiles).toBe(clean.totalFiles);
+  });
+});

--- a/test/release-readiness-tracked.test.js
+++ b/test/release-readiness-tracked.test.js
@@ -53,4 +53,14 @@ describe('auditBdCallSites is deterministic under working-tree pollution (1d4077
     expect(polluted.totalCount).toBe(clean.totalCount);
     expect(polluted.totalFiles).toBe(clean.totalFiles);
   });
+
+  test('falls back to the raw walk in a non-git tree (no tracked set)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-bd-nogit-'));
+    tempDirs.push(dir);
+    fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'docs', 'note.md'), 'run `bd list`\n');
+    // Not a git repo -> trackedRepoFiles() returns null -> auditBdCallSites still scans.
+    const audit = auditBdCallSites(dir, { scanRoots: ['docs'] });
+    expect(audit.totalCount).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the flaky release-readiness gate (`1d4077d8`) that was blocking legitimate PRs (e.g. #338).

`auditBdCallSites` walked the **raw filesystem** under each scan root (`lib/`, `docs/`, `skills/`, …) and read whatever was on disk. Under the parallel CI test run the working tree isn't pristine — an untracked file a concurrent test drops under a scan root gets counted, so the bd call-site census drifts and the checked-in **D20 kill-list artifact** reads "stale." The same tests **pass in isolation** (no pollution), which is the classic flake signature.

## Fix

Restrict the audit to **git-tracked files** (`git ls-files`):
- On a **clean tree** the tracked set equals the raw walk → census and the committed artifact are **unchanged** (verified: `release.test.js` still passes).
- Under **working-tree pollution**, untracked files are ignored → the census is deterministic → the flake is gone.
- Falls back to the raw walk if `git ls-files` fails (non-git contexts), so nothing breaks outside a repo.

## Test

`test/release-readiness-tracked.test.js`: seeds a committed bd-referencing file, then drops an **untracked** bd-referencing file under the same scan root and asserts the census is **unchanged** (pollution excluded) while the committed file is still counted. Pre-fix, the raw walk would have counted the pollution.

## Impact

Unblocks **#338** (and any future PR) from spurious release-gate reds. After this merges, #338 rebases on top and its CI goes green.

Issue: `1d4077d8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release-readiness audits now ignore untracked files, preventing temporary or unintended working-tree files from affecting results.
  * Audits continue to work as before when tracked-file information is unavailable.

* **Tests**
  * Added regression coverage to verify that newly added untracked files do not change audit results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->