### PR TITLE
fix: detect package manager for lefthook remediation instead of hardcoding bun (7937c7a6)

### DIFF
--- a/lib/lefthook-check.js
+++ b/lib/lefthook-check.js
@@ -5,6 +5,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { getInstallCommand, getAddDevCommand } = require('./package-manager-remediation');
 
 /**
  * Check whether lefthook is declared in package.json AND whether the binary
@@ -55,7 +56,7 @@ function checkLefthookStatus(projectRoot) {
       installed: false,
       binaryAvailable: false,
       state: 'missing-dependency',
-      message: 'lefthook not found. Run: bun add -D lefthook && bun install',
+      message: `lefthook not found. Run: ${getAddDevCommand(root, 'lefthook')}`,
     };
   }
 
@@ -74,7 +75,7 @@ function checkLefthookStatus(projectRoot) {
       binaryAvailable: false,
       state: 'missing-binary',
       message:
-        'lefthook is in package.json but not installed. Run: bun install',
+        `lefthook is in package.json but not installed. Run: ${getInstallCommand(root)}`,
     };
   }
 

--- a/lib/package-manager-remediation.js
+++ b/lib/package-manager-remediation.js
@@ -1,0 +1,103 @@
+/**
+ * package-manager-remediation.js — Detect the caller's package manager from
+ * lockfile presence so remediation messages (e.g. "lefthook is missing, run
+ * X") give the correct install command instead of hard-coding a single tool.
+ *
+ * This is deliberately separate from lib/detection-utils.js#detectPackageManager,
+ * which shells out to probe installed binaries and prints setup-wizard output.
+ * Remediation messages need a fast, side-effect-free, synchronous lookup that
+ * never spawns a process — it runs on every stage-gate health check.
+ *
+ * @module lib/package-manager-remediation
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Ordered lockfile → package manager mapping. First match wins.
+ * `install` is the command to fetch already-declared dependencies.
+ * `addDev(pkg)` is the command to add a new dev dependency and install it.
+ */
+const PACKAGE_MANAGERS = [
+  {
+    name: 'bun',
+    lockFiles: ['bun.lockb', 'bun.lock'],
+    install: 'bun install',
+    addDev: pkg => `bun add -D ${pkg} && bun install`
+  },
+  {
+    name: 'pnpm',
+    lockFiles: ['pnpm-lock.yaml'],
+    install: 'pnpm install',
+    addDev: pkg => `pnpm add -D ${pkg}`
+  },
+  {
+    name: 'yarn',
+    lockFiles: ['yarn.lock'],
+    install: 'yarn install',
+    addDev: pkg => `yarn add -D ${pkg}`
+  },
+  {
+    name: 'npm',
+    lockFiles: ['package-lock.json'],
+    install: 'npm install',
+    addDev: pkg => `npm install -D ${pkg}`
+  }
+];
+
+// npm is the safest universal fallback when no lockfile is present or
+// recognized — it ships with Node itself, so it is always a documented,
+// reasonable default rather than assuming any particular toolchain.
+const DEFAULT_MANAGER = PACKAGE_MANAGERS[PACKAGE_MANAGERS.length - 1];
+
+/**
+ * Detect the package manager in use for a project from lockfile presence.
+ *
+ * @param {string} [projectRoot] - Absolute path to the project root. Falls
+ *   back to process.cwd() when omitted or not a non-empty string.
+ * @returns {{ name: string, install: string, addDev: (pkg: string) => string }}
+ *   The detected (or default) package manager descriptor.
+ */
+function detectPackageManagerForRemediation(projectRoot) {
+  const root = typeof projectRoot === 'string' && projectRoot.trim()
+    ? projectRoot
+    : process.cwd();
+
+  for (const manager of PACKAGE_MANAGERS) {
+    const hasLockFile = manager.lockFiles.some(file =>
+      fs.existsSync(path.join(root, file))
+    );
+    if (hasLockFile) return manager;
+  }
+
+  return DEFAULT_MANAGER;
+}
+
+/**
+ * Get the install command for the detected package manager (e.g. when a
+ * dependency is already declared but not installed).
+ *
+ * @param {string} [projectRoot] - Absolute path to the project root.
+ * @returns {string} Install command, e.g. "npm install".
+ */
+function getInstallCommand(projectRoot) {
+  return detectPackageManagerForRemediation(projectRoot).install;
+}
+
+/**
+ * Get the "add as dev dependency" command for the detected package manager.
+ *
+ * @param {string} [projectRoot] - Absolute path to the project root.
+ * @param {string} pkg - Package name to add, e.g. "lefthook".
+ * @returns {string} Add-dev-dependency command, e.g. "npm install -D lefthook".
+ */
+function getAddDevCommand(projectRoot, pkg) {
+  return detectPackageManagerForRemediation(projectRoot).addDev(pkg);
+}
+
+module.exports = {
+  detectPackageManagerForRemediation,
+  getInstallCommand,
+  getAddDevCommand
+};

