### PR TITLE
fix: bound the 2 remaining unbounded git-common-dir spawns

### DIFF
--- a/lib/beads-bootstrap.js
+++ b/lib/beads-bootstrap.js
@@ -5,12 +5,13 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { safeBeadsInit } = require('./beads-setup');
 
+// Same class of risk as ba388d01 / #356's Kernel broker fix: an unbounded
+// `git rev-parse --git-common-dir` spawn can hang on Windows/Node. Bound it so
+// it fails fast (ETIMEDOUT) instead of wedging worktree bootstrap forever.
+const GIT_COMMON_DIR_TIMEOUT_MS = 30000;
+
 function isIgnorableFsError(error) {
   return ['EACCES', 'ENOENT', 'ENOTDIR', 'EPERM'].includes(error?.code);
-}
-
-function isRecoverableCommandError(error) {
-  return error?.code === 'ENOENT' || typeof error?.status === 'number';
 }
 
 function hasBackupJsonl(backupDir, fsApi) {
@@ -24,19 +25,32 @@ function hasBackupJsonl(backupDir, fsApi) {
   }
 }
 
-function resolveMainWorktree(projectRoot, exec) {
+function resolveMainWorktree(projectRoot, exec, deps = {}) {
+  const warn = deps.warn || ((message) => console.warn(message));
+
   try {
     const commonDir = exec('git', ['rev-parse', '--git-common-dir'], {
       cwd: projectRoot,
       encoding: 'utf8',
-      stdio: 'pipe'
+      stdio: 'pipe',
+      timeout: GIT_COMMON_DIR_TIMEOUT_MS,
     }).trim();
-    return path.resolve(projectRoot, commonDir, '..');
-  } catch (err) {
-    if (isRecoverableCommandError(err)) {
+
+    if (!commonDir) {
+      warn(`[forge] git rev-parse --git-common-dir returned an empty path for ${projectRoot}; `
+        + `falling back to ${projectRoot}`);
       return projectRoot;
     }
-    throw err;
+
+    return path.resolve(projectRoot, commonDir, '..');
+  } catch (err) {
+    // A timed-out (ETIMEDOUT), missing-git (ENOENT), or otherwise-failing spawn
+    // MUST NOT crash worktree bootstrap. Degrade gracefully to treating
+    // projectRoot as its own main worktree — correct for the common
+    // non-worktree case, and a working fallback beats a hard failure.
+    warn(`[forge] git rev-parse --git-common-dir failed (${err.code || err.message}); `
+      + `falling back to ${projectRoot}`);
+    return projectRoot;
   }
 }
 
@@ -201,7 +215,8 @@ function bootstrapBeads(projectRoot, options = {}) {
   const fsApi = options._fs || fs;
   const platform = options._platform || process.platform;
   const runSafeBeadsInit = options._safeBeadsInit || safeBeadsInit;
-  const mainProjectRoot = options.mainProjectRoot || resolveMainWorktree(projectRoot, exec);
+  const mainProjectRoot = options.mainProjectRoot
+    || resolveMainWorktree(projectRoot, exec, { warn: options._warn });
   const beadsSource = path.resolve(mainProjectRoot, '.beads');
   const beadsDest = path.resolve(projectRoot, '.beads');
 

--- a/lib/detect-worktree.js
+++ b/lib/detect-worktree.js
@@ -30,6 +30,18 @@ function detectWorktree(cwd = process.cwd(), deps = {}) {
       encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: GIT_SPAWN_TIMEOUT_MS
     }).trim();
 
+    // Empty output from either probe is not a valid git dir. Do NOT feed it to
+    // path.resolve — an empty string resolves to `cwd`, which would make an
+    // empty gitDir compare equal-or-unequal by accident (falsely reporting
+    // inWorktree, or returning extra non-fallback fields). Degrade to the
+    // documented { inWorktree: false } fallback with a warning instead.
+    if (!gitDir || !gitCommonDir) {
+      warn('[forge] git worktree detection got empty git dir output '
+        + `(gitDir=${JSON.stringify(gitDir)}, gitCommonDir=${JSON.stringify(gitCommonDir)}); `
+        + 'falling back to { inWorktree: false }');
+      return { inWorktree: false };
+    }
+
     // Resolve to absolute paths for reliable comparison
     const absGitDir = path.resolve(cwd, gitDir);
     const absCommonDir = path.resolve(cwd, gitCommonDir);

--- a/lib/detect-worktree.js
+++ b/lib/detect-worktree.js
@@ -3,29 +3,39 @@
 const { execFileSync } = require('child_process');
 const path = require('path');
 
+// This synchronous git spawn can hang on Windows/Node (same class of issue as
+// ba388d01 / #356's Kernel broker fix). A bounded `timeout` makes each spawn
+// fail fast (ETIMEDOUT) instead of hanging forever; git normally answers these
+// in milliseconds, so 30s only guards against a pathological wedge.
+const GIT_SPAWN_TIMEOUT_MS = 30000;
+
 /**
  * Detect if the current directory is inside a git worktree.
  * Uses git rev-parse --git-dir vs --git-common-dir — they differ in worktrees.
  *
  * @param {string} [cwd=process.cwd()] - Directory to check
+ * @param {object} [deps] - Injectable dependencies for testing (execFileSync, warn)
  * @returns {{ inWorktree: boolean, branch?: string, mainWorktree?: string, currentWorktree?: string }}
  */
-function detectWorktree(cwd = process.cwd()) {
+function detectWorktree(cwd = process.cwd(), deps = {}) {
+  const exec = deps.execFileSync || execFileSync;
+  const warn = deps.warn || ((message) => console.warn(message));
+
   try {
-    const gitDir = execFileSync('git', ['rev-parse', '--git-dir'], {
-      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe']
+    const gitDir = exec('git', ['rev-parse', '--git-dir'], {
+      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: GIT_SPAWN_TIMEOUT_MS
     }).trim();
 
-    const gitCommonDir = execFileSync('git', ['rev-parse', '--git-common-dir'], {
-      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe']
+    const gitCommonDir = exec('git', ['rev-parse', '--git-common-dir'], {
+      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: GIT_SPAWN_TIMEOUT_MS
     }).trim();
 
     // Resolve to absolute paths for reliable comparison
     const absGitDir = path.resolve(cwd, gitDir);
     const absCommonDir = path.resolve(cwd, gitCommonDir);
 
-    const branch = execFileSync('git', ['branch', '--show-current'], {
-      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe']
+    const branch = exec('git', ['branch', '--show-current'], {
+      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: GIT_SPAWN_TIMEOUT_MS
     }).trim();
     const mainWorktree = path.resolve(absCommonDir, '..');
     const currentWorktree = path.resolve(cwd);
@@ -37,8 +47,12 @@ function detectWorktree(cwd = process.cwd()) {
     }
 
     return { inWorktree: false, branch, mainWorktree, currentWorktree };
-  } catch (_err) {
-    // Not in a git repo or git not available
+  } catch (err) {
+    // Not in a git repo, git not available, or a spawn that hung past the
+    // bound (ETIMEDOUT) — none of these should crash the caller. Degrade
+    // gracefully to the same shape callers already handle.
+    warn(`[forge] git worktree detection failed (${err.code || err.message}); `
+      + 'falling back to { inWorktree: false }');
     return { inWorktree: false };
   }
 }

--- a/test/beads-bootstrap.test.js
+++ b/test/beads-bootstrap.test.js
@@ -2,7 +2,7 @@
 
 const path = require('node:path');
 const { describe, test, expect } = require('bun:test');
-const { bootstrapBeads, isRecoverableBeadsError } = require('../lib/beads-bootstrap');
+const { bootstrapBeads, isRecoverableBeadsError, resolveMainWorktree } = require('../lib/beads-bootstrap');
 
 function createMockSafeBeadsInit() {
   return (root, options) => {
@@ -357,6 +357,77 @@ describe('bootstrapBeads', () => {
       cmd: 'bd',
       args: ['backup', 'restore', path.resolve('/main', '.beads', 'backup')]
     });
+  });
+});
+
+describe('resolveMainWorktree', () => {
+  test('degrades gracefully to projectRoot when the git spawn times out', () => {
+    const warnCalls = [];
+    const timeoutError = new Error('spawnSync git ETIMEDOUT');
+    timeoutError.code = 'ETIMEDOUT';
+    const throwingExec = () => {
+      throw timeoutError;
+    };
+
+    const result = resolveMainWorktree('/worktree', throwingExec, {
+      warn: (message) => warnCalls.push(message),
+    });
+
+    expect(result).toBe('/worktree');
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]).toContain('ETIMEDOUT');
+  });
+
+  test('degrades gracefully to projectRoot on empty git output', () => {
+    const warnCalls = [];
+    const emptyExec = () => '';
+
+    const result = resolveMainWorktree('/worktree', emptyExec, {
+      warn: (message) => warnCalls.push(message),
+    });
+
+    expect(result).toBe('/worktree');
+    expect(warnCalls).toHaveLength(1);
+  });
+
+  test('bounds the git spawn with a timeout option', () => {
+    let seenOptions;
+    const fakeExec = (_cmd, _args, options) => {
+      seenOptions = options;
+      return '.git';
+    };
+
+    resolveMainWorktree('/worktree', fakeExec);
+
+    expect(typeof seenOptions.timeout).toBe('number');
+    expect(seenOptions.timeout).toBeGreaterThan(0);
+  });
+
+  test('bootstrapBeads falls back instead of throwing when git rev-parse times out', () => {
+    const warnCalls = [];
+    const timeoutError = new Error('spawnSync git ETIMEDOUT');
+    timeoutError.code = 'ETIMEDOUT';
+    const mockExec = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'rev-parse') {
+        throw timeoutError;
+      }
+      throw new Error(`unexpected exec ${cmd}`);
+    };
+    const mockFs = {
+      // mainProjectRoot falls back to projectRoot itself, so beadsSource === beadsDest
+      existsSync: () => false,
+    };
+
+    const result = bootstrapBeads('/worktree', {
+      _exec: mockExec,
+      _fs: mockFs,
+      _platform: 'linux',
+      _warn: (message) => warnCalls.push(message),
+    });
+
+    expect(result).toEqual({ success: true, strategy: 'in-place', warning: null });
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]).toContain('ETIMEDOUT');
   });
 });
 

--- a/test/detect-worktree.test.js
+++ b/test/detect-worktree.test.js
@@ -52,6 +52,40 @@ describe('detectWorktree', () => {
     expect(typeof result.inWorktree).toBe('boolean');
   });
 
+  test('degrades gracefully to { inWorktree: false } when the git spawn times out', () => {
+    const warnCalls = [];
+    const timeoutError = new Error('spawnSync git ETIMEDOUT');
+    timeoutError.code = 'ETIMEDOUT';
+    const throwingExec = () => {
+      throw timeoutError;
+    };
+
+    const result = detectWorktree('/some/dir', {
+      execFileSync: throwingExec,
+      warn: (message) => warnCalls.push(message),
+    });
+
+    expect(result).toEqual({ inWorktree: false });
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]).toContain('ETIMEDOUT');
+  });
+
+  test('bounds each git spawn with a timeout option', () => {
+    const seenOptions = [];
+    const fakeExec = (_cmd, _args, options) => {
+      seenOptions.push(options);
+      return 'main';
+    };
+
+    detectWorktree('/some/dir', { execFileSync: fakeExec });
+
+    expect(seenOptions.length).toBeGreaterThan(0);
+    for (const options of seenOptions) {
+      expect(typeof options.timeout).toBe('number');
+      expect(options.timeout).toBeGreaterThan(0);
+    }
+  });
+
   test('returns { inWorktree: false } from the main repo root', () => {
     // The main forge repo (not the worktree) — find it via git-common-dir
     const { execFileSync } = require('child_process');

--- a/test/detect-worktree.test.js
+++ b/test/detect-worktree.test.js
@@ -70,6 +70,42 @@ describe('detectWorktree', () => {
     expect(warnCalls[0]).toContain('ETIMEDOUT');
   });
 
+  test('degrades gracefully when gitDir output is empty (does not resolve to cwd)', () => {
+    const warnCalls = [];
+    // --git-dir returns empty, --git-common-dir returns a real path. Without the
+    // guard, path.resolve(cwd, '') === cwd would make absGitDir !== absCommonDir
+    // and falsely report inWorktree: true.
+    const emptyGitDirExec = (_cmd, args) => {
+      if (args[1] === '--git-dir') return '';
+      if (args[1] === '--git-common-dir') return '/repo/.git';
+      return 'main';
+    };
+
+    const result = detectWorktree('/repo', {
+      execFileSync: emptyGitDirExec,
+      warn: (message) => warnCalls.push(message),
+    });
+
+    expect(result).toEqual({ inWorktree: false });
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]).toContain('empty git dir output');
+  });
+
+  test('degrades gracefully when both git dir outputs are empty', () => {
+    const warnCalls = [];
+    const bothEmptyExec = () => '';
+
+    const result = detectWorktree('/repo', {
+      execFileSync: bothEmptyExec,
+      warn: (message) => warnCalls.push(message),
+    });
+
+    // Must be the bare fallback shape — no extra branch/mainWorktree fields.
+    expect(result).toEqual({ inWorktree: false });
+    expect(warnCalls).toHaveLength(1);
+    expect(warnCalls[0]).toContain('empty git dir output');
+  });
+
   test('bounds each git spawn with a timeout option', () => {
     const seenOptions = [];
     const fakeExec = (_cmd, _args, options) => {


### PR DESCRIPTION
## Summary
- Bounds two unbounded `git rev-parse --git-common-dir` (and sibling git) spawns that carried the same Windows-hang risk fixed for the Kernel broker in #356 (issue ba388d01).
- `lib/detect-worktree.js` — all three git spawns (`--git-dir`, `--git-common-dir`, `branch --show-current`) now bounded by a 30s timeout; on ETIMEDOUT/any failure, degrades gracefully to `{ inWorktree: false }` with a `console.warn` instead of relying on a bare catch-and-swallow.
- `lib/beads-bootstrap.js`'s `resolveMainWorktree` — bounded by the same 30s timeout; on ETIMEDOUT/any git failure/empty output, degrades gracefully to treating `projectRoot` as its own main worktree, with a `console.warn`, instead of conditionally rethrowing via the old `isRecoverableCommandError` check.
- Both functions accept an injectable `warn` dependency (matching the existing `_exec`/`_fs` test-injection convention).

Fixes forge kernel issue `6ca8c00b-e118-44fc-ba99-a8b91b9ade7d`.

## Test plan
- [x] New tests: `detect-worktree.test.js` — ETIMEDOUT-falls-back-gracefully + spawn-is-bounded-by-timeout
- [x] New tests: `beads-bootstrap.test.js` — ETIMEDOUT-falls-back, empty-output-falls-back, spawn-is-bounded-by-timeout, and `bootstrapBeads` end-to-end fallback
- [x] `bun test test/detect-worktree.test.js test/beads-bootstrap.test.js` — 20 pass
- [x] `bun test test/commands/status.test.js test/beads-health-check.test.js` (consumers) — 38 pass
- [x] `eslint lib/detect-worktree.js lib/beads-bootstrap.js test/detect-worktree.test.js test/beads-bootstrap.test.js --max-warnings 0` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented worktree detection and bootstrap from hanging by enforcing bounded Git command timeouts.
  * Improved resilience when Git commands fail or return empty output by falling back to non-worktree behavior instead of erroring.
  * Added clearer warnings including timeout/error details during worktree detection and bootstrap.
* **Tests**
  * Expanded unit coverage for timeout handling, empty-output scenarios, warning emission, and verification that Git commands are invoked with positive timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->