### PR TITLE
fix(release): bd-audit staleness must ignore line numbers

### DIFF
--- a/lib/release-readiness.js
+++ b/lib/release-readiness.js
@@ -1690,6 +1690,23 @@ function freshCloneAcceptanceStatus(projectRoot) {
   };
 }
 
+// Canonicalize the kill-list for the currency comparison: drop the per-file
+// `- lines: …` detail so the check is line-number-INSENSITIVE. The rendered
+// artifact keeps those line numbers as an informational aid, but they are
+// volatile — any PR that edits a scanned file shifts them, which would
+// otherwise mark the artifact "stale" and red the release-readiness gate on
+// every unrelated PR. The comparison therefore keeps only the stable signal:
+// the summary table plus each file's path and bd-term COUNT. A real change in
+// call-site counts (adding/removing bd usage) still trips staleness; a pure
+// line shift no longer does.
+function canonicalizeAuditArtifact(markdown) {
+  return markdown
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter(line => !/^\s*- lines:/.test(line))
+    .join('\n');
+}
+
 function isAuditArtifactCurrent(projectRoot, audit) {
   const artifactPath = absolutePath(projectRoot, AUDIT_ARTIFACT);
   if (!fs.existsSync(artifactPath)) {
@@ -1700,9 +1717,8 @@ function isAuditArtifactCurrent(projectRoot, audit) {
     };
   }
 
-  const normalizeLineEndings = value => value.replace(/\r\n/g, '\n');
-  const expected = normalizeLineEndings(renderBdCallSiteAuditMarkdown(audit));
-  const actual = normalizeLineEndings(fs.readFileSync(artifactPath, 'utf8'));
+  const expected = canonicalizeAuditArtifact(renderBdCallSiteAuditMarkdown(audit));
+  const actual = canonicalizeAuditArtifact(fs.readFileSync(artifactPath, 'utf8'));
   if (actual !== expected) {
     return {
       ok: false,
@@ -2064,6 +2080,7 @@ module.exports = {
   SUPPORTED_TARGET,
   auditBdCallSites,
   buildReadinessReport,
+  canonicalizeAuditArtifact,
   renderBdCallSiteAuditMarkdown,
   renderReadinessReport,
   // Exposed for the premerge-de-stage certification tests.

--- a/test/commands/release.test.js
+++ b/test/commands/release.test.js
@@ -8,6 +8,7 @@ const path = require('node:path');
 const releaseCommand = require('../../lib/commands/release');
 const {
   buildReadinessReport,
+  canonicalizeAuditArtifact,
   renderBdCallSiteAuditMarkdown,
   renderReadinessReport,
 } = require('../../lib/release-readiness');
@@ -110,4 +111,24 @@ describe('0.1.0 readiness report', () => {
     expect(auditMarkdown).toContain('## hooks');
     expect(fs.existsSync(artifactPath)).toBe(true);
   }, FULL_REPO_READINESS_TIMEOUT_MS);
+
+  test('artifact-currency comparison ignores line-number shifts but not count changes', () => {
+    const base = [
+      '# D20 bd Call-Site Kill List',
+      '',
+      '## command',
+      '',
+      '- [ ] bin/forge.js (26)',
+      '  - lines: 10 (bd), 12 (bd)',
+    ].join('\n');
+
+    // Same file + same COUNT, only the recorded line numbers differ (what a PR
+    // editing an unrelated part of a scanned file produces). Must canonicalize equal.
+    const lineShifted = base.replace('  - lines: 10 (bd), 12 (bd)', '  - lines: 40 (bd), 42 (bd)');
+    expect(canonicalizeAuditArtifact(lineShifted)).toBe(canonicalizeAuditArtifact(base));
+
+    // A real change in the per-file COUNT must still be detected as stale.
+    const countChanged = base.replace('- [ ] bin/forge.js (26)', '- [ ] bin/forge.js (27)');
+    expect(canonicalizeAuditArtifact(countChanged)).not.toBe(canonicalizeAuditArtifact(base));
+  });
 });


### PR DESCRIPTION
## Problem

The \`d20-audit-artifact-current\` release-readiness blocker compared the checked-in \`docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md\` **byte-for-byte** against a freshly rendered audit. That render embeds **per-file line numbers** for all ~732 bd sites across ~90 tracked files (\`bin/forge.js\`, \`lib/commands/migrate.js\`, many docs).

Result: any PR that shifts a line in ANY scanned file made the artifact "stale", which reddened 4 baseline release-readiness tests on **every unrelated PR** — even though \`master\` itself is green. This un-reds #350 (touches migrate.js), #351, and #342.

## Root cause

`isAuditArtifactCurrent` (lib/release-readiness.js) did an exact-render equality check that included volatile line-number data. Not a scan-drift / orphaned-worktree issue — the audit already filters to \`git ls-files\` (#339) and \`.claude/worktrees/\` is untracked/invisible.

## Fix

Make the currency comparison **line-number-INSENSITIVE**: `canonicalizeAuditArtifact()` drops the volatile `- lines: …` detail from both sides before equality, keeping the summary table and each file's path + bd-term **count**. A genuine change in call-site counts still trips staleness; a pure line shift no longer does. Line numbers remain in the rendered artifact as an informational aid. The artifact is NOT regenerated per-PR (that would guarantee cross-PR merge conflicts).

## Verification

- 4 previously-red tests now green: `test/commands/release.test.js` — "passes the 0.1.0 readiness gate", "writes JSON reports to stdout and passes the CLI gate", "tracks bd call sites by migration group", "renders human-readable blocker output".
- Added regression test: line-shift canonicalizes equal; count-change canonicalizes unequal.
- Empirically confirmed: injecting blank lines into `migrate.js` (shifting all bd line numbers) no longer yields a stale blocker; adding a new bd reference still does.
- `eslint --max-warnings 0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)