--- a/lib/runtime-health.js
+++ b/lib/runtime-health.js
@@ -13,6 +13,7 @@ const { execFileSync: defaultExecFileSync } = require('node:child_process');
 
 const { checkLefthookStatus } = require('./lefthook-check');
 const { resolveIssueBackend } = require('./issue-backend');
+const { getInstallCommand, getAddDevCommand } = require('./package-manager-remediation');
 
 const WINDOWS_GIT_BASH_CANDIDATES = [
   String.raw`C:\Program Files\Git\bin\bash.exe`,
@@ -518,11 +519,14 @@ function checkRuntimeHealth(projectRoot, options = {}) {
     || lefthook.state === 'missing-binary';
 
   if (lefthookMissing) {
+    const lefthookRepair = lefthook.state === 'missing-binary'
+      ? getInstallCommand(root)
+      : getAddDevCommand(root, 'lefthook');
     diagnostics.push(createDiagnostic(
       'LEFTHOOK_MISSING',
       'lefthook',
       lefthook.message || 'lefthook is required for hook installation.',
-      'bun add -D lefthook && bun install'
+      lefthookRepair
     ));
   }
 

--- a/test/lefthook-check.test.js
+++ b/test/lefthook-check.test.js
@@ -49,6 +49,40 @@ describe('checkLefthookStatus', () => {
     const result = checkLefthookStatus(tmpDir);
     expect(result.installed).toBe(true);
     expect(result.binaryAvailable).toBe(false);
+    expect(result.message).toContain('npm install');
+  });
+
+  it('recommends the detected lockfile package manager for a missing binary (pnpm)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { lefthook: '^1.0.0' } })
+    );
+    fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '');
+
+    const result = checkLefthookStatus(tmpDir);
+    expect(result.message).toContain('pnpm install');
+    expect(result.message).not.toContain('bun install');
+  });
+
+  it('recommends the detected lockfile package manager for a missing binary (yarn)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { lefthook: '^1.0.0' } })
+    );
+    fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '');
+
+    const result = checkLefthookStatus(tmpDir);
+    expect(result.message).toContain('yarn install');
+  });
+
+  it('recommends bun install for a missing binary when a bun lockfile is present', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { lefthook: '^1.0.0' } })
+    );
+    fs.writeFileSync(path.join(tmpDir, 'bun.lockb'), '');
+
+    const result = checkLefthookStatus(tmpDir);
     expect(result.message).toContain('bun install');
   });
 
