### PR TITLE
feat(shepherd): --pull emits a comprehensive actionable blocker payload (a94d4a08)

### DIFF
--- a/docs/reference/shepherd.md
+++ b/docs/reference/shepherd.md
@@ -8,7 +8,39 @@ the pre-merge gate (the embedded documentation-and-handoff gate in `/ship` and `
 ```bash
 forge shepherd <pr-number>
 forge shepherd <pr-number> --auto-rebase   # opt-in, default OFF
+forge shepherd <pr-number> --pull          # read-only: WHY it is blocked + what to fix
+forge shepherd <pr-number> --pull --json   # same payload as machine-readable JSON
+forge shepherd <pr-number> --bundle --json # read-only: the COMPLETE PR-state bundle
 ```
+
+## `--pull`: the actionable blocker payload
+
+`--pull` is a **strictly read-only** signal-gather. It computes the decision
+state via a dry-run pass (no rerun, no rebase, no merge, no thread resolution)
+and returns ONE bounded, **actionable-only** payload so an agent gets "everything
+blocking this PR + exactly what to fix" in a single call instead of running
+`gh pr checks`, `gh run view --log-failed`, GraphQL thread queries, and branch
+-protection lookups by hand. Default output is a compact human summary; `--json`
+emits the structured payload. Every field is something to ACT on — passing
+checks, resolved/outdated threads, and satisfied policy are omitted.
+
+| Field | Meaning |
+| --- | --- |
+| `state` / `summary` | Decision state + a one-line WHY (leads with the primary blocker). |
+| `mergeable` / `mergeStateStatus` | GitHub's raw merge signals (e.g. `BLOCKED`, `BEHIND`, `DIRTY`, `UNSTABLE`). |
+| `blockers[]` | Ordered `{type, detail}` list — the human-readable WHY. Types: `draft`, `conflict`, `check-failing`, `check-missing`, `check-skipped`, `check-pending`, `behind`, `changes-requested`, `review-required`, `unresolved-threads`, `blocked-unknown`, `unstable`. |
+| `requiredChecks` | Branch-protection required set classified vs what the PR produced: `missing` (never reported), `skipped` (a **required** check that resolved SKIPPED — NOT a pass to branch protection; this is why an all-green PR can stay `BLOCKED`), `pending`, `failing`. Omitted entirely when the required set is all green. |
+| `failures[]` | Per failed check: `name`, `conclusion`, `jobUrl`, the exact failure **excerpt** pulled from the job log, and `alsoFailedOn` (matrix duplicates collapse to one). |
+| `pendingChecks[]` | Names of checks still running. |
+| `reviewThreads[]` | Every UNRESOLVED, non-outdated thread from a human or a review bot (CodeRabbit et al.): `file`, `line`, `author`, `body`, `threadId`, `commentId`. Never the shepherd's own or resolved threads. |
+| `behind` | Commits behind base (present only when > 0). |
+| `conflicts` | `{conflicted, files[]}` — present only when a merge would conflict. |
+| `reviewDecision` | Present only when actionable (`CHANGES_REQUESTED` / `REVIEW_REQUIRED`); `APPROVED` is omitted. |
+| `draft` | Present only when the PR is a draft. |
+| `truncated` | Flags when `failures`/`reviewThreads` were capped for size. |
+
+`--bundle --json` is the sibling COMPLETE (not-only-actionable) read-only state
+bundle; `--pull` and `--bundle` are mutually exclusive.
 
 ## Why it is a utility, not a stage
 

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -34,6 +34,12 @@ const PR_VIEW_FIELDS = [
   'mergeStateStatus',
   'state',
   'statusCheckRollup',
+  // `reviewDecision` (REVIEW_REQUIRED / CHANGES_REQUESTED / APPROVED / '') and
+  // `isDraft` are PR-level MERGE BLOCKERS the pull-signal payload surfaces — a
+  // draft PR or a missing/negative review decision blocks merge even when every
+  // check is green. Both are valid `gh pr view --json` fields.
+  'reviewDecision',
+  'isDraft',
 ].join(',');
 
 /**
@@ -96,6 +102,11 @@ class PrStateAdapter {
       state: String(data.state || 'OPEN').toUpperCase(),
       mergeable: data.mergeable || 'UNKNOWN',
       mergeStateStatus: data.mergeStateStatus || 'UNKNOWN',
+      // PR-level merge blockers (surfaced by the pull signal). `reviewDecision` is
+      // '' when no review is required; normalized to null so consumers can treat
+      // "not required" and "unknown" uniformly. `isDraft` blocks merge outright.
+      reviewDecision: data.reviewDecision || null,
+      isDraft: Boolean(data.isDraft),
       checks: rollup.map((check) => ({
         name: check.name || check.context || '',
         status: check.status || check.state || '',

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -30,7 +30,7 @@ const { execFileSync } = require('node:child_process');
 
 const { runShepherdPass } = require('../pr-shepherd');
 const { gatherPrBundle } = require('../pr-bundle');
-const { gatherPullSignal } = require('../pr-pull');
+const { gatherPullSignal, renderPullSummary } = require('../pr-pull');
 const { PrStateAdapter } = require('../adapters/pr-state-adapter');
 const { validatePrStateAdapter } = require('../pr-state-validator');
 
@@ -132,6 +132,7 @@ async function handler(args, _flags, projectRoot, deps = {}) {
   const autoRebase = flags.has('--auto-rebase');
   const wantBundle = flags.has('--bundle');
   const wantPull = flags.has('--pull');
+  const wantJson = flags.has('--json');
 
   const ctx = await buildContext({ pr, gh, git, projectRoot });
 
@@ -149,7 +150,13 @@ async function handler(args, _flags, projectRoot, deps = {}) {
   if (wantPull) {
     const runGh = (ghArgs) => gh('gh', ghArgs);
     const pull = await gatherPull({ ...ctx, adapter, runGh, runPass, self: deps.self });
-    return { success: true, pull };
+    // `output` is what the registry CLI dispatch (bin/forge.js) actually PRINTS —
+    // returning only `pull` silently dropped the whole payload on that path (it
+    // prints `result.output`, nothing else). `--json` → machine payload; default
+    // → the compact human WHY+fix summary. `pull` is kept for the legacy
+    // bin/forge-cmd.js path and for programmatic callers/tests.
+    const output = wantJson ? JSON.stringify(pull, null, 2) : renderPullSummary(pull);
+    return { success: true, pull, output };
   }
 
   // --bundle: gather the COMPLETE read-only PR-state bundle the monitor will
@@ -157,7 +164,9 @@ async function handler(args, _flags, projectRoot, deps = {}) {
   // the gather half only — it decides nothing and takes no action.
   if (wantBundle) {
     const bundle = await gatherBundle({ ...ctx, adapter });
-    return { success: true, bundle };
+    // Same rationale as --pull: the registry dispatch prints `output`. The bundle
+    // is a machine payload, so it is always emitted as JSON.
+    return { success: true, bundle, output: JSON.stringify(bundle, null, 2) };
   }
 
   const result = await runPass({

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -28,7 +28,7 @@
  * @module pr-pull
  */
 
-const { isFailed, runShepherdPass } = require('./pr-shepherd');
+const { isFailed, isGreen, runShepherdPass } = require('./pr-shepherd');
 
 /** Token caps that keep the payload bounded regardless of PR size. */
 const DEFAULT_MAX_FAILURES = 10;
@@ -206,18 +206,232 @@ function buildReviewThreads(threads, self, opts = {}) {
   return out;
 }
 
+/** A check whose conclusion is SKIPPED — green-ish by `isGreen`, but for a
+ * REQUIRED context a skip means the gate never actually ran to success, so
+ * branch protection keeps the PR blocked. Detected separately from real greens. */
+function isSkipped(check) {
+  return String(check.conclusion || '').toUpperCase() === 'SKIPPED';
+}
+
+/** A check still in flight (not green, not failed) — e.g. IN_PROGRESS/QUEUED or
+ * a status context with no conclusion yet. */
+function isPending(check) {
+  return !isGreen(check) && !isFailed(check);
+}
+
+/**
+ * Classify the branch-protection REQUIRED set against what the PR actually
+ * produced — the ONLY reliable way to explain a PR that is BLOCKED while every
+ * visible check is green. A required context is:
+ *   - `missing`  — it never reported at all (a workflow that didn't trigger);
+ *   - `skipped`  — every instance resolved SKIPPED (the policy-block cause: a
+ *     required gate that skipped is NOT a success to branch protection);
+ *   - `failing`  — any instance failed;
+ *   - `pending`  — still running / not yet reported a conclusion.
+ * Green required checks are intentionally OMITTED — the payload is actionable-only.
+ * Matrix duplicates (same context name reported by multiple jobs) are aggregated
+ * with failing > pending > skipped > green precedence.
+ *
+ * @param {object[]} checks - normalized rollup from readState.
+ * @param {string[]|null} requiredSet - branch-protection contexts, or null when unreadable.
+ * @returns {{ missing: string[], skipped: string[], pending: string[], failing: string[], unreadable: boolean }}
+ */
+function classifyRequiredChecks(checks, requiredSet) {
+  if (!Array.isArray(requiredSet)) {
+    return { missing: [], skipped: [], pending: [], failing: [], unreadable: true };
+  }
+  const byName = new Map();
+  for (const c of (Array.isArray(checks) ? checks : [])) {
+    const name = c.name || c.context || '';
+    if (!byName.has(name)) byName.set(name, []);
+    byName.get(name).push(c);
+  }
+  const missing = []; const skipped = []; const pending = []; const failing = [];
+  for (const name of requiredSet) {
+    const instances = byName.get(name);
+    if (!instances || instances.length === 0) { missing.push(name); continue; }
+    if (instances.some(isFailed)) { failing.push(name); continue; }
+    if (instances.some(isPending)) { pending.push(name); continue; }
+    // All instances are green-ish. If EVERY instance only ever skipped, the
+    // required gate did not truly pass → policy block.
+    if (instances.every(isSkipped)) { skipped.push(name); continue; }
+    // otherwise a genuine success — omitted (actionable-only).
+  }
+  return { missing, skipped, pending, failing, unreadable: false };
+}
+
+/**
+ * The unique names of checks still pending (any check, not just required),
+ * deduped and bounded — surfaced so an agent knows the PR is simply not done yet
+ * versus actively broken.
+ */
+function pendingCheckNames(checks, cap = DEFAULT_MAX_THREADS) {
+  const seen = new Set();
+  for (const c of (Array.isArray(checks) ? checks : [])) {
+    if (isPending(c)) seen.add(c.name || c.context || '');
+  }
+  return [...seen].filter(Boolean).slice(0, cap);
+}
+
+const AND_LIST_CAP = 6;
+
+/** Join a list of names for a blocker detail, truncating with a count. */
+function joinNames(names) {
+  const list = names.slice(0, AND_LIST_CAP);
+  const extra = names.length - list.length;
+  return extra > 0 ? `${list.join(', ')} (+${extra} more)` : list.join(', ');
+}
+
+/**
+ * Compute the ordered, deduped list of concrete merge BLOCKERS — the
+ * human-readable WHY behind `mergeStateStatus`. Ordered most-actionable-first so
+ * an agent fixes the real gate, not a symptom. Every entry is something to ACT
+ * on; nothing that is already satisfied is listed (actionable-only). When
+ * `mergeStateStatus` is BLOCKED/UNSTABLE but no specific cause is derivable from
+ * the available signals, a single explicit "unknown policy" blocker is emitted so
+ * the block is never silently invisible (the #353 failure mode).
+ *
+ * @param {object} args
+ * @returns {Array<{ type: string, detail: string }>}
+ */
+function computeBlockers({
+  mergeable,
+  mergeStateStatus,
+  draft = false,
+  reviewDecision = null,
+  requiredClass = { missing: [], skipped: [], pending: [], failing: [], unreadable: false },
+  unresolvedThreadCount = 0,
+  behind = 0,
+  conflicts = null,
+  failuresCount = 0,
+}) {
+  const status = String(mergeStateStatus || '').toUpperCase();
+  const merge = String(mergeable || '').toUpperCase();
+  const decision = String(reviewDecision || '').toUpperCase();
+  const rc = requiredClass || {};
+  const out = [];
+
+  if (draft) {
+    out.push({ type: 'draft', detail: 'PR is a draft — mark it "Ready for review" before it can merge.' });
+  }
+
+  const conflictFiles = conflicts && conflicts.conflicted && Array.isArray(conflicts.files) ? conflicts.files : null;
+  if (conflictFiles && conflictFiles.length > 0) {
+    out.push({ type: 'conflict', detail: `Merge conflict in ${conflictFiles.length} file(s): ${joinNames(conflictFiles)} — resolve against base.` });
+  } else if (merge === 'CONFLICTING' || status === 'DIRTY') {
+    out.push({ type: 'conflict', detail: 'Branch conflicts with base (mergeable=CONFLICTING) — rebase/merge base and resolve.' });
+  }
+
+  if ((rc.failing || []).length > 0) {
+    out.push({ type: 'check-failing', detail: `Required check(s) failing: ${joinNames(rc.failing)} — see failures[] for the exact log excerpt.` });
+  }
+  if ((rc.missing || []).length > 0) {
+    out.push({ type: 'check-missing', detail: `Required check(s) never reported: ${joinNames(rc.missing)} — the workflow did not trigger; push a commit or re-run CI.` });
+  }
+  if ((rc.skipped || []).length > 0) {
+    out.push({ type: 'check-skipped', detail: `Required check(s) SKIPPED: ${joinNames(rc.skipped)} — a required gate that skips is NOT a pass to branch protection; it must run to success (this is why an all-green PR can stay BLOCKED).` });
+  }
+  if ((rc.pending || []).length > 0) {
+    out.push({ type: 'check-pending', detail: `Required check(s) still running: ${joinNames(rc.pending)} — wait for them to finish.` });
+  }
+
+  if (behind > 0) {
+    out.push({ type: 'behind', detail: `Branch is ${behind} commit(s) behind base — update/rebase the branch (protection requires branches be up to date).` });
+  }
+
+  if (decision === 'CHANGES_REQUESTED') {
+    out.push({ type: 'changes-requested', detail: 'A reviewer requested changes — address the feedback and re-request review.' });
+  } else if (decision === 'REVIEW_REQUIRED') {
+    out.push({ type: 'review-required', detail: 'An approving review is still required before merge.' });
+  }
+
+  if (unresolvedThreadCount > 0) {
+    out.push({ type: 'unresolved-threads', detail: `${unresolvedThreadCount} unresolved review thread(s) must be resolved before merge (see reviewThreads[]).` });
+  }
+
+  // Nothing concrete explained a BLOCKED/UNSTABLE status → make the block visible
+  // rather than let the PR sit mysteriously un-mergeable.
+  if (out.length === 0) {
+    if (status === 'BLOCKED') {
+      out.push({ type: 'blocked-unknown', detail: 'Merge is blocked by branch protection (mergeStateStatus=BLOCKED) but no failing check, missing/skipped required check, unresolved thread, or negative review was detected — check required reviews, code-owner approval, or other protection rules.' });
+    } else if (status === 'UNSTABLE' && failuresCount > 0) {
+      out.push({ type: 'unstable', detail: 'A non-required check is failing (mergeStateStatus=UNSTABLE). It does not gate merge but is worth fixing — see failures[].' });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Render the bounded payload as a compact human-readable summary (the non-JSON
+ * view). Actionable-only, so a maintainer reads exactly what to fix.
+ *
+ * @param {object} payload - a payload produced by buildPullPayload.
+ * @returns {string}
+ */
+function renderPullSummary(payload) {
+  const p = payload || {};
+  const lines = [];
+  const merge = `mergeable=${p.mergeable || 'UNKNOWN'}, mergeStateStatus=${p.mergeStateStatus || 'UNKNOWN'}`;
+  lines.push(`PR #${p.pr || '?'} — ${p.state || 'UNKNOWN'} (${merge})`);
+  if (p.summary) lines.push(p.summary);
+
+  const blockers = Array.isArray(p.blockers) ? p.blockers : [];
+  if (blockers.length === 0) {
+    lines.push('Blockers: none detected (nothing actionable this pass).');
+  } else {
+    lines.push(`Blockers (${blockers.length}):`);
+    blockers.forEach((b, i) => lines.push(`  ${i + 1}. [${b.type}] ${b.detail}`));
+  }
+
+  const failures = Array.isArray(p.failures) ? p.failures : [];
+  if (failures.length > 0) {
+    lines.push(`Failing checks (${failures.length}):`);
+    for (const f of failures) {
+      const also = f.alsoFailedOn ? ` (+${f.alsoFailedOn} matrix job(s))` : '';
+      lines.push(`  • ${f.name}${also}`);
+      const first = String(f.excerpt || '').split('\n').filter(Boolean)[0];
+      if (first) lines.push(`      ${first}`);
+    }
+  }
+
+  const threads = Array.isArray(p.reviewThreads) ? p.reviewThreads : [];
+  if (threads.length > 0) {
+    lines.push(`Unresolved review threads (${threads.length}):`);
+    for (const t of threads) {
+      const loc = t.file ? `${t.file}${t.line != null ? `:${t.line}` : ''}` : '(general)';
+      const firstLine = String(t.body || '').split('\n').filter(Boolean)[0] || '';
+      lines.push(`  • ${loc} — ${t.author}: ${firstLine.slice(0, 120)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 /**
  * Assemble the final bounded payload, enforcing every token cap (failures,
  * threads, per-excerpt line count) and flagging truncation so a consumer knows
- * the view was trimmed.
+ * the view was trimmed. Carries the full actionable-only blocker picture:
+ * mergeability + WHY (`blockers`), required-check classification, pending checks,
+ * behind-base, conflicts, review decision, and draft state.
  *
  * @param {object} args
  * @returns {object}
  */
 function buildPullPayload({
+  pr,
   state,
   summary,
   reason,
+  mergeable = 'UNKNOWN',
+  mergeStateStatus = 'UNKNOWN',
+  draft = false,
+  reviewDecision = null,
+  blockers = [],
+  requiredChecks = null,
+  pendingChecks = [],
+  behind = 0,
+  conflicts = null,
   failures = [],
   reviewThreads = [],
   maxFailures = DEFAULT_MAX_FAILURES,
@@ -229,10 +443,44 @@ function buildPullPayload({
     excerpt: String(f.excerpt || '').split('\n').slice(0, maxExcerptLines).join('\n'),
   }));
   const cappedThreads = reviewThreads.slice(0, maxThreads);
+
+  // Actionable-only: include a required-check block only when SOMETHING about the
+  // required set needs attention (or it was unreadable). All-green required sets
+  // are omitted entirely.
+  const rc = requiredChecks || {};
+  const rcActionable = (rc.missing && rc.missing.length)
+    || (rc.skipped && rc.skipped.length)
+    || (rc.pending && rc.pending.length)
+    || (rc.failing && rc.failing.length)
+    || rc.unreadable;
+
   return {
+    ...(pr !== undefined ? { pr: String(pr) } : {}),
     state,
     summary,
     ...(reason ? { reason } : {}),
+    mergeable,
+    mergeStateStatus,
+    ...(draft ? { draft: true } : {}),
+    // Surface reviewDecision only when it is a BLOCKER (actionable-only): APPROVED
+    // and "not required" ('') are omitted.
+    ...(reviewDecision === 'CHANGES_REQUESTED' || reviewDecision === 'REVIEW_REQUIRED'
+      ? { reviewDecision } : {}),
+    blockers,
+    ...(rcActionable ? {
+      requiredChecks: {
+        ...(rc.missing && rc.missing.length ? { missing: rc.missing } : {}),
+        ...(rc.skipped && rc.skipped.length ? { skipped: rc.skipped } : {}),
+        ...(rc.pending && rc.pending.length ? { pending: rc.pending } : {}),
+        ...(rc.failing && rc.failing.length ? { failing: rc.failing } : {}),
+        ...(rc.unreadable ? { unreadable: true } : {}),
+      },
+    } : {}),
+    ...(pendingChecks && pendingChecks.length ? { pendingChecks } : {}),
+    ...(behind > 0 ? { behind } : {}),
+    ...(conflicts && conflicts.conflicted ? {
+      conflicts: { conflicted: true, files: Array.isArray(conflicts.files) ? conflicts.files : [] },
+    } : {}),
     failures: cappedFailures,
     reviewThreads: cappedThreads,
     truncated: {
@@ -256,13 +504,15 @@ function orderFailedChecks(checks, requiredSet) {
 }
 
 /**
- * One-line human summary of the pull signal.
+ * One-line human summary of the pull signal — leads with the primary (first,
+ * most-actionable) blocker so the WHY is legible at a glance.
  */
-function summarize({ state, failureCount, threadCount }) {
+function summarize({ state, failureCount, threadCount, blockers = [] }) {
   const parts = [];
   parts.push(`${failureCount} failing check${failureCount === 1 ? '' : 's'}`);
   parts.push(`${threadCount} review thread${threadCount === 1 ? '' : 's'} to address`);
-  return `${state}: ${parts.join(', ')}.`;
+  const primary = (Array.isArray(blockers) && blockers[0]) ? ` Primary blocker: ${blockers[0].detail}` : '';
+  return `${state}: ${parts.join(', ')}.${primary}`;
 }
 
 /**
@@ -353,16 +603,68 @@ async function gatherPullSignal(ctx) {
   }
   const reviewThreads = buildReviewThreads(threads, self, { maxThreads });
 
+  // --- Additional actionable blockers, each guarded so one failing read never
+  // sinks the payload. All read-only. ---
+
+  // Branch divergence (behind base → needs an update/rebase).
+  let behind = 0;
+  try {
+    if (typeof adapter.readDivergence === 'function') {
+      const div = await adapter.readDivergence({ baseRef: ctx.baseRef, cwd });
+      behind = div.behind || 0;
+    }
+  } catch (_err) {
+    void _err; // unknown divergence → treat as not-behind, keep diagnosing
+  }
+
+  // Predicted merge conflicts (which files) — optional adapter capability.
+  let conflicts = null;
+  try {
+    if (typeof adapter.detectConflicts === 'function') {
+      conflicts = await adapter.detectConflicts({ baseRef: ctx.baseRef, cwd });
+    }
+  } catch (_err) {
+    void _err; // conflict prediction unsupported → omit, keep diagnosing
+  }
+
+  // Required-vs-produced classification (missing / skipped / pending / failing) —
+  // the reliable explanation for an all-green-but-BLOCKED PR.
+  const requiredChecks = classifyRequiredChecks(state.checks, requiredSet);
+  const pendingChecks = pendingCheckNames(state.checks, maxThreads);
+
+  const blockers = computeBlockers({
+    mergeable: state.mergeable,
+    mergeStateStatus: state.mergeStateStatus,
+    draft: state.isDraft || state.draft || false,
+    reviewDecision: state.reviewDecision || null,
+    requiredClass: requiredChecks,
+    unresolvedThreadCount: reviewThreads.length,
+    behind,
+    conflicts,
+    failuresCount: failures.length,
+  });
+
   const summary = summarize({
     state: pass.state,
     failureCount: failures.length,
     threadCount: reviewThreads.length,
+    blockers,
   });
 
   return buildPullPayload({
+    pr,
     state: pass.state,
     reason: pass.reason,
     summary,
+    mergeable: state.mergeable || 'UNKNOWN',
+    mergeStateStatus: state.mergeStateStatus || 'UNKNOWN',
+    draft: state.isDraft || state.draft || false,
+    reviewDecision: state.reviewDecision || null,
+    blockers,
+    requiredChecks,
+    pendingChecks,
+    behind,
+    conflicts,
     failures,
     reviewThreads,
     maxFailures,
@@ -378,7 +680,13 @@ module.exports = {
   jobIdFromUrl,
   dedupeFailures,
   buildReviewThreads,
+  classifyRequiredChecks,
+  pendingCheckNames,
+  computeBlockers,
+  renderPullSummary,
   buildPullPayload,
+  isSkipped,
+  isPending,
   REVIEW_BOT_LOGINS,
   AUTOMATION_BOT_LOGINS,
 };

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -282,14 +282,109 @@ function joinNames(names) {
   return extra > 0 ? `${list.join(', ')} (+${extra} more)` : list.join(', ');
 }
 
+/** Push `item` onto `arr` only when it is truthy (small helper so the blocker
+ * assembly reads as a flat list without repeated `if`/`push` nesting). */
+function pushMaybe(arr, item) {
+  if (item) arr.push(item);
+}
+
+/** The draft blocker, or null when the PR is not a draft. */
+function draftBlocker(draft) {
+  return draft
+    ? { type: 'draft', detail: 'PR is a draft — mark it "Ready for review" before it can merge.' }
+    : null;
+}
+
+/**
+ * The conflict blocker. A predicted conflict (`conflicts.conflicted === true`)
+ * ALWAYS produces a blocker — even when the `files` list is empty/unparseable and
+ * `mergeable`/`mergeStateStatus` don't literally say CONFLICTING/DIRTY — so the
+ * payload's `conflicts` object and `blockers[]` never disagree. Falls back to the
+ * mergeable/status signal when no file-level prediction is available.
+ */
+function conflictBlocker(conflicts, merge, status) {
+  if (conflicts && conflicts.conflicted) {
+    const files = Array.isArray(conflicts.files) ? conflicts.files : [];
+    const detail = files.length > 0
+      ? `Merge conflict in ${files.length} file(s): ${joinNames(files)} — resolve against base.`
+      : 'Merge conflict detected against base — resolve and push.';
+    return { type: 'conflict', detail };
+  }
+  if (merge === 'CONFLICTING' || status === 'DIRTY') {
+    return { type: 'conflict', detail: 'Branch conflicts with base (mergeable=CONFLICTING) — rebase/merge base and resolve.' };
+  }
+  return null;
+}
+
+/** All required-check blockers (failing / missing / skipped / pending) in
+ * most-actionable-first order. Empty when the required set is all green. */
+function requiredCheckBlockers(rc) {
+  const out = [];
+  if ((rc.failing || []).length > 0) {
+    out.push({ type: 'check-failing', detail: `Required check(s) failing: ${joinNames(rc.failing)} — see failures[] for the exact log excerpt.` });
+  }
+  if ((rc.missing || []).length > 0) {
+    out.push({ type: 'check-missing', detail: `Required check(s) never reported: ${joinNames(rc.missing)} — the workflow did not trigger; push a commit or re-run CI.` });
+  }
+  if ((rc.skipped || []).length > 0) {
+    out.push({ type: 'check-skipped', detail: `Required check(s) SKIPPED: ${joinNames(rc.skipped)} — a required gate that skips is NOT a pass to branch protection; it must run to success (this is why an all-green PR can stay BLOCKED).` });
+  }
+  if ((rc.pending || []).length > 0) {
+    out.push({ type: 'check-pending', detail: `Required check(s) still running: ${joinNames(rc.pending)} — wait for them to finish.` });
+  }
+  return out;
+}
+
+/** The review-decision blocker (changes requested / review required), or null
+ * when the decision is APPROVED or not required (actionable-only). */
+function reviewDecisionBlocker(decision) {
+  if (decision === 'CHANGES_REQUESTED') {
+    return { type: 'changes-requested', detail: 'A reviewer requested changes — address the feedback and re-request review.' };
+  }
+  if (decision === 'REVIEW_REQUIRED') {
+    return { type: 'review-required', detail: 'An approving review is still required before merge.' };
+  }
+  return null;
+}
+
+/**
+ * Last-resort blocker for a PR that is NOT clean yet nothing concrete explained
+ * why. Emitted ONLY when no specific blocker fired, so a non-mergeable PR is
+ * never silently invisible (the #353 failure mode). Covers, in priority order:
+ *   - unreadable required checks (a branch-protection 403 must not stay hidden);
+ *   - UNSTABLE with a failing non-required check;
+ *   - BLOCKED by branch protection;
+ *   - any OTHER non-clean, known status (BEHIND, HAS_HOOKS, …) whose cause wasn't
+ *     otherwise derivable — e.g. BEHIND when the commit count was unavailable.
+ * A clean or unknown status yields no fallback.
+ */
+function fallbackBlocker(status, rc, failuresCount) {
+  if (rc.unreadable) {
+    return { type: 'check-required-unreadable', detail: 'Branch-protection required checks could not be read (e.g. a 403 from the protection API) — cannot confirm the required gates passed; verify branch-protection settings and token permissions.' };
+  }
+  if (status === 'UNSTABLE') {
+    return failuresCount > 0
+      ? { type: 'unstable', detail: 'A non-required check is failing (mergeStateStatus=UNSTABLE). It does not gate merge but is worth fixing — see failures[].' }
+      : null;
+  }
+  if (status === 'BLOCKED') {
+    return { type: 'blocked-unknown', detail: 'Merge is blocked by branch protection (mergeStateStatus=BLOCKED) but no failing check, missing/skipped required check, unresolved thread, or negative review was detected — check required reviews, code-owner approval, or other protection rules.' };
+  }
+  if (status && status !== 'CLEAN' && status !== 'UNKNOWN') {
+    return { type: 'blocked-unknown', detail: `Merge is not clean (mergeStateStatus=${status}) but no specific cause was derivable — update the branch and re-check required gates, reviews, or protection rules.` };
+  }
+  return null;
+}
+
 /**
  * Compute the ordered, deduped list of concrete merge BLOCKERS — the
  * human-readable WHY behind `mergeStateStatus`. Ordered most-actionable-first so
  * an agent fixes the real gate, not a symptom. Every entry is something to ACT
- * on; nothing that is already satisfied is listed (actionable-only). When
- * `mergeStateStatus` is BLOCKED/UNSTABLE but no specific cause is derivable from
- * the available signals, a single explicit "unknown policy" blocker is emitted so
- * the block is never silently invisible (the #353 failure mode).
+ * on; nothing that is already satisfied is listed (actionable-only). When the
+ * status is non-clean but no specific cause is derivable from the available
+ * signals, a single explicit fallback blocker is emitted so the block is never
+ * silently invisible (the #353 failure mode). Per-concern logic lives in the
+ * small helpers above; this function just orders and assembles them.
  *
  * @param {object} args
  * @returns {Array<{ type: string, detail: string }>}
@@ -311,60 +406,64 @@ function computeBlockers({
   const rc = requiredClass || {};
   const out = [];
 
-  if (draft) {
-    out.push({ type: 'draft', detail: 'PR is a draft — mark it "Ready for review" before it can merge.' });
-  }
-
-  const conflictFiles = conflicts && conflicts.conflicted && Array.isArray(conflicts.files) ? conflicts.files : null;
-  if (conflictFiles && conflictFiles.length > 0) {
-    out.push({ type: 'conflict', detail: `Merge conflict in ${conflictFiles.length} file(s): ${joinNames(conflictFiles)} — resolve against base.` });
-  } else if (merge === 'CONFLICTING' || status === 'DIRTY') {
-    out.push({ type: 'conflict', detail: 'Branch conflicts with base (mergeable=CONFLICTING) — rebase/merge base and resolve.' });
-  }
-
-  if ((rc.failing || []).length > 0) {
-    out.push({ type: 'check-failing', detail: `Required check(s) failing: ${joinNames(rc.failing)} — see failures[] for the exact log excerpt.` });
-  }
-  if ((rc.missing || []).length > 0) {
-    out.push({ type: 'check-missing', detail: `Required check(s) never reported: ${joinNames(rc.missing)} — the workflow did not trigger; push a commit or re-run CI.` });
-  }
-  if ((rc.skipped || []).length > 0) {
-    out.push({ type: 'check-skipped', detail: `Required check(s) SKIPPED: ${joinNames(rc.skipped)} — a required gate that skips is NOT a pass to branch protection; it must run to success (this is why an all-green PR can stay BLOCKED).` });
-  }
-  if ((rc.pending || []).length > 0) {
-    out.push({ type: 'check-pending', detail: `Required check(s) still running: ${joinNames(rc.pending)} — wait for them to finish.` });
-  }
-
+  pushMaybe(out, draftBlocker(draft));
+  pushMaybe(out, conflictBlocker(conflicts, merge, status));
+  out.push(...requiredCheckBlockers(rc));
   if (behind > 0) {
     out.push({ type: 'behind', detail: `Branch is ${behind} commit(s) behind base — update/rebase the branch (protection requires branches be up to date).` });
   }
-
-  if (decision === 'CHANGES_REQUESTED') {
-    out.push({ type: 'changes-requested', detail: 'A reviewer requested changes — address the feedback and re-request review.' });
-  } else if (decision === 'REVIEW_REQUIRED') {
-    out.push({ type: 'review-required', detail: 'An approving review is still required before merge.' });
-  }
-
+  pushMaybe(out, reviewDecisionBlocker(decision));
   if (unresolvedThreadCount > 0) {
     out.push({ type: 'unresolved-threads', detail: `${unresolvedThreadCount} unresolved review thread(s) must be resolved before merge (see reviewThreads[]).` });
   }
 
-  // Nothing concrete explained a BLOCKED/UNSTABLE status → make the block visible
-  // rather than let the PR sit mysteriously un-mergeable.
+  // Nothing concrete explained a non-clean status → make the block visible.
   if (out.length === 0) {
-    if (status === 'BLOCKED') {
-      out.push({ type: 'blocked-unknown', detail: 'Merge is blocked by branch protection (mergeStateStatus=BLOCKED) but no failing check, missing/skipped required check, unresolved thread, or negative review was detected — check required reviews, code-owner approval, or other protection rules.' });
-    } else if (status === 'UNSTABLE' && failuresCount > 0) {
-      out.push({ type: 'unstable', detail: 'A non-required check is failing (mergeStateStatus=UNSTABLE). It does not gate merge but is worth fixing — see failures[].' });
-    }
+    pushMaybe(out, fallbackBlocker(status, rc, failuresCount));
   }
 
   return out;
 }
 
+/** Summary lines for the blockers section (numbered, or a "none" note). */
+function blockerLines(blockers) {
+  if (blockers.length === 0) {
+    return ['Blockers: none detected (nothing actionable this pass).'];
+  }
+  const lines = [`Blockers (${blockers.length}):`];
+  blockers.forEach((b, i) => lines.push(`  ${i + 1}. [${b.type}] ${b.detail}`));
+  return lines;
+}
+
+/** Summary lines for the failing-checks section (empty when none). */
+function failureLines(failures) {
+  if (failures.length === 0) return [];
+  const lines = [`Failing checks (${failures.length}):`];
+  for (const f of failures) {
+    const also = f.alsoFailedOn ? ` (+${f.alsoFailedOn} matrix job(s))` : '';
+    lines.push(`  • ${f.name}${also}`);
+    const first = String(f.excerpt || '').split('\n').filter(Boolean)[0];
+    if (first) lines.push(`      ${first}`);
+  }
+  return lines;
+}
+
+/** Summary lines for the unresolved-review-threads section (empty when none). */
+function threadLines(threads) {
+  if (threads.length === 0) return [];
+  const lines = [`Unresolved review threads (${threads.length}):`];
+  for (const t of threads) {
+    const loc = t.file ? `${t.file}${t.line != null ? `:${t.line}` : ''}` : '(general)';
+    const firstLine = String(t.body || '').split('\n').filter(Boolean)[0] || '';
+    lines.push(`  • ${loc} — ${t.author}: ${firstLine.slice(0, 120)}`);
+  }
+  return lines;
+}
+
 /**
  * Render the bounded payload as a compact human-readable summary (the non-JSON
- * view). Actionable-only, so a maintainer reads exactly what to fix.
+ * view). Actionable-only, so a maintainer reads exactly what to fix. Section
+ * construction lives in the small helpers above; this function just orders them.
  *
  * @param {object} payload - a payload produced by buildPullPayload.
  * @returns {string}
@@ -375,37 +474,54 @@ function renderPullSummary(payload) {
   const merge = `mergeable=${p.mergeable || 'UNKNOWN'}, mergeStateStatus=${p.mergeStateStatus || 'UNKNOWN'}`;
   lines.push(`PR #${p.pr || '?'} — ${p.state || 'UNKNOWN'} (${merge})`);
   if (p.summary) lines.push(p.summary);
-
-  const blockers = Array.isArray(p.blockers) ? p.blockers : [];
-  if (blockers.length === 0) {
-    lines.push('Blockers: none detected (nothing actionable this pass).');
-  } else {
-    lines.push(`Blockers (${blockers.length}):`);
-    blockers.forEach((b, i) => lines.push(`  ${i + 1}. [${b.type}] ${b.detail}`));
-  }
-
-  const failures = Array.isArray(p.failures) ? p.failures : [];
-  if (failures.length > 0) {
-    lines.push(`Failing checks (${failures.length}):`);
-    for (const f of failures) {
-      const also = f.alsoFailedOn ? ` (+${f.alsoFailedOn} matrix job(s))` : '';
-      lines.push(`  • ${f.name}${also}`);
-      const first = String(f.excerpt || '').split('\n').filter(Boolean)[0];
-      if (first) lines.push(`      ${first}`);
-    }
-  }
-
-  const threads = Array.isArray(p.reviewThreads) ? p.reviewThreads : [];
-  if (threads.length > 0) {
-    lines.push(`Unresolved review threads (${threads.length}):`);
-    for (const t of threads) {
-      const loc = t.file ? `${t.file}${t.line != null ? `:${t.line}` : ''}` : '(general)';
-      const firstLine = String(t.body || '').split('\n').filter(Boolean)[0] || '';
-      lines.push(`  • ${loc} — ${t.author}: ${firstLine.slice(0, 120)}`);
-    }
-  }
-
+  lines.push(...blockerLines(Array.isArray(p.blockers) ? p.blockers : []));
+  lines.push(...failureLines(Array.isArray(p.failures) ? p.failures : []));
+  lines.push(...threadLines(Array.isArray(p.reviewThreads) ? p.reviewThreads : []));
   return lines.join('\n');
+}
+
+/** `{ pr }` (stringified) when a PR number is given, else `{}`. */
+function prField(pr) {
+  return pr !== undefined ? { pr: String(pr) } : {};
+}
+
+/** Surface reviewDecision only when it is a BLOCKER (actionable-only): APPROVED
+ * and "not required" ('') are omitted. */
+function reviewDecisionField(reviewDecision) {
+  return (reviewDecision === 'CHANGES_REQUESTED' || reviewDecision === 'REVIEW_REQUIRED')
+    ? { reviewDecision }
+    : {};
+}
+
+/**
+ * Actionable-only required-check block: included only when SOMETHING about the
+ * required set needs attention (missing/skipped/pending/failing) or it was
+ * unreadable. All-green required sets are omitted entirely.
+ */
+function requiredChecksField(requiredChecks) {
+  const rc = requiredChecks || {};
+  const hasMissing = !!(rc.missing && rc.missing.length);
+  const hasSkipped = !!(rc.skipped && rc.skipped.length);
+  const hasPending = !!(rc.pending && rc.pending.length);
+  const hasFailing = !!(rc.failing && rc.failing.length);
+  if (!(hasMissing || hasSkipped || hasPending || hasFailing || rc.unreadable)) return {};
+  return {
+    requiredChecks: {
+      ...(hasMissing ? { missing: rc.missing } : {}),
+      ...(hasSkipped ? { skipped: rc.skipped } : {}),
+      ...(hasPending ? { pending: rc.pending } : {}),
+      ...(hasFailing ? { failing: rc.failing } : {}),
+      ...(rc.unreadable ? { unreadable: true } : {}),
+    },
+  };
+}
+
+/** `{ conflicts }` when a conflict is predicted, else `{}`. Mirrors the
+ * conflict blocker: any `conflicted === true` surfaces here. */
+function conflictsField(conflicts) {
+  return (conflicts && conflicts.conflicted)
+    ? { conflicts: { conflicted: true, files: Array.isArray(conflicts.files) ? conflicts.files : [] } }
+    : {};
 }
 
 /**
@@ -413,7 +529,8 @@ function renderPullSummary(payload) {
  * threads, per-excerpt line count) and flagging truncation so a consumer knows
  * the view was trimmed. Carries the full actionable-only blocker picture:
  * mergeability + WHY (`blockers`), required-check classification, pending checks,
- * behind-base, conflicts, review decision, and draft state.
+ * behind-base, conflicts, review decision, and draft state. The conditional
+ * field construction lives in the small helpers above.
  *
  * @param {object} args
  * @returns {object}
@@ -444,43 +561,20 @@ function buildPullPayload({
   }));
   const cappedThreads = reviewThreads.slice(0, maxThreads);
 
-  // Actionable-only: include a required-check block only when SOMETHING about the
-  // required set needs attention (or it was unreadable). All-green required sets
-  // are omitted entirely.
-  const rc = requiredChecks || {};
-  const rcActionable = (rc.missing && rc.missing.length)
-    || (rc.skipped && rc.skipped.length)
-    || (rc.pending && rc.pending.length)
-    || (rc.failing && rc.failing.length)
-    || rc.unreadable;
-
   return {
-    ...(pr !== undefined ? { pr: String(pr) } : {}),
+    ...prField(pr),
     state,
     summary,
     ...(reason ? { reason } : {}),
     mergeable,
     mergeStateStatus,
     ...(draft ? { draft: true } : {}),
-    // Surface reviewDecision only when it is a BLOCKER (actionable-only): APPROVED
-    // and "not required" ('') are omitted.
-    ...(reviewDecision === 'CHANGES_REQUESTED' || reviewDecision === 'REVIEW_REQUIRED'
-      ? { reviewDecision } : {}),
+    ...reviewDecisionField(reviewDecision),
     blockers,
-    ...(rcActionable ? {
-      requiredChecks: {
-        ...(rc.missing && rc.missing.length ? { missing: rc.missing } : {}),
-        ...(rc.skipped && rc.skipped.length ? { skipped: rc.skipped } : {}),
-        ...(rc.pending && rc.pending.length ? { pending: rc.pending } : {}),
-        ...(rc.failing && rc.failing.length ? { failing: rc.failing } : {}),
-        ...(rc.unreadable ? { unreadable: true } : {}),
-      },
-    } : {}),
+    ...requiredChecksField(requiredChecks),
     ...(pendingChecks && pendingChecks.length ? { pendingChecks } : {}),
     ...(behind > 0 ? { behind } : {}),
-    ...(conflicts && conflicts.conflicted ? {
-      conflicts: { conflicted: true, files: Array.isArray(conflicts.files) ? conflicts.files : [] },
-    } : {}),
+    ...conflictsField(conflicts),
     failures: cappedFailures,
     reviewThreads: cappedThreads,
     truncated: {

--- a/test/pr-pull.test.js
+++ b/test/pr-pull.test.js
@@ -8,6 +8,10 @@ const {
   jobIdFromUrl,
   dedupeFailures,
   buildReviewThreads,
+  classifyRequiredChecks,
+  pendingCheckNames,
+  computeBlockers,
+  renderPullSummary,
   buildPullPayload,
   gatherPullSignal,
 } = require('../lib/pr-pull');
@@ -180,6 +184,148 @@ describe('buildReviewThreads', () => {
   });
 });
 
+describe('classifyRequiredChecks (required-vs-produced)', () => {
+  const green = (name) => ({ name, status: 'COMPLETED', conclusion: 'SUCCESS' });
+  const fail = (name) => ({ name, status: 'COMPLETED', conclusion: 'FAILURE' });
+  const skip = (name) => ({ name, status: 'COMPLETED', conclusion: 'SKIPPED' });
+  const running = (name) => ({ name, status: 'IN_PROGRESS', conclusion: '' });
+
+  test('a required context that never reported is MISSING', () => {
+    const out = classifyRequiredChecks([green('Lint')], ['Lint', 'CodeQL']);
+    expect(out.missing).toEqual(['CodeQL']);
+    expect(out.skipped).toEqual([]);
+  });
+
+  test('a required context that only SKIPPED is a policy-block (the all-green-but-BLOCKED cause)', () => {
+    const out = classifyRequiredChecks([skip('Cross-OS Gate'), green('Lint')], ['Cross-OS Gate', 'Lint']);
+    expect(out.skipped).toEqual(['Cross-OS Gate']);
+    expect(out.failing).toEqual([]);
+    expect(out.missing).toEqual([]);
+  });
+
+  test('failing beats pending beats skipped when a matrix reports the same context multiple times', () => {
+    const checks = [skip('Gate'), running('Gate'), fail('Gate')];
+    expect(classifyRequiredChecks(checks, ['Gate']).failing).toEqual(['Gate']);
+    expect(classifyRequiredChecks([skip('Gate'), running('Gate')], ['Gate']).pending).toEqual(['Gate']);
+  });
+
+  test('a genuinely green required check appears in NONE of the actionable buckets', () => {
+    const out = classifyRequiredChecks([green('Lint'), skip('Lint')], ['Lint']);
+    expect(out.missing).toEqual([]);
+    expect(out.skipped).toEqual([]);
+    expect(out.pending).toEqual([]);
+    expect(out.failing).toEqual([]);
+  });
+
+  test('a null (unreadable) required set is flagged, not guessed', () => {
+    const out = classifyRequiredChecks([green('Lint')], null);
+    expect(out.unreadable).toBe(true);
+  });
+});
+
+describe('pendingCheckNames', () => {
+  test('returns unique names of only the in-flight checks', () => {
+    const checks = [
+      { name: 'a', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'b', status: 'IN_PROGRESS', conclusion: '' },
+      { name: 'b', status: 'QUEUED', conclusion: '' },
+      { name: 'c', status: 'COMPLETED', conclusion: 'FAILURE' },
+    ];
+    expect(pendingCheckNames(checks)).toEqual(['b']);
+  });
+});
+
+describe('computeBlockers (the human-readable WHY)', () => {
+  test('surfaces unresolved review threads as a blocker (the live #353 cause)', () => {
+    const blockers = computeBlockers({
+      mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED',
+      unresolvedThreadCount: 2,
+    });
+    const types = blockers.map((b) => b.type);
+    expect(types).toContain('unresolved-threads');
+    // no phantom blockers for things that are fine
+    expect(types).not.toContain('draft');
+    expect(types).not.toContain('behind');
+  });
+
+  test('a SKIPPED required check produces an explicit policy-block blocker', () => {
+    const blockers = computeBlockers({
+      mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED',
+      requiredClass: { missing: [], skipped: ['Cross-OS Gate'], pending: [], failing: [] },
+    });
+    expect(blockers.some((b) => b.type === 'check-skipped')).toBe(true);
+  });
+
+  test('behind-base, conflicts, draft, and changes-requested each surface', () => {
+    expect(computeBlockers({ mergeStateStatus: 'BEHIND', behind: 3 }).some((b) => b.type === 'behind')).toBe(true);
+    expect(computeBlockers({ mergeStateStatus: 'DIRTY', mergeable: 'CONFLICTING', conflicts: { conflicted: true, files: ['a.js'] } }).some((b) => b.type === 'conflict')).toBe(true);
+    expect(computeBlockers({ mergeStateStatus: 'BLOCKED', draft: true }).some((b) => b.type === 'draft')).toBe(true);
+    expect(computeBlockers({ mergeStateStatus: 'BLOCKED', reviewDecision: 'CHANGES_REQUESTED' }).some((b) => b.type === 'changes-requested')).toBe(true);
+  });
+
+  test('APPROVED review decision is NOT a blocker (actionable-only)', () => {
+    const blockers = computeBlockers({ mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED' });
+    expect(blockers.some((b) => b.type === 'changes-requested' || b.type === 'review-required')).toBe(false);
+  });
+
+  test('BLOCKED with no derivable cause still emits an explicit "blocked-unknown" so it is never invisible', () => {
+    const blockers = computeBlockers({ mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED' });
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].type).toBe('blocked-unknown');
+  });
+
+  test('a clean, mergeable PR has zero blockers', () => {
+    expect(computeBlockers({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' })).toEqual([]);
+  });
+});
+
+describe('renderPullSummary', () => {
+  test('renders the merge state, numbered blockers, and thread locations', () => {
+    const text = renderPullSummary({
+      pr: '353', state: 'NEEDS_REVIEW', mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED',
+      blockers: [{ type: 'unresolved-threads', detail: '2 unresolved review thread(s) must be resolved before merge (see reviewThreads[]).' }],
+      failures: [],
+      reviewThreads: [{ file: 'lib/x.js', line: 44, author: 'coderabbitai', body: 'guard null' }],
+    });
+    expect(text).toContain('PR #353');
+    expect(text).toContain('mergeStateStatus=BLOCKED');
+    expect(text).toContain('[unresolved-threads]');
+    expect(text).toContain('lib/x.js:44');
+    expect(text).toContain('coderabbitai');
+  });
+});
+
+describe('buildPullPayload (extended actionable-only fields)', () => {
+  test('omits reviewDecision when APPROVED, includes it when CHANGES_REQUESTED', () => {
+    const approved = buildPullPayload({ state: 'PENDING', summary: 's', reviewDecision: 'APPROVED', failures: [], reviewThreads: [] });
+    expect(approved.reviewDecision).toBeUndefined();
+    const changes = buildPullPayload({ state: 'PENDING', summary: 's', reviewDecision: 'CHANGES_REQUESTED', failures: [], reviewThreads: [] });
+    expect(changes.reviewDecision).toBe('CHANGES_REQUESTED');
+  });
+
+  test('omits the requiredChecks block entirely when the required set is all green', () => {
+    const payload = buildPullPayload({
+      state: 'MERGE_READY', summary: 's',
+      requiredChecks: { missing: [], skipped: [], pending: [], failing: [], unreadable: false },
+      failures: [], reviewThreads: [],
+    });
+    expect(payload.requiredChecks).toBeUndefined();
+  });
+
+  test('includes requiredChecks + behind + conflicts only when actionable', () => {
+    const payload = buildPullPayload({
+      state: 'ESCALATE', summary: 's',
+      requiredChecks: { missing: [], skipped: ['Gate'], pending: [], failing: [], unreadable: false },
+      behind: 4,
+      conflicts: { conflicted: true, files: ['a.js', 'b.js'] },
+      failures: [], reviewThreads: [],
+    });
+    expect(payload.requiredChecks.skipped).toEqual(['Gate']);
+    expect(payload.behind).toBe(4);
+    expect(payload.conflicts.files).toEqual(['a.js', 'b.js']);
+  });
+});
+
 describe('buildPullPayload', () => {
   test('assembles the compact shape and enforces caps + truncation flags', () => {
     const failures = Array.from({ length: 15 }, (_, i) => ({
@@ -318,5 +464,108 @@ describe('gatherPullSignal (orchestrator — injected gh runner, no live GitHub)
     });
     expect(payload.failures.length).toBe(1);
     expect(payload.failures[0].excerpt).toBe('');
+  });
+
+  test('surfaces mergeState, blockers, failing-required + unresolved-threads together', async () => {
+    const { adapter, runGh, runPass } = makeCtx();
+    const payload = await gatherPullSignal({
+      pr: '5', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh, runPass, self: 'me',
+    });
+    expect(payload.mergeStateStatus).toBe('BLOCKED');
+    expect(payload.mergeable).toBe('MERGEABLE');
+    const types = payload.blockers.map((b) => b.type);
+    expect(types).toContain('check-failing'); // required matrix checks are FAILURE
+    expect(types).toContain('unresolved-threads'); // the CodeRabbit thread
+    expect(payload.requiredChecks.failing).toContain('test (ubuntu, 20)');
+  });
+
+  test('models the live #353 case: all-green required + BLOCKED + unresolved CodeRabbit thread', async () => {
+    // All required checks green (incl. a matrix that reports twice), NOT behind,
+    // reviewDecision empty, but 2 unresolved CodeRabbit threads → BLOCKED by
+    // required-conversation-resolution. The payload must name that cause and the threads.
+    const checks = [
+      { name: 'CodeQL', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'Cross-OS Gate', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'Cross-OS Gate', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'Beads Integration', status: 'COMPLETED', conclusion: 'SKIPPED' }, // not required → ignored
+    ];
+    const threads = [
+      { threadId: 'PRRT_a', path: 'lib/workflow/stage-transition.js', line: 44, isResolved: false, isOutdated: false, comments: [{ author: 'coderabbitai', body: 'Functional Correctness | Minor', commentId: '111' }] },
+      { threadId: 'PRRT_b', path: 'lib/workflow/stage-transition.js', line: 77, isResolved: false, isOutdated: false, comments: [{ author: 'coderabbitai', body: 'Data Integrity | Major', commentId: '222' }] },
+    ];
+    const adapter = {
+      id: 'fake', kind: 'pr-state',
+      async readState() { return { headSha: 's', state: 'OPEN', mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED', reviewDecision: null, isDraft: false, checks, threads: [] }; },
+      async readRequiredChecks() { return ['CodeQL', 'Cross-OS Gate']; },
+      async readDivergence() { return { behind: 0, ahead: 2 }; },
+      async detectConflicts() { return { supported: true, conflicted: false, files: [] }; },
+      async readComments() { return threads; },
+    };
+    const payload = await gatherPullSignal({
+      pr: '353', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh: () => '', runPass: async () => ({ state: 'NEEDS_REVIEW', reason: 'threads' }), self: 'me',
+    });
+    expect(payload.mergeStateStatus).toBe('BLOCKED');
+    // No required-check block: every required context is green → actionable-only omits it.
+    expect(payload.requiredChecks).toBeUndefined();
+    // The one and only blocker is the unresolved threads — named explicitly.
+    expect(payload.blockers.map((b) => b.type)).toEqual(['unresolved-threads']);
+    expect(payload.reviewThreads).toHaveLength(2);
+    expect(payload.reviewThreads[0]).toMatchObject({ file: 'lib/workflow/stage-transition.js', line: 44, author: 'coderabbitai', threadId: 'PRRT_a', commentId: '111' });
+    expect(payload.behind).toBeUndefined(); // not behind → omitted
+  });
+
+  test('behind base → a behind blocker with the commit count', async () => {
+    const adapter = {
+      id: 'fake', kind: 'pr-state',
+      async readState() { return { headSha: 's', state: 'OPEN', mergeable: 'MERGEABLE', mergeStateStatus: 'BEHIND', checks: [], threads: [] }; },
+      async readRequiredChecks() { return []; },
+      async readDivergence() { return { behind: 5, ahead: 1 }; },
+      async readComments() { return []; },
+    };
+    const payload = await gatherPullSignal({
+      pr: '9', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh: () => '', runPass: async () => ({ state: 'ESCALATE', reason: 'behind' }), self: 'me',
+    });
+    expect(payload.behind).toBe(5);
+    expect(payload.blockers.some((b) => b.type === 'behind')).toBe(true);
+  });
+
+  test('predicted merge conflicts → a conflict blocker listing the files', async () => {
+    const adapter = {
+      id: 'fake', kind: 'pr-state',
+      async readState() { return { headSha: 's', state: 'OPEN', mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY', checks: [], threads: [] }; },
+      async readRequiredChecks() { return []; },
+      async readDivergence() { return { behind: 0, ahead: 1 }; },
+      async detectConflicts() { return { supported: true, conflicted: true, files: ['lib/a.js', 'lib/b.js'] }; },
+      async readComments() { return []; },
+    };
+    const payload = await gatherPullSignal({
+      pr: '9', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh: () => '', runPass: async () => ({ state: 'ESCALATE', reason: 'conflict' }), self: 'me',
+    });
+    expect(payload.conflicts.files).toEqual(['lib/a.js', 'lib/b.js']);
+    expect(payload.blockers.some((b) => b.type === 'conflict')).toBe(true);
+  });
+
+  test('a skipped REQUIRED check surfaces as the policy-block cause even when the rollup looks green', async () => {
+    const checks = [
+      { name: 'CodeQL', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'Cross-OS Gate', status: 'COMPLETED', conclusion: 'SKIPPED' },
+    ];
+    const adapter = {
+      id: 'fake', kind: 'pr-state',
+      async readState() { return { headSha: 's', state: 'OPEN', mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED', checks, threads: [] }; },
+      async readRequiredChecks() { return ['CodeQL', 'Cross-OS Gate']; },
+      async readDivergence() { return { behind: 0, ahead: 1 }; },
+      async readComments() { return []; },
+    };
+    const payload = await gatherPullSignal({
+      pr: '9', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh: () => '', runPass: async () => ({ state: 'ESCALATE', reason: 'skipped required' }), self: 'me',
+    });
+    expect(payload.requiredChecks.skipped).toEqual(['Cross-OS Gate']);
+    expect(payload.blockers.some((b) => b.type === 'check-skipped')).toBe(true);
   });
 });

--- a/test/pr-pull.test.js
+++ b/test/pr-pull.test.js
@@ -277,6 +277,34 @@ describe('computeBlockers (the human-readable WHY)', () => {
   test('a clean, mergeable PR has zero blockers', () => {
     expect(computeBlockers({ mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN' })).toEqual([]);
   });
+
+  test('a predicted conflict with an empty files list still fires a conflict blocker (payload/blocker consistency)', () => {
+    // conflicts.conflicted is true but files is empty AND mergeable/status do not
+    // literally say CONFLICTING/DIRTY — the blocker must still fire so the
+    // payload's conflicts object and blockers[] never disagree.
+    const blockers = computeBlockers({
+      mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED',
+      conflicts: { conflicted: true, files: [] },
+    });
+    const conflict = blockers.find((b) => b.type === 'conflict');
+    expect(conflict).toBeDefined();
+    expect(conflict.detail).toMatch(/conflict/i);
+  });
+
+  test('BEHIND status with no derivable commit count still surfaces a fallback blocker', () => {
+    // The #363 edge: mergeStateStatus=BEHIND but `behind` is unavailable (0) —
+    // the PR is not mergeable, so it must not report "none detected".
+    const blockers = computeBlockers({ mergeable: 'MERGEABLE', mergeStateStatus: 'BEHIND', behind: 0 });
+    expect(blockers.length).toBeGreaterThan(0);
+  });
+
+  test('unreadable required checks (branch-protection 403) surface as an explicit blocker', () => {
+    const blockers = computeBlockers({
+      mergeable: 'UNKNOWN', mergeStateStatus: 'BLOCKED',
+      requiredClass: { missing: [], skipped: [], pending: [], failing: [], unreadable: true },
+    });
+    expect(blockers.some((b) => b.type === 'check-required-unreadable')).toBe(true);
+  });
 });
 
 describe('renderPullSummary', () => {


### PR DESCRIPTION
## Summary

Rebuilds `forge shepherd <pr> --pull` so it extracts **every PR-blocking signal** into ONE bounded, actionable-only payload — the token-efficiency backbone. Refs kernel issue `a94d4a08`.

### Root cause of the empty `--pull` output (STEP 1)
The registry dispatch in `bin/forge.js` prints only `result.output`, but the shepherd handler returned `{ success, pull }` with **no `output` field**, so the whole payload was silently dropped (exit 0, empty). Only the legacy `bin/forge-cmd.js` path special-cased `result.pull`. Fix: the handler now sets `result.output` (compact human summary by default, JSON with `--json`) for `--pull` and `--bundle`, so the real entry point actually prints the payload.

### Comprehensive coverage (STEP 2)
`gatherPullSignal` now surfaces, in one deduped bounded payload:
- **Mergeability + WHY** — `mergeable` + `mergeStateStatus` + an ordered human-readable `blockers[]`.
- **Failed checks** with exact matrix-deduped log excerpts (existing, verified).
- **Pending checks** still running.
- **Required-but-missing / SKIPPED required checks** — classifies the branch-protection required set vs what the PR produced (`missing` / `skipped` / `pending` / `failing`). A SKIPPED *required* check is the invisible policy-block cause behind an all-green-but-BLOCKED PR.
- **Unresolved inline review threads** (human + CodeRabbit): file:line, body, threadId, commentId — the core bug that wasn't surfacing.
- **reviewDecision** (only when actionable: CHANGES_REQUESTED / REVIEW_REQUIRED).
- **Merge conflicts** (predicted conflicted files).
- **Behind-base** (commit count).
- **Draft state**.

**Actionable-only:** passing checks, resolved/outdated threads, APPROVED reviews, and satisfied policy are omitted — the agent receives only what it must ACT on.

### Verification
- Full shepherd/pr-pull/pr-state-adapter/pr-bundle/command test surface: **181 pass, 0 fail**. `eslint --max-warnings 0` clean.
- TDD on the pure extraction/formatting (injected gh/adapter). A fixture test models #353's exact blocked state (all-green + BLOCKED + 2 unresolved CodeRabbit threads) and asserts every blocker surfaces.
- Verified live against PR #353 via `bin/forge.js`: the payload now emits (was empty), correctly reporting current live merge state, pending checks, and threads.

### Scope split
Item 6 (direct PR comments / review-level summaries not in inline threads) deferred to follow-up `shepherd-pull-surface-actionable-b03ddbf2` — will be built actionable-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `forge shepherd <pr-number> --pull` to return a compact, strictly read-only actionable payload (or `--json`) including merge state, actionable blockers, required-check breakdown, pending checks, and unresolved review threads.
  * Added JSON output support for both `--pull` and `--bundle` (full PR-state snapshot).
  * Extended mergeability context with draft and review-decision indicators when they affect outcomes.
  * Improved human-readable summaries to highlight the primary blocker.
* **Documentation**
  * Documented `--pull` behavior, JSON fields, and clarified that `--pull` and `--bundle` are mutually exclusive.
* **Bug Fixes**
  * Refined blocker classification and ordering, including clearer handling of skipped/pending/unreadable required checks and unknown blocked states.
* **Tests**
  * Added comprehensive unit coverage for required-check classification, blocker generation, and JSON/human summary output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->