### PR TITLE
feat(shepherd): surface bot status signals — StatusContext failures + bot status comments (69e18ac6)

### DIFF
--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -332,18 +332,16 @@ class PrStateAdapter {
       if (after) args.push('-f', `after=${after}`);
       const raw = this._gh('gh', args);
       const data = JSON.parse(raw || '{}');
-      const conn = data.data && data.data.repository
-        && data.data.repository.pullRequest
-        && data.data.repository.pullRequest.comments;
-      const nodes = (conn && conn.nodes) || [];
+      const conn = data?.data?.repository?.pullRequest?.comments;
+      const nodes = conn?.nodes || [];
       for (const c of nodes) {
         all.push({
-          author: (c.author && c.author.login) || '',
+          author: c.author?.login || '',
           body: c.body || '',
           createdAt: c.createdAt || '',
         });
       }
-      after = conn && conn.pageInfo && conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
+      after = conn?.pageInfo?.hasNextPage ? conn.pageInfo.endCursor : null;
       guard += 1;
     } while (after && guard < MAX_PAGES);
     return all;

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -249,31 +249,60 @@ class PrStateAdapter {
    */
   _fetchAllReviewThreads({ owner, repo, pr }) {
     const query = 'query($o:String!,$n:String!,$pr:Int!,$after:String){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{id isResolved isOutdated path line comments(first:100){pageInfo{hasNextPage endCursor} nodes{fullDatabaseId author{login} body}}}}}}}';
+    return this._paginateConnection(
+      (after) => this._ghGraphqlPage(query, { owner, repo, pr }, after)
+        ?.data?.repository?.pullRequest?.reviewThreads,
+      (t) => {
+        // A thread whose first comment page is truncated → fetch the rest.
+        if (t.comments?.pageInfo?.hasNextPage) {
+          t.comments = { nodes: this._fetchAllThreadComments(t.id, t.comments) };
+        }
+        return t;
+      },
+    );
+  }
+
+  /**
+   * Run ONE `gh api graphql` page request for an owner/repo/pr-shaped query and
+   * return the parsed JSON (or `{}`). `after` appends the opaque cursor only when
+   * present — omitting it on the first page tells GraphQL to start from the top.
+   * Extracted so the arg-building scaffold lives in exactly one place.
+   *
+   * @param {string} query
+   * @param {{ owner: string, repo: string, pr: string }} vars
+   * @param {string|null} after
+   * @returns {object}
+   */
+  _ghGraphqlPage(query, { owner, repo, pr }, after) {
+    const args = [
+      'api', 'graphql', '-f', `query=${query}`,
+      '-F', `o=${owner}`, '-F', `n=${repo}`, '-F', `pr=${pr}`,
+    ];
+    if (after) args.push('-f', `after=${after}`);
+    return JSON.parse(this._gh('gh', args) || '{}');
+  }
+
+  /**
+   * Page through a cursored GraphQL connection until `hasNextPage` is false,
+   * accumulating `mapNode(node)` for every node across all pages. `runPage(after)`
+   * performs one page request and returns the connection object
+   * (`{ pageInfo, nodes }`) or a falsy value when unreadable. A page guard bounds
+   * the loop against a pathological/looping cursor. Shared by every paginated
+   * read so the do-while cursor scaffold is defined exactly once.
+   *
+   * @param {(after: string|null) => ({ pageInfo?: object, nodes?: object[] }|null|undefined)} runPage
+   * @param {(node: object) => object} mapNode
+   * @returns {object[]}
+   */
+  _paginateConnection(runPage, mapNode) {
     const all = [];
     let after = null;
     let guard = 0;
     const MAX_PAGES = 1000;
     do {
-      const args = [
-        'api', 'graphql', '-f', `query=${query}`,
-        '-F', `o=${owner}`, '-F', `n=${repo}`, '-F', `pr=${pr}`,
-      ];
-      // Omit `after` on the first page → GraphQL treats the null cursor as "from
-      // the start". Use `-f` (string) since cursors are opaque base64.
-      if (after) args.push('-f', `after=${after}`);
-      const raw = this._gh('gh', args);
-      const data = JSON.parse(raw || '{}');
-      const conn = data.data && data.data.repository
-        && data.data.repository.pullRequest
-        && data.data.repository.pullRequest.reviewThreads;
-      const nodes = (conn && conn.nodes) || [];
-      for (const t of nodes) {
-        if (t.comments && t.comments.pageInfo && t.comments.pageInfo.hasNextPage) {
-          t.comments = { nodes: this._fetchAllThreadComments(t.id, t.comments) };
-        }
-        all.push(t);
-      }
-      after = conn && conn.pageInfo && conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
+      const conn = runPage(after);
+      for (const node of (conn?.nodes || [])) all.push(mapNode(node));
+      after = conn?.pageInfo?.hasNextPage ? conn.pageInfo.endCursor : null;
       guard += 1;
     } while (after && guard < MAX_PAGES);
     return all;
@@ -320,31 +349,15 @@ class PrStateAdapter {
    */
   async readIssueComments({ owner, repo, pr }) {
     const query = 'query($o:String!,$n:String!,$pr:Int!,$after:String){repository(owner:$o,name:$n){pullRequest(number:$pr){comments(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{author{login} body createdAt}}}}}';
-    const all = [];
-    let after = null;
-    let guard = 0;
-    const MAX_PAGES = 1000;
-    do {
-      const args = [
-        'api', 'graphql', '-f', `query=${query}`,
-        '-F', `o=${owner}`, '-F', `n=${repo}`, '-F', `pr=${pr}`,
-      ];
-      if (after) args.push('-f', `after=${after}`);
-      const raw = this._gh('gh', args);
-      const data = JSON.parse(raw || '{}');
-      const conn = data?.data?.repository?.pullRequest?.comments;
-      const nodes = conn?.nodes || [];
-      for (const c of nodes) {
-        all.push({
-          author: c.author?.login || '',
-          body: c.body || '',
-          createdAt: c.createdAt || '',
-        });
-      }
-      after = conn?.pageInfo?.hasNextPage ? conn.pageInfo.endCursor : null;
-      guard += 1;
-    } while (after && guard < MAX_PAGES);
-    return all;
+    return this._paginateConnection(
+      (after) => this._ghGraphqlPage(query, { owner, repo, pr }, after)
+        ?.data?.repository?.pullRequest?.comments,
+      (c) => ({
+        author: c.author?.login || '',
+        body: c.body || '',
+        createdAt: c.createdAt || '',
+      }),
+    );
   }
 
   /**

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -107,12 +107,18 @@ class PrStateAdapter {
       // "not required" and "unknown" uniformly. `isDraft` blocks merge outright.
       reviewDecision: data.reviewDecision || null,
       isDraft: Boolean(data.isDraft),
+      // The rollup mixes two GraphQL types: a CheckRun (name/status/conclusion/
+      // detailsUrl) and a legacy commit StatusContext (context/state/targetUrl —
+      // Vercel/Netlify/other deploy+quality bots). Both are normalized into ONE
+      // shape here so the failing/pending classification treats them identically;
+      // `state` fills the conclusion slot for a StatusContext (SUCCESS/FAILURE/
+      // ERROR/PENDING) and `targetUrl` fills the details link.
       checks: rollup.map((check) => ({
         name: check.name || check.context || '',
         status: check.status || check.state || '',
         conclusion: check.conclusion || check.state || '',
         databaseId: check.databaseId,
-        detailsUrl: check.detailsUrl,
+        detailsUrl: check.detailsUrl || check.targetUrl,
       })),
       // gh pr view cannot return review threads; the shepherd reads them via
       // readComments() (GraphQL). Kept for return-shape stability, always empty here.
@@ -299,6 +305,48 @@ class PrStateAdapter {
       guard += 1;
     }
     return acc;
+  }
+
+  /**
+   * Read the PR's plain ISSUE comments (NOT review threads) — the surface where
+   * status/deploy/quality bots post their summaries: SonarCloud's Quality-Gate
+   * comment, Vercel/Netlify deployment comments, Codecov coverage comments. These
+   * are regular PR comments, never resolvable review threads, so `readComments`
+   * (reviewThreads GraphQL) never sees them. Fully paginated by cursor so a long
+   * PR never drops a bot's latest comment. Returns `{ author, body, createdAt }`.
+   *
+   * @param {{ owner: string, repo: string, pr: string }} ctx
+   * @returns {Promise<Array<{ author: string, body: string, createdAt: string }>>}
+   */
+  async readIssueComments({ owner, repo, pr }) {
+    const query = 'query($o:String!,$n:String!,$pr:Int!,$after:String){repository(owner:$o,name:$n){pullRequest(number:$pr){comments(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{author{login} body createdAt}}}}}';
+    const all = [];
+    let after = null;
+    let guard = 0;
+    const MAX_PAGES = 1000;
+    do {
+      const args = [
+        'api', 'graphql', '-f', `query=${query}`,
+        '-F', `o=${owner}`, '-F', `n=${repo}`, '-F', `pr=${pr}`,
+      ];
+      if (after) args.push('-f', `after=${after}`);
+      const raw = this._gh('gh', args);
+      const data = JSON.parse(raw || '{}');
+      const conn = data.data && data.data.repository
+        && data.data.repository.pullRequest
+        && data.data.repository.pullRequest.comments;
+      const nodes = (conn && conn.nodes) || [];
+      for (const c of nodes) {
+        all.push({
+          author: (c.author && c.author.login) || '',
+          body: c.body || '',
+          createdAt: c.createdAt || '',
+        });
+      }
+      after = conn && conn.pageInfo && conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
+      guard += 1;
+    } while (after && guard < MAX_PAGES);
+    return all;
   }
 
   /**

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -85,7 +85,15 @@ const STATUS_BOT_LOGINS = new Set([
 // failure glyph. Kept line-scoped (matched per line) so an unrelated word in a
 // success comment ("0 failed") is unlikely to trip it, and so the matched line
 // itself becomes the human-readable summary.
-const BOT_STATUS_FAILURE_SIGNAL = /quality gate failed|failed the quality gate|deployment (?:has )?failed|deploy(?:ment)? (?:error|errored)|failed to deploy|build failed|coverage (?:decreased|dropped|declined|reduced)|patch coverage[^\n]*\bfail|❌|✖|✗|:x:|:no_entry(?:_sign)?:|⛔/i;
+// Split across several smaller alternations (grouped by theme) rather than one
+// giant regex — each stays simple to read and none is individually over-complex.
+// `botFailureSummary` matches a line against ANY of them.
+const BOT_STATUS_FAILURE_PATTERNS = [
+  /quality gate failed|failed the quality gate/i,
+  /deployment (?:has )?failed|deploy(?:ment)? (?:error|errored)|failed to deploy/i,
+  /build failed|coverage (?:decreased|dropped|declined|reduced)|patch coverage[^\n]*\bfail/i,
+  /❌|✖|✗|:x:|:no_entry(?:_sign)?:|⛔/,
+];
 
 // Signals that a log line is part of the actual failure (test framework "fail"
 // markers, assertion diffs, error prose) rather than passing/progress noise.
@@ -197,7 +205,7 @@ function commentAuthorClass(author) {
 
 /** Lowercased login of an issue comment ({author:{login}} or a bare string). */
 function issueCommentLogin(comment) {
-  return String((comment.author && comment.author.login) || comment.author || '').toLowerCase();
+  return String(comment.author?.login || comment.author || '').toLowerCase();
 }
 
 /** Drop the trailing `[bot]` suffix for a readable bot name in the blocker text. */
@@ -213,7 +221,7 @@ function prettyBotName(login) {
 function botFailureSummary(body) {
   const lines = String(body || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
   for (const line of lines) {
-    if (BOT_STATUS_FAILURE_SIGNAL.test(line)) return line.slice(0, 200);
+    if (BOT_STATUS_FAILURE_PATTERNS.some((re) => re.test(line))) return line.slice(0, 200);
   }
   return null;
 }
@@ -500,10 +508,13 @@ function computeBlockers({
 
   pushMaybe(out, draftBlocker(draft));
   pushMaybe(out, conflictBlocker(conflicts, merge, status));
-  out.push(...requiredCheckBlockers(rc));
-  // Bot status/deploy/quality comment failures (Vercel/SonarCloud/Codecov...) —
-  // as actionable as a failing check, so they slot in right after them.
-  out.push(...(Array.isArray(botStatusBlockers) ? botStatusBlockers : []));
+  // Required-check blockers, then bot status/deploy/quality comment failures
+  // (Vercel/SonarCloud/Codecov...) — as actionable as a failing check, so they
+  // slot in right after them. Combined into ONE push.
+  out.push(
+    ...requiredCheckBlockers(rc),
+    ...(Array.isArray(botStatusBlockers) ? botStatusBlockers : []),
+  );
   if (behind > 0) {
     out.push({ type: 'behind', detail: `Branch is ${behind} commit(s) behind base — update/rebase the branch (protection requires branches be up to date).` });
   }
@@ -825,8 +836,8 @@ async function gatherPullSignal(ctx) {
     if (typeof adapter.readIssueComments === 'function') {
       issueComments = await adapter.readIssueComments({ owner, repo, pr, cwd });
     }
-  } catch (_err) {
-    void _err; // unreadable issue comments → skip the scanner, keep diagnosing
+  } catch {
+    // unreadable issue comments → skip the scanner, keep diagnosing
   }
   const botStatusBlockers = buildBotStatusBlockers(issueComments, { cap: maxThreads });
 

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -51,12 +51,41 @@ const REVIEW_BOT_LOGINS = new Set([
   'sonarqubecloud', 'sonarqubecloud[bot]',
 ]);
 
-/** Pure-automation bots whose threads are never review feedback. */
+/** Pure-automation bots whose review THREADS are never review feedback. NOTE:
+ * codecov lives here for THREAD classification (its inline threads are noise),
+ * but its plain status COMMENT is still scanned for a failure signal by the
+ * bot-status scanner below — the two paths are deliberately independent so a
+ * failure-signalling status comment is never dropped as "automation noise". */
 const AUTOMATION_BOT_LOGINS = new Set([
   'github-actions', 'github-actions[bot]',
   'codecov', 'codecov[bot]',
   'dependabot', 'dependabot[bot]',
 ]);
+
+/**
+ * Status/deploy/quality bots that report FAILURE by posting a plain PR ISSUE
+ * comment (a Quality-Gate/Deployment/coverage summary) rather than — or in
+ * addition to — a check-run or commit-status. Their latest comment is scanned
+ * for a failure signal by `buildBotStatusBlockers`. This is the FALLBACK path
+ * for bots that only comment; the structured statusCheckRollup signal (handled
+ * by classifyRequiredChecks) stays the primary, reliable catch.
+ */
+const STATUS_BOT_LOGINS = new Set([
+  'vercel', 'vercel[bot]',
+  'netlify', 'netlify[bot]',
+  'sonarqubecloud', 'sonarqubecloud[bot]',
+  'codecov', 'codecov[bot]', 'codecov-commenter',
+  'cloudflare-pages', 'cloudflare-pages[bot]',
+  'cloudflare-workers-and-pages', 'cloudflare-workers-and-pages[bot]',
+  'render', 'render[bot]',
+]);
+
+// A line in a bot status comment that signals FAILURE / not-ready: an explicit
+// failed quality gate, a failed/errored deployment, dropped coverage, or a
+// failure glyph. Kept line-scoped (matched per line) so an unrelated word in a
+// success comment ("0 failed") is unlikely to trip it, and so the matched line
+// itself becomes the human-readable summary.
+const BOT_STATUS_FAILURE_SIGNAL = /quality gate failed|failed the quality gate|deployment (?:has )?failed|deploy(?:ment)? (?:error|errored)|failed to deploy|build failed|coverage (?:decreased|dropped|declined|reduced)|patch coverage[^\n]*\bfail|❌|✖|✗|:x:|:no_entry(?:_sign)?:|⛔/i;
 
 // Signals that a log line is part of the actual failure (test framework "fail"
 // markers, assertion diffs, error prose) rather than passing/progress noise.
@@ -164,6 +193,68 @@ function commentAuthorClass(author) {
   if (REVIEW_BOT_LOGINS.has(a)) return 'review-bot';
   if (AUTOMATION_BOT_LOGINS.has(a)) return 'automation';
   return 'human';
+}
+
+/** Lowercased login of an issue comment ({author:{login}} or a bare string). */
+function issueCommentLogin(comment) {
+  return String((comment.author && comment.author.login) || comment.author || '').toLowerCase();
+}
+
+/** Drop the trailing `[bot]` suffix for a readable bot name in the blocker text. */
+function prettyBotName(login) {
+  return String(login || '').replace(/\[bot\]$/i, '');
+}
+
+/**
+ * The first line of a bot comment body that signals FAILURE, trimmed and capped —
+ * or null when the comment shows no failure signal (i.e. it is healthy/ready, so
+ * an earlier failure has been superseded).
+ */
+function botFailureSummary(body) {
+  const lines = String(body || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  for (const line of lines) {
+    if (BOT_STATUS_FAILURE_SIGNAL.test(line)) return line.slice(0, 200);
+  }
+  return null;
+}
+
+/**
+ * Scan plain PR ISSUE comments from known status/deploy/quality bots and surface
+ * an actionable blocker for each bot whose LATEST comment signals failure.
+ *
+ * ACTIONABLE-ONLY + SUPERSESSION: only the newest comment per bot (by
+ * `createdAt`, not array order) is examined — a later success comment supersedes
+ * an earlier failure, and a bot edit-in-place is reflected in that one comment's
+ * final body. Comments from non-status bots and humans are ignored (their
+ * feedback flows through the review-thread path, not here). Capped at `cap`.
+ *
+ * @param {Array<{author:(object|string),body:string,createdAt?:string}>} comments
+ * @param {{ cap?: number }} [opts]
+ * @returns {Array<{ type: 'bot-status', detail: string }>}
+ */
+function buildBotStatusBlockers(comments, opts = {}) {
+  const cap = opts.cap || DEFAULT_MAX_THREADS;
+  const latestByBot = new Map();
+  for (const c of (Array.isArray(comments) ? comments : [])) {
+    const login = issueCommentLogin(c);
+    if (!STATUS_BOT_LOGINS.has(login)) continue;
+    const ts = Date.parse(c.createdAt || c.updatedAt || '') || 0;
+    const prev = latestByBot.get(login);
+    // `>=` so a same-timestamp (or timestamp-less) tie keeps the LATER array
+    // entry — GitHub returns issue comments oldest-first.
+    if (!prev || ts >= prev.ts) latestByBot.set(login, { ts, login, body: String(c.body || '') });
+  }
+  const out = [];
+  for (const { login, body } of latestByBot.values()) {
+    const summary = botFailureSummary(body);
+    if (!summary) continue; // latest comment is healthy → superseded, not actionable
+    out.push({
+      type: 'bot-status',
+      detail: `${prettyBotName(login)} reports a failing status: ${summary}`,
+    });
+    if (out.length >= cap) break;
+  }
+  return out;
 }
 
 /**
@@ -395,6 +486,7 @@ function computeBlockers({
   draft = false,
   reviewDecision = null,
   requiredClass = { missing: [], skipped: [], pending: [], failing: [], unreadable: false },
+  botStatusBlockers = [],
   unresolvedThreadCount = 0,
   behind = 0,
   conflicts = null,
@@ -409,6 +501,9 @@ function computeBlockers({
   pushMaybe(out, draftBlocker(draft));
   pushMaybe(out, conflictBlocker(conflicts, merge, status));
   out.push(...requiredCheckBlockers(rc));
+  // Bot status/deploy/quality comment failures (Vercel/SonarCloud/Codecov...) —
+  // as actionable as a failing check, so they slot in right after them.
+  out.push(...(Array.isArray(botStatusBlockers) ? botStatusBlockers : []));
   if (behind > 0) {
     out.push({ type: 'behind', detail: `Branch is ${behind} commit(s) behind base — update/rebase the branch (protection requires branches be up to date).` });
   }
@@ -721,6 +816,20 @@ async function gatherPullSignal(ctx) {
     void _err; // conflict prediction unsupported → omit, keep diagnosing
   }
 
+  // Bot STATUS COMMENTS (SonarCloud Quality-Gate / Vercel-Netlify deployment /
+  // Codecov coverage) — plain PR issue comments, NOT review threads. The FALLBACK
+  // for bots that only comment; guarded so an unreadable comment feed never sinks
+  // the payload.
+  let issueComments = [];
+  try {
+    if (typeof adapter.readIssueComments === 'function') {
+      issueComments = await adapter.readIssueComments({ owner, repo, pr, cwd });
+    }
+  } catch (_err) {
+    void _err; // unreadable issue comments → skip the scanner, keep diagnosing
+  }
+  const botStatusBlockers = buildBotStatusBlockers(issueComments, { cap: maxThreads });
+
   // Required-vs-produced classification (missing / skipped / pending / failing) —
   // the reliable explanation for an all-green-but-BLOCKED PR.
   const requiredChecks = classifyRequiredChecks(state.checks, requiredSet);
@@ -732,6 +841,7 @@ async function gatherPullSignal(ctx) {
     draft: state.isDraft || state.draft || false,
     reviewDecision: state.reviewDecision || null,
     requiredClass: requiredChecks,
+    botStatusBlockers,
     unresolvedThreadCount: reviewThreads.length,
     behind,
     conflicts,
@@ -781,6 +891,9 @@ module.exports = {
   buildPullPayload,
   isSkipped,
   isPending,
+  buildBotStatusBlockers,
+  botFailureSummary,
   REVIEW_BOT_LOGINS,
   AUTOMATION_BOT_LOGINS,
+  STATUS_BOT_LOGINS,
 };

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -84,9 +84,15 @@ function isGreen(check) {
   return SUCCESS_CONCLUSIONS.has(c);
 }
 
+// Includes ERROR and STARTUP_FAILURE so a failing legacy commit STATUS
+// (StatusContext, e.g. Vercel/Netlify deploy checks report state=ERROR/FAILURE)
+// is classified as failing — not silently treated as "pending" — exactly like a
+// CheckRun FAILURE. gh's statusCheckRollup normalizes a StatusContext `state`
+// into the `conclusion` slot, so both check types flow through this one gate.
 function isFailed(check) {
   const c = String(check.conclusion || '').toUpperCase();
-  return c === 'FAILURE' || c === 'TIMED_OUT' || c === 'CANCELLED' || c === 'ACTION_REQUIRED';
+  return c === 'FAILURE' || c === 'ERROR' || c === 'TIMED_OUT'
+    || c === 'CANCELLED' || c === 'ACTION_REQUIRED' || c === 'STARTUP_FAILURE';
 }
 
 /**

--- a/test/pr-pull.test.js
+++ b/test/pr-pull.test.js
@@ -14,6 +14,8 @@ const {
   renderPullSummary,
   buildPullPayload,
   gatherPullSignal,
+  buildBotStatusBlockers,
+  STATUS_BOT_LOGINS,
 } = require('../lib/pr-pull');
 
 // A gh `run view --log-failed` line: `jobName\tstepName\t<ISO-timestamp> content`.
@@ -595,5 +597,139 @@ describe('gatherPullSignal (orchestrator — injected gh runner, no live GitHub)
     });
     expect(payload.requiredChecks.skipped).toEqual(['Cross-OS Gate']);
     expect(payload.blockers.some((b) => b.type === 'check-skipped')).toBe(true);
+  });
+
+  test('a failing StatusContext (Vercel-style ERROR) is classified as a failing required check', async () => {
+    // GAP 1: Vercel/Netlify report via the legacy commit-Status API (StatusContext,
+    // state=ERROR/FAILURE), not a CheckRun. The rollup normalizes state → conclusion,
+    // so an ERROR status must classify as FAILING (previously it looked "pending").
+    const checks = [
+      { name: 'Vercel', status: '', conclusion: 'ERROR', detailsUrl: 'https://vercel.com/x/deployments/abc' },
+      { name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS' },
+    ];
+    const adapter = {
+      id: 'fake', kind: 'pr-state',
+      async readState() { return { headSha: 's', state: 'OPEN', mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED', checks, threads: [] }; },
+      async readRequiredChecks() { return ['Vercel', 'unit']; },
+      async readDivergence() { return { behind: 0, ahead: 1 }; },
+      async readComments() { return []; },
+    };
+    const payload = await gatherPullSignal({
+      pr: '9', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh: () => '', runPass: async () => ({ state: 'ESCALATE', reason: 'vercel error' }), self: 'me',
+    });
+    expect(payload.requiredChecks.failing).toContain('Vercel');
+    expect(payload.blockers.some((b) => b.type === 'check-failing')).toBe(true);
+  });
+
+  test('a failing bot status COMMENT (SonarCloud quality gate) surfaces as a bot-status blocker', async () => {
+    // GAP 2: SonarCloud posts a Quality-Gate summary as a plain PR issue comment,
+    // NOT a resolvable review thread — the thread path never sees it.
+    const adapter = {
+      id: 'fake', kind: 'pr-state',
+      async readState() { return { headSha: 's', state: 'OPEN', mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED', checks: [], threads: [] }; },
+      async readRequiredChecks() { return []; },
+      async readDivergence() { return { behind: 0, ahead: 1 }; },
+      async readComments() { return []; },
+      async readIssueComments() {
+        return [{ author: 'sonarqubecloud', body: '## Quality Gate failed\n❌ 3 New issues', createdAt: '2026-07-12T10:00:00Z' }];
+      },
+    };
+    const payload = await gatherPullSignal({
+      pr: '9', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh: () => '', runPass: async () => ({ state: 'NEEDS_REVIEW', reason: 'quality gate' }), self: 'me',
+    });
+    const bs = payload.blockers.find((b) => b.type === 'bot-status');
+    expect(bs).toBeDefined();
+    expect(bs.detail).toMatch(/sonarqubecloud/i);
+    expect(bs.detail).toMatch(/quality gate failed/i);
+  });
+
+  test('a bot whose LATEST comment is a success does NOT surface (superseded)', async () => {
+    const adapter = {
+      id: 'fake', kind: 'pr-state',
+      async readState() { return { headSha: 's', state: 'OPEN', mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', checks: [], threads: [] }; },
+      async readRequiredChecks() { return []; },
+      async readDivergence() { return { behind: 0, ahead: 1 }; },
+      async readComments() { return []; },
+      async readIssueComments() {
+        return [
+          { author: 'vercel', body: '❌ Deployment failed', createdAt: '2026-07-12T10:00:00Z' },
+          { author: 'vercel', body: '✅ Deployment has completed — Ready', createdAt: '2026-07-12T11:00:00Z' },
+        ];
+      },
+    };
+    const payload = await gatherPullSignal({
+      pr: '9', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter, runGh: () => '', runPass: async () => ({ state: 'MERGE_READY', reason: 'clean' }), self: 'me',
+    });
+    expect(payload.blockers.some((b) => b.type === 'bot-status')).toBe(false);
+  });
+});
+
+describe('buildBotStatusBlockers (bot status/deploy/quality comment scanner)', () => {
+  test('surfaces a failing Vercel deployment comment', () => {
+    const out = buildBotStatusBlockers([
+      { author: 'vercel', body: 'Latest commit\n❌  Failed — Deployment error', createdAt: '2026-07-12T10:00:00Z' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('bot-status');
+    expect(out[0].detail).toMatch(/vercel/i);
+  });
+
+  test('surfaces a failing Codecov comment (an "automation" bot for threads, but its status comment is actionable)', () => {
+    const out = buildBotStatusBlockers([
+      { author: 'codecov[bot]', body: '❌ Patch coverage decreased below threshold', createdAt: '2026-07-12T10:00:00Z' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].detail).toMatch(/codecov/i);
+  });
+
+  test('a later SUCCESS comment supersedes an earlier failure (uses timestamps, not array order)', () => {
+    const out = buildBotStatusBlockers([
+      { author: 'sonarqubecloud', body: 'Quality Gate passed ✅', createdAt: '2026-07-12T11:00:00Z' },
+      { author: 'sonarqubecloud', body: 'Quality Gate failed ❌', createdAt: '2026-07-12T10:00:00Z' },
+    ]);
+    expect(out).toHaveLength(0);
+  });
+
+  test('ignores comments from non-status bots and humans', () => {
+    const out = buildBotStatusBlockers([
+      { author: 'coderabbitai', body: 'Quality issue: guard null ❌', createdAt: '2026-07-12T10:00:00Z' },
+      { author: 'a-human', body: 'this deployment failed for me too ❌', createdAt: '2026-07-12T10:00:00Z' },
+    ]);
+    expect(out).toHaveLength(0);
+  });
+
+  test('a healthy latest status comment is not a blocker', () => {
+    const out = buildBotStatusBlockers([
+      { author: 'netlify', body: '✅ Deploy Preview ready!', createdAt: '2026-07-12T10:00:00Z' },
+    ]);
+    expect(out).toHaveLength(0);
+  });
+
+  test('STATUS_BOT_LOGINS covers the named deploy/quality bots', () => {
+    for (const login of ['vercel', 'netlify', 'sonarqubecloud', 'codecov', 'cloudflare-pages', 'render']) {
+      expect(STATUS_BOT_LOGINS.has(login)).toBe(true);
+    }
+  });
+});
+
+describe('computeBlockers with bot-status blockers', () => {
+  test('bot-status blockers are folded into the ordered blocker list', () => {
+    const blockers = computeBlockers({
+      mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED',
+      botStatusBlockers: [{ type: 'bot-status', detail: 'vercel reports a failing status: ❌ Failed' }],
+    });
+    expect(blockers.some((b) => b.type === 'bot-status')).toBe(true);
+  });
+
+  test('a bot-status failure is enough to avoid the blocked-unknown fallback', () => {
+    const blockers = computeBlockers({
+      mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED',
+      botStatusBlockers: [{ type: 'bot-status', detail: 'sonarqubecloud reports a failing status: Quality Gate failed' }],
+    });
+    expect(blockers.some((b) => b.type === 'blocked-unknown')).toBe(false);
+    expect(blockers.some((b) => b.type === 'bot-status')).toBe(true);
   });
 });

--- a/test/pr-shepherd.test.js
+++ b/test/pr-shepherd.test.js
@@ -4,7 +4,7 @@ const { describe, test, expect } = require('bun:test');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { runShepherdPass, TERMINAL_STATES } = require('../lib/pr-shepherd');
+const { runShepherdPass, TERMINAL_STATES, isFailed, isGreen } = require('../lib/pr-shepherd');
 
 /**
  * Build a fake pr-state adapter from a declarative spec. Every mutating action
@@ -312,5 +312,18 @@ describe('runShepherdPass — bounded pass state machine', () => {
     expect(/\.beads\b/i.test(src)).toBe(false);
     expect(/\bdolt\b/i.test(src)).toBe(false);
     expect(/gh pr merge/.test(src)).toBe(false);
+  });
+});
+
+describe('isFailed covers StatusContext error states (Vercel/Netlify)', () => {
+  test('ERROR (a StatusContext failure state) counts as failed', () => {
+    expect(isFailed({ conclusion: 'ERROR' })).toBe(true);
+    expect(isFailed({ conclusion: 'STARTUP_FAILURE' })).toBe(true);
+    expect(isFailed({ conclusion: 'FAILURE' })).toBe(true);
+  });
+  test('SUCCESS / PENDING are not failures', () => {
+    expect(isFailed({ conclusion: 'SUCCESS' })).toBe(false);
+    expect(isFailed({ conclusion: 'PENDING' })).toBe(false);
+    expect(isGreen({ conclusion: 'SUCCESS' })).toBe(true);
   });
 });

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -332,4 +332,42 @@ describe('PrStateAdapter — bundle gather fields', () => {
     expect(res.supported).toBe(false);
     expect(res.reason).toContain('--write-tree');
   });
+
+  test('readState maps a StatusContext (commit-status, no conclusion) into the same shape as a CheckRun', async () => {
+    // Vercel/Netlify report via the legacy commit-Status API — statusCheckRollup
+    // entries carry `context`+`state`+`targetUrl` (no name/conclusion/detailsUrl).
+    const rollupJson = JSON.stringify({
+      headRefOid: 'sha',
+      mergeStateStatus: 'BLOCKED',
+      statusCheckRollup: [
+        { __typename: 'StatusContext', context: 'Vercel', state: 'FAILURE', targetUrl: 'https://vercel.com/x' },
+        { __typename: 'CheckRun', name: 'unit', status: 'COMPLETED', conclusion: 'SUCCESS', detailsUrl: 'https://gh/job/1' },
+      ],
+    });
+    const { run } = makeRunner([['pr view', rollupJson]]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const state = await adapter.readState('7');
+    const vercel = state.checks.find((c) => c.name === 'Vercel');
+    expect(vercel).toBeDefined();
+    expect(vercel.conclusion).toBe('FAILURE'); // state → conclusion
+    expect(vercel.detailsUrl).toBe('https://vercel.com/x'); // targetUrl → detailsUrl
+  });
+
+  test('readIssueComments returns author/body/createdAt from paginated GraphQL', async () => {
+    const page = JSON.stringify({
+      data: { repository: { pullRequest: { comments: {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          { author: { login: 'sonarqubecloud' }, body: 'Quality Gate failed', createdAt: '2026-07-12T10:00:00Z' },
+          { author: { login: 'a-human' }, body: 'thanks', createdAt: '2026-07-12T11:00:00Z' },
+        ],
+      } } } },
+    });
+    const { run, calls } = makeRunner([['api graphql', page]]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const comments = await adapter.readIssueComments({ owner: 'o', repo: 'r', pr: '7' });
+    expect(comments).toHaveLength(2);
+    expect(comments[0]).toEqual({ author: 'sonarqubecloud', body: 'Quality Gate failed', createdAt: '2026-07-12T10:00:00Z' });
+    expect(calls.some((c) => [c.cmd, ...c.args].join(' ').includes('api graphql'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Surface bot status signals in the shepherd pull payload

Extends the shepherd's `--pull` signal (lib/pr-pull.js + lib/adapters/pr-state-adapter.js)
to catch two failure-signal classes it previously missed. Refs 69e18ac6 (epic a94d4a08).

### GAP 1 — commit STATUSES (StatusContext), not just check-runs
Vercel/Netlify and some quality bots report via the legacy commit-Status API
(GraphQL `StatusContext`), not a `CheckRun`. `statusCheckRollup` already carries
both, and the adapter already normalizes a StatusContext `state` into the
`conclusion` slot — but `isFailed` (lib/pr-shepherd.js) did **not** treat `ERROR`
as a failure, so a Vercel-style `state=ERROR` looked *pending* instead of failing.

- `isFailed` now includes `ERROR` and `STARTUP_FAILURE`, so a failing
  StatusContext classifies identically to a CheckRun `FAILURE` (failing vs pending).
- `readState` now also maps `targetUrl → detailsUrl` (StatusContext's link field),
  so status entries carry a details URL like check-runs do.
- A failing StatusContext now flows through `classifyRequiredChecks` and surfaces
  as a `check-failing` blocker.

### GAP 2 — plain BOT STATUS COMMENTS (not review threads)
SonarCloud (Quality-Gate summary), Vercel/Netlify (deployment), and Codecov
(coverage) post regular PR **issue comments**, not resolvable review threads, so
the unresolved-thread path never saw them.

- New adapter method `readIssueComments` (paginated GraphQL) reads plain PR issue
  comments (`author`, `body`, `createdAt`).
- New `buildBotStatusBlockers` scanner: for known status/deploy/quality bots
  (`vercel`, `netlify`, `sonarqubecloud`, `codecov`, `cloudflare-pages`,
  `cloudflare-workers-and-pages`, `render`), it inspects each bot's **latest**
  comment (by `createdAt`) and emits a `bot-status` blocker when it signals
  failure (`Quality Gate failed`, `Deployment failed/error`, dropped coverage,
  `❌`, ...). **Actionable-only + supersession**: a later success comment
  supersedes an earlier failure; healthy latest comments produce no blocker.
- Classification note: `codecov` stays an *automation* bot for review-THREAD
  purposes (its inline threads are noise), but its status COMMENT is scanned
  independently — so a failure-signalling status comment is never dropped as noise.

Structured signal (rollup) stays the primary catch; the comment scanner is the
fallback for bots that only comment.

### Tests (TDD)
- `test/pr-state-adapter.test.js`: StatusContext → normalized shape (`state →
  conclusion`, `targetUrl → detailsUrl`); `readIssueComments` GraphQL parsing.
- `test/pr-shepherd.test.js`: `isFailed` covers `ERROR`/`STARTUP_FAILURE`.
- `test/pr-pull.test.js`: `buildBotStatusBlockers` (failing Vercel/Codecov,
  superseded-by-success, non-status bots ignored, healthy latest); `computeBlockers`
  folds bot-status in; `gatherPullSignal` integration for a failing StatusContext
  and a failing SonarCloud comment.

Full suite + `eslint --max-warnings 0` green. Deferred b03ddbf2 (out-of-thread
review-level comments) left as-is — not trivial, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request blockers now include failures reported in comments from recognized status and quality bots.
  * Bot failures are updated by the latest comment, allowing later successful statuses to clear outdated blockers.
  * Legacy status checks are now handled consistently with modern checks.

* **Bug Fixes**
  * Error and startup-failure check states are now correctly treated as failures.
  * Blocker details now retain available links from legacy status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->