@@ -77,7 +111,29 @@ describe('checkLefthookStatus', () => {
     const result = checkLefthookStatus(tmpDir);
     expect(result.installed).toBe(false);
     expect(result.binaryAvailable).toBe(false);
-    expect(result.message).toContain('bun add');
+    expect(result.message).toContain('npm install -D lefthook');
+  });
+
+  it('recommends the detected lockfile package manager for a missing dependency (yarn)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { jest: '^29.0.0' } })
+    );
+    fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '');
+
+    const result = checkLefthookStatus(tmpDir);
+    expect(result.message).toContain('yarn add -D lefthook');
+  });
+
+  it('recommends bun add for a missing dependency when a bun lockfile is present', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ devDependencies: { jest: '^29.0.0' } })
+    );
+    fs.writeFileSync(path.join(tmpDir, 'bun.lockb'), '');
+
+    const result = checkLefthookStatus(tmpDir);
+    expect(result.message).toContain('bun add -D lefthook');
   });
 
   it('returns installed=false and binaryAvailable=false when no package.json exists', () => {

--- a/test/package-manager-remediation.test.js
+++ b/test/package-manager-remediation.test.js
@@ -1,0 +1,73 @@
+const { describe, it, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const {
+  detectPackageManagerForRemediation,
+  getInstallCommand,
+  getAddDevCommand
+} = require('../lib/package-manager-remediation');
+
+describe('package-manager-remediation', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-remediation-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects bun from bun.lockb', () => {
+    fs.writeFileSync(path.join(tmpDir, 'bun.lockb'), '');
+    expect(detectPackageManagerForRemediation(tmpDir).name).toBe('bun');
+    expect(getInstallCommand(tmpDir)).toBe('bun install');
+    expect(getAddDevCommand(tmpDir, 'lefthook')).toBe('bun add -D lefthook && bun install');
+  });
+
+  it('detects bun from bun.lock (text lockfile)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'bun.lock'), '');
+    expect(detectPackageManagerForRemediation(tmpDir).name).toBe('bun');
+    expect(getInstallCommand(tmpDir)).toBe('bun install');
+  });
+
+  it('detects pnpm from pnpm-lock.yaml', () => {
+    fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), '');
+    expect(detectPackageManagerForRemediation(tmpDir).name).toBe('pnpm');
+    expect(getInstallCommand(tmpDir)).toBe('pnpm install');
+    expect(getAddDevCommand(tmpDir, 'lefthook')).toBe('pnpm add -D lefthook');
+  });
+
+  it('detects yarn from yarn.lock', () => {
+    fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '');
+    expect(detectPackageManagerForRemediation(tmpDir).name).toBe('yarn');
+    expect(getInstallCommand(tmpDir)).toBe('yarn install');
+    expect(getAddDevCommand(tmpDir, 'lefthook')).toBe('yarn add -D lefthook');
+  });
+
+  it('detects npm from package-lock.json', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '');
+    expect(detectPackageManagerForRemediation(tmpDir).name).toBe('npm');
+    expect(getInstallCommand(tmpDir)).toBe('npm install');
+    expect(getAddDevCommand(tmpDir, 'lefthook')).toBe('npm install -D lefthook');
+  });
+
+  it('falls back to npm install when no lockfile is present', () => {
+    expect(detectPackageManagerForRemediation(tmpDir).name).toBe('npm');
+    expect(getInstallCommand(tmpDir)).toBe('npm install');
+    expect(getAddDevCommand(tmpDir, 'lefthook')).toBe('npm install -D lefthook');
+  });
+
+  it('prefers the first matching lockfile when multiple are present', () => {
+    fs.writeFileSync(path.join(tmpDir, 'bun.lockb'), '');
+    fs.writeFileSync(path.join(tmpDir, 'package-lock.json'), '');
+    expect(detectPackageManagerForRemediation(tmpDir).name).toBe('bun');
+  });
+
+  it('defaults to process.cwd() when projectRoot is not a string', () => {
+    expect(() => detectPackageManagerForRemediation(undefined)).not.toThrow();
+    expect(() => detectPackageManagerForRemediation(null)).not.toThrow();
+  });
+});

--- a/test/runtime-health.test.js
+++ b/test/runtime-health.test.js
@@ -114,7 +114,51 @@ describe('runtime health checks', () => {
       })
     );
     expect(result.checks.lefthook.state).toBe('missing-binary');
