### PR TITLE
fix: bound test lanes with wall-clock timeout so a hung test cannot block push (8aef79e8)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ export default [
       'build/',
       '*.min.js',
       '.worktrees/',
+      '.claude/worktrees/',
       'test-env/fixtures/**',
       'packages/skills/test/fixtures/**',
       'test/e2e/fixtures/**',

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -39,6 +39,31 @@ const ALWAYS_RUN_RISK_TEST_TARGETS = [
 
 const isWindows = process.platform === 'win32';
 
+// Wall-clock ceiling for a single spawned test lane. Bun's per-test `--timeout`
+// races a JS timer and CANNOT preempt a synchronous blocking spawn (e.g. an
+// `execFileSync` of git/bash that hangs during git mid-push state). Without this
+// ceiling such a hang blocks `forge push` indefinitely (observed ~50 min on
+// Windows, issue 8aef79e8). This kills the lane process so the push fails fast
+// instead of hanging forever. Override with FORGE_TEST_TIMEOUT_MS.
+const DEFAULT_TEST_COMMAND_TIMEOUT_MS = 15 * 60 * 1000;
+
+// Conventional shell exit code for a command terminated by a timeout.
+const TIMEOUT_EXIT_CODE = 124;
+
+/**
+ * Resolves the per-lane wall-clock timeout, honoring FORGE_TEST_TIMEOUT_MS.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env] Environment to read the override from.
+ * @returns {number} Timeout in milliseconds (defaults to DEFAULT_TEST_COMMAND_TIMEOUT_MS).
+ */
+function resolveCommandTimeoutMs(env = process.env) {
+  const parsed = Number.parseInt(env.FORGE_TEST_TIMEOUT_MS, 10);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return DEFAULT_TEST_COMMAND_TIMEOUT_MS;
+}
+
 /**
  * @typedef {Object} TestExecutionPlan
  * @property {string[]} changedFiles
@@ -263,6 +288,15 @@ function runCommand(command, args, options = {}, spawnSync = defaultSpawnSync) {
   });
 
   if (result.error) {
+    if (result.error.code === 'ETIMEDOUT') {
+      const seconds = Math.round((options.timeout ?? 0) / 1000);
+      console.error('');
+      console.error(`Test lane timed out after ${seconds}s and was terminated: ${command} ${args.join(' ')}`);
+      console.error('A single test likely hung (e.g. a spawned git/bash call that never returns).');
+      console.error('Failing the run instead of blocking the push. See issue 8aef79e8.');
+      console.error('');
+      return TIMEOUT_EXIT_CODE;
+    }
     throw result.error;
   }
 
@@ -282,30 +316,32 @@ function runTestExecutionPlan(plan, deps = {}) {
   const env = deps.env || stripGitHookEnv(process.env);
   const bunCommand = deps.bunCommand || env.BUN_EXE || process.env.BUN_EXE || 'bun';
   const label = deps.label || 'tests';
+  const timeout = resolveCommandTimeoutMs(env);
+  const laneOptions = { env, killSignal: 'SIGKILL', timeout };
 
   console.log(`Running ${label} (${pkgManager})...`);
 
   try {
     if (plan.runFullSuite) {
       console.log(`  Mode: full suite (${plan.reason})`);
-      const status = runCommand('node', ['scripts/test-full-suite.js'], { env }, spawnSync);
+      const status = runCommand('node', ['scripts/test-full-suite.js'], laneOptions, spawnSync);
       if (status !== 0) return status;
     } else if (plan.testTargets.length > 0) {
       console.log(`  Mode: targeted (${plan.testTargets.length} test file${plan.testTargets.length === 1 ? '' : 's'})`);
       const command = pkgManager === 'bun' ? bunCommand : pkgManager;
-      const status = runCommand(command, ['run', 'test', ...plan.testTargets], { env }, spawnSync);
+      const status = runCommand(command, ['run', 'test', ...plan.testTargets], laneOptions, spawnSync);
       if (status !== 0) return status;
     }
 
     if (plan.runE2E) {
       console.log('  Extra: running affected e2e tests');
-      const status = runCommand(bunCommand, ['test', '--timeout', '15000', 'test/e2e/'], { env }, spawnSync);
+      const status = runCommand(bunCommand, ['test', '--timeout', '15000', 'test/e2e/'], laneOptions, spawnSync);
       if (status !== 0) return status;
     }
 
     if (!plan.runFullSuite && plan.runTestEnv) {
       console.log('  Extra: running affected edge-case tests');
-      const status = runCommand(bunCommand, ['test', '--timeout', '15000', 'test-env/'], { env }, spawnSync);
+      const status = runCommand(bunCommand, ['test', '--timeout', '15000', 'test-env/'], laneOptions, spawnSync);
       if (status !== 0) return status;
     }
 
@@ -354,9 +390,11 @@ if (require.main === module) {
 
 module.exports = {
   ALWAYS_RUN_RISK_TEST_TARGETS,
+  DEFAULT_TEST_COMMAND_TIMEOUT_MS,
   buildTestExecutionPlan,
   classifyPushTests,
   detectPackageManager,
+  resolveCommandTimeoutMs,
   runLocalValidationTests,
   runPrePushTests,
   runTestExecutionPlan,

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -289,11 +289,11 @@ function runCommand(command, args, options = {}, spawnSync = defaultSpawnSync) {
 
   if (result.error) {
     if (result.error.code === 'ETIMEDOUT') {
-      const seconds = Math.round((options.timeout ?? 0) / 1000);
       console.error('');
-      console.error(`Test lane timed out after ${seconds}s and was terminated: ${command} ${args.join(' ')}`);
+      console.error('Test lane exceeded its wall-clock ceiling and was terminated.');
       console.error('A single test likely hung (e.g. a spawned git/bash call that never returns).');
-      console.error('Failing the run instead of blocking the push. See issue 8aef79e8.');
+      console.error('Adjust the ceiling with FORGE_TEST_TIMEOUT_MS. Failing the run instead of');
+      console.error('blocking the push. See issue 8aef79e8.');
       console.error('');
       return TIMEOUT_EXIT_CODE;
     }

--- a/test-env/automation/setup-fixtures.test.js
+++ b/test-env/automation/setup-fixtures.test.js
@@ -16,6 +16,11 @@ const { validateEnvFile: _validateEnvFile } = require('../validation/env-validat
 
 const SETUP_SCRIPT = path.join(__dirname, 'setup-fixtures.sh');
 
+// Bound the synchronous setup spawn: bun's per-test `--timeout` cannot preempt a
+// blocking execFileSync, so a hung git/bash would hang the whole push (issue
+// 8aef79e8). A timeout makes it throw ETIMEDOUT and fail fast instead.
+const SETUP_SPAWN_TIMEOUT_MS = 60000;
+
 const EXPECTED_FIXTURES = [
   'fresh-project', 'existing-forge-v1', 'partial-install', 'conflicting-configs',
   'read-only-dirs', 'no-git', 'dirty-git', 'detached-head', 'merge-conflict',
@@ -91,7 +96,8 @@ describe('setup-fixtures.sh', () => {
 
   test('Idempotency: should be safe to run multiple times', () => {
     const result = execFileSync(resolveBashCommand(), [SETUP_SCRIPT], {
-      cwd: __dirname, stdio: 'pipe', encoding: 'utf8'
+      cwd: __dirname, stdio: 'pipe', encoding: 'utf8',
+      timeout: SETUP_SPAWN_TIMEOUT_MS, killSignal: 'SIGKILL'
     });
     expect(result).toMatch(/Fixture already exists|Skipped/i);
   });

--- a/test-env/helpers/fixtures.js
+++ b/test-env/helpers/fixtures.js
@@ -8,6 +8,10 @@ const TEST_ENV_DIR = path.join(__dirname, '..');
 const FIXTURES_DIR = path.join(TEST_ENV_DIR, 'fixtures');
 const SETUP_SCRIPT = path.join(TEST_ENV_DIR, 'automation', 'setup-fixtures.sh');
 
+// Wall-clock ceiling for the synchronous fixture-setup spawn. Generous enough
+// for a cold Windows checkout, but bounded so a hung git/bash aborts fast.
+const SETUP_SPAWN_TIMEOUT_MS = 60000;
+
 function sleep(ms) {
 	const end = Date.now() + ms;
 	while (Date.now() < end) {
@@ -34,6 +38,11 @@ function repairFixtures(setupScript) {
 	execFileSync(resolveBashCommand(), [setupScript, '--force', '--no-validate'], {
 		cwd: path.dirname(setupScript),
 		stdio: 'pipe',
+		// Bound this synchronous spawn: bun's per-test `--timeout` cannot preempt a
+		// blocking execFileSync, so a hung git/bash here would hang the whole push
+		// (issue 8aef79e8). A timeout makes it throw ETIMEDOUT and fail fast instead.
+		timeout: SETUP_SPAWN_TIMEOUT_MS,
+		killSignal: 'SIGKILL',
 	});
 }
 

--- a/test/scripts/test-runner.test.js
+++ b/test/scripts/test-runner.test.js
@@ -5,10 +5,13 @@ const path = require('node:path');
 
 const {
   ALWAYS_RUN_RISK_TEST_TARGETS,
+  DEFAULT_TEST_COMMAND_TIMEOUT_MS,
   buildTestExecutionPlan,
   classifyPushTests,
+  resolveCommandTimeoutMs,
   runLocalValidationTests,
   runPrePushTests,
+  runTestExecutionPlan,
   stripGitHookEnv,
 } = require('../../scripts/test');
 
@@ -464,5 +467,71 @@ describe('scripts/test pre-push runner', () => {
     expect(spawnSync.calls).toHaveLength(1);
     expect(spawnSync.calls[0].command).toBe('node');
     expect(spawnSync.calls[0].args).toEqual(['scripts/test-full-suite.js']);
+  });
+
+  test('every spawned test lane carries a wall-clock timeout so a hung test cannot block the push forever', () => {
+    const spawnSync = makeSpawnSync(0);
+    runPrePushTests(repoRoot, {
+      env: { PATH: process.env.PATH || '' },
+      execFileSync: makeExecFileSync({
+        changedFiles: 'lib/commands/ship.js\n',
+      }),
+      pkgManager: 'bun',
+      spawnSync,
+    });
+
+    expect(spawnSync.calls.length).toBeGreaterThan(0);
+    for (const call of spawnSync.calls) {
+      expect(call.options.timeout).toBe(DEFAULT_TEST_COMMAND_TIMEOUT_MS);
+      expect(call.options.killSignal).toBe('SIGKILL');
+    }
+  });
+
+  test('FORGE_TEST_TIMEOUT_MS overrides the wall-clock lane timeout', () => {
+    const spawnSync = makeSpawnSync(0);
+    runPrePushTests(repoRoot, {
+      env: { FORGE_TEST_TIMEOUT_MS: '5000', PATH: process.env.PATH || '' },
+      execFileSync: makeExecFileSync({
+        changedFiles: 'lib/commands/ship.js\n',
+      }),
+      pkgManager: 'bun',
+      spawnSync,
+    });
+
+    expect(spawnSync.calls.length).toBeGreaterThan(0);
+    for (const call of spawnSync.calls) {
+      expect(call.options.timeout).toBe(5000);
+    }
+  });
+
+  test('resolveCommandTimeoutMs ignores invalid overrides and falls back to the default', () => {
+    expect(resolveCommandTimeoutMs({})).toBe(DEFAULT_TEST_COMMAND_TIMEOUT_MS);
+    expect(resolveCommandTimeoutMs({ FORGE_TEST_TIMEOUT_MS: 'nonsense' })).toBe(DEFAULT_TEST_COMMAND_TIMEOUT_MS);
+    expect(resolveCommandTimeoutMs({ FORGE_TEST_TIMEOUT_MS: '-1' })).toBe(DEFAULT_TEST_COMMAND_TIMEOUT_MS);
+    expect(resolveCommandTimeoutMs({ FORGE_TEST_TIMEOUT_MS: '20000' })).toBe(20000);
+  });
+
+  test('a lane that times out fails fast with a non-zero status instead of hanging', () => {
+    const timedOutSpawnSync = () => ({
+      error: Object.assign(new Error('spawnSync bun ETIMEDOUT'), { code: 'ETIMEDOUT' }),
+      signal: 'SIGKILL',
+      status: null,
+    });
+
+    const status = runTestExecutionPlan({
+      changedFiles: ['lib/commands/ship.js'],
+      mode: 'targeted',
+      reason: 'known changes mapped to targeted tests',
+      runE2E: false,
+      runFullSuite: false,
+      runTestEnv: false,
+      testTargets: ['test/commands/ship.test.js'],
+    }, {
+      env: { PATH: process.env.PATH || '' },
+      pkgManager: 'bun',
+      spawnSync: timedOutSpawnSync,
+    });
+
+    expect(status).not.toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

The full-suite pre-push hook could hang indefinitely on Windows (~50 min, never completing), blocking `forge push`. Refs kernel issue `8aef79e8`.

**Root cause:** bun's per-test `--timeout` races a JS timer and **cannot preempt a synchronous blocking spawn**. When a `test-env/` fixture test runs `execFileSync(bash, [setup-script...])` and that bash/git hangs (e.g. during git mid-push state), the JS thread stays blocked so bun's timeout timer never fires — the whole shard hangs forever.

## Fix (two layers)

1. **Durable safety net — `scripts/test.js`:** every spawned test lane now carries a wall-clock `timeout` + `killSignal` (default 15 min, override via `FORGE_TEST_TIMEOUT_MS`). A timed-out lane is terminated and reported as a fast non-zero failure (exit 124) instead of hanging forever, regardless of the hang's cause. This alone unblocks the pipeline.
2. **Root-cause fix — test-env fixture setup:** the two previously-unbounded synchronous `execFileSync` calls (`test-env/helpers/fixtures.js`, `test-env/automation/setup-fixtures.test.js`) now pass a 60s timeout, so a hung git/bash aborts the test fast at the source.

Also fixes an unrelated pre-existing blocker: eslint scanned the gitignored `.claude/worktrees/` nested worktree and failed on its files, aborting every push. Added it to eslint ignores for parity with the existing `.worktrees/` entry.

## Tests

`test/scripts/test-runner.test.js` (TDD): lane timeout propagation, `FORGE_TEST_TIMEOUT_MS` override, `resolveCommandTimeoutMs` validation, and fast-fail-on-timeout behavior. All 30 test-runner tests + 10 setup-fixtures tests pass; changed files lint clean.

## Notes
- Pushed with `forge push --quick` (lint-only local; CI runs the full suite) because the full local push still hangs until this lands.
- Do **not** merge — leaving for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added time limits to test commands and fixture setup processes, preventing stalled operations from hanging indefinitely.
  * Timed-out test processes are now forcefully terminated and reported as failures.

* **Tests**
  * Added coverage for default and configurable test timeouts, timeout handling, and process termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->