### PR TITLE
fix(docs,recap): document core workflow loop; drop redundant recap error noise

### DIFF
--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -33,7 +33,6 @@ Use `--agents`, not `--agent`.
 ## Local State
 
 ```bash
-forge status --json
 forge board --json
 forge options lint
 forge options diff
@@ -41,9 +40,37 @@ forge options why <key>
 forge options stages
 ```
 
-`forge status` also supports workflow-state and issue-state inputs used by tests and stage recovery.
-
 `forge options` inspects the runtime graph and `.forge/` adoption config created by `forge init`.
+
+`forge status` (full flags below) also supports workflow-state and issue-state inputs used by tests and stage recovery.
+
+## Core Workflow Loop
+
+These are the CLI commands behind the default agent workflow template (`/plan -> /dev -> /validate -> /ship`, then the `/review` skill) plus the session-orientation and memory commands agents run alongside it. Verified against `lib/commands/<name>.js` and `forge <cmd> --help`.
+
+```bash
+forge plan "<feature description>"
+forge dev [--issue-id <id>] [--phase red|green|refactor]
+forge validate
+forge ship <feature-slug> [<title>] [--dry-run]
+forge status [--full] [--json]
+forge prime [--budget N] [--json]
+forge orient [--budget N] [--json]
+forge recap <issue> [--budget N] [--json]
+forge recall [query] [--limit N] [--all] [--json]
+forge remember <note> [--tag <label>]... [--json]
+```
+
+- `forge plan` creates the implementation plan, kernel issue, and feature branch/worktree from a researched feature description; it prints the created issue id, branch name, and the suggested next command.
+- `forge dev` runs the TDD development stage with RED/GREEN/REFACTOR phase guidance; `--issue-id` scopes it to a specific kernel issue and `--phase` overrides auto-detection.
+- `forge validate` runs the validation orchestration pipeline (conflict markers, type check, lint, security, tests) with no arguments — see also `bun run check` under Validation And Packaging.
+- `forge ship` creates the pull request from validated feature work (wraps `gh pr create`); `--dry-run` previews without creating a PR.
+- `forge status` is the one-glance orientation command: where you are, what to run next, and your active work; `--full` also shows blocked/stale/recently-completed issues.
+- `forge prime` emits the bounded session-entry orientation envelope agents read at the start of a session.
+- `forge orient` emits bounded project orientation from deterministic source files (broader than `prime`, still token-budgeted via `--budget`).
+- `forge recap <issue>` is the issue-scoped counterpart to `forge orient`/`forge prime` — it summarizes a single issue from the same deterministic file assembly instead of the whole project. Requires an issue id; running it with no id (or `--help`) prints usage only.
+- `forge recall` retrieves project-memory notes from the kernel-backed memory store; omit `query` to list recent notes.
+- `forge remember` persists a project-memory note to the kernel-backed memory store; repeat `--tag` to attach multiple labels.
 
 ## Issue Wrappers
 

--- a/lib/commands/recap.js
+++ b/lib/commands/recap.js
@@ -38,7 +38,10 @@ function readIssueArg(args) {
 async function handler(args, _flags, projectRoot) {
   const issueId = readIssueArg(args);
   if (!issueId) {
-    return { success: false, output: `${usage}\n` };
+    // Use `error` (not `output`) so the CLI dispatcher prints the usage line
+    // once via console.error instead of also appending a redundant bare
+    // "Command failed" (see bin/forge.js registry dispatch).
+    return { success: false, error: usage };
   }
 
   const recap = buildIssueRecap(projectRoot, issueId, {

--- a/test/commands/recap.test.js
+++ b/test/commands/recap.test.js
@@ -74,6 +74,10 @@ describe('forge recap command', () => {
     const result = await recap.handler([], {}, root);
 
     expect(result.success).toBe(false);
-    expect(result.output).toContain('forge recap <issue>');
+    // Usage goes on `error` (not `output`) so the CLI dispatcher prints it
+    // once via console.error instead of also appending a bare "Command
+    // failed" (see bin/forge.js registry dispatch).
+    expect(result.error).toContain('forge recap <issue>');
+    expect(result.output).toBeUndefined();
   });
 });

--- a/test/orientation.test.js
+++ b/test/orientation.test.js
@@ -173,7 +173,11 @@ describe('issue-scoped recap command', () => {
     const result = await recap.handler([], {}, root);
 
     expect(result.success).toBe(false);
-    expect(result.output).toContain('forge recap <issue>');
+    // Usage goes on `error` (not `output`) so the CLI dispatcher prints it
+    // once via console.error instead of also appending a bare "Command
+    // failed" (see bin/forge.js registry dispatch).
+    expect(result.error).toContain('forge recap <issue>');
+    expect(result.output).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- `docs/reference/COMMANDS.md` omitted the entire core workflow loop (plan, dev, validate, ship, status, prime, orient, recap, recall, remember). Added a "Core Workflow Loop" section, verified against `lib/commands/<name>.js` and `forge <cmd> --help` output for each command.
- `forge recap` with no/invalid id printed the usage line via `output` AND a redundant bare `Command failed` from the CLI dispatcher's generic fallback (`bin/forge.js` line ~4041). Switched `lib/commands/recap.js` to return the usage message via `error` instead — matching the convention used by every other command in `lib/commands/` (e.g. `audit.js`, `add.js`, `doc-gate.js`) — so only the usage line prints once, still exiting non-zero.

Fixes 3faa93ac-c010-458f-a454-4da8282b07bd
Fixes ce24e824-36fc-4346-a084-d3a9cdfbcdb3

## Test plan
- [x] `bun test test/commands/recap.test.js` — 6 pass (updated the no-id test to assert `result.error` instead of `result.output`)
- [x] `bun test test/commands/` — 725 pass, 0 fail (full commands suite)
- [x] `npx eslint lib/commands/recap.js test/commands/recap.test.js --max-warnings 0` — clean
- [x] Manually verified `forge recap` (no args) now prints the usage line once and exits 1, no more bare "Command failed"
- [x] Manually verified `forge plan/dev/validate/ship/status/prime/orient/recap/recall/remember --help` output against the new doc section

🤖 Generated with [Claude Code](https://claude.com/claude-code)