-    expect(result.checks.lefthook.message).toContain('bun install');
+    expect(result.checks.lefthook.message).toContain('npm install');
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'LEFTHOOK_MISSING',
+        repair: 'npm install'
+      })
+    );
+  });
+
+  test('missing lefthook binary recommends the detected lockfile package manager instead of bun', () => {
+    const projectRoot = createProjectRoot({ lefthookDependency: true, lefthookBinary: false });
+    fs.writeFileSync(path.join(projectRoot, 'pnpm-lock.yaml'), '');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.git/hooks-empty', resolvedHooksDir: path.join(projectRoot, '.git', 'hooks-empty') }),
+      platform: 'linux',
+      shellRuntime: { available: true, command: '/bin/sh', policy: 'system-shell' }
+    });
+
+    expect(result.checks.lefthook.message).toContain('pnpm install');
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'LEFTHOOK_MISSING',
+        repair: 'pnpm install'
+      })
+    );
+  });
+
+  test('missing lefthook dependency recommends the detected lockfile package manager instead of bun', () => {
+    const projectRoot = createProjectRoot({ lefthookDependency: false, lefthookBinary: false });
+    fs.writeFileSync(path.join(projectRoot, 'yarn.lock'), '');
+
+    const result = checkRuntimeHealth(projectRoot, {
+      _exec: createExecStub({ hooksPath: '.git/hooks-empty' }),
+      platform: 'linux',
+      shellRuntime: { available: true, command: '/bin/sh', policy: 'system-shell' }
+    });
+
+    expect(result.checks.lefthook.message).toContain('yarn add -D lefthook');
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'LEFTHOOK_MISSING',
+        repair: 'yarn add -D lefthook'
+      })
+    );
   });
 
   test('bun-created lefthook exe and bunx shims count as an installed binary', () => {


### PR DESCRIPTION
## Summary
Fixes issue `7937c7a6` (`[BETA] Bun-hardcoded remediation dead-ends non-bun users on core stage verbs`).

The core stage verbs (`plan`/`dev`/`ship`/`review`) gate behind a `LEFTHOOK_MISSING` health check whose remediation was hard-coded to `bun install` / `bun add -D lefthook && bun install`. An npm/pnpm/yarn user on any OS was told to run bun on the exact commands the workflow revolves around — a dead-end that violates Forge's any-OS x any-package-manager principle.

## What changed
- **New helper `lib/package-manager-remediation.js`** — a small, side-effect-free, synchronous module that detects the package manager from lockfile presence and emits the correct remediation command:
  - `bun.lockb` / `bun.lock` -> `bun install` / `bun add -D <pkg> && bun install`
  - `pnpm-lock.yaml` -> `pnpm install` / `pnpm add -D <pkg>`
  - `yarn.lock` -> `yarn install` / `yarn add -D <pkg>`
  - `package-lock.json` -> `npm install` / `npm install -D <pkg>`
  - no/ambiguous lockfile -> falls back to `npm install` (npm ships with Node — safest universal default)
- **`lib/lefthook-check.js`** and **`lib/runtime-health.js`** now both call this single helper instead of hard-coding bun or duplicating lockfile logic.
- Uses only Node `fs`/`path` — no shelling out, no bash-only assumptions, cross-platform.

## Tests (TDD)
- New `test/package-manager-remediation.test.js` — each lockfile -> correct command, no-lockfile fallback, multi-lockfile precedence, non-string projectRoot safety.
- Updated `test/lefthook-check.test.js` and `test/runtime-health.test.js` with pnpm/yarn/bun/npm remediation assertions end-to-end.
- 58 affected tests pass; `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package-manager-aware repair recommendations for Lefthook issues.
  * Installation guidance now adapts to npm, pnpm, Yarn, or Bun lockfiles.
  * Missing Lefthook dependencies provide the appropriate development-dependency command.

* **Bug Fixes**
  * Replaced fixed Bun remediation commands with accurate project-specific instructions.
  * Improved guidance when Lefthook is declared but its executable is unavailable.

* **Tests**
  * Added coverage for package-manager detection and remediation recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->