### PR TITLE
fix(kernel): backlog-correctness cluster — status transitions, claim eligibility, parked deps + status bucket

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -15,7 +15,7 @@ const {
 	isValidIssuePriority,
 	normalizePriority,
 } = require('./issue-command-contract');
-const { isValidIssueStatus, rankForPriorityLabel } = require('./taxonomy-validator');
+const { isValidIssueStatus, isValidStatusTransition, rankForPriorityLabel } = require('./taxonomy-validator');
 const { assertFilesystemSafeForKernel } = require('./fs-class');
 const { resolveIssueIdArgs } = require('./issue-id-resolver');
 
@@ -704,6 +704,23 @@ async function buildIssueMutationEvent(driver, operation, args, context, config)
 		return buildDependencyMutationEvent(operation, flags, actor, origin, context, args);
 	}
 	if (CLAIM_OPERATIONS.has(operation)) {
+		// Claim eligibility: a `backlog` (parked) issue is NOT workable — beginning it
+		// would jump backlog->in_progress and skip the required promote (backlog->open).
+		// Reject the claim here rather than minting a lease that silently activates parked
+		// work. `release` is never gated (an over-eager park must always be releasable).
+		if (operation === 'claim') {
+			const claimIssueId = typeof flags.issue === 'string' ? flags.issue : firstPositionalArg(args);
+			const claimEntity = await driver.loadKernelEntity('issue', claimIssueId, context, config);
+			if (claimEntity && claimEntity.status === 'backlog') {
+				const err = new Error(
+					`Cannot claim a parked (backlog) issue ${claimIssueId}: promote it first `
+					+ `(forge issue update ${claimIssueId} --status open)`,
+				);
+				err.isIssueValidation = true;
+				err.validationField = 'status';
+				throw err;
+			}
+		}
 		return buildClaimMutationEvent(operation, flags, actor, origin, context, args);
 	}
 
@@ -729,6 +746,22 @@ async function buildIssueMutationEvent(driver, operation, args, context, config)
 	// comment carries no taxonomy fields, so it is exempt.
 	if (operation !== 'comment') {
 		assertValidIssueMutationPayload(payload, false);
+	}
+	// Enforce the stored status-transition graph on any status CHANGE the payload
+	// carries (an `update --status`, or a `close --status` rework move). Without this
+	// the row-level CAS happily persists an illegal jump — done->open resurrects a
+	// terminal issue, backlog->in_progress skips the required promote. isValidStatusTransition
+	// treats an unchanged status as an idempotent no-op, so a re-set to the same value passes.
+	// Only gate when the CURRENT status is a known-valid stored value: if the loaded entity
+	// carries no readable status (minimal driver fakes; a not-yet-materialized row), fall
+	// through to the CAS/quarantine path rather than manufacturing a false validation error.
+	if (payload.status !== undefined
+		&& isValidIssueStatus(entity.status)
+		&& !isValidStatusTransition(entity.status, payload.status)) {
+		const err = new Error(`Illegal status transition: ${entity.status} -> ${payload.status}`);
+		err.isIssueValidation = true;
+		err.validationField = 'status';
+		throw err;
 	}
 	// Comments never bump entity_revision, so a revision-based key would collide for
 	// every comment on the same issue (second → false duplicate → silently dropped).

