### PR TITLE
fix: make forge migrate honest about preview-only status (a1561ca1)

### DIFF
--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -461,7 +461,8 @@ async function autoMigrateBeadsAtRuntime({ projectRoot, databasePath, broker, dr
 
 module.exports = {
   name: 'migrate',
-  description: 'Migrate a Beads issue store into the Forge Kernel, or preview the v2→v3 migration',
+  description: 'Migrate a Beads issue store into the Forge Kernel with --from beads, '
+    + 'or preview the v2→v3 migration (preview only — --dry-run required; applying it is not yet available)',
   detectBeadsJsonlSource,
   autoMigrateBeadsIfPresent,
   autoMigrateBeadsAtRuntime,
@@ -472,9 +473,10 @@ module.exports = {
       + 'A split .beads layout is tolerated: files missing from the given dir are also read from a '
       + 'backup/ subdir and the parent dir, so events (under .beads/backup/) and interactions '
       + '(at .beads/interactions.jsonl) are both picked up regardless of which you point at.',
-    '--dry-run': 'Read + map only; print what WOULD be imported without writing to the Kernel.',
+    '--dry-run': 'Read + map only; print what WOULD be imported without writing to the Kernel. '
+      + 'Without --from, this is the only supported mode (preview only).',
     '--json': 'Emit a structured JSON result (counts + gaps + dryRun flag).',
-    '--fixture-corpus': 'v2→v3 PoC only: also dry-run the source-tree v2 fixture corpus when available.',
+    '--fixture-corpus': 'v2→v3 preview only: also dry-run the source-tree v2 fixture corpus when available.',
   },
 
   async handler(args, flags, projectRoot, opts = {}) {
@@ -502,7 +504,8 @@ module.exports = {
     if (!dryRun) {
       return {
         success: false,
-        error: 'Only forge migrate --dry-run is implemented in the Wave 0 PoC.',
+        error: "forge migrate currently supports preview only. Run 'forge migrate --dry-run' "
+          + 'to see what would change; applying migrations is not yet available.',
       };
     }
 

--- a/test/commands/migrate.test.js
+++ b/test/commands/migrate.test.js
@@ -73,11 +73,13 @@ describe('forge migrate command contract', () => {
 		expect(typeof migrateCommand.handler).toBe('function');
 	});
 
-	// The pre-existing v2 → v3 dry-run PoC contract must survive the beads path.
+	// The pre-existing v2 → v3 dry-run-only contract must survive the beads path.
 	test('still refuses the non-dry-run v2→v3 path when --from is absent', async () => {
 		const result = await migrateCommand.handler([], {}, process.cwd());
 		expect(result.success).toBe(false);
-		expect(result.error).toContain('Only forge migrate --dry-run is implemented');
+		expect(result.error).toContain('forge migrate currently supports preview only');
+		expect(result.error).toContain('forge migrate --dry-run');
+		expect(result.error).not.toContain('Wave 0 PoC');
 	});
 
 	// A flag supplied without a value must be rejected, not silently swallowed —

--- a/test/migrate-dry-run.test.js
+++ b/test/migrate-dry-run.test.js
@@ -125,11 +125,13 @@ describe('migrate dry-run', () => {
     expect(output).toContain('Result: PASS');
   });
 
-  test('command refuses non-dry-run migration for this Wave 0 PoC', async () => {
+  test('command refuses non-dry-run migration for the preview-only v2→v3 path', async () => {
     const result = await migrateCommand.handler([], {}, process.cwd());
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Only forge migrate --dry-run is implemented');
+    expect(result.error).toContain('forge migrate currently supports preview only');
+    expect(result.error).toContain('forge migrate --dry-run');
+    expect(result.error).not.toContain('Wave 0 PoC');
   });
 
   test('command emits the dry-run report for a target repo', async () => {


### PR DESCRIPTION
## Problem

`forge migrate` was advertised in `--help` as a real command, but any non-`--dry-run` invocation of the legacy v2→v3 path returned the internal-jargon message:

> Only forge migrate --dry-run is implemented in the Wave 0 PoC.

A beta user hit a dead-end plus leaked internal roadmap jargon (`lib/commands/migrate.js:505`).

## Fix (honest, not a migration engine)

- Replaced the "Wave 0 PoC" message with a clear user-facing one:
  > forge migrate currently supports preview only. Run 'forge migrate --dry-run' to see what would change; applying migrations is not yet available.
- Relabeled the command `description` and the `--dry-run` / `--fixture-corpus` flag help to mark the v2→v3 path **preview only** (no longer advertised as fully working). The `--from beads` real import path is unchanged and unaffected.
- The non-dry-run path still returns `success: false` and exits non-zero consistently, now pointing the user at `--dry-run`.
- Updated the two tests that asserted the old jargon string (they now assert the new message and that "Wave 0 PoC" is gone).

## Verification

- `bun test test/commands/migrate.test.js test/migrate-dry-run.test.js` → 21 pass
- Adjacent suites (setup/runtime auto-migrate, kernel migrations/ledger) → 40 pass
- `eslint --max-warnings 0` clean on changed files
- Manual: `forge migrate` → new message, exit 1; `forge migrate --dry-run` → unchanged; `--help` reflects preview-only

Fixes a1561ca1-b17c-438a-a5c7-4efe6eff6e2f (beta-audit epic be7ce156).

🤖 Generated with [Claude Code](https://claude.com/claude-code)