### PR TITLE
feat(kernel): expose active leases as a read (forge claims)

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -2314,7 +2314,7 @@ async function _interactiveSetup() {
 // deliberately NOT listed here — it stays documented.
 const ISSUE_ALIAS_COMMANDS = [
   'create', 'update', 'claim', 'close', 'show', 'list',
-  'ready', 'blocked', 'stale', 'orphans', 'lint', 'issues',
+  'ready', 'blocked', 'stale', 'orphans', 'lint', 'claims', 'issues',
 ];
 
 function parseFlags() {

--- a/lib/adapters/beads-issue-adapter.js
+++ b/lib/adapters/beads-issue-adapter.js
@@ -107,6 +107,12 @@ class BeadsIssueAdapter extends IssueAdapter {
     return this.run('owns', args, context);
   }
 
+  // Active-lease listing is Kernel-only (kernel_claims); the beads layer returns the
+  // Kernel-only contract error (handled in runBeadsOperation), matching owns/release.
+  claims(args = [], context = {}) {
+    return this.run('claims', args, context);
+  }
+
   mapStatus(status, context = {}) {
     return normalizeIssueStatus(status, context);
   }

--- a/lib/adapters/kernel-issue-adapter.js
+++ b/lib/adapters/kernel-issue-adapter.js
@@ -17,6 +17,7 @@ const KERNEL_ISSUE_OPERATIONS = Object.freeze({
 	lint: 'lint',
 	children: 'children',
 	owns: 'owns',
+	claims: 'claims',
 	read: 'show',
 	show: 'show',
 	create: 'create',

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -101,6 +101,14 @@ const SUBCOMMANDS = {
     description: 'Verify the current actor holds the live lease on an issue via Forge',
     usage: 'forge issue owns <id> [--json]',
   },
+  // Active-lease listing (kernel issue 7dc229d4). A bare passthrough to the Kernel
+  // lease table (kernel_claims); Beads has no lease table to enumerate, so
+  // forge-issues.js rejects the Beads path explicitly. A READ, so intentionally NOT
+  // in WRITE_SUBCOMMANDS.
+  claims: {
+    description: 'Show active issue leases (claims) via Forge',
+    usage: 'forge issue claims [--json]',
+  },
   dep: {
     description: 'Manage issue dependencies via Forge',
     usage: 'forge issue dep <add|remove> <issue-id> <blocks-issue-id>',

--- a/lib/commands/_resolve-command-opts.js
+++ b/lib/commands/_resolve-command-opts.js
@@ -51,6 +51,9 @@ const ISSUE_COMMANDS = new Set([
   // Lease-ownership verification — a kernel-only read (leases live in the Kernel),
   // so it is kernel-routed like the rest of the issue surface.
   'owns',
+  // Active-lease listing — a kernel-only read (leases live in the Kernel), so it
+  // is kernel-routed like the rest of the issue surface.
+  'claims',
   'search',
   'stats',
   'dep',

--- a/lib/commands/claims.js
+++ b/lib/commands/claims.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { createIssueSubcommand } = require('./_issue');
+
+// `forge claims` — the active-lease/claims read (issue 7dc229d4). A bare passthrough
+// to `forge issue claims`, mirroring the other kernel derived reads (blocked/stale).
+module.exports = createIssueSubcommand('claims');

--- a/lib/forge-issues.js
+++ b/lib/forge-issues.js
@@ -52,6 +52,12 @@ const BEADS_CHILDREN_KERNEL_ONLY_ERROR =
 const BEADS_OWNS_KERNEL_ONLY_ERROR =
   'forge issue owns <id> is defined for the Kernel issue backend; Beads passthrough has no lease-ownership verification.';
 
+// Active leases live only in the Kernel backend (kernel_claims); Beads has no lease
+// table to enumerate. Reject the beads path explicitly so `forge claims` fails loudly
+// instead of mapping to an absent Beads subcommand.
+const BEADS_CLAIMS_KERNEL_ONLY_ERROR =
+  'forge claims is defined for the Kernel issue backend; Beads passthrough has no active-lease listing.';
+
 const OPERATION_METHOD_ALIASES = {
   'dep.add': 'depAdd',
   'dep.remove': 'depRemove',
@@ -279,6 +285,12 @@ async function runBeadsOperation(operation, args, context, deps) {
   // than silently proxy to a non-existent Beads subcommand.
   if (operation === 'owns' && !isHelpInvocation(args)) {
     return { success: false, error: BEADS_OWNS_KERNEL_ONLY_ERROR };
+  }
+
+  // `claims` enumerates the Kernel lease table; Beads has none. Fail loudly rather
+  // than silently proxy to a non-existent Beads subcommand.
+  if (operation === 'claims' && !isHelpInvocation(args)) {
+    return { success: false, error: BEADS_CLAIMS_KERNEL_ONLY_ERROR };
   }
 
   const checkInit = deps.isBeadsInitialized || isBeadsInitialized;

--- a/lib/kernel/issue-command-contract.js
+++ b/lib/kernel/issue-command-contract.js
@@ -269,6 +269,45 @@ const ISSUE_COMMAND_RESPONSE_SCHEMAS = deepFreeze({
 			next_commands: NEXT_COMMANDS_SCHEMA,
 		},
 	},
+	// Issue 7dc229d4: the active-lease/claims read. `claims` is an array of live
+	// lease rows (state='active' AND not expired at read time). Each row carries the
+	// full who/what/where the dashboard live layer needs: actor + session_id +
+	// worktree_id + expires_at + issue_id (plus the lease id and claimed_at). The
+	// kernel_claims schema has no `agent` column, so none is surfaced. session_id /
+	// worktree_id / expires_at are nullable (a claim may carry none / never expire).
+	claimsList: {
+		type: 'object',
+		required: ['ok', 'schema_version', 'command', 'data', 'next_commands'],
+		properties: {
+			ok: { const: true },
+			schema_version: { const: ISSUE_COMMAND_SCHEMA_VERSION },
+			command: { type: 'string' },
+			data: {
+				type: 'object',
+				required: ['claims', 'count'],
+				properties: {
+					claims: {
+						type: 'array',
+						items: {
+							type: 'object',
+							required: ['id', 'issue_id', 'actor', 'session_id', 'worktree_id', 'claimed_at', 'expires_at'],
+							properties: {
+								id: { type: 'string' },
+								issue_id: { type: 'string' },
+								actor: { type: ['string', 'null'] },
+								session_id: { type: ['string', 'null'] },
+								worktree_id: { type: ['string', 'null'] },
+								claimed_at: { type: ['string', 'null'] },
+								expires_at: { type: ['string', 'null'] },
+							},
+						},
+					},
+					count: { type: 'integer', minimum: 0 },
+				},
+			},
+			next_commands: NEXT_COMMANDS_SCHEMA,
+		},
+	},
 	mutation: {
 		type: 'object',
 		required: ['ok', 'schema_version', 'command', 'data', 'next_commands'],
@@ -416,6 +455,10 @@ const COMMANDS = [
 		'forge issue update <id> --acceptance "<criteria>"',
 	]),
 	command('issue.children', 'forge issue children <id> --json', 'children', 'read', ISSUE_COMMAND_RESPONSE_SCHEMAS.children, [
+		'forge issue show <id> --json',
+		'forge claim <id>',
+	]),
+	command('issue.claims', 'forge claims --json', 'claims', 'read', ISSUE_COMMAND_RESPONSE_SCHEMAS.claimsList, [
 		'forge issue show <id> --json',
 		'forge claim <id>',
 	]),

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -695,6 +695,37 @@ function runIssueReadOperation(runtime, db, operation, args, context) {
 			count: children.length,
 		});
 	}
+	// Issue 7dc229d4: active lease/claims read for the dashboard live layer. The
+	// kernel_claims lease row carries the full who/what/where set (actor,
+	// session_id, worktree_id, expires_at, issue_id) — the CLI previously exposed
+	// only `claimed_by` (the actor). A lease is LIVE iff state='active' AND it has
+	// NOT expired at the read `now` (isLeaseExpired; a null expires_at never
+	// expires). An expired-but-not-yet-reclaimed lease is deliberately excluded:
+	// planClaimAcquisition would supersede it, so it is not a live presence signal
+	// (this mirrors the expiry check the `owns` verdict re-applies). Reads that
+	// derive claimed_by (loadBoardReadiness/loadActiveKernelClaimRow) filter on
+	// state only; THIS read additionally honors the lease TTL. Sorted by
+	// claimed_at (then issue_id) for deterministic output. The kernel_claims
+	// schema has NO `agent` column — the lease's who-dimension is actor +
+	// session_id + worktree_id — so no agent field is surfaced.
+	if (operation === 'claims') {
+		const nowIso = context.now || new Date().toISOString();
+		const rows = safeAll(runtime, db, "SELECT * FROM kernel_claims WHERE state = 'active'");
+		const claims = rows
+			.filter(row => !isLeaseExpired(row, nowIso))
+			.map(row => ({
+				id: row.id,
+				issue_id: row.issue_id,
+				actor: row.actor ?? null,
+				session_id: row.session_id ?? null,
+				worktree_id: row.worktree_id ?? null,
+				claimed_at: row.claimed_at ?? null,
+				expires_at: row.expires_at ?? null,
+			}))
+			.sort((a, b) => String(a.claimed_at).localeCompare(String(b.claimed_at))
+				|| String(a.issue_id).localeCompare(String(b.issue_id)));
+		return okIssueResponse('issue.claims', { claims, count: claims.length });
+	}
 	return null;
 }
 
@@ -2057,7 +2088,7 @@ function createDriver(runtime, configuredDatabasePath) {
 		},
 		async issueOperation(operation, args = [], context = {}, config = {}) {
 			const database = getDatabase(config);
-			const READ_OPERATIONS = new Set(['ready', 'list', 'show', 'search', 'stats', 'blocked', 'stale', 'orphans', 'lint', 'children', 'owns']);
+			const READ_OPERATIONS = new Set(['ready', 'list', 'show', 'search', 'stats', 'blocked', 'stale', 'orphans', 'lint', 'children', 'owns', 'claims']);
 			if (READ_OPERATIONS.has(operation)) {
 				return runIssueReadOperation(runtime, database, operation, args, context);
 			}

--- a/test/commands/claims.test.js
+++ b/test/commands/claims.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const claims = require('../../lib/commands/claims');
+
+// Issue 7dc229d4: `forge claims` is the active-lease read alias. It routes through
+// the shared runIssueOperation seam with the `claims` operation (like blocked/stale),
+// so the kernel driver's active-lease read is what ultimately answers it.
+describe('forge claims command', () => {
+  test('exports the claims alias command', () => {
+    expect(claims.name).toBe('claims');
+    expect(typeof claims.description).toBe('string');
+    expect(typeof claims.handler).toBe('function');
+  });
+
+  test('routes through the shared issue operation runner with the claims op', async () => {
+    const calls = [];
+
+    const result = await claims.handler(['--json'], {}, '/repo', {
+      useKernelBroker: true,
+      runIssueOperation: async (operation, args, projectRoot, deps) => {
+        calls.push({ operation, args, projectRoot, deps });
+        return {
+          ok: true,
+          schema_version: 'forge.issue.v1',
+          command: 'issue.claims',
+          data: { claims: [], count: 0 },
+          next_commands: [],
+        };
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.operation).toBe('claims');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].operation).toBe('claims');
+    expect(calls[0].args).toEqual(['--json']);
+  });
+});

--- a/test/forge-cli-registry.test.js
+++ b/test/forge-cli-registry.test.js
@@ -71,7 +71,7 @@ function parseAdditionalCommands(stdout) {
 // canonical `forge issue` surface is unambiguous (kernel issue 450c6e34).
 const HIDDEN_ISSUE_ALIASES = [
   'create', 'update', 'claim', 'close', 'show', 'list',
-  'ready', 'blocked', 'stale', 'orphans', 'lint', 'issues',
+  'ready', 'blocked', 'stale', 'orphans', 'lint', 'claims', 'issues',
 ];
 
 describe('CLI Registry Integration', () => {

--- a/test/kernel/issue-command-contract.test.js
+++ b/test/kernel/issue-command-contract.test.js
@@ -22,6 +22,7 @@ describe('Kernel issue command contract', () => {
 			'issue.orphans',
 			'issue.lint',
 			'issue.children',
+			'issue.claims',
 			'issue.create',
 			'issue.update',
 			'issue.close',

--- a/test/kernel/sqlite-driver-claims-read.test.js
+++ b/test/kernel/sqlite-driver-claims-read.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Issue 7dc229d4: expose the active lease/claims set as a read (`forge claims`).
+// The kernel_claims lease row holds actor + session_id + worktree_id + expires_at
+// + issue_id — everything a dashboard's live layer needs to show "who/what is on
+// which issue". The `claims` read op returns the ACTIVE, non-expired leases with
+// their full fields. Active = state='active' AND NOT isLeaseExpired(claim, now)
+// (an expired-but-not-yet-reclaimed lease is NOT live).
+describe('Kernel SQLite driver — claims read op (active leases)', () => {
+	let tmpDir;
+	let driver;
+	let broker;
+	let config;
+	const now = '2026-06-20T00:00:00.000Z';
+
+	async function createIssue(id, title = id) {
+		return broker.runIssueOperation(
+			'create',
+			['--id', id, '--title', title, '--type', 'task'],
+			{ now, actor: 'tester' },
+		);
+	}
+
+	beforeEach(async () => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kdrv-claims-read-'));
+		const dbPath = path.join(tmpDir, 'kernel.sqlite');
+		config = { databasePath: dbPath };
+		driver = createBuiltinSQLiteDriver({});
+		broker = createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: dbPath,
+			driver,
+		});
+		await broker.initialize();
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('returns an empty list (count 0) when no claims exist', async () => {
+		const res = await driver.issueOperation('claims', [], { now }, config);
+		expect(res.ok).toBe(true);
+		expect(res.command).toBe('issue.claims');
+		expect(res.data.claims).toEqual([]);
+		expect(res.data.count).toBe(0);
+	});
+
+	test('returns active leases with their full lease fields', async () => {
+		await createIssue('clm-a', 'Alpha');
+		await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-a'],
+			{ now, actor: 'alice', sessionId: 'sess-a', worktreeId: 'wt-a' },
+		);
+
+		const res = await driver.issueOperation('claims', [], { now }, config);
+		expect(res.ok).toBe(true);
+		expect(res.data.count).toBe(1);
+		expect(res.data.claims).toHaveLength(1);
+
+		const claim = res.data.claims[0];
+		// The dashboard-facing lease shape: every field the live layer needs.
+		expect(claim.issue_id).toBe('clm-a');
+		expect(claim.actor).toBe('alice');
+		expect(claim.claimed_at).toBe(now);
+		// session_id / worktree_id / expires_at are surfaced (may be null when the
+		// claim carried none) — the KEYS must always be present so consumers can rely
+		// on the shape.
+		expect(claim).toHaveProperty('session_id');
+		expect(claim).toHaveProperty('worktree_id');
+		expect(claim).toHaveProperty('expires_at');
+		expect(claim).toHaveProperty('id');
+	});
+
+	test('excludes released leases (state != active)', async () => {
+		await createIssue('clm-b', 'Beta');
+		await broker.runIssueOperation('claim', ['--issue', 'clm-b'], { now, actor: 'alice' });
+		await broker.runIssueOperation(
+			'release',
+			['--issue', 'clm-b'],
+			{ now: '2026-06-20T00:01:00.000Z', actor: 'alice' },
+		);
+
+		const res = await driver.issueOperation('claims', [], { now: '2026-06-20T00:02:00.000Z' }, config);
+		expect(res.ok).toBe(true);
+		expect(res.data.count).toBe(0);
+		expect(res.data.claims).toEqual([]);
+	});
+
+	test('excludes expired leases (state active but past expires_at at read `now`)', async () => {
+		await createIssue('clm-c', 'Gamma');
+		await broker.runIssueOperation(
+			'claim',
+			['--issue', 'clm-c', '--expires', '2026-06-20T00:00:30.000Z'],
+			{ now, actor: 'alice' },
+		);
+
+		// Read BEFORE expiry → the lease is live.
+		const live = await driver.issueOperation('claims', [], { now: '2026-06-20T00:00:10.000Z' }, config);
+		expect(live.data.count).toBe(1);
+
+		// Read AFTER expiry → the still-active-but-expired lease is NOT reported live.
+		const expired = await driver.issueOperation('claims', [], { now: '2026-06-20T01:00:00.000Z' }, config);
+		expect(expired.data.count).toBe(0);
+		expect(expired.data.claims).toEqual([]);
+	});
+
+	test('a null-expiry lease never expires and is always reported active', async () => {
+		await createIssue('clm-d', 'Delta');
+		await broker.runIssueOperation('claim', ['--issue', 'clm-d'], { now, actor: 'alice' });
+
+		const res = await driver.issueOperation('claims', [], { now: '3000-01-01T00:00:00.000Z' }, config);
+		expect(res.data.count).toBe(1);
+		expect(res.data.claims[0].expires_at).toBeNull();
+	});
+});

--- a/test/kernel/sqlite-driver-claims-read.test.js
+++ b/test/kernel/sqlite-driver-claims-read.test.js
@@ -74,13 +74,17 @@ describe('Kernel SQLite driver — claims read op (active leases)', () => {
 		expect(claim.issue_id).toBe('clm-a');
 		expect(claim.actor).toBe('alice');
 		expect(claim.claimed_at).toBe(now);
-		// session_id / worktree_id / expires_at are surfaced (may be null when the
-		// claim carried none) — the KEYS must always be present so consumers can rely
-		// on the shape.
-		expect(claim).toHaveProperty('session_id');
-		expect(claim).toHaveProperty('worktree_id');
-		expect(claim).toHaveProperty('expires_at');
-		expect(claim).toHaveProperty('id');
+		// session_id / worktree_id echo the claim's context exactly (not just present —
+		// mapped to the RIGHT value). expires_at is null because no --expires was passed
+		// (buildClaimRow / insertKernelClaimRow default it to null).
+		expect(claim.session_id).toBe('sess-a');
+		expect(claim.worktree_id).toBe('wt-a');
+		expect(claim.expires_at).toBeNull();
+		// `id` is the claim lease row id (a fresh randomUUID minted per claim in
+		// buildClaimMutationEvent — never the issue id), so its exact value isn't
+		// predictable here; assert its shape instead of just its presence.
+		expect(typeof claim.id).toBe('string');
+		expect(claim.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
 	});
 
 	test('excludes released leases (state != active)', async () => {


### PR DESCRIPTION
## Summary

Adds a `claims` kernel read op + a `forge claims [--json]` CLI verb that returns the **active (non-expired) lease set** with the full lease fields the dashboard live layer needs.

The `kernel_claims` lease table already stored `actor + session_id + worktree_id + expires_at + issue_id`, but the CLI read surface exposed only `claimed_by` (the actor). There was no way to read the full live-lease set, blocking the dashboard's live badges / presence view (who/what/which session is on which issue).

## What it returns

`forge claims --json` → `issue.claims` envelope:
```json
{ "ok": true, "command": "issue.claims",
  "data": { "claims": [ { "id", "issue_id", "actor", "session_id", "worktree_id", "claimed_at", "expires_at" } ], "count": N } }
```

## Active vs expired

Active = `state='active'` **AND** `NOT isLeaseExpired(claim, now)` (the lease TTL). An expired-but-not-yet-reclaimed lease is deliberately excluded (planClaimAcquisition would supersede it) — mirroring the expiry check the `owns` verdict re-applies. A null `expires_at` never expires. `now` is the read context clock, falling back to the wall clock.

## Note on `agent`

The `kernel_claims` schema has **no `agent` column** — the lease's who-dimension is `actor + session_id + worktree_id`, so no `agent` field is surfaced (the issue mentioned it, but it is not stored).

## Wiring

Follows the existing kernel-only-read precedent (`owns`): driver `READ_OPERATIONS` + read branch, `issue.claims` contract entry + `claimsList` schema, kernel/beads issue adapters, a Beads-path reject (`kernel_claims` is kernel-only), `_issue` SUBCOMMANDS, the `claims.js` command, and the hidden bare-alias list.

## Tests

- `test/kernel/sqlite-driver-claims-read.test.js` — active leases with full fields, excludes released, excludes expired, empty when none, null-expiry never expires.
- `test/commands/claims.test.js` — command exports + routes to the `claims` op.
- Updated `issue-command-contract.test.js` (ordered catalog) + `forge-cli-registry.test.js` (hidden alias).

Full kernel/adapter/forge-issues suites: **568 pass / 0 fail**. ESLint `--max-warnings 0` clean. Verified end-to-end against the real kernel store.

Refs 7dc229d4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `forge claims` and `forge issue claims` commands to list active issue claims.
  * Added JSON output with claim details, including issue, actor, session, worktree, and lease timing information.
  * Results exclude released or expired claims while retaining claims without an expiration.

* **Bug Fixes**
  * Prevented unsupported backends from processing the kernel-only claims operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->