--- a/lib/kernel/readiness-model.js
+++ b/lib/kernel/readiness-model.js
@@ -7,6 +7,11 @@ const { getTypeBehavior, isTerminalStatus, normalizeRank, toEpochMillis } = requ
 // they are NEVER stored as issue status values.
 const READINESS_REASONS = Object.freeze({
 	DEPENDENCY: 'dependency',
+	// A blocker that is itself PARKED (backlog): it will never complete on its own, so it
+	// blocks its dependents indefinitely. Surfaced as a distinct code (not plain
+	// `dependency`) so a parked blocker is not mistaken for ordinary in-flight work — a
+	// consumer can flag it for promotion instead of waiting on it forever.
+	DEPENDENCY_PARKED: 'dependency_parked',
 	QUARANTINE: 'quarantine',
 	CONFLICT: 'conflict',
 	GATE: 'gate',
@@ -83,7 +88,14 @@ function collectDependencyBlockers(context, reasons, blockedBy) {
 		// blocks — a cancelled dependency must not wedge the dependent as permanently blocked.
 		if (isTerminalStatus(dependency.status)) continue;
 		blockedBy.push(dependency.id);
-		const reason = { code: READINESS_REASONS.DEPENDENCY, issue_id: dependency.id, status: dependency.status };
+		// A parked (backlog) blocker earns a distinct code + flag: it is stalled by design,
+		// not being actively worked, so consumers can call it out for promotion.
+		const isParked = dependency.status === 'backlog';
+		const code = isParked ? READINESS_REASONS.DEPENDENCY_PARKED : READINESS_REASONS.DEPENDENCY;
+		const reason = { code, issue_id: dependency.id, status: dependency.status };
+		if (isParked) {
+			reason.parked = true;
+		}
 		if (dependency.type === 'decision') {
 			reason.decision = true;
 		}

--- a/lib/status/presenter.js
+++ b/lib/status/presenter.js
@@ -143,6 +143,7 @@ function formatZeroArgStatus({ context, snapshot, workflowResult = null, full = 
 		blocks.push(
 			buildSection('Blocked', (snapshot.blocked || []).map(issue => formatIssue(issue, { includeStatus: true })), { limit: DEFAULT_SECTION_LIMIT }).join('\n').trim(),
 			buildSection('Stale', (snapshot.stale || []).map(issue => formatIssue(issue, { includeStatus: true })), { limit: DEFAULT_SECTION_LIMIT }).join('\n').trim(),
+			buildSection('Parked', (snapshot.parked || []).map(issue => formatIssue(issue, { includeStatus: true })), { limit: DEFAULT_SECTION_LIMIT }).join('\n').trim(),
 			buildSection('Recent Completions', (snapshot.recentCompleted || []).map(issue => formatIssue(issue)), { limit: DEFAULT_SECTION_LIMIT }).join('\n').trim(),
 		);
 	}
@@ -158,6 +159,7 @@ function buildPersonalStatusJson({ context, snapshot, workflowResult = null }) {
 			ready: (snapshot.ready || []).map(toIssueSummary),
 			blocked: (snapshot.blocked || []).map(toIssueSummary),
 			stale: (snapshot.stale || []).map(toIssueSummary),
+			parked: (snapshot.parked || []).map(toIssueSummary),
 			recentCompleted: (snapshot.recentCompleted || []).map(toIssueSummary),
 		},
 		workflow: workflowResult ? {
@@ -183,6 +185,7 @@ function formatBoard({ context, snapshot }) {
 		...buildSection('Ready', (snapshot.ready || []).map(issue => formatIssue(issue)), { limit: DEFAULT_SECTION_LIMIT }),
 		...buildSection('Blocked', (snapshot.blocked || []).map(issue => formatIssue(issue, { includeStatus: true })), { limit: DEFAULT_SECTION_LIMIT }),
 		...buildSection('Stale', (snapshot.stale || []).map(issue => formatIssue(issue, { includeStatus: true })), { limit: DEFAULT_SECTION_LIMIT }),
+		...buildSection('Parked', (snapshot.parked || []).map(issue => formatIssue(issue, { includeStatus: true })), { limit: DEFAULT_SECTION_LIMIT }),
 		...buildSection('Recent Completions', (snapshot.recentCompleted || []).map(issue => formatIssue(issue)), { limit: DEFAULT_SECTION_LIMIT }),
 		...buildSection('Limits', snapshot.limits || []),
 	].join('\n');
@@ -196,6 +199,7 @@ function buildBoardJson({ context, snapshot }) {
 			ready: (snapshot.ready || []).map(toIssueSummary),
 			blocked: (snapshot.blocked || []).map(toIssueSummary),
 			stale: (snapshot.stale || []).map(toIssueSummary),
+			parked: (snapshot.parked || []).map(toIssueSummary),
 			recentCompleted: (snapshot.recentCompleted || []).map(toIssueSummary),
 		},
 		limits: snapshot.limits || [],

--- a/lib/status/snapshot.js
+++ b/lib/status/snapshot.js
@@ -4,9 +4,11 @@ const { resolveIssueBackend } = require('../issue-backend.js');
 const { runIssueOperation: defaultRunIssueOperation } = require('../forge-issues.js');
 const { readBeadsSnapshot, getDeveloperIdentity } = require('./beads-snapshot.js');
 
-// Kernel status vocabulary: 'open' (ready / blocked / in-progress work) and the
-// terminal 'done' / 'cancelled'. There is no 'in_progress' status — an issue is "in
-// progress" when it is OPEN and carries a live claim (claimed_by). These buckets
+// Kernel status vocabulary (taxonomy-validator): 'open', 'in_progress', 'review',
+// the parked 'backlog', and the terminal 'done' / 'cancelled'. `ready` / `blocked`
+// are DERIVED read-model facts, never stored. An issue is treated as active here when
+// it is OPEN and carries a live claim (claimed_by); parked (`backlog`) work is its own
+// bucket so it stays visible instead of vanishing between ready and done. These buckets
 // mirror the shape readBeadsSnapshot produces so lib/status/presenter.js consumes
 // either backend's snapshot identically.
 const KERNEL_LIMITS = Object.freeze([
@@ -82,6 +84,7 @@ function emptyKernelSnapshot(developer) {
 		ready: [],
 		blocked: [],
 		stale: [],
+		parked: [],
 		recentCompleted: [],
 		limits: KERNEL_LIMITS,
 	};
@@ -128,6 +131,9 @@ async function readKernelSnapshot(projectRoot, options = {}) {
 		const active = all.filter(isActiveKernelIssue).sort(sortByUpdatedAtDesc);
 		const activeAssigned = active.filter(issue => identities.has(String(issue.claimed_by || '').toLowerCase()));
 		const recentCompleted = all.filter(issue => issue.status === 'done').sort(sortByUpdatedAtDesc);
+		// Parked (`backlog`) work is a first-class lifecycle state that never appears in
+		// ready/blocked/active — surface it as its own bucket so it stays visible.
+		const parked = all.filter(issue => issue.status === 'backlog').sort(sortByUpdatedAtDesc);
 
 		return {
 			developer,
@@ -137,6 +143,7 @@ async function readKernelSnapshot(projectRoot, options = {}) {
 			ready: ready.map(annotateKernelIssue),
 			blocked: [...blocked].sort(sortByUpdatedAtDesc).map(annotateKernelIssue),
 			stale: [...stale].sort(sortByUpdatedAtDesc).map(annotateKernelIssue),
+			parked: parked.map(annotateKernelIssue),
 			recentCompleted: recentCompleted.map(annotateKernelIssue),
 			limits: KERNEL_LIMITS,
 		};

--- a/test/kernel/kernel-parity-bugs.test.js
+++ b/test/kernel/kernel-parity-bugs.test.js
@@ -304,4 +304,80 @@ describe('Kernel parity bugs', () => {
 		expect(order.indexOf('ord-c')).toBeLessThan(order.indexOf('ord-b'));
 		expect(order.indexOf('ord-b')).toBeLessThan(order.indexOf('ord-a'));
 	});
+
+	// --- BUG: update mutation must enforce the status-transition graph -----------
+
+	async function currentStatus(id) {
+		const shown = await driver.issueOperation('show', [id], {}, config);
+		return shown.data.status;
+	}
+
+	test('update rejects an illegal status transition (backlog -> in_progress) and does not persist it', async () => {
+		await createIssue(['--id', 'tg-1', '--title', 'parked', '--type', 'task', '--status', 'backlog']);
+		const result = await broker.runIssueOperation(
+			'update',
+			['tg-1', '--status', 'in_progress'],
+			{ now: '2026-06-29T00:02:00.000Z', actor: 'tester' },
+		);
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+		expect(result.error.code).toContain('VALIDATION');
+		// The illegal move was rejected before the write — status is still backlog.
+		expect(await currentStatus('tg-1')).toBe('backlog');
+	});
+
+	test('update rejects resurrecting a terminal issue (done -> open)', async () => {
+		await createIssue(['--id', 'tg-2', '--title', 'to close', '--type', 'task']);
+		// open -> in_progress -> review -> done are all legal moves.
+		await broker.runIssueOperation('update', ['tg-2', '--status', 'in_progress'], { now, actor: 'tester' });
+		await broker.runIssueOperation('update', ['tg-2', '--status', 'review'], { now, actor: 'tester' });
+		await broker.runIssueOperation('update', ['tg-2', '--status', 'done'], { now, actor: 'tester' });
+		expect(await currentStatus('tg-2')).toBe('done');
+
+		const result = await broker.runIssueOperation('update', ['tg-2', '--status', 'open'], { now, actor: 'tester' });
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+		expect(await currentStatus('tg-2')).toBe('done');
+	});
+
+	test('update allows a legal status transition (open -> in_progress)', async () => {
+		await createIssue(['--id', 'tg-3', '--title', 'legal move', '--type', 'task']);
+		const result = await broker.runIssueOperation(
+			'update',
+			['tg-3', '--status', 'in_progress'],
+			{ now, actor: 'tester' },
+		);
+		expect(result.ok).toBe(true);
+		expect(await currentStatus('tg-3')).toBe('in_progress');
+	});
+
+	test('update with no status change (only other fields) is unaffected by the transition gate', async () => {
+		await createIssue(['--id', 'tg-4', '--title', 'parked', '--type', 'task', '--status', 'backlog']);
+		const result = await broker.runIssueOperation(
+			'update',
+			['tg-4', '--title', 'parked but renamed'],
+			{ now, actor: 'tester' },
+		);
+		expect(result.ok).toBe(true);
+		expect(await currentStatus('tg-4')).toBe('backlog');
+	});
+
+	// --- BUG: claim must not begin a parked (backlog) issue ----------------------
+
+	test('claim rejects a parked (backlog) issue — no backlog -> in_progress jump', async () => {
+		await createIssue(['--id', 'cl-1', '--title', 'parked idea', '--type', 'task', '--status', 'backlog']);
+		const result = await broker.runIssueOperation('claim', ['cl-1'], { now, actor: 'alice' });
+		expect(result.ok).toBe(false);
+		expect(result.error.exit_code).toBe(6);
+		expect(result.error.code).toContain('VALIDATION');
+		// No claim lease was minted for the parked issue.
+		const claims = await driver.queryAll('SELECT * FROM kernel_claims', config);
+		expect(claims).toHaveLength(0);
+	});
+
+	test('claim still succeeds for a workable (open) issue', async () => {
+		await createIssue(['--id', 'cl-2', '--title', 'ready work', '--type', 'task']);
+		const result = await broker.runIssueOperation('claim', ['cl-2'], { now, actor: 'alice' });
+		expect(result.ok).toBe(true);
+	});
 });

--- a/test/kernel/readiness-model.test.js
+++ b/test/kernel/readiness-model.test.js
@@ -13,6 +13,7 @@ const NOW = '2026-06-17T00:00:00.000Z';
 describe('readiness reason and state vocabularies', () => {
 	test('exposes stable reason codes', () => {
 		expect(READINESS_REASONS.DEPENDENCY).toBe('dependency');
+		expect(READINESS_REASONS.DEPENDENCY_PARKED).toBe('dependency_parked');
 		expect(READINESS_REASONS.CLAIM).toBe('claimed');
 		expect(READINESS_REASONS.QUARANTINE).toBe('quarantine');
 		expect(READINESS_REASONS.GATE).toBe('gate');
@@ -86,6 +87,25 @@ describe('deriveReadiness — derived facts, never stored', () => {
 		);
 		expect(result.ready).toBe(true);
 		expect(result.blocked).toBe(false);
+	});
+
+	test('a parked (backlog) dependency blocks with a distinct blocked-by-parked reason', () => {
+		const result = deriveReadiness(
+			{ id: 'a', status: 'open' },
+			{ now: NOW, dependencyStatuses: [{ id: 'b', status: 'backlog' }] },
+		);
+		// A parked dependency still blocks (it is not done), but it must be
+		// distinguishable from ordinary in-flight work so a consumer can flag it for
+		// promotion rather than mistaking it for a task someone is actively working.
+		expect(result.blocked).toBe(true);
+		expect(result.blocked_by).toContain('b');
+		expect(result.state).toBe('blocked');
+		const depReason = result.reasons.find(reason => reason.issue_id === 'b');
+		expect(depReason).toBeDefined();
+		expect(depReason.code).toBe(READINESS_REASONS.DEPENDENCY_PARKED);
+		expect(depReason.code).toBe('dependency_parked');
+		expect(depReason.parked).toBe(true);
+		expect(depReason.status).toBe('backlog');
 	});
 
 	test('non-blocking dependency types are ignored', () => {

--- a/test/kernel/sqlite-driver-mutations.test.js
+++ b/test/kernel/sqlite-driver-mutations.test.js
@@ -592,7 +592,10 @@ describe('Kernel SQLite driver — issue mutations via guarded path (Wave 3)', (
 			driver: guarded,
 		});
 
-		const res = await guardedBroker.runIssueOperation('update', ['race-3', '--status', 'review'], { now: '2026-06-19T00:12:00.000Z', actor: 'tester' });
+		// open -> in_progress is a legal transition, so the request reaches the driver's
+		// applyAcceptedIssueMutation (which throws the revision conflict) rather than being
+		// short-circuited by the status-transition gate.
+		const res = await guardedBroker.runIssueOperation('update', ['race-3', '--status', 'in_progress'], { now: '2026-06-19T00:12:00.000Z', actor: 'tester' });
 
 		expect(res.ok).toBe(false);
 		expect(res.command).toBe('issue.update');

--- a/test/status/presenter.test.js
+++ b/test/status/presenter.test.js
@@ -116,11 +116,13 @@ describe('buildPersonalStatusJson stays full-fidelity (machine consumers)', () =
         ready: [{ id: 'r', title: 'R' }],
         blocked: [{ id: 'b', title: 'B' }],
         stale: [{ id: 's', title: 'S' }],
+        parked: [{ id: 'p', title: 'P' }],
         recentCompleted: [{ id: 'd', title: 'D' }],
       },
       workflowResult: workflowResult(),
     });
     expect(json.personal.blocked.map(i => i.id)).toEqual(['b']);
+    expect(json.personal.parked.map(i => i.id)).toEqual(['p']);
     expect(json.personal.recentCompleted.map(i => i.id)).toEqual(['d']);
     expect(json.workflow.runCommand).toBe('ship');
   });

--- a/test/status/snapshot.test.js
+++ b/test/status/snapshot.test.js
@@ -114,6 +114,44 @@ describe('readKernelSnapshot — the flagship status snapshot reads the Kernel',
 	}, 20000);
 });
 
+describe('readKernelSnapshot — parked (backlog) work is a visible bucket', () => {
+	test('surfaces parked issues in a dedicated bucket, out of ready', async () => {
+		const { dir, kernelDeps } = makeKernelRepo();
+		try {
+			const readyId = await createIssue(dir, kernelDeps, 'Active work');
+			const parkedId = await createIssue(dir, kernelDeps, 'Parked idea');
+			// open -> backlog is a legal move; park the second issue.
+			const parked = await runIssueOperation('update', [parkedId, '--status', 'backlog'], dir, kernelDeps);
+			expect(parked.ok).toBe(true);
+
+			const snapshot = await readKernelSnapshot(dir, {
+				runIssueOperation: kernelReaderFor(kernelDeps),
+				env: {},
+			});
+
+			expect(Array.isArray(snapshot.parked)).toBe(true);
+			const parkedIds = snapshot.parked.map(issue => issue.id);
+			expect(parkedIds).toContain(parkedId);
+			// Parked work must never leak into ready — it needs a promote first.
+			expect(snapshot.ready.map(issue => issue.id)).not.toContain(parkedId);
+			expect(snapshot.ready.map(issue => issue.id)).toContain(readyId);
+		} finally {
+			cleanup(dir);
+		}
+	}, 20000);
+
+	test('the empty snapshot still exposes a parked bucket', async () => {
+		const snapshot = await readKernelSnapshot('/repo', {
+			runIssueOperation: async () => {
+				throw new Error('forced hard failure');
+			},
+			env: {},
+		});
+		expect(Array.isArray(snapshot.parked)).toBe(true);
+		expect(snapshot.parked).toEqual([]);
+	});
+});
+
 describe('readStatusSnapshot — backend routing', () => {
 	test('defaults to the Kernel reader when no backend is selected', async () => {
 		const calls = [];


### PR DESCRIPTION
## Backlog-correctness cluster (4 related follow-ups, one subsystem)

Fixes four related kernel correctness gaps found in the backlog cross-check. All in the issue/readiness/status subsystem; TDD per fix.

- **23dde2ac** — broker `issue update` now consults `isValidStatusTransition` (taxonomy-validator) before persisting a status change, rejecting illegal moves (`done->open`, `backlog->in_progress`) with a `FORGE_ISSUE_VALIDATION` (exit 6) error instead of silently storing. Only gates when the current status is a known-valid stored value (minimal driver fakes / not-yet-materialized rows fall through to the CAS path). `lib/kernel/broker.js`
- **53a9705a** — claim eligibility now rejects claiming a parked (`backlog`) issue, so a claim can no longer jump `backlog->in_progress` and skip the required promote. `release` is never gated. `lib/kernel/broker.js`
- **45987130** — a parked (`backlog`) dependency now surfaces a distinct `READINESS_REASONS.DEPENDENCY_PARKED` reason code + `parked: true` flag, so it is not mistaken for ordinary in-flight work. It still blocks (a parked dep never completes on its own) — the fix adds the missing signal. `lib/kernel/readiness-model.js`
- **5280c4c8** — `forge status` snapshot gains a `parked` bucket in `readKernelSnapshot` (+ `emptyKernelSnapshot`) and the presenter human + JSON views (personal + board), and refreshes the stale status-vocabulary comment. Parked work is now visible instead of vanishing between ready and done. `lib/status/snapshot.js`, `lib/status/presenter.js`

### Tests (written first, RED→GREEN)
- `test/kernel/kernel-parity-bugs.test.js` — update transition gate (reject/allow/no-op) + claim rejects backlog
- `test/kernel/readiness-model.test.js` — parked-dependency distinct reason + vocab
- `test/status/snapshot.test.js` — parked bucket populated + present in empty snapshot
- `test/status/presenter.test.js` — parked in personal JSON
- `test/kernel/sqlite-driver-mutations.test.js` — updated one incidentally-illegal `open->review` transition to a legal `open->in_progress` so it still exercises the revision-conflict path

### Verification
- Full `test/kernel` + `test/status` + `test/commands/status*` + adapters/issue-verify: **605 passing, 0 fail**
- `eslint --max-warnings 0`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)