### PR TITLE
feat(dashboard): wire phase + live layer to real kernel feeds (5bfd2414)

### DIFF
--- a/web/dashboard/app.js
+++ b/web/dashboard/app.js
@@ -122,11 +122,20 @@ function matchesFilter(i) {
   return true;
 }
 function isLive(i) { return i.status === 'open' && !!i.claimed_by; }
-// Phase from real signals only (kernel has no currentStage — SEAM a2279f65). A done
-// issue is shipped; a claimed-open issue is in progress with the remaining stage UNKNOWN.
+// Phase from the REAL kernel stage_runs (f61601ab): the generator bakes
+// current_stage/current_stage_status (from `forge show`) onto claimed-open issues.
+// When a stage_run exists we show the actual stage; otherwise fall back honestly —
+// done = shipped, a claimed-open issue with NO stage_run yet is in progress with the
+// exact stage still UNKNOWN, an unclaimed one is planned.
 function lifecyclePhase(i) {
   if (i.status === 'done') return { idx: 6, label: 'shipped' };
   if (i.status === 'cancelled') return { idx: 0, label: 'cancelled' };
+  const stage = i.current_stage;
+  if (stage && PHASES.includes(stage)) {
+    const si = PHASES.indexOf(stage);
+    const complete = i.current_stage_status === 'done';
+    return { idx: complete ? si + 1 : si, label: stage, stage, stageStatus: i.current_stage_status || 'active' };
+  }
   if (i.claimed_by) return { idx: 2, label: 'in progress', unknown: true };
   return { idx: 1, label: 'planned' };
 }
