### PR TITLE
feat(kernel): auto-record stage_runs from stage-transition comments (5a5ba3a6)

### DIFF
--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -11,6 +11,7 @@ const {
 } = require('../kernel/issue-command-contract');
 const { getResolvedRuntimeGraph } = require('../core/runtime-graph');
 const { renderIssueEnvelope } = require('../issue-render');
+const { recordStageTransition } = require('../workflow/stage-transition');
 
 // The Forge issue command surface. Each subcommand routes through the shared
 // runIssueOperation, which selects the active backend (Kernel by --kernel /
@@ -100,6 +101,15 @@ const SUBCOMMANDS = {
   owns: {
     description: 'Verify the current actor holds the live lease on an issue via Forge',
     usage: 'forge issue owns <id> [--json]',
+  },
+  // Issue 7dc229d4: active-lease/claims read for the dashboard live layer. Returns
+  // every LIVE lease (state='active', not expired) with its full who/what/where —
+  // actor, session_id, worktree_id, expires_at, issue_id — data the CLI never
+  // exposed before (only `claimed_by`). A READ, so intentionally NOT in
+  // WRITE_SUBCOMMANDS.
+  claims: {
+    description: 'List active issue leases (who/what is working on which issue) via Forge',
+    usage: 'forge claims [--json]',
   },
   dep: {
     description: 'Manage issue dependencies via Forge',
@@ -323,6 +333,31 @@ async function applyIssueVerification(subcommand, operationArgs, result, runner,
 
 function normalizeArgs(args = []) {
   return args.filter(arg => arg !== '--');
+}
+
+// 5a5ba3a6: auto-wire stage_runs. When a kernel `comment` carries the Descriptive
+// Context Convention's `stage: <from> -> <to>` line, mirror it into stage_runs
+// (complete the from-stage, start the to-stage) so `current_stage` becomes real
+// without a manual `forge stage` verb call. Best-effort and non-blocking:
+// recordStageTransition never throws, so a stage_run write can never break the
+// comment that already succeeded. Kernel path only — reuses the driver already
+// assembled on opts (no second DB handle).
+function recordStageTransitionFromComment(subcommand, operationArgs, result, opts) {
+  if (subcommand !== 'comment' || !shouldUseKernelBroker(opts)) return;
+  if (!result || result.ok !== true || !result.data) return;
+  const issueId = typeof result.data.id === 'string' ? result.data.id : null;
+  if (!issueId) return;
+  // Drop the leading issue-ref positional; the rest is the comment body.
+  const body = normalizeArgs(operationArgs)
+    .filter(arg => typeof arg === 'string' && !arg.startsWith('-'))
+    .slice(1)
+    .join(' ');
+  recordStageTransition({
+    driver: opts.kernelDriver,
+    issueId,
+    body,
+    config: opts.kernelDatabasePath ? { databasePath: opts.kernelDatabasePath } : {},
+  });
 }
 
 function formatIssueHelp() {
@@ -733,6 +768,8 @@ async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
   if (verifyEnabled && result && typeof result === 'object' && result.ok === true && result.success === undefined) {
     await applyIssueVerification(subcommand, operationArgs, result, runIssueOperation, projectRoot, opts);
   }
+  // Best-effort, non-blocking: mirror a stage-transition comment into stage_runs.
+  recordStageTransitionFromComment(subcommand, operationArgs, result, opts);
   // Contract output is opt-in for the human-first reads: an explicit --json flag
   // or FORGE_JSON=1 in the environment (for scripts that cannot alter argv).
   const jsonRequested = normalizeArgs(args).includes('--json')

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -102,15 +102,6 @@ const SUBCOMMANDS = {
     description: 'Verify the current actor holds the live lease on an issue via Forge',
     usage: 'forge issue owns <id> [--json]',
   },
-  // Issue 7dc229d4: active-lease/claims read for the dashboard live layer. Returns
-  // every LIVE lease (state='active', not expired) with its full who/what/where —
-  // actor, session_id, worktree_id, expires_at, issue_id — data the CLI never
-  // exposed before (only `claimed_by`). A READ, so intentionally NOT in
-  // WRITE_SUBCOMMANDS.
-  claims: {
-    description: 'List active issue leases (who/what is working on which issue) via Forge',
-    usage: 'forge claims [--json]',
-  },
   dep: {
     description: 'Manage issue dependencies via Forge',
     usage: 'forge issue dep <add|remove> <issue-id> <blocks-issue-id>',

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -1248,6 +1248,42 @@ function recordStageRunRow(runtime, db, input) {
 	return row;
 }
 
+// Atomic stage transition: complete the `from` stage and start the `to` stage as
+// ONE all-or-nothing write. Auto-recording from a `stage: <from> -> <to>` comment
+// (5a5ba3a6) used to issue these as two separate recordStageRun calls at the caller;
+// if the second threw, the first had already persisted — leaving a half-transition
+// (from marked done, to never started) so `current_stage` was wrong. Wrapping both
+// writes in a single BEGIN IMMEDIATE transaction makes a mid-transition failure roll
+// back cleanly. Best-effort/non-blocking is the CALLER's contract; this method still
+// throws on failure so the caller can observe it (and roll back has happened).
+function recordStageTransitionRow(runtime, db, input) {
+	const issueId = input && input.issue_id;
+	const from = input && input.from;
+	const to = input && input.to;
+	if (!issueId || !from || !to) {
+		throw new Error('recordStageTransition requires issue_id, from, and to');
+	}
+	const now = input.now || new Date().toISOString();
+	execSql(runtime, db, 'BEGIN IMMEDIATE;');
+	try {
+		const completed = recordStageRunRow(runtime, db, {
+			issue_id: issueId, stage: from, action: 'complete', now,
+		});
+		const started = recordStageRunRow(runtime, db, {
+			issue_id: issueId, stage: to, action: 'start', now,
+		});
+		execSql(runtime, db, 'COMMIT;');
+		return { from: completed, to: started };
+	} catch (error) {
+		try {
+			execSql(runtime, db, 'ROLLBACK;');
+		} catch {
+			// A rollback failure must not mask the original transition error.
+		}
+		throw error;
+	}
+}
+
 function listStageRunRows(runtime, db, issueId) {
 	if (!issueId) return [];
 	// Deterministic order: started_at first, then rowid (the implicit INSERT sequence)
@@ -2176,6 +2212,11 @@ function createDriver(runtime, configuredDatabasePath) {
 		// (issue_id, stage). getCurrentStage powers the real workflow-phase read.
 		recordStageRun(input, config = {}) {
 			return recordStageRunRow(runtime, getDatabase(config), input);
+		},
+		// Atomic complete(from)+start(to) in ONE transaction: a mid-transition failure
+		// rolls back both writes so `current_stage` never reflects a half-transition.
+		recordStageTransition(input, config = {}) {
+			return recordStageTransitionRow(runtime, getDatabase(config), input);
 		},
 		listStageRuns(filter = {}, config = {}) {
 			return listStageRunRows(runtime, getDatabase(config), filter.issue_id);

--- a/lib/workflow/stage-transition.js
+++ b/lib/workflow/stage-transition.js
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * Stage-transition auto-recording (5a5ba3a6).
+ *
+ * PR #348 (f61601ab) added the stage_runs record/read capability but nothing
+ * populated it automatically — `current_stage` stayed unknown. The Descriptive
+ * Context Convention (AGENTS.md) already has agents record each stage boundary as
+ * a kernel issue comment shaped:
+ *
+ *     stage: <from> -> <to>
+ *     summary: ...
+ *
+ * This module turns that existing, already-followed convention into a structured
+ * stage_run WITHOUT any new manual verb call: parse the `stage:` line and, best
+ * effort, complete the from-stage and start the to-stage. Recording is strictly
+ * non-blocking — a stage_run write failure must NEVER break the comment that
+ * triggered it.
+ *
+ * @module workflow/stage-transition
+ */
+
+const { normalizeStageId } = require('./stages');
+
+// `stage: <from> -> <to>` on its own line, case-insensitive, arrow spacing optional.
+const STAGE_LINE = /^\s*stage:\s*([a-z]+)\s*->\s*([a-z]+)\s*$/im;
+
+/**
+ * Parse a stage-transition line out of a comment body.
+ *
+ * @param {string} body - Comment body (may be multi-line).
+ * @returns {{from: string, to: string}|null} Normalized stages, or null when the
+ *   body has no valid `stage: X -> Y` line (both tokens must be canonical stages).
+ */
+function parseStageTransition(body) {
+  if (typeof body !== 'string' || body.length === 0) {
+    return null;
+  }
+  const match = body.match(STAGE_LINE);
+  if (!match) {
+    return null;
+  }
+  const from = normalizeStageId(match[1]);
+  const to = normalizeStageId(match[2]);
+  if (!from || !to) {
+    return null;
+  }
+  return { from, to };
+}
+
+/**
+ * Best-effort record of a stage transition into stage_runs. Parses the comment
+ * body; on a valid transition it completes the from-stage and starts the to-stage
+ * via `driver.recordStageRun`. ANY failure (parse miss, missing driver, DB error)
+ * is swallowed and reported as `{ recorded: false }` — this function never throws.
+ *
+ * @param {object} params
+ * @param {object} [params.driver] - Kernel driver exposing recordStageRun(input, config).
+ * @param {string} params.issueId - Full kernel issue id the comment targets.
+ * @param {string} params.body - The comment body just written.
+ * @param {object} [params.config] - Driver config (e.g. { databasePath }).
+ * @returns {{recorded: boolean, from?: string, to?: string}}
+ */
+function recordStageTransition({ driver, issueId, body, config = {} } = {}) {
+  try {
+    const transition = parseStageTransition(body);
+    if (!transition || !issueId || !driver || typeof driver.recordStageRun !== 'function') {
+      return { recorded: false };
+    }
+    driver.recordStageRun(
+      { issue_id: issueId, stage: transition.from, action: 'complete' },
+      config,
+    );
+    driver.recordStageRun(
+      { issue_id: issueId, stage: transition.to, action: 'start' },
+      config,
+    );
+    return { from: transition.from, to: transition.to, recorded: true };
+  } catch {
+    // Non-blocking by contract: never let a stage_run write break the comment.
+    return { recorded: false };
+  }
+}
+
+module.exports = {
+  parseStageTransition,
+  recordStageTransition,
+};

--- a/lib/workflow/stage-transition.js
+++ b/lib/workflow/stage-transition.js
@@ -40,8 +40,11 @@ function parseStageTransition(body) {
   if (!match) {
     return null;
   }
-  const from = normalizeStageId(match[1]);
-  const to = normalizeStageId(match[2]);
+  // STAGE_LINE is case-insensitive, so an uppercase token (e.g. `stage: DEV ->
+  // VALIDATE`) matches. normalizeStageId only knows lowercase canonical ids, so
+  // lowercase both captures first or an uppercase-but-valid stage is wrongly rejected.
+  const from = normalizeStageId(match[1].toLowerCase());
+  const to = normalizeStageId(match[2].toLowerCase());
   if (!from || !to) {
     return null;
   }
@@ -50,12 +53,22 @@ function parseStageTransition(body) {
 
 /**
  * Best-effort record of a stage transition into stage_runs. Parses the comment
- * body; on a valid transition it completes the from-stage and starts the to-stage
- * via `driver.recordStageRun`. ANY failure (parse miss, missing driver, DB error)
- * is swallowed and reported as `{ recorded: false }` — this function never throws.
+ * body; on a valid transition it completes the from-stage and starts the to-stage.
+ *
+ * The write must be ATOMIC: completing `from` and starting `to` are one logical
+ * transition, so a failure partway through must leave neither persisted (otherwise
+ * `current_stage` reflects a half-transition — from marked done, to never started).
+ * The preferred path is a single transactional `driver.recordStageTransition` that
+ * wraps both writes in one transaction; a driver that only exposes `recordStageRun`
+ * falls back to two sequential writes (non-atomic, tolerated only because the whole
+ * operation is non-blocking).
+ *
+ * ANY failure (parse miss, missing driver, DB error) is swallowed and reported as
+ * `{ recorded: false }` — this function never throws.
  *
  * @param {object} params
- * @param {object} [params.driver] - Kernel driver exposing recordStageRun(input, config).
+ * @param {object} [params.driver] - Kernel driver exposing recordStageTransition
+ *   (preferred) and/or recordStageRun(input, config).
  * @param {string} params.issueId - Full kernel issue id the comment targets.
  * @param {string} params.body - The comment body just written.
  * @param {object} [params.config] - Driver config (e.g. { databasePath }).
@@ -64,18 +77,32 @@ function parseStageTransition(body) {
 function recordStageTransition({ driver, issueId, body, config = {} } = {}) {
   try {
     const transition = parseStageTransition(body);
-    if (!transition || !issueId || !driver || typeof driver.recordStageRun !== 'function') {
+    if (!transition || !issueId || !driver) {
       return { recorded: false };
     }
-    driver.recordStageRun(
-      { issue_id: issueId, stage: transition.from, action: 'complete' },
-      config,
-    );
-    driver.recordStageRun(
-      { issue_id: issueId, stage: transition.to, action: 'start' },
-      config,
-    );
-    return { from: transition.from, to: transition.to, recorded: true };
+    // Preferred: one atomic driver op — complete(from) + start(to) inside a single
+    // transaction, so a mid-transition failure rolls back and never persists a
+    // wrong `current_stage`.
+    if (typeof driver.recordStageTransition === 'function') {
+      driver.recordStageTransition(
+        { issue_id: issueId, from: transition.from, to: transition.to },
+        config,
+      );
+      return { from: transition.from, to: transition.to, recorded: true };
+    }
+    // Fallback for a minimal driver without the atomic op: two sequential writes.
+    if (typeof driver.recordStageRun === 'function') {
+      driver.recordStageRun(
+        { issue_id: issueId, stage: transition.from, action: 'complete' },
+        config,
+      );
+      driver.recordStageRun(
+        { issue_id: issueId, stage: transition.to, action: 'start' },
+        config,
+      );
+      return { from: transition.from, to: transition.to, recorded: true };
+    }
+    return { recorded: false };
   } catch {
     // Non-blocking by contract: never let a stage_run write break the comment.
     return { recorded: false };

--- a/test/commands/comment-stage-transition.test.js
+++ b/test/commands/comment-stage-transition.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// 5a5ba3a6: a kernel `comment` carrying the Descriptive Context Convention's
+// `stage: <from> -> <to>` line auto-records a stage_run (complete from, start to)
+// through the real runIssueSubcommand dispatch — proving the wiring, not just the
+// helper. Uses the injectable runIssueOperation + a fake kernelDriver so no DB is
+// needed; the assertions are on what the driver was asked to record.
+
+const { describe, test, expect } = require('bun:test');
+const { runIssueSubcommand } = require('../../lib/commands/_issue');
+
+function fakeKernelDriver() {
+  const stageCalls = [];
+  return {
+    stageCalls,
+    recordStageRun(input) {
+      stageCalls.push(input);
+      return { id: `row-${stageCalls.length}`, ...input };
+    },
+  };
+}
+
+function kernelOpts(driver, extra = {}) {
+  return {
+    useKernelBroker: true,
+    issueBackend: 'kernel',
+    kernelDriver: driver,
+    // Fake runner returns the kernel-contract mutation shape (ok:true + data.id).
+    runIssueOperation: async () => ({
+      ok: true,
+      data: { id: 'forge-full-id', revision: 1, comment_id: 'c1' },
+    }),
+    // Keep check-after-write out of the way; the stage hook is independent of it.
+    isIssueVerifyEnabled: () => false,
+    resolveRuntimeGraph: () => ({}),
+    env: { FORGE_JSON: '1' },
+    ...extra,
+  };
+}
+
+describe('comment auto-records stage_runs (5a5ba3a6)', () => {
+  test('a stage-transition comment completes from-stage and starts to-stage', async () => {
+    const driver = fakeKernelDriver();
+    await runIssueSubcommand(
+      'comment',
+      ['forge-full-id', 'stage: dev -> validate\nsummary: all tasks done'],
+      '/repo',
+      kernelOpts(driver),
+    );
+
+    expect(driver.stageCalls).toEqual([
+      { issue_id: 'forge-full-id', stage: 'dev', action: 'complete' },
+      { issue_id: 'forge-full-id', stage: 'validate', action: 'start' },
+    ]);
+  });
+
+  test('a plain comment records no stage_run', async () => {
+    const driver = fakeKernelDriver();
+    await runIssueSubcommand(
+      'comment',
+      ['forge-full-id', 'just a normal handoff note'],
+      '/repo',
+      kernelOpts(driver),
+    );
+    expect(driver.stageCalls).toEqual([]);
+  });
+
+  test('a driver failure never breaks the comment', async () => {
+    const throwingDriver = {
+      recordStageRun() {
+        throw new Error('db locked');
+      },
+    };
+    const result = await runIssueSubcommand(
+      'comment',
+      ['forge-full-id', 'stage: dev -> validate'],
+      '/repo',
+      kernelOpts(throwingDriver),
+    );
+    // The comment result still comes back successful (contract ok:true).
+    const parsed = typeof result.output === 'string' ? JSON.parse(result.output) : result;
+    expect(parsed.ok).toBe(true);
+  });
+});

--- a/test/kernel/stage-runs.test.js
+++ b/test/kernel/stage-runs.test.js
@@ -144,6 +144,52 @@ describe('Kernel stage_runs registry (f61601ab)', () => {
 		expect(rows.map(r => r.stage)).toEqual(['dev', 'ship']);
 	}, TIMEOUT);
 
+	test('recordStageTransition atomically completes from + starts to in one transaction', () => {
+		driver.recordStageRun(
+			{ issue_id: issueId, stage: 'dev', action: 'start', now: '2026-07-11T01:00:00.000Z' },
+			config,
+		);
+		const result = driver.recordStageTransition(
+			{ issue_id: issueId, from: 'dev', to: 'validate', now: '2026-07-11T02:00:00.000Z' },
+			config,
+		);
+		expect(result.from.status).toBe('done');
+		expect(result.from.completed_at).toBe('2026-07-11T02:00:00.000Z');
+		expect(result.to.status).toBe('active');
+
+		const current = driver.getCurrentStage({ issue_id: issueId }, config);
+		expect(current.stage).toBe('validate');
+		expect(current.status).toBe('active');
+	}, TIMEOUT);
+
+	test('recordStageTransition rolls back the completed from-stage when the to-write fails', () => {
+		// Start `dev` so a successful complete(dev) would flip it to done. The `to`
+		// write is forced to fail mid-transaction by passing an unbindable stage value
+		// (simulating a driver-level write error on the second stage_run). The whole
+		// transition MUST roll back: `dev` stays active, and no `to` row is persisted.
+		driver.recordStageRun(
+			{ issue_id: issueId, stage: 'dev', action: 'start', now: '2026-07-11T01:00:00.000Z' },
+			config,
+		);
+		expect(() => {
+			driver.recordStageTransition(
+				{ issue_id: issueId, from: 'dev', to: {}, now: '2026-07-11T02:00:00.000Z' },
+				config,
+			);
+		}).toThrow();
+
+		// No half-transition: dev was NOT flipped to done, and only the one dev row exists.
+		const rows = driver.listStageRuns({ issue_id: issueId }, config);
+		expect(rows.length).toBe(1);
+		expect(rows[0].stage).toBe('dev');
+		expect(rows[0].status).toBe('active');
+		expect(rows[0].completed_at).toBeNull();
+
+		const current = driver.getCurrentStage({ issue_id: issueId }, config);
+		expect(current.stage).toBe('dev');
+		expect(current.status).toBe('active');
+	}, TIMEOUT);
+
 	test('show attaches current_stage + current_stage_status from stage_runs', async () => {
 		driver.recordStageRun({ issue_id: issueId, stage: 'dev', action: 'start', now: '2026-07-11T01:00:00.000Z' }, config);
 		driver.recordStageRun({ issue_id: issueId, stage: 'dev', action: 'complete', now: '2026-07-11T02:00:00.000Z' }, config);

--- a/test/workflow/stage-transition.test.js
+++ b/test/workflow/stage-transition.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// 5a5ba3a6: auto-wire stage_runs. The Descriptive Context Convention already has
+// agents record a stage boundary as a kernel comment shaped `stage: <from> -> <to>`.
+// This module parses that line and, best-effort, records the structured stage_run
+// ALONGSIDE the comment (complete the from-stage, start the to-stage) so
+// current_stage becomes real without a manual `forge stage` verb call.
+//
+// parseStageTransition is a pure parser (unit-tested directly). recordStageTransition
+// is the best-effort recorder: it must NEVER throw, so a stage_run write failure can
+// never break the comment that triggered it.
+
+const { describe, test, expect } = require('bun:test');
+const {
+  parseStageTransition,
+  recordStageTransition,
+} = require('../../lib/workflow/stage-transition');
+
+describe('parseStageTransition', () => {
+  test('extracts from/to from a canonical stage line', () => {
+    expect(parseStageTransition('stage: dev -> validate\nsummary: done')).toEqual({
+      from: 'dev',
+      to: 'validate',
+    });
+  });
+
+  test('is case-insensitive and tolerates extra whitespace', () => {
+    expect(parseStageTransition('  STAGE:   plan  ->  dev  ')).toEqual({
+      from: 'plan',
+      to: 'dev',
+    });
+  });
+
+  test('accepts an arrow without surrounding spaces', () => {
+    expect(parseStageTransition('stage: ship->review')).toEqual({
+      from: 'ship',
+      to: 'review',
+    });
+  });
+
+  test('finds the stage line among other lines', () => {
+    const body = 'handoff note\nstage: validate -> ship\nnext: open PR';
+    expect(parseStageTransition(body)).toEqual({ from: 'validate', to: 'ship' });
+  });
+
+  test('returns null when there is no stage line', () => {
+    expect(parseStageTransition('just a normal comment')).toBeNull();
+  });
+
+  test('returns null when a token is not a canonical stage', () => {
+    expect(parseStageTransition('stage: dev -> bogus')).toBeNull();
+    expect(parseStageTransition('stage: nope -> dev')).toBeNull();
+  });
+
+  test('returns null for empty / non-string input', () => {
+    expect(parseStageTransition('')).toBeNull();
+    expect(parseStageTransition(null)).toBeNull();
+    expect(parseStageTransition(undefined)).toBeNull();
+    expect(parseStageTransition(42)).toBeNull();
+  });
+});
+
+describe('recordStageTransition (best-effort)', () => {
+  function fakeDriver() {
+    const calls = [];
+    return {
+      calls,
+      recordStageRun(input) {
+        calls.push(input);
+        return { id: `row-${calls.length}`, ...input };
+      },
+    };
+  }
+
+  test('completes the from-stage and starts the to-stage', () => {
+    const driver = fakeDriver();
+    const result = recordStageTransition({
+      driver,
+      issueId: 'forge-1',
+      body: 'stage: dev -> validate',
+    });
+
+    expect(driver.calls).toEqual([
+      { issue_id: 'forge-1', stage: 'dev', action: 'complete' },
+      { issue_id: 'forge-1', stage: 'validate', action: 'start' },
+    ]);
+    expect(result).toEqual({ from: 'dev', to: 'validate', recorded: true });
+  });
+
+  test('does nothing (recorded:false) when the body has no stage line', () => {
+    const driver = fakeDriver();
+    const result = recordStageTransition({
+      driver,
+      issueId: 'forge-1',
+      body: 'plain comment',
+    });
+    expect(driver.calls).toEqual([]);
+    expect(result).toEqual({ recorded: false });
+  });
+
+  test('never throws when the driver throws — returns recorded:false', () => {
+    const throwingDriver = {
+      recordStageRun() {
+        throw new Error('db locked');
+      },
+    };
+    let result;
+    expect(() => {
+      result = recordStageTransition({
+        driver: throwingDriver,
+        issueId: 'forge-1',
+        body: 'stage: dev -> validate',
+      });
+    }).not.toThrow();
+    expect(result.recorded).toBe(false);
+  });
+
+  test('never throws when driver is missing', () => {
+    let result;
+    expect(() => {
+      result = recordStageTransition({ issueId: 'forge-1', body: 'stage: dev -> ship' });
+    }).not.toThrow();
+    expect(result.recorded).toBe(false);
+  });
+});

--- a/test/workflow/stage-transition.test.js
+++ b/test/workflow/stage-transition.test.js
@@ -31,6 +31,20 @@ describe('parseStageTransition', () => {
     });
   });
 
+  test('normalizes uppercase stage tokens (case-insensitive match must not reject)', () => {
+    // STAGE_LINE matches case-insensitively, so an uppercase token reaches
+    // normalizeStageId — which only knows lowercase canonical ids. Both captures
+    // must be lowercased first or a valid transition is wrongly rejected.
+    expect(parseStageTransition('stage: DEV -> VALIDATE')).toEqual({
+      from: 'dev',
+      to: 'validate',
+    });
+    expect(parseStageTransition('STAGE: Ship -> Review')).toEqual({
+      from: 'ship',
+      to: 'review',
+    });
+  });
+
   test('accepts an arrow without surrounding spaces', () => {
     expect(parseStageTransition('stage: ship->review')).toEqual({
       from: 'ship',
@@ -72,7 +86,7 @@ describe('recordStageTransition (best-effort)', () => {
     };
   }
 
-  test('completes the from-stage and starts the to-stage', () => {
+  test('fallback: completes the from-stage and starts the to-stage via recordStageRun', () => {
     const driver = fakeDriver();
     const result = recordStageTransition({
       driver,
@@ -85,6 +99,45 @@ describe('recordStageTransition (best-effort)', () => {
       { issue_id: 'forge-1', stage: 'validate', action: 'start' },
     ]);
     expect(result).toEqual({ from: 'dev', to: 'validate', recorded: true });
+  });
+
+  test('prefers the atomic driver.recordStageTransition op when available', () => {
+    const calls = [];
+    const driver = {
+      recordStageTransition(input) {
+        calls.push(input);
+        return { from: { stage: input.from }, to: { stage: input.to } };
+      },
+      recordStageRun() {
+        throw new Error('should not use the non-atomic path when atomic op exists');
+      },
+    };
+    const result = recordStageTransition({
+      driver,
+      issueId: 'forge-1',
+      body: 'stage: dev -> validate',
+      config: { databasePath: '/tmp/x' },
+    });
+
+    expect(calls).toEqual([{ issue_id: 'forge-1', from: 'dev', to: 'validate' }]);
+    expect(result).toEqual({ from: 'dev', to: 'validate', recorded: true });
+  });
+
+  test('never throws when the atomic driver op throws — returns recorded:false', () => {
+    const driver = {
+      recordStageTransition() {
+        throw new Error('rolled back');
+      },
+    };
+    let result;
+    expect(() => {
+      result = recordStageTransition({
+        driver,
+        issueId: 'forge-1',
+        body: 'stage: dev -> validate',
+      });
+    }).not.toThrow();
+    expect(result.recorded).toBe(false);
   });
 
   test('does nothing (recorded:false) when the body has no stage line', () => {


### PR DESCRIPTION
## Summary

Completes the phase fix started in PR #348. #348 added the `stage_runs` record/read capability (`recordStageRun`, `getCurrentStage`, `listStageRuns`, the `forge stage` verb, and `current_stage` on `forge show`) but **nothing called it automatically**, so `stage_runs` stayed empty and `current_stage` was always unknown.

This wires it into normal use. The Descriptive Context Convention (AGENTS.md) already has agents record every stage boundary as a kernel comment shaped `stage: <from> -> <to>`. This PR turns that already-followed convention into a structured stage run: on a successful kernel `comment`, Forge best-effort **completes `<from>` and starts `<to>`** in `stage_runs`. No new manual verb call, no change to agent behavior — `current_stage` just becomes real.

## Integration point & why

The comment write path (`lib/commands/_issue.js`) — not `enforceStageEntry` — because Forge stages are agent-driven via skills; agents don't run `forge plan`/`forge dev` as CLI commands, but they DO already run `forge issue comment "stage: X -> Y ..."` at every stage exit (with the resolved issue id in hand). Hooking there makes recording automatic through the path agents already traverse.

## How a stage now records a run

`forge comment <id> "stage: dev -> validate\n..."` → after the comment lands, `recordStageTransitionFromComment` parses the `stage:` line and calls `driver.recordStageRun` complete(dev) + start(validate). `forge show <id>` then reports `current_stage: validate (active)`.

## Best-effort / non-blocking

`recordStageTransition` **never throws** — a `stage_run` write failure (parse miss, DB error, missing driver) can never fail the comment that triggered it. Kernel path only; reuses the driver already on `opts` (no second DB handle).

## Changes
- `lib/workflow/stage-transition.js` (new): `parseStageTransition` (pure) + `recordStageTransition` (best-effort).
- `lib/commands/_issue.js`: fire `recordStageTransitionFromComment` after a successful kernel comment.
- Tests: unit (parser + recorder edge cases) + end-to-end through `runIssueSubcommand`.

## Tests
- `test/workflow/stage-transition.test.js`, `test/commands/comment-stage-transition.test.js` — new, green.
- Existing stage/comment/issue suites green; `eslint --max-warnings 0` clean.

## Scope call / follow-up (5bfd2414)
Smallest version that makes phase real for the main stages via the transition comment. Deferred: (1) explicit `forge stage --start/--complete` in each canonical skill so the first stage's start and final stage's completion (no transition comment) are also recorded; (2) dashboard/status snapshot consuming `current_stage`; (3) the AGENTS.md doc note (protected `generated_harness` surface).

Issue: 5a5ba3a6-e3a9-4f55-a1c9-4707182c2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the read-only `forge claims [--json]` command to list active issue leases.
  * Comments containing `stage: <from> -> <to>` now automatically record completion of the previous stage and start of the next stage when using the Kernel backend.
* **Bug Fixes**
  * Stage-recording failures no longer interrupt or invalidate successful comment submissions.
  * Invalid or non-stage comments are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->