### PR TITLE
refactor(kernel): typed conflict signal at driver boundary (89bf8930 / d4ce47bb)

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -4,6 +4,7 @@ const { execFileSync } = require('node:child_process');
 const path = require('node:path');
 const { randomUUID } = require('node:crypto');
 const { buildConflict, evaluateKernelEvent, normalizePayload } = require('./evaluators');
+const { CONFLICT_SIGNAL, classifyConflictSignal } = require('./conflict-signal');
 const { buildKernelMigrationPlan } = require('./migrations');
 const { buildClaimConflict, isValidExpiresAt, planClaimAcquisition } = require('./lease-enforcer');
 const {
@@ -116,26 +117,27 @@ function recordMigrationSql(id) {
 	return `INSERT OR IGNORE INTO ${MIGRATION_LEDGER_TABLE} (id, applied_at) VALUES ('${id}', '${new Date().toISOString()}');`;
 }
 
+// Conflict classification is delegated to the typed classifier at the driver
+// boundary (lib/kernel/conflict-signal.js). The broker branches on stable TYPED
+// codes and NEVER parses raw SQLite error text — that error-dialect knowledge
+// lives in one place, so a future backend (libSQL/Turso/CF) is decoupled here.
 function isIdempotencyConflict(error) {
-	const msg = String(error?.message ?? error);
-	return /UNIQUE constraint failed/i.test(msg) && /idempotency_key/i.test(msg);
+	return classifyConflictSignal(error) === CONFLICT_SIGNAL.UNIQUE_IDEMPOTENCY;
 }
 
-// Match ONLY the active-lease partial UNIQUE index (kernel_claims.issue_id), not
-// the table's primary key (kernel_claims.id): a duplicate-id violation is a
-// distinct bug and must not be misclassified as a lease conflict.
+// The active-lease partial UNIQUE index (kernel_claims.issue_id) — a distinct code
+// from a duplicate-id (kernel_claims.id) violation, which classifies as null and is
+// re-thrown rather than misclassified as a lease conflict.
 function isClaimLeaseConflict(error) {
-	const msg = String(error?.message ?? error);
-	return /UNIQUE constraint failed/i.test(msg) && /kernel_claims\.issue_id/i.test(msg);
+	return classifyConflictSignal(error) === CONFLICT_SIGNAL.UNIQUE_CLAIM_LEASE;
 }
 
-// The real driver's applyAcceptedIssueMutation tags a lost-update collision (its
-// row-level CAS UPDATE matched 0 rows because the issue's revision moved between
-// the evaluator's out-of-transaction pre-read and the serialized commit). It is the
-// issue-revision analogue of the claim-lease partial-UNIQUE backstop: a structural
-// guarantee the evaluator's pre-read alone cannot provide under concurrency.
+// The driver's applyAcceptedIssueMutation tags a lost-update collision structurally
+// (its row-level CAS UPDATE matched 0 rows because the issue's revision moved
+// between the evaluator's out-of-transaction pre-read and the serialized commit).
+// classifyConflictSignal maps that driver-supplied tag to CAS_STALE.
 function isRevisionConflict(error) {
-	return Boolean(error?.kernelRevisionConflict);
+	return classifyConflictSignal(error) === CONFLICT_SIGNAL.CAS_STALE;
 }
 
 async function execMigrationStatement(driver, statement, config) {

--- a/lib/kernel/conflict-signal.js
+++ b/lib/kernel/conflict-signal.js
@@ -1,0 +1,82 @@
+'use strict';
+
+// Typed conflict-signal classification (issues 89bf8930 / d4ce47bb).
+//
+// The broker used to classify write conflicts by substring-parsing raw SQLite
+// error text (`/UNIQUE constraint failed/`, `kernel_claims.issue_id`, ...) inline.
+// That coupled the broker to one driver's error dialect and was fragile across
+// SQLite versions/runtimes and future backends (libSQL/Turso/CF).
+//
+// This module is the SINGLE place that owns that driver-boundary knowledge. It
+// maps a raw driver/SQLite error into a stable TYPED code; the broker branches on
+// the code and never parses strings. It mirrors the driver's existing structural
+// signal (`error.kernelRevisionConflict`, set by applyAcceptedIssueMutation's
+// row-level CAS) and generalizes it to every conflict class.
+//
+// When a new backend is added, only classifyConflictSignal changes — the broker's
+// branching stays put. A CI integration test (test/kernel/conflict-signal.test.js)
+// provokes real conflicts against the deployed driver and asserts the mapping,
+// converting the standing "error text" assumption into a build-time contract.
+
+const CONFLICT_SIGNAL = Object.freeze({
+	// Optimistic-CAS lost update: the row-level revision guard matched 0 rows because
+	// the entity's revision moved between the evaluator's out-of-transaction pre-read
+	// and the serialized commit. Driver-tagged structurally (never string-derived).
+	CAS_STALE: 'CAS_STALE',
+	// Duplicate idempotency key — a same-key event replay collided on the events
+	// UNIQUE(idempotency_key) index. The broker replays the committed winner.
+	UNIQUE_IDEMPOTENCY: 'UNIQUE_IDEMPOTENCY',
+	// Two active leases raced on one issue: the partial UNIQUE active-lease index
+	// (kernel_claims.issue_id WHERE state='active') rejected the second. The broker
+	// quarantines it as a claim_conflict.
+	UNIQUE_CLAIM_LEASE: 'UNIQUE_CLAIM_LEASE',
+	// Transient lock contention (SQLITE_BUSY / "database is locked"). Part of the
+	// typed vocabulary; the broker does not currently branch on it (behavior parity).
+	BUSY: 'BUSY',
+	// Transient table-level lock (SQLITE_LOCKED). Typed for completeness as above.
+	LOCKED: 'LOCKED',
+});
+
+// Map a raw driver/SQLite error → typed conflict code, or null if it is not a
+// recognized conflict. Precedence: an already-typed signal (driver-supplied or a
+// prior classification) wins over any string inspection, so once the driver tags
+// an error at its boundary this never re-parses text.
+function classifyConflictSignal(error) {
+	if (!error) return null;
+
+	// 1. Already-typed, driver-supplied signals take priority over any string parse.
+	if (typeof error === 'object') {
+		if (error.conflictSignal && isKnownSignal(error.conflictSignal)) {
+			return error.conflictSignal;
+		}
+		// The driver's row-level CAS backstop tags this structurally.
+		if (error.kernelRevisionConflict) return CONFLICT_SIGNAL.CAS_STALE;
+	}
+
+	// 2. Fallback for un-tagged native errors: inspect the driver's error surface.
+	//    This is the ONLY place any error-text/code inspection is permitted.
+	const message = String(error && error.message != null ? error.message : error);
+	const code = String((error && error.code) || '');
+
+	if (/UNIQUE constraint failed/i.test(message)) {
+		// Match ONLY the active-lease partial index (kernel_claims.issue_id), not the
+		// table PK (kernel_claims.id): a duplicate-id violation is a distinct bug.
+		if (/kernel_claims\.issue_id/i.test(message)) return CONFLICT_SIGNAL.UNIQUE_CLAIM_LEASE;
+		if (/idempotency_key/i.test(message)) return CONFLICT_SIGNAL.UNIQUE_IDEMPOTENCY;
+		return null;
+	}
+
+	if (/^SQLITE_BUSY/i.test(code) || /database is locked/i.test(message)) return CONFLICT_SIGNAL.BUSY;
+	if (/^SQLITE_LOCKED/i.test(code) || /database table is locked/i.test(message)) return CONFLICT_SIGNAL.LOCKED;
+
+	return null;
+}
+
+function isKnownSignal(value) {
+	return Object.prototype.hasOwnProperty.call(CONFLICT_SIGNAL, value);
+}
+
+module.exports = {
+	CONFLICT_SIGNAL,
+	classifyConflictSignal,
+};

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -16,6 +16,7 @@ const { buildReadinessIndex } = require('./readiness-model');
 const { buildMemoryProjectionMigration, memoryFtsDdl } = require('./migrations');
 const { rankForPriorityLabel } = require('./taxonomy-validator');
 const { isLeaseExpired } = require('./lease-enforcer');
+const { CONFLICT_SIGNAL, classifyConflictSignal } = require('./conflict-signal');
 
 const BUILTIN_SQLITE_RUNTIME_ORDER = Object.freeze(['bun:sqlite', 'node:sqlite']);
 let probeCounter = 0;
@@ -1271,6 +1272,10 @@ function applyAcceptedIssueEvent(runtime, db, event, context = {}) {
 		// means the CAS predicate (entity_revision = expected) matched no row.
 		if (Number(result?.changes || 0) === 0) {
 			const error = new Error('kernel issue revision conflict');
+			// Driver-supplied TYPED conflict signal (issues 89bf8930 / d4ce47bb): the
+			// broker branches on this code, never on error text. kernelRevisionConflict
+			// is retained as the structural marker classifyConflictSignal also honors.
+			error.conflictSignal = CONFLICT_SIGNAL.CAS_STALE;
 			error.kernelRevisionConflict = true;
 			error.entityId = issueId;
 			error.expectedRevision = Number(event.expected_revision || 0);
@@ -2244,6 +2249,8 @@ function createBuiltinSQLiteDriver(options = {}, deps = {}) {
 
 module.exports = {
 	BUILTIN_SQLITE_RUNTIME_ORDER,
+	CONFLICT_SIGNAL,
+	classifyConflictSignal,
 	createBuiltinSQLiteDriver,
 	requireSqliteRuntimeModule,
 	selectBuiltinSQLiteRuntime,

--- a/test/kernel/conflict-signal.test.js
+++ b/test/kernel/conflict-signal.test.js
@@ -1,0 +1,147 @@
+const { describe, expect, test, beforeEach, afterEach } = require('bun:test');
+const os = require('node:os');
+const path = require('node:path');
+
+const fs = require('node:fs');
+
+const {
+	CONFLICT_SIGNAL,
+	classifyConflictSignal,
+} = require('../../lib/kernel/conflict-signal');
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// The typed conflict-signal refactor (issues 89bf8930 / d4ce47bb): the broker must
+// branch on a driver-supplied TYPED signal, not on engine-specific error text. These
+// tests assert the classification is produced by the typed classifier — the SINGLE
+// place that owns SQLite error-dialect knowledge — so the broker never parses strings.
+
+describe('classifyConflictSignal — typed classification (no string-matching in broker)', () => {
+	test('exposes a frozen, stable enum of conflict codes', () => {
+		expect(CONFLICT_SIGNAL).toEqual({
+			CAS_STALE: 'CAS_STALE',
+			UNIQUE_IDEMPOTENCY: 'UNIQUE_IDEMPOTENCY',
+			UNIQUE_CLAIM_LEASE: 'UNIQUE_CLAIM_LEASE',
+			BUSY: 'BUSY',
+			LOCKED: 'LOCKED',
+		});
+		expect(Object.isFrozen(CONFLICT_SIGNAL)).toBe(true);
+	});
+
+	test('CAS lost-update: honors the driver-tagged structural marker', () => {
+		const err = Object.assign(new Error('kernel issue revision conflict'), {
+			kernelRevisionConflict: true,
+			actualRevision: 3,
+		});
+		expect(classifyConflictSignal(err)).toBe(CONFLICT_SIGNAL.CAS_STALE);
+	});
+
+	test('CAS lost-update: honors a pre-tagged typed conflictSignal', () => {
+		const err = Object.assign(new Error('anything'), {
+			conflictSignal: CONFLICT_SIGNAL.CAS_STALE,
+		});
+		expect(classifyConflictSignal(err)).toBe(CONFLICT_SIGNAL.CAS_STALE);
+	});
+
+	test('idempotency UNIQUE violation → UNIQUE_IDEMPOTENCY', () => {
+		const err = new Error('UNIQUE constraint failed: kernel_events.idempotency_key');
+		expect(classifyConflictSignal(err)).toBe(CONFLICT_SIGNAL.UNIQUE_IDEMPOTENCY);
+	});
+
+	test('claim-lease partial UNIQUE violation → UNIQUE_CLAIM_LEASE', () => {
+		const err = new Error('UNIQUE constraint failed: kernel_claims.issue_id');
+		expect(classifyConflictSignal(err)).toBe(CONFLICT_SIGNAL.UNIQUE_CLAIM_LEASE);
+	});
+
+	test('a duplicate kernel_claims.id (PK) is NOT a lease conflict', () => {
+		// The PK collision is a distinct bug; it must not be misclassified as a lease
+		// conflict (preserves the isClaimLeaseConflict targeting semantics).
+		const err = new Error('UNIQUE constraint failed: kernel_claims.id');
+		expect(classifyConflictSignal(err)).toBeNull();
+	});
+
+	test('BUSY / LOCKED are recognized from code or message', () => {
+		expect(classifyConflictSignal(Object.assign(new Error('x'), { code: 'SQLITE_BUSY' })))
+			.toBe(CONFLICT_SIGNAL.BUSY);
+		expect(classifyConflictSignal(new Error('database is locked')))
+			.toBe(CONFLICT_SIGNAL.BUSY);
+		expect(classifyConflictSignal(Object.assign(new Error('x'), { code: 'SQLITE_LOCKED' })))
+			.toBe(CONFLICT_SIGNAL.LOCKED);
+	});
+
+	test('unrelated errors and nullish input classify as null', () => {
+		expect(classifyConflictSignal(new Error('CHECK constraint failed: foo'))).toBeNull();
+		expect(classifyConflictSignal(new Error('no such table: bar'))).toBeNull();
+		expect(classifyConflictSignal(null)).toBeNull();
+		expect(classifyConflictSignal(undefined)).toBeNull();
+	});
+
+	test('accepts a bare string error message', () => {
+		expect(classifyConflictSignal('UNIQUE constraint failed: kernel_events.idempotency_key'))
+			.toBe(CONFLICT_SIGNAL.UNIQUE_IDEMPOTENCY);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// CI CONTRACT / INTEGRATION TEST (per d4ce47bb comment, 2026-07-09):
+// Provoke REAL conflicts against the actually-deployed SQLite driver and assert
+// the typed classifier recognizes them. This converts the standing "error text"
+// assumption into a CI-enforced, backend-agnostic contract: if a future backend
+// (libSQL/Turso/CF) emits a different error dialect, this fails at build time.
+// ---------------------------------------------------------------------------
+
+describe('real-backend conflict contract (CI-enforced)', () => {
+	let tmpDir;
+	let driver;
+	let broker;
+	let config;
+	const now = '2026-07-10T00:00:00.000Z';
+
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'confsig-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// Provoke a GENUINE partial-UNIQUE(active-lease) violation from the real driver
+	// (two active claims on one issue_id) and assert BOTH the error dialect (the
+	// substring the classifier keys on) AND that the typed classifier recognizes it.
+	// If a future backend emits a different error dialect, this fails at build time.
+	test('the deployed SQLite driver emits a claim-lease UNIQUE error the classifier recognizes', async () => {
+		await broker.runIssueOperation(
+			'create', ['--id', 'issue-cs', '--title', 'cs', '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+		const baseClaim = {
+			issue_id: 'issue-cs', actor: 'tester', state: 'active',
+			claimed_at: now, expires_at: null,
+		};
+		await driver.insertKernelClaim({ ...baseClaim, id: 'claim-1' }, {}, config);
+
+		let caught = null;
+		try {
+			await driver.insertKernelClaim({ ...baseClaim, id: 'claim-2' }, {}, config);
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).not.toBeNull();
+		// Contract pin: the real error dialect still contains the substring we key on.
+		expect(String(caught.message)).toContain('kernel_claims.issue_id');
+		// Typed classification recognizes the real backend error.
+		expect(classifyConflictSignal(caught)).toBe(CONFLICT_SIGNAL.UNIQUE_CLAIM_LEASE);
+	});
+});


### PR DESCRIPTION
## Summary

Replaces the broker's fragile SQLite-error-**string** conflict classification (`broker.js:119–130`) with a **typed conflict signal** produced at the driver boundary. The broker now branches on a stable typed `code` instead of substring-parsing engine-specific error text.

Resolves **89bf8930-d02a-44e2-86c8-d66e0a9bbb11** ([BETA] Typed conflict-signal refactor in broker, P0) and **d4ce47bb-69e1-46cc-8f77-a80ea1c12db8** (BETA: decouple broker conflict classification from SQLite error-text, P1) — the two issues describe the **same work**; d4ce47bb will be closed as a duplicate of 89bf8930.

## Typed-signal design

- **New `lib/kernel/conflict-signal.js`** — the single owner of SQLite error-dialect knowledge. `classifyConflictSignal(error)` maps a raw driver/SQLite error to a stable typed code:
  - `CAS_STALE` — row-level optimistic-CAS lost update (driver-tagged, never string-derived)
  - `UNIQUE_IDEMPOTENCY` — duplicate idempotency key
  - `UNIQUE_CLAIM_LEASE` — active-lease partial-UNIQUE (`kernel_claims.issue_id`), distinct from a PK collision (`kernel_claims.id` → `null`, re-thrown)
  - `BUSY` / `LOCKED` — transient lock contention (typed vocabulary; broker does not branch on them → behavior parity)
  - Precedence: an already-typed, driver-supplied signal wins over any string inspection; string/code inspection is the **only** fallback and lives **only** here.
- **`broker.js`** — `isIdempotencyConflict` / `isClaimLeaseConflict` / `isRevisionConflict` are now thin wrappers over the typed code. No regex in the broker.
- **`sqlite-driver.js`** — the CAS lost-update throw is tagged with a driver-supplied `error.conflictSignal = CAS_STALE` (`kernelRevisionConflict` retained as the structural marker the classifier also honors); module re-exports `CONFLICT_SIGNAL` + `classifyConflictSignal`.

## Behavior

**Identical** — same conflicts classified the same way. This is a decoupling refactor, not a behavior change. De-risks every future backend (libSQL/Turso/CF) at the classification boundary in one place.

## Tests

- **`test/kernel/conflict-signal.test.js`** (new, 10 tests):
  - Unit coverage for each typed code, driver-tag precedence, PK-vs-lease disambiguation, BUSY/LOCKED, and null/unknown inputs.
  - **CI-enforced real-backend contract test** (per the d4ce47bb 2026-07-09 comment): provokes a *genuine* claim-lease UNIQUE from the deployed SQLite driver and asserts **both** the error dialect substring **and** the typed classification — so any future error-dialect divergence fails at build time.
- Regression: `broker.test.js`, `broker-concurrency.test.js`, `broker-guards.test.js`, `broker-multiprocess.test.js`, `sqlite-driver*.test.js` — **all green** (84 tests). The concurrency suite (which injects fake drivers throwing the exact SQLite strings) is the behavioral safety net and remains passing unchanged.
- `eslint --max-warnings 0` on all changed files: clean.

Do **not** merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)