@@ -181,8 +190,15 @@ function progress(r) {
 // 6-cell stepper — DETAIL ONLY now (removed from cards per the diet).
 function phaseTag(i) {
   const ph = lifecyclePhase(i);
-  const cells = PHASES.map((_, n) => n < ph.idx ? '<i class="on"></i>' : (ph.unknown ? '<i class="unk"></i>' : '<i></i>')).join('');
-  const t = ph.unknown ? `${ph.label} · exact stage unknown (SEAM a2279f65)` : ph.label;
+  // The current stage cell pulses when the real stage is active (not yet completed).
+  const activeCell = ph.stage && ph.stageStatus !== 'done' ? PHASES.indexOf(ph.stage) : -1;
+  const cells = PHASES.map((_, n) => {
+    if (n < ph.idx) return '<i class="on"></i>';
+    if (n === activeCell) return '<i class="act"></i>';
+    return ph.unknown ? '<i class="unk"></i>' : '<i></i>';
+  }).join('');
+  const t = ph.stage ? `stage ${ph.stage} (${ph.stageStatus}) — real, from kernel stage_runs`
+    : (ph.unknown ? `${ph.label} · exact stage unknown until a stage_run is recorded (a2279f65)` : ph.label);
   return `<span class="phase" title="lifecycle: ${esc(t)}"><span class="steps">${cells}</span><span class="lbl">${esc(ph.label)}</span></span>`;
 }
 
@@ -518,12 +534,23 @@ function renderNow() {
 
   const sentence = `<div class="nowline"><b>${agents}</b> agent${agents !== 1 ? 's' : ''} active · <b>${prs.length}</b> open PR${prs.length !== 1 ? 's' : ''} · <a href="#/overview" class="needslink"><b>${needs}</b> need${needs === 1 ? 's' : ''} you</a></div>`;
 
-  // Each live claim = one active thread. The branch/PR join is a SEAM (issue↔worktree
-  // linkage 56461780) — rendered as a slot so the shape is always visible.
-  const seam = seamId('workFolderGraph', '56461780');
+  // Each active lease = one thread of work, from the kernel lease feed (forge claims,
+  // 7dc229d4). actor + claimed-at are real; session / worktree / expiry render when
+  // present, else fall back to a SEAM. The branch/PR join stays a SEAM (work-graph 56461780).
+  const leaseSeam = seamId('harnessRegion', '7dc229d4');
+  const liveGlyph = (c) => (c.liveness === 'expired' ? '<span class="glyph" title="lease is past its expiry — stale">◐</span>' : pulse(true));
+  const leaseMeta = (c) => {
+    const bits = [];
+    if (c.claimed_at) bits.push(`<span class="slabel" title="lease claimed ${esc(c.claimed_at)}">claimed ${esc(relTime(c.claimed_at))} ago</span>`);
+    if (c.session_id) bits.push(`<span class="tag tag--soft" title="session">sess ${esc(clamp(String(c.session_id), 10))}</span>`);
+    if (c.worktree_id) bits.push(`<span class="tag tag--soft" title="worktree">wt ${esc(clamp(String(c.worktree_id), 10))}</span>`);
+    if (c.expires_at) bits.push(`<span class="${c.liveness === 'expired' ? 'seamtag' : 'slabel'}" title="lease expires ${esc(c.expires_at)}">${c.liveness === 'expired' ? 'expired' : 'expires ' + esc(relTime(c.expires_at))}</span>`);
+    else bits.push(`<span class="seamtag" title="session · worktree · expiry land when the kernel writes them">SEAM ${esc(leaseSeam)}</span>`);
+    return bits.join(' · ');
+  };
   const rows = claims.length ? claims.slice().sort(rankByPrio).map((c) => `<div class="nowrow" data-act="open" data-kind="issue" data-id="${esc(c.id)}">
-    ${pulse(true)}<span class="card__owner">${esc(c.owner)}</span><span class="nowrow__t">${esc(clamp(c.title, 66))}</span>${pmark(c.priority)}<span class="nowrow__link">→ branch · PR <span class="seamtag">SEAM ${esc(seam)}</span></span><span class="when">${esc(relTime(c.updated_at))}</span>
-  </div>`).join('') : `<div class="empty-state"><h4>Nothing running</h4><p>No open, claimed issues right now.</p></div>`;
+    ${liveGlyph(c)}<span class="card__owner">${esc(c.owner)}</span><span class="nowrow__t">${esc(clamp(c.title, 60))}</span>${pmark(c.priority)}<span class="nowrow__link">${leaseMeta(c)}</span><span class="when">${esc(relTime(c.updated_at))}</span>
+  </div>`).join('') : `<div class="empty-state"><h4>Nothing running</h4><p>No active leases right now.</p></div>`;
 
   const prRows = prs.length ? prs.map((p) => {
     const ci = p.ci ? p.ci.state : '';
@@ -542,7 +569,7 @@ function renderNow() {
       <div class="panel"><h3>Open pull requests · ${prs.length}</h3>${prRows}</div>
       <div class="panel"><h3>Worktrees · ${trees.filter((w) => !w.archived).length} <a href="#/workspaces" class="slabel" style="float:right">all →</a></h3>${wtRows}</div>
     </div>
-    <div class="seamnote">Real per-agent session · worktree · harness · region come from the kernel lease-read (${esc(seamId('harnessRegion', '7dc229d4'))}); today only <span class="mono">claimed_by</span> + git + PRs are exposed, so branch/PR↔issue joins above are SEAMs.</div>
+    <div class="seamnote">Active leases now come from the kernel lease feed (<span class="mono">forge claims</span> · ${esc(leaseSeam)}): actor + claimed-at are real. Per-lease session · worktree · harness · region · expiry render the moment the kernel writes them; branch/PR↔issue joins remain a SEAM (${esc(seamId('workFolderGraph', '56461780'))}).</div>
   </div>`;
 }
 
@@ -557,12 +584,20 @@ function renderAttention() {
     ${it.link ? `<a class="go" href="${esc(it.link)}" target="_blank" rel="noopener">open ↗</a>` : ''}
   </div>`).join('');
   const empty = !items.length ? `<div class="attn-row"><span class="glyph">●</span><span class="det">Nothing needs you — all open PRs are clean or in flight.</span></div>` : '';
-  const staleSeam = `<div class="attn-row"><span class="glyph">◐</span><span class="subj">Stale claims</span>
-    <span class="det">lease near expiry / heartbeat gone — not derivable from the CLI yet</span>
-    <span class="seamtag">SEAM ${esc(seamId('staleClaims', '7dc229d4'))}</span></div>`;
+  // Stale claims: real once the kernel writes expires_at (leases past expiry are stale).
+  // Until then, expires_at is null on every lease, so this honestly stays a SEAM.
+  const claims = (State.snapshot.ops && State.snapshot.ops.activeClaims) || [];
+  const expired = claims.filter((c) => c.liveness === 'expired');
+  const staleRow = expired.length
+    ? `<div class="attn-row"><span class="glyph">◐</span><span class="subj">Stale claims</span>
+        <span class="det">${expired.length} lease${expired.length > 1 ? 's' : ''} past expiry: ${esc(expired.slice(0, 3).map((c) => c.owner).join(', '))}</span>
+        <span class="why">reclaim or heartbeat</span></div>`
+    : `<div class="attn-row"><span class="glyph">◐</span><span class="subj">Stale claims</span>
+        <span class="det">no lease is past expiry — wired to <span class="mono">forge claims</span> expires_at, null until the kernel writes it</span>
+        <span class="seamtag">SEAM ${esc(seamId('staleClaims', '7dc229d4'))}</span></div>`;
   return `<div class="attention">
     <div class="attention__head"><span class="glyph">△</span><span class="ttl">Needs Attention</span><span class="ct">${items.length} now</span></div>
-    ${rows}${empty}${staleSeam}</div>`;
+    ${rows}${empty}${staleRow}</div>`;
 }
 
 /* ---- Workspaces ---- (worktree = card; "working on" makes the relation explicit) */

--- a/web/dashboard/app.test.js
+++ b/web/dashboard/app.test.js
@@ -40,6 +40,24 @@ test('lifecyclePhase derives phase from real signals; claimed-open is UNKNOWN, n
   expect(app.lifecyclePhase({ status: 'open' })).toEqual({ idx: 1, label: 'planned' });
 });
 
