### PR TITLE
feat(preflight): fast deterministic-gate parity gate (forge preflight)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,9 +17,11 @@
         "@stryker-mutator/core": "^9.6.0",
         "c8": "^11.0.0",
         "eslint": "^10.0.2",
+        "eslint-plugin-sonarjs": "^4.1.0",
         "globals": "^17.3.0",
         "js-yaml": "^5.1.0",
         "lefthook": "^2.1.4",
+        "typescript": "5.4.5",
       },
       "peerDependencies": {
         "lefthook": "^1.0.0",
@@ -276,6 +278,10 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
+    "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "c8": ["c8@11.0.0", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.1", "@istanbuljs/schema": "^0.1.3", "find-up": "^5.0.0", "foreground-child": "^3.1.1", "istanbul-lib-coverage": "^3.2.0", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.1.6", "test-exclude": "^8.0.0", "v8-to-istanbul": "^9.0.0", "yargs": "^17.7.2", "yargs-parser": "^21.1.1" }, "peerDependencies": { "monocart-coverage-reports": "^2" }, "optionalPeers": ["monocart-coverage-reports"], "bin": { "c8": "bin/c8.js" } }, "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -352,6 +358,8 @@
 
     "eslint": ["eslint@10.0.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.2", "@eslint/config-helpers": "^0.5.2", "@eslint/core": "^1.1.0", "@eslint/plugin-kit": "^0.6.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.1", "eslint-visitor-keys": "^5.0.1", "espree": "^11.1.1", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.1", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw=="],
 
+    "eslint-plugin-sonarjs": ["eslint-plugin-sonarjs@4.1.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "builtin-modules": "^3.3.0", "bytes": "^3.1.2", "functional-red-black-tree": "^1.0.1", "globals": "^17.6.0", "jsx-ast-utils-x": "^0.1.0", "lodash.merge": "^4.6.2", "minimatch": "^10.2.5", "scslre": "^0.3.0", "semver": "^7.8.4", "ts-api-utils": "^2.5.0", "typescript": ">=5", "yaml": "^2.9.0" }, "peerDependencies": { "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0" } }, "sha512-rh+FlVz0yfd2RNIb6WqSkuGh0addX/Qi5scwQ5FphXDFrM6fZKcxP1+attJ78yUKcyYfiu6MTaISPpAFPzqRJw=="],
+
     "eslint-scope": ["eslint-scope@9.1.1", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
@@ -397,6 +405,8 @@
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "functional-red-black-tree": ["functional-red-black-tree@1.0.1", "", {}, "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -494,6 +504,8 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "jsx-ast-utils-x": ["jsx-ast-utils-x@0.1.0", "", {}, "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
@@ -529,6 +541,8 @@
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.groupby": ["lodash.groupby@4.6.0", "", {}, "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
@@ -600,6 +614,10 @@
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
+    "refa": ["refa@0.12.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0" } }, "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g=="],
+
+    "regexp-ast-analysis": ["regexp-ast-analysis@0.7.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.1" } }, "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
@@ -611,6 +629,8 @@
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scslre": ["scslre@0.3.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.8.0", "refa": "^0.12.0", "regexp-ast-analysis": "^0.7.0" } }, "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -644,6 +664,8 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
@@ -654,7 +676,7 @@
 
     "typed-rest-client": ["typed-rest-client@2.2.0", "", { "dependencies": { "des.js": "^1.1.0", "js-md4": "^0.3.2", "qs": "^6.14.1", "tunnel": "0.0.6", "underscore": "^1.12.1" } }, "sha512-/e2Rk9g20N0r44kaQLb3v6QGuryOD8SPb53t43Y5kqXXA+SqWuU7zLiMxetw61jNn/JFrxTdr5nPDhGY/eTNhQ=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -799,6 +821,14 @@
     "cross-spawn/path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "eslint-plugin-sonarjs/globals": ["globals@17.7.0", "", {}, "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg=="],
+
+    "eslint-plugin-sonarjs/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "eslint-plugin-sonarjs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "eslint-plugin-sonarjs/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 

--- a/lib/commands/preflight.js
+++ b/lib/commands/preflight.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/**
+ * `forge preflight` — fast (~2-4 min) blast-radius gate.
+ *
+ * Gives DETERMINISTIC-GATE PARITY with CI so an agent catches what CI catches
+ * WITHOUT waiting on the hanging full suite. Runs four gates in order, fast-fail:
+ *
+ *   1. lint     — eslint --max-warnings 0 on changed files (--all → whole tree)
+ *   2. drift    — skills mirror + registry sync + agentic-workflow structural asserts
+ *   3. sonar    — eslint-plugin-sonarjs cognitive-complexity=15 (+ parity rules)
+ *   4. affected — only the tests mapped from the changed files
+ *
+ * Exit non-zero on any gate failure. Run this before `forge push`.
+ *
+ * @module commands/preflight
+ */
+
+const { execFileSync } = require('node:child_process');
+const { getChangedFiles } = require('./test');
+const { buildGates } = require('../preflight/gates');
+const { runGates } = require('../preflight/runner');
+
+module.exports = {
+  name: 'preflight',
+  description: 'Fast deterministic-gate parity with CI (lint, drift/registry, sonar, affected tests)',
+  usage: 'forge preflight [--all]',
+  flags: {
+    '--all': 'Lint/scan the whole tree instead of only changed files',
+  },
+
+  /**
+   * @param {string[]} _args
+   * @param {Object} flags
+   * @param {string} projectRoot
+   * @param {Object} [deps] - injectable { log, resolveChangedFiles, buildGates, runGates }
+   * @returns {Promise<{ success: boolean, results?: Array }>}
+   */
+  handler: async (_args, flags, projectRoot, deps = {}) => {
+    const log = deps.log || console.log;
+    const build = deps.buildGates || buildGates;
+    const run = deps.runGates || runGates;
+    const resolveChangedFiles = deps.resolveChangedFiles
+      || (() => {
+        try {
+          return getChangedFiles(execFileSync, {}) || [];
+        } catch (_err) {
+          return [];
+        }
+      });
+
+    const runAll = !!(flags && (flags['--all'] || flags.all));
+    const changedFiles = resolveChangedFiles();
+
+    log('forge preflight — fast blast-radius gate (deterministic parity with CI)');
+    log(runAll
+      ? '  scope: whole tree (--all)'
+      : `  scope: ${changedFiles.length} changed file(s) vs base branch`);
+    log('');
+
+    const gates = build({ projectRoot, changedFiles, runAll });
+    const { ok, results } = await run(gates, { log: (line) => log(`  ${line}`) });
+
+    log('');
+    log('Preflight summary:');
+    for (const r of results) {
+      const mark = r.skipped ? 'SKIP' : (r.ok ? 'PASS' : 'FAIL');
+      log(`  [${mark}] ${r.name}${r.summary ? ` — ${r.summary}` : ''}`);
+    }
+    log('');
+    log(ok
+      ? 'preflight passed — safe to push'
+      : 'preflight FAILED — fix the failing gate above before `forge push`');
+
+    return { success: ok, results };
+  },
+};

--- a/lib/preflight/gates.js
+++ b/lib/preflight/gates.js
@@ -1,0 +1,184 @@
+'use strict';
+
+/**
+ * Gate composition + real sub-runners for `forge preflight`.
+ *
+ * Each real runner takes an injectable `spawn` (defaults to spawnSync) so the
+ * composition and the runners are unit-testable without touching the shell.
+ * The four gates give DETERMINISTIC-GATE PARITY with CI on the blast radius of
+ * a change, without the slow full matrix:
+ *
+ *   1. lint     — eslint --max-warnings 0 on changed files (or all with --all)
+ *   2. drift    — skills-mirror + registry-sync + agentic-workflow structural asserts
+ *   3. sonar    — eslint-plugin-sonarjs (cognitive-complexity=15 + parity rules)
+ *   4. affected — only the tests mapped from the changed files
+ *
+ * @module preflight/gates
+ */
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { execFileSync } = require('node:child_process');
+const nodeFs = require('node:fs');
+const { getAffectedTestFiles } = require('../commands/test');
+
+const IS_WINDOWS = process.platform === 'win32';
+
+/** Filter a changed-file list down to the JS files eslint should look at. */
+function lintableFiles(files) {
+  if (!Array.isArray(files)) return [];
+  return files.filter((f) => /\.(mjs|cjs|js)$/.test(f) && !f.includes('node_modules'));
+}
+
+/** Short, bounded summary for a spawn result. */
+function statusSummary(result, okMsg, failMsg) {
+  return result && result.status === 0
+    ? { ok: true, summary: okMsg }
+    : { ok: false, summary: failMsg };
+}
+
+/**
+ * Gate 1 — ESLint on the change blast radius (or the whole tree with --all).
+ * `files === null` means "lint everything" (`eslint .`).
+ */
+function runEslint(files, { projectRoot, spawn = spawnSync } = {}) {
+  const lintAll = files === null;
+  const targets = lintAll ? ['.'] : lintableFiles(files);
+  if (targets.length === 0) {
+    return { ok: true, summary: 'no changed JS files' };
+  }
+  const result = spawn(
+    'npx',
+    ['eslint', '--max-warnings', '0', ...targets],
+    { cwd: projectRoot, stdio: 'inherit', shell: IS_WINDOWS },
+  );
+  return statusSummary(
+    result,
+    lintAll ? 'whole tree clean' : `${targets.length} changed file(s) clean`,
+    'eslint reported errors/warnings',
+  );
+}
+
+/**
+ * Gate 2 — deterministic structural asserts that CI enforces:
+ *   - skills mirror drift (test/structural/skills-sync-drift.test.js)
+ *   - SUBCOMMANDS<->ISSUE_COMMANDS registry sync (test/commands/_resolve-command-opts.test.js)
+ *   - committed agentic-workflow mirror (scripts/sync-agentic-workflow.js --check)
+ */
+function runStructural({ projectRoot, spawn = spawnSync } = {}) {
+  const structuralTests = [
+    'test/structural/skills-sync-drift.test.js',
+    'test/commands/_resolve-command-opts.test.js',
+  ];
+  const bun = spawn(
+    'bun',
+    ['test', '--timeout', '15000', ...structuralTests],
+    { cwd: projectRoot, stdio: 'inherit', shell: IS_WINDOWS },
+  );
+  if (!bun || bun.status !== 0) {
+    return { ok: false, summary: 'skills-mirror / registry-sync asserts failed' };
+  }
+  const agentic = spawn(
+    'node',
+    ['scripts/sync-agentic-workflow.js', '--check'],
+    { cwd: projectRoot, stdio: 'inherit', shell: IS_WINDOWS },
+  );
+  return statusSummary(
+    agentic,
+    'skills + registry + agentic-workflow in sync',
+    'agentic-workflow mirror drift (run: node scripts/sync-agentic-workflow.js)',
+  );
+}
+
+/**
+ * Gate 3 — SonarCloud parity via eslint-plugin-sonarjs on changed files only,
+ * using an isolated flat config (cognitive-complexity pinned to 15 + the parity
+ * rules) so it never merges with the repo's main eslint config.
+ */
+function runSonar(files, { projectRoot, spawn = spawnSync } = {}) {
+  const targets = lintableFiles(files);
+  if (targets.length === 0) {
+    return { ok: true, summary: 'no changed JS files' };
+  }
+  const config = path.join(projectRoot, 'scripts', 'preflight-sonar.eslint.config.mjs');
+  const result = spawn(
+    'npx',
+    ['eslint', '--no-config-lookup', '--config', config, '--max-warnings', '0', ...targets],
+    { cwd: projectRoot, stdio: 'inherit', shell: IS_WINDOWS },
+  );
+  return statusSummary(
+    result,
+    `sonarjs clean (${targets.length} file(s))`,
+    'sonarjs parity violations (e.g. cognitive-complexity > 15)',
+  );
+}
+
+/**
+ * Gate 4 — run ONLY the tests mapped from the changed files (reuses the
+ * pre-push affected-test mapping). No affected tests → fast-lane pass.
+ */
+function runAffectedTests({
+  projectRoot,
+  changedFiles: _changedFiles,
+  spawn = spawnSync,
+  resolveTests,
+} = {}) {
+  const resolver = typeof resolveTests === 'function'
+    ? resolveTests
+    : () => getAffectedTestFiles(projectRoot, execFileSync, nodeFs);
+  let targets;
+  try {
+    targets = resolver() || [];
+  } catch (_err) {
+    targets = [];
+  }
+  if (targets.length === 0) {
+    return { ok: true, summary: 'no affected tests resolved (fast lane)' };
+  }
+  const result = spawn(
+    'bun',
+    ['test', '--timeout', '15000', ...targets],
+    { cwd: projectRoot, stdio: 'inherit', shell: IS_WINDOWS },
+  );
+  return statusSummary(
+    result,
+    `${targets.length} affected test file(s) passed`,
+    'affected tests failed',
+  );
+}
+
+/**
+ * Compose the ordered gate list. Each gate delegates to a sub-runner that can
+ * be injected via `deps` for testing; defaults wire the real runners above.
+ *
+ * @param {Object} args
+ * @param {string} args.projectRoot
+ * @param {string[]} args.changedFiles
+ * @param {boolean} [args.runAll]  - lint/scan whole tree instead of changed files
+ * @param {Object} [args.deps]     - { eslint, structural, sonar, affected }
+ * @returns {{ name: string, run: () => Promise<{ok:boolean, summary?:string}> }[]}
+ */
+function buildGates({ projectRoot, changedFiles = [], runAll = false, deps = {} }) {
+  const eslint = deps.eslint || ((files) => runEslint(files, { projectRoot }));
+  const structural = deps.structural || (() => runStructural({ projectRoot }));
+  const sonar = deps.sonar || ((files) => runSonar(files, { projectRoot }));
+  const affected = deps.affected || (() => runAffectedTests({ projectRoot, changedFiles }));
+
+  const lintTargets = runAll ? null : changedFiles;
+
+  return [
+    { name: 'lint', run: async () => eslint(lintTargets) },
+    { name: 'drift/registry/mirror', run: async () => structural() },
+    { name: 'sonar (cognitive-complexity=15)', run: async () => sonar(changedFiles) },
+    { name: 'affected-tests', run: async () => affected() },
+  ];
+}
+
+module.exports = {
+  buildGates,
+  lintableFiles,
+  runEslint,
+  runStructural,
+  runSonar,
+  runAffectedTests,
+};

--- a/lib/preflight/runner.js
+++ b/lib/preflight/runner.js
@@ -1,0 +1,97 @@
+'use strict';
+
+/**
+ * Fast-fail gate runner for `forge preflight`.
+ *
+ * Executes an ordered list of gates one at a time. The first gate to fail
+ * short-circuits the run: every later gate is reported as `skipped` and never
+ * executed. This keeps preflight FAST — an agent fixes the first broken gate
+ * and re-runs rather than waiting for the whole matrix.
+ *
+ * A gate is `{ name: string, run: () => Promise<{ ok: boolean, summary?: string }> }`.
+ * The sub-runner behind each `run` is injected by the composer (see gates.js),
+ * so this module stays pure and trivially testable.
+ *
+ * @module preflight/runner
+ */
+
+/**
+ * @typedef {Object} GateOutcome
+ * @property {boolean} ok       - Whether the gate passed.
+ * @property {string} [summary] - Short human-readable result line.
+ *
+ * @typedef {Object} Gate
+ * @property {string} name
+ * @property {() => Promise<GateOutcome>} run
+ *
+ * @typedef {Object} GateResult
+ * @property {string} name
+ * @property {boolean|null} ok       - true/false, or null when skipped.
+ * @property {boolean} skipped
+ * @property {string} summary
+ * @property {number} [durationMs]
+ */
+
+/**
+ * Execute a single gate, normalizing thrown errors into a failed outcome.
+ *
+ * @param {Gate} gate
+ * @returns {Promise<GateResult>}
+ */
+async function executeGate(gate) {
+  const started = Date.now();
+  let outcome;
+  try {
+    outcome = await gate.run();
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    outcome = { ok: false, summary: `error: ${message}` };
+  }
+  const durationMs = Date.now() - started;
+  return {
+    name: gate.name,
+    ok: !!(outcome && outcome.ok),
+    skipped: false,
+    summary: (outcome && outcome.summary) || '',
+    durationMs,
+  };
+}
+
+/**
+ * Run gates in order, fast-failing at the first failure.
+ *
+ * @param {Gate[]} gates
+ * @param {{ log?: (line: string) => void }} [options]
+ * @returns {Promise<{ ok: boolean, results: GateResult[], failedIndex: number }>}
+ */
+async function runGates(gates, options = {}) {
+  const log = typeof options.log === 'function' ? options.log : () => {};
+  const results = [];
+  let ok = true;
+  let failedIndex = -1;
+
+  for (const gate of gates) {
+    if (!ok) {
+      results.push({
+        name: gate.name,
+        ok: null,
+        skipped: true,
+        summary: 'skipped (earlier gate failed)',
+      });
+      continue;
+    }
+
+    const result = await executeGate(gate);
+    results.push(result);
+    log(`${result.ok ? 'PASS' : 'FAIL'} ${gate.name}${result.summary ? ` — ${result.summary}` : ''}`);
+
+    if (!result.ok) {
+      ok = false;
+      failedIndex = results.length - 1;
+    }
+  }
+
+  return { ok, results, failedIndex };
+}
+
+module.exports = { runGates };

--- a/package.json
+++ b/package.json
@@ -49,9 +49,11 @@
     "@stryker-mutator/core": "^9.6.0",
     "c8": "^11.0.0",
     "eslint": "^10.0.2",
+    "eslint-plugin-sonarjs": "^4.1.0",
     "globals": "^17.3.0",
     "js-yaml": "^5.1.0",
-    "lefthook": "^2.1.4"
+    "lefthook": "^2.1.4",
+    "typescript": "5.4.5"
   },
   "keywords": [
     "ai",

--- a/scripts/preflight-sonar.eslint.config.mjs
+++ b/scripts/preflight-sonar.eslint.config.mjs
@@ -1,0 +1,44 @@
+// Isolated ESLint flat config for `forge preflight`'s SonarCloud-parity gate.
+//
+// Run ONLY via `eslint --no-config-lookup --config scripts/preflight-sonar.eslint.config.mjs`
+// on changed files, so these Sonar rules never merge with the repo's main
+// eslint.config.js. The point is deterministic parity with the SonarCloud
+// quality gate WITHOUT the full (slow) Sonar scanner, on the change blast radius.
+//
+// cognitive-complexity is pinned to 15 — the same threshold SonarCloud's default
+// "Cognitive Complexity" (S3776) gate uses, and the most common gate failure.
+//
+// Rule name ↔ Sonar rule ID (eslint-plugin-sonarjs v4):
+//   sonarjs/cognitive-complexity  S3776  (pinned to 15)
+//   sonarjs/void-use              S3735  (void should not be used)
+//   sonarjs/regex-complexity      S5843  (regex too complex)
+//
+// prefer-optional-chain (S6582) is intentionally omitted: sonarjs exposes it
+// only through the TypeScript type-checker path, which this fast JS-only gate
+// does not wire (it would require @typescript-eslint/parser + a project graph
+// and defeats the speed goal). CI's full Sonar scan still enforces it.
+import sonarjs from 'eslint-plugin-sonarjs';
+
+const sonarRules = {
+  'sonarjs/cognitive-complexity': ['error', 15],
+  'sonarjs/void-use': 'error',
+  'sonarjs/regex-complexity': 'error',
+};
+
+export default [
+  {
+    ignores: ['node_modules/', 'coverage/', 'dist/', 'build/', '**/*.min.js'],
+  },
+  {
+    files: ['**/*.mjs'],
+    languageOptions: { ecmaVersion: 2023, sourceType: 'module' },
+    plugins: { sonarjs },
+    rules: sonarRules,
+  },
+  {
+    files: ['**/*.js', '**/*.cjs'],
+    languageOptions: { ecmaVersion: 2023, sourceType: 'commonjs' },
+    plugins: { sonarjs },
+    rules: sonarRules,
+  },
+];

--- a/test/commands/preflight.test.js
+++ b/test/commands/preflight.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const preflight = require('../../lib/commands/preflight');
+
+describe('forge preflight command — contract', () => {
+  test('exports a valid registry command interface', () => {
+    expect(preflight.name).toBe('preflight');
+    expect(typeof preflight.description).toBe('string');
+    expect(typeof preflight.handler).toBe('function');
+  });
+
+  test('returns success:true when all gates pass', async () => {
+    const lines = [];
+    const res = await preflight.handler([], {}, '/x', {
+      log: (m) => lines.push(m),
+      resolveChangedFiles: () => ['lib/a.js'],
+      buildGates: () => [{ name: 'g', run: async () => ({ ok: true, summary: 'ok' }) }],
+    });
+    expect(res.success).toBe(true);
+    expect(lines.join('\n')).toContain('preflight passed');
+  });
+
+  test('returns success:false and reports FAIL when a gate fails', async () => {
+    const lines = [];
+    const res = await preflight.handler([], {}, '/x', {
+      log: (m) => lines.push(m),
+      resolveChangedFiles: () => ['lib/a.js'],
+      buildGates: () => [{ name: 'broken', run: async () => ({ ok: false, summary: 'nope' }) }],
+    });
+    expect(res.success).toBe(false);
+    expect(lines.join('\n')).toContain('[FAIL] broken');
+    expect(lines.join('\n')).toContain('preflight FAILED');
+  });
+
+  test('--all flag forces whole-tree scope through to buildGates', async () => {
+    let received;
+    await preflight.handler([], { '--all': true }, '/x', {
+      log: () => {},
+      resolveChangedFiles: () => [],
+      buildGates: (opts) => { received = opts; return []; },
+    });
+    expect(received.runAll).toBe(true);
+  });
+});

--- a/test/preflight/gates.test.js
+++ b/test/preflight/gates.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const {
+  buildGates,
+  lintableFiles,
+  runEslint,
+  runSonar,
+  runAffectedTests,
+} = require('../../lib/preflight/gates');
+
+describe('lintableFiles', () => {
+  test('keeps js/mjs/cjs, drops others and node_modules', () => {
+    const out = lintableFiles([
+      'lib/a.js', 'scripts/b.mjs', 'x.cjs',
+      'README.md', 'data.json', 'node_modules/pkg/index.js',
+    ]);
+    expect(out).toEqual(['lib/a.js', 'scripts/b.mjs', 'x.cjs']);
+  });
+});
+
+describe('buildGates — composition', () => {
+  const deps = {
+    eslint: (files) => ({ ok: true, summary: `lint:${JSON.stringify(files)}` }),
+    structural: () => ({ ok: true, summary: 'structural' }),
+    sonar: (files) => ({ ok: true, summary: `sonar:${JSON.stringify(files)}` }),
+    affected: () => ({ ok: true, summary: 'affected' }),
+  };
+
+  test('produces the four gates in the required order', () => {
+    const gates = buildGates({ projectRoot: '/x', changedFiles: [], deps });
+    expect(gates.map((g) => g.name)).toEqual([
+      'lint',
+      'drift/registry/mirror',
+      'sonar (cognitive-complexity=15)',
+      'affected-tests',
+    ]);
+  });
+
+  test('each gate delegates to its injected sub-runner', async () => {
+    const gates = buildGates({ projectRoot: '/x', changedFiles: ['lib/a.js'], deps });
+    const outcomes = await Promise.all(gates.map((g) => g.run()));
+    expect(outcomes[0].summary).toBe('lint:["lib/a.js"]');
+    expect(outcomes[1].summary).toBe('structural');
+    expect(outcomes[2].summary).toBe('sonar:["lib/a.js"]');
+    expect(outcomes[3].summary).toBe('affected');
+  });
+
+  test('changed-file mode passes changedFiles to lint; --all passes null (lint everything)', async () => {
+    const changed = ['lib/a.js'];
+    const scoped = buildGates({ projectRoot: '/x', changedFiles: changed, deps });
+    expect((await scoped[0].run()).summary).toBe('lint:["lib/a.js"]');
+
+    const all = buildGates({ projectRoot: '/x', changedFiles: changed, runAll: true, deps });
+    expect((await all[0].run()).summary).toBe('lint:null');
+  });
+});
+
+describe('runEslint — real runner (injected spawn)', () => {
+  test('no changed JS files → passes without spawning', () => {
+    let called = false;
+    const spawn = () => { called = true; return { status: 0 }; };
+    const res = runEslint(['README.md'], { projectRoot: '/x', spawn });
+    expect(res.ok).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  test('spawns eslint with --max-warnings 0 and the target files; maps exit status', () => {
+    const calls = [];
+    const spawn = (cmd, args) => { calls.push({ cmd, args }); return { status: 1 }; };
+    const res = runEslint(['lib/a.js', 'lib/b.js'], { projectRoot: '/x', spawn });
+    expect(res.ok).toBe(false);
+    const args = calls[0].args;
+    expect(args).toContain('--max-warnings');
+    expect(args).toContain('0');
+    expect(args).toContain('lib/a.js');
+    expect(args).toContain('lib/b.js');
+  });
+
+  test('null files (lint-all) targets the whole tree', () => {
+    const calls = [];
+    const spawn = (cmd, args) => { calls.push(args); return { status: 0 }; };
+    const res = runEslint(null, { projectRoot: '/x', spawn });
+    expect(res.ok).toBe(true);
+    expect(calls[0]).toContain('.');
+  });
+});
+
+describe('runSonar — real runner (injected spawn)', () => {
+  test('runs eslint with the isolated sonar config and pinned rules on changed files', () => {
+    const calls = [];
+    const spawn = (cmd, args) => { calls.push(args); return { status: 0 }; };
+    const res = runSonar(['lib/a.js'], { projectRoot: '/x', spawn });
+    expect(res.ok).toBe(true);
+    const args = calls[0];
+    expect(args.join(' ')).toContain('--config');
+    expect(args.some((a) => String(a).includes('sonar'))).toBe(true);
+    expect(args).toContain('lib/a.js');
+  });
+
+  test('no changed JS files → skip-pass without spawning', () => {
+    let called = false;
+    const spawn = () => { called = true; return { status: 0 }; };
+    const res = runSonar([], { projectRoot: '/x', spawn });
+    expect(res.ok).toBe(true);
+    expect(called).toBe(false);
+  });
+});
+
+describe('runAffectedTests — real runner (injected)', () => {
+  test('no affected tests → fast-lane pass without spawning', () => {
+    let called = false;
+    const spawn = () => { called = true; return { status: 0 }; };
+    const res = runAffectedTests({
+      projectRoot: '/x',
+      changedFiles: [],
+      spawn,
+      resolveTests: () => [],
+    });
+    expect(res.ok).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  test('affected tests resolved → runs them and maps status', () => {
+    const calls = [];
+    const spawn = (cmd, args) => { calls.push({ cmd, args }); return { status: 0 }; };
+    const res = runAffectedTests({
+      projectRoot: '/x',
+      changedFiles: ['lib/a.js'],
+      spawn,
+      resolveTests: () => ['test/a.test.js'],
+    });
+    expect(res.ok).toBe(true);
+    expect(calls[0].args).toContain('test/a.test.js');
+  });
+});

--- a/test/preflight/runner.test.js
+++ b/test/preflight/runner.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const { runGates } = require('../../lib/preflight/runner');
+
+const passGate = (name) => ({ name, run: async () => ({ ok: true, summary: `${name} ok` }) });
+const failGate = (name) => ({ name, run: async () => ({ ok: false, summary: `${name} boom` }) });
+
+describe('runGates — fast-fail gate runner', () => {
+  test('all gates pass → ok:true with one result per gate', async () => {
+    const { ok, results } = await runGates([passGate('a'), passGate('b')]);
+    expect(ok).toBe(true);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.ok && !r.skipped)).toBe(true);
+  });
+
+  test('stops at first failure and marks later gates skipped (fast-fail)', async () => {
+    let ran3 = false;
+    const gate3 = { name: 'c', run: async () => { ran3 = true; return { ok: true }; } };
+    const { ok, results, failedIndex } = await runGates([passGate('a'), failGate('b'), gate3]);
+    expect(ok).toBe(false);
+    expect(failedIndex).toBe(1);
+    expect(ran3).toBe(false); // third gate never executed
+    expect(results[0]).toMatchObject({ name: 'a', ok: true, skipped: false });
+    expect(results[1]).toMatchObject({ name: 'b', ok: false, skipped: false });
+    expect(results[2]).toMatchObject({ name: 'c', skipped: true });
+  });
+
+  test('a throwing gate is caught and treated as a failure', async () => {
+    const boom = { name: 'x', run: async () => { throw new Error('kaboom'); } };
+    const { ok, results } = await runGates([boom]);
+    expect(ok).toBe(false);
+    expect(results[0].ok).toBe(false);
+    expect(results[0].summary).toContain('kaboom');
+  });
+
+  test('runs gates strictly in order', async () => {
+    const order = [];
+    const g = (n) => ({ name: n, run: async () => { order.push(n); return { ok: true }; } });
+    await runGates([g('1'), g('2'), g('3')]);
+    expect(order).toEqual(['1', '2', '3']);
+  });
+
+  test('logs a line per executed gate', async () => {
+    const lines = [];
+    await runGates([passGate('a'), failGate('b')], { log: (m) => lines.push(m) });
+    expect(lines.some((l) => l.includes('a'))).toBe(true);
+    expect(lines.some((l) => l.includes('b'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Composes **`forge preflight`** — a fast (~2-4 min) blast-radius gate that gives
DETERMINISTIC-GATE PARITY with CI so agents catch what CI catches WITHOUT the
hanging full suite. This is the #1 reliability lever: it kills the
fix-and-repush loop.

Runs four gates fast-fail, in order (exits non-zero on the first failure):

1. **lint** — `eslint --max-warnings 0` on changed files (git diff vs base branch), or the whole tree with `--all`.
2. **drift/registry/mirror** — the existing structural asserts CI enforces: skills-sync drift (`test/structural/skills-sync-drift.test.js`), the SUBCOMMANDS↔ISSUE_COMMANDS registry sync (`test/commands/_resolve-command-opts.test.js`), and the committed agentic-workflow mirror (`node scripts/sync-agentic-workflow.js --check`).
3. **sonar** — SonarCloud parity via `eslint-plugin-sonarjs` on changed files using an isolated flat config (`scripts/preflight-sonar.eslint.config.mjs`): `cognitive-complexity` pinned to **15**, plus `void-use` (S3735) and `regex-complexity` (S5843).
4. **affected-tests** — only the tests mapped from the changed files (reuses `getAffectedTestFiles` from the pre-push mapping).

## Files

- `lib/preflight/runner.js` — pure fast-fail gate runner (DI'd).
- `lib/preflight/gates.js` — composition + real sub-runners (injectable `spawn`).
- `lib/commands/preflight.js` — registered `forge preflight` verb.
- `scripts/preflight-sonar.eslint.config.mjs` — isolated sonarjs flat config.
- `test/preflight/*.test.js`, `test/commands/preflight.test.js` — 20 TDD tests (composition + gate-runner with injected sub-runners).

## Notes / follow-ups

- **`typescript` pinned to exactly `5.4.5`**: eslint-plugin-sonarjs v4's CJS build hard-requires the TS analyzer, and TypeScript ≥5.7 broke its `__importDefault` interop (rule load throws `typescript_1.default undefined`). 5.4.5 is the last pre-regression line that loads cleanly under eslint 10. The caret is intentionally omitted.
- **prefer-optional-chain (S6582)** is NOT enforced by this fast JS-only gate — sonarjs exposes it only through the TS type-checker path (needs `@typescript-eslint/parser` + a project graph), which would defeat the speed goal. CI's full Sonar scan still enforces it.
- **AGENTS.md doc was intentionally NOT committed**: the `protected-state` gate blocks direct edits to AGENTS.md (`generated_harness`). The intended doc line is: *"Push only after `forge preflight` passes"* in the Preferred push workflow section — it should be added via the owning harness surface (`forge setup` / template), not a hand-edit.

## Dogfood (deterministic gates run on this change)

- `eslint --max-warnings 0` on the 7 new JS files: clean.
- sonarjs config on the new files: clean (cognitive-complexity ≤ 15) — it caught and I fixed a 25-complexity `runGates` during development.
- 20 affected unit tests: pass.
- End-to-end `forge preflight` on the committed change: all 4 gates PASS, exit 0.

Refs 9a5088ef-10d8-455f-b768-cc82de2f5bc3

🤖 Generated with [Claude Code](https://claude.com/claude-code)