+test('lifecyclePhase uses the REAL kernel stage when stage_runs supply current_stage (f61601ab)', () => {
+  // active stage → filled cells = index of that stage (prior stages done, this one running)
+  const dev = app.lifecyclePhase({ status: 'open', claimed_by: 'a', current_stage: 'dev', current_stage_status: 'active' });
+  expect(dev).toEqual({ idx: 1, label: 'dev', stage: 'dev', stageStatus: 'active' });
+  expect(dev.unknown).toBeUndefined(); // real stage → not the "unknown" guess
+  // completed stage → that stage counts as done too (idx = index + 1)
+  const val = app.lifecyclePhase({ status: 'open', claimed_by: 'a', current_stage: 'validate', current_stage_status: 'done' });
+  expect(val).toEqual({ idx: 3, label: 'validate', stage: 'validate', stageStatus: 'done' });
+  // verify is the last stage (index 5); completed → idx 6
+  expect(app.lifecyclePhase({ status: 'open', current_stage: 'verify', current_stage_status: 'done' }).idx).toBe(6);
+  // status 'done' still wins over any recorded stage
+  expect(app.lifecyclePhase({ status: 'done', current_stage: 'dev', current_stage_status: 'active' })).toEqual({ idx: 6, label: 'shipped' });
+  // a non-canonical stage string is ignored → falls back to the claimed 'unknown' guess
+  const bogus = app.lifecyclePhase({ status: 'open', claimed_by: 'a', current_stage: 'bogus' });
+  expect(bogus.unknown).toBe(true);
+  expect(bogus.label).toBe('in progress');
+});
+
 test('epicRollup includes a live count', () => {
   const kids = [{ status: 'open', claimed_by: 'a' }, { status: 'open', claimed_by: 'b' }, { status: 'open' }, { status: 'done' }];
   expect(app.epicRollup({ id: 'e' }, kids).live).toBe(2);

--- a/web/dashboard/generate-snapshot.mjs
+++ b/web/dashboard/generate-snapshot.mjs
@@ -261,9 +261,65 @@ worktrees.forEach((w) => {
   w.archived = !op && !!mp;
 });
 
-const activeClaims = issues
-  .filter((i) => i.claimed_by && i.status === 'open')
-  .map((i) => ({ id: i.id, title: i.title, owner: i.claimed_by, priority: i.priority, updated_at: i.updated_at }));
+// ---- real workflow stage (f61601ab) ---------------------------------------
+// `forge issue list` omits current_stage, so read it per-issue with `forge show`
+// for the bounded open+claimed set — the only issues whose phase previously fell
+// back to the status+claim guess. Attaches current_stage/current_stage_status onto
+// the issue record so the client renders the REAL stage (unknown fallback stays
+// only while a claimed issue has no stage_run yet).
+const claimedOpen = issues.filter((i) => i.claimed_by && i.status === 'open');
+let stagePopulated = 0;
+claimedOpen.forEach((i) => {
+  const shown = tryRun(() => forge(['show', i.id, '--json']), null, `forge show ${String(i.id).slice(0, 8)}`);
+  const d = shown?.data;
+  if (d) {
+    i.current_stage = d.current_stage ?? null;
+    i.current_stage_status = d.current_stage_status ?? null;
+    if (i.current_stage) stagePopulated++;
+  }
+});
+
+// ---- live leases (7dc229d4 · forge claims) --------------------------------
+// Authoritative active-lease feed replaces inferring liveness from issue.claimed_by.
+// actor + claimed_at are real today; session_id / worktree_id / expires_at arrive
+// null until the kernel writes them (liveness-by-expiry lights up automatically).
+const PRANK = { P0: 0, P1: 1, P2: 2, P3: 3, P4: 4 };
+const leaseRes = tryRun(() => forge(['claims', '--json']), null, 'forge claims');
+const leaseList = Array.isArray(leaseRes?.data?.claims) ? leaseRes.data.claims : null;
+const nowMs = Date.now();
+const leaseLiveness = (lease) => {
+  if (!lease.expires_at) return 'active'; // no expiry known yet (kernel not writing it)
+  return Date.parse(lease.expires_at) > nowMs ? 'live' : 'expired';
+};
+let activeClaims;
+if (leaseList) {
+  // One lease per issue (latest claimed_at wins if the single-active invariant ever
+  // breaks); keep only leases whose issue exists and is open — the "what's running" set.
+  const issueById = new Map(issues.map((i) => [i.id, i]));
+  const leaseByIssue = new Map();
+  for (const l of leaseList) {
+    const prev = leaseByIssue.get(l.issue_id);
+    if (!prev || Date.parse(l.claimed_at || 0) > Date.parse(prev.claimed_at || 0)) leaseByIssue.set(l.issue_id, l);
+  }
+  activeClaims = [...leaseByIssue.values()]
+    .map((l) => ({ l, issue: issueById.get(l.issue_id) }))
+    .filter(({ issue }) => issue && issue.status === 'open')
+    .map(({ l, issue }) => ({
+      id: issue.id, title: issue.title, owner: l.actor, priority: issue.priority, updated_at: issue.updated_at,
+      claimed_at: l.claimed_at ?? null, session_id: l.session_id ?? null,
+      worktree_id: l.worktree_id ?? null, expires_at: l.expires_at ?? null,
+      liveness: leaseLiveness(l),
+    }))
+    .sort((a, b) => (PRANK[a.priority] ?? 9) - (PRANK[b.priority] ?? 9));
+} else {
+  // Fallback for a kernel without `forge claims`: infer from issue.claimed_by.
+  activeClaims = claimedOpen.map((i) => ({
+    id: i.id, title: i.title, owner: i.claimed_by, priority: i.priority, updated_at: i.updated_at,
+    claimed_at: null, session_id: null, worktree_id: null, expires_at: null, liveness: 'active',
+  }));
+}
+const staleLeaseCount = activeClaims.filter((c) => c.liveness === 'expired').length;
+const leaseSourced = !!leaseList;
 
 // ---- Needs Attention (control surface, ranked) ----------------------------
 const needsAttention = [];
@@ -276,7 +332,8 @@ prs.forEach((p) => {
 });
 needsAttention.sort((a, b) => a.rank - b.rank);
 
-console.log(`  ops: ${worktrees.length} worktrees, ${prs.length} open PRs, ${mergedPrs.length} merged, ${activeClaims.length} active claims`);
+console.log(`  ops: ${worktrees.length} worktrees, ${prs.length} open PRs, ${mergedPrs.length} merged, ${activeClaims.length} active claims (${leaseSourced ? 'forge claims' : 'inferred'})`);
+console.log(`  stage_runs: ${stagePopulated}/${claimedOpen.length} claimed issues have a real current_stage · stale leases: ${staleLeaseCount}`);
 console.log(`  needs-attention: ${needsAttention.length}`);
 
 // ---- assemble + write -----------------------------------------------------
@@ -292,13 +349,23 @@ const snapshot = {
     needsAttention: needsAttention.length,
   },
   liveSeam: {
-    exposed: ['claimed_by (actor)', 'git worktree list (+ahead/behind/dirty)', 'gh pr list (+CI/mergeable)'],
-    pending: ['session_id', 'worktree_id', 'harness', 'region', 'lease expires_at'],
+    exposed: ['active leases via forge claims (actor, claimed_at)', 'current_stage via forge show (stage_runs)', 'git worktree list (+ahead/behind/dirty)', 'gh pr list (+CI/mergeable)'],
+    pending: ['lease session_id', 'lease worktree_id', 'harness', 'region', 'lease expires_at'],
+  },
+  // Real-vs-pending flags for the consumer wiring (5bfd2414).
+  live: {
+    leaseSourced,                 // activeClaims came from `forge claims` (authoritative) vs inferred
+    stagePopulated,               // # claimed issues with a real current_stage today
+    claimedOpen: claimedOpen.length,
+    staleLeaseCount,              // leases past expires_at (0 until the kernel writes expires_at)
+    expiryKnown: activeClaims.some((c) => c.expires_at),
+    worktreeIdKnown: activeClaims.some((c) => c.worktree_id),
+    sessionKnown: activeClaims.some((c) => c.session_id),
   },
   // Data seams — filed kernel issues that will replace best-effort/SEAM rendering.
   seams: {
-    staleClaims: '7dc229d4 · lease-read (session_id, worktree_id, harness, expires_at, heartbeat)',
-    workflowStage: 'a2279f65 · issue currentStage (phase is derived best-effort until then)',
+    staleClaims: '7dc229d4 · lease-read expiry/heartbeat (forge claims exposes leases; expires_at null until the kernel writes it)',
+    workflowStage: 'a2279f65 · current_stage now read from stage_runs (f61601ab); unknown only until a stage_run is recorded',
     workFolderGraph: '56461780 · work-folder ↔ PR/issue/decision connection graph',
     graphiti: 'c7971150 · Graphiti temporal-memory render feed (memory.backend=graphiti, opt-in)',
     backlogState: 'b2f856b1 · kernel backlog lifecycle state (parked ideas)',

--- a/web/dashboard/styles.css
+++ b/web/dashboard/styles.css
@@ -410,6 +410,9 @@ tr.child .rowname .tt { color: var(--muted); font-size: 12px; }
 .kcol__note { font-family: var(--mono); font-size: 9px; color: var(--faint); text-transform: uppercase; letter-spacing: .05em; }
 .phase .steps i.unk { border-style: dashed; background: transparent; opacity: .55; }
 .phase.dim .steps i.unk { border-color: var(--faint); }
+/* real current stage, in progress (from kernel stage_runs) — a half-filled, pulsing cell */
+.phase .steps i.act { background: linear-gradient(var(--text) 0 0) 0/100% 50% no-repeat; animation: phasePulse 1.6s ease-in-out infinite; }
+@keyframes phasePulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
 .epicfocus { border: 1px solid var(--line); background: var(--bg); color: var(--muted); font-family: var(--mono); font-size: 9px; text-transform: uppercase; letter-spacing: .05em; padding: 1px 6px; cursor: pointer; margin-left: auto; }
 .epicfocus:hover { background: var(--text); color: var(--bg); border-color: var(--text); }
 .kcard--epic .kcard__id { margin-left: 0; }


### PR DESCRIPTION
Consumer-side wiring for issue **5bfd2414** — turns two SEAM labels into real consumers of the now-merged kernel reads. Builds on the merged v6 dashboard.

## What's now REAL
**Phase from `stage_runs` (f61601ab, PR #348/#353)**
- `forge issue list` omits `current_stage`, so the generator reads it per-issue via `forge show` for the bounded open+claimed set and bakes `current_stage`/`current_stage_status` onto those records.
- `lifecyclePhase()` maps the real kernel stage (vocabulary is identical to the dashboard `PHASES`) into the detail stepper — completed cells + a pulsing active cell. Honest `unknown` fallback stays only when a claimed issue has no stage_run yet.

**Live layer from leases (7dc229d4, PR #354 `forge claims`)**
- `activeClaims` is built from the authoritative `forge claims --json` lease feed (actor + claimed_at), replacing inference from `issue.claimed_by`; falls back to inference for a kernel without the command.
- **Now** view renders real actor + claimed-age + liveness. **Needs-Attention** stale-claims row is wired to lease `expires_at`.

## Honest state today (real vs pending)
- `stage_runs` is empty (0/22 claimed issues populated) → stepper shows the honest `unknown` fallback until a stage_run lands. Verified the real path renders correctly by injecting a stage.
- Lease `session_id` / `worktree_id` / `expires_at` are **null** on all 46 leases → those chips, liveness-by-expiry, and the worktree↔lease join render the moment the kernel writes them; SEAM until then.
- **Still SEAMs** (kernel feeds not built): work-graph `56461780`, Graphiti `c7971150`.
- A `live` block in the snapshot flags what's real vs pending.

## Verification
- 14/14 dashboard tests pass (added real-stage mapping coverage), ESLint clean (`--max-warnings 0`).
- Playwright: Now view shows 22 real leases (`forge-cs · claimed 8d ago · SEAM 7dc229d4`); injected `validate`/`active` renders cells `[on,on,act,off,off,off]`.
- Mono/dark/routing/one-card intact.

**DO NOT MERGE** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)