### PR TITLE
fix(shepherd): trustworthy merge verdict — never false-clean

### DIFF
--- a/docs/work/2026-07-12-shepherd-merge-safety/design.md
+++ b/docs/work/2026-07-12-shepherd-merge-safety/design.md
@@ -1,0 +1,178 @@
+# Shepherd merge-safety — trustworthy merge verdict (Tier-1)
+
+**Issues:** c01936be, 35ee8d78
+**Branch:** `feat/shepherd-merge-safety`
+**Scope:** READ + verdict only. The shepherd still NEVER merges and NEVER
+resolves threads. No resolve/reply verbs, no auto-trigger (that is Tier-2, left
+filed).
+
+## Rebase reconciliation (master shipped an overlapping model)
+
+While this branch was open, another PR merged to `master` that reworked the same
+files into a **pull-signal `blockers[]` model** — it already delivers: the
+`--pull`/`--bundle` `output` plumbing, `REVIEW_BOT_LOGINS`/`AUTOMATION_BOT_LOGINS`/
+`STATUS_BOT_LOGINS`, `classifyRequiredChecks` (missing/skipped/pending/failing),
+`buildBotStatusBlockers` (Sonar/Vercel/Netlify/Codecov quality-gate COMMENT
+scanning — the #353 class), `reviewDecision`+`isDraft`, `readIssueComments`,
+conflict/behind/draft blockers, and `computeBlockers`/`renderPullSummary`.
+
+The rebase therefore **adopts master's model as the base** and layers ONLY the
+pieces master lacks, without duplicating its helpers or editing its reviewed
+bot-sets:
+
+- **`pr-shepherd.js`** — the two-set bot classification so an unresolved
+  CodeRabbit *thread* makes the pass `NEEDS_REVIEW` (master's pr-shepherd still
+  used the old single `BOT_LOGINS`; this is a genuine, unique fix).
+- **`readReviews`** (adapter) — review-at-head oid; master has no review-at-head.
+- **`readHeadCommitTime`** (adapter) — head-push time to anchor the settle window.
+- **`computeVerdict`** (pr-pull) — a single fail-closed `verdict` enum that
+  CONSUMES master's raw signals (mergeStateStatus, `classifyRequiredChecks`,
+  `buildBotStatusBlockers` count, conflicts, behind, reviewDecision, thread count)
+  PLUS review-at-head, settle window, torn-read, and UNKNOWN-on-unreadable.
+
+### Adversarial false-clean fixes folded in (same pass)
+
+- **F1** — CLEAN is reachable ONLY from an explicitly-good `mergeStateStatus`
+  (`CLEAN`). `UNKNOWN`/`''`/`BLOCKED` fail closed to `UNKNOWN` (GitHub returns
+  UNKNOWN while recomputing right after a push; the adapter also defaults UNKNOWN).
+- **F2** — BLOCKED-THREADS gates on the RAW unresolved-thread count, so a thread
+  missing `threadId`/`id` still blocks.
+- **F3** — the settle window anchors to `max(headPushTime, latestReview,
+  latestComment)`; a fresh green PR whose CI passed before the review bots ran is
+  `REVIEW-PENDING`, not CLEAN. CLEAN also requires a KNOWN head-push time.
+- **F5** — a code-review-bot direct comment is compared to the head-push time
+  (not to later agent chatter), so an unrelated agent comment can't clear it.
+- **F4** left as filed Tier-2 (no merge-path consumer yet).
+
+### Agnostic actor classification (supersedes the two-set / F6 name lists)
+
+Classification is by **MECHANISM, not by a hardcoded bot-name list** — a name
+list fails closed the WRONG way (an unknown/new review bot not on the list has
+its signal silently ignored → false-clean). Unknown actors default to BLOCKING.
+
+- **Threads** — any unresolved, non-outdated review thread blocks
+  (`BLOCKED-THREADS`), **author-agnostic**. `pr-shepherd.actionableComments` drops
+  the author filter entirely; the verdict counts unresolved threads from the RAW
+  `readComments` output (independent of master's display fix-list, which keeps its
+  own filtering and tests).
+- **Checks/status** — any failing/missing/skipped/pending required check OR a
+  failing bot-status COMMENT (`buildBotStatusBlockers`) blocks (`BLOCKED-CHECKS`),
+  with zero name knowledge. SonarCloud/Vercel/Netlify/Codecov surface here.
+- **Direct comments** — a NON-HUMAN top-level comment newer than the last head
+  push blocks. Non-human is detected generically: GraphQL `author.__typename ===
+  'Bot'` OR a `[bot]` login suffix (`readIssueComments`/`readReviews` now surface
+  `authorTypename`). The ONLY name list is an INVERTED **suppression allowlist**
+  (`STATUS_BOT_LOGINS`) — known status/deploy/quality bots whose gate already
+  blocks via checks, so their comment does not also drive an unresolvable
+  `BLOCKED-THREADS`. Every bot NOT on the allowlist (known or unknown) is
+  actionable.
+
+This makes F6's intent intrinsic to the mechanism: SonarCloud's failing gate is a
+failing check → `BLOCKED-CHECKS`; its unresolvable comment is a suppressed
+status-bot comment → not `BLOCKED-THREADS`. No special-casing by name.
+
+## Problem
+
+The PR shepherd (the merge-safety surface) is untrustworthy. On PR #365 it would
+have reported merge-ready while 13 CodeRabbit threads were unresolved. Four
+verified root causes:
+
+1. **Plumbing.** `bin/forge.js` prints only `result.output`/`result.error`;
+   `lib/commands/shepherd.js` returned `{success, pull}` / `{success, bundle}` —
+   neither field is serialized, so `forge shepherd <pr> --pull --json` and
+   `--bundle --json` emitted NOTHING to stdout.
+2. **Bot misclassification.** `lib/pr-shepherd.js` listed `coderabbitai` in
+   `BOT_LOGINS`; `actionableComments` filtered those threads OUT, so a pass
+   reached `MERGE_READY` with unresolved CodeRabbit threads. `lib/pr-pull.js`
+   already had the correct split (`REVIEW_BOT_LOGINS` vs
+   `AUTOMATION_BOT_LOGINS`) — adopt that model in `pr-shepherd.js`.
+3. **No review-at-head check.** A stale CodeRabbit review (from an earlier
+   commit) was treated as current, so post-push re-reviews were missed (the #365
+   race). `headSha` was only used as a mutation guard.
+4. **Author-agnostic direct comments missed.** Direct PR issue comments +
+   submitted review bodies were not gathered author-agnostically (the #353
+   "Additional Comments (N)" miss class).
+
+## Verdict vocabulary (fail-closed precedence, top wins)
+
+Computed in `gatherPullSignal` (lib/pr-pull.js) as a NEW `verdict` field
+alongside the existing `state`. Never defaults clean.
+
+| Rank | Verdict | Trigger |
+|------|---------|---------|
+| 1 | `UNKNOWN` | Any verdict-relevant read THREW (never default clean). Also: torn read (head oid moved during gather). |
+| 2 | `BLOCKED-CONFLICT` | `mergeStateStatus === 'DIRTY'` (merge conflict). |
+| 3 | `BEHIND` | `mergeStateStatus === 'BEHIND'` (branch behind base). |
+| 4 | `BLOCKED-CHECKS` | A required check is FAILING, or a required check is SKIPPED under `strictSkipped` (default ON), or `mergeStateStatus === 'UNSTABLE'`. |
+| 5 | `BLOCKED-THREADS` | An unresolved, non-outdated inline thread authored by a human or review-bot; OR a review-bot direct issue comment / `CHANGES_REQUESTED` review newer than the last head push / last agent reply. |
+| 6 | `REVIEW-PENDING` | Latest review-bot review `commit.oid !== headOid` (review is stale vs head); OR the settle window is not yet met. |
+| 7 | `CLEAN-MERGEABLE` | None of the above. Only reachable when every input was readable, head did not move, and nothing is outstanding. |
+
+### Settle window
+
+`now - max(latest review submittedAt, latest issue-comment createdAt) >= settleWindowMs`.
+Default `600_000` ms (600 s), configurable via `ctx.settleWindowMs`. If the most
+recent human/bot activity is inside the window, the PR has not settled →
+`REVIEW-PENDING`.
+
+### Torn-read guard
+
+Head oid is re-read at the END of gather. If it differs from the head oid read at
+the start, the whole snapshot is stale/untrustworthy → verdict downgraded to
+`UNKNOWN` (never CLEAN). Evidence records `tornRead: true`.
+
+### Fail-closed rule
+
+Absent adapter method (older adapter that never implemented `readReviews` /
+`readIssueComments`) is treated as "readable, empty" — NOT unreadable. Only a
+method that THROWS marks its input unreadable → `UNKNOWN`. This keeps the verdict
+meaningful for adapters that predate the new reads while still failing closed on
+real read errors.
+
+### Evidence
+
+Every verdict carries `evidence` with the arrays that drove it:
+`failingRequired[]`, `skippedRequired[]`, `unresolvedThreads[]`, `staleReviews[]`,
+`botComments[]`, `changesRequested[]`, `unreadable[]`, `tornRead`,
+`settleRemainingMs`, `headOid`.
+
+## Changes by Tier-1 item
+
+1. **Plumbing** (`lib/commands/shepherd.js`): `--pull` and `--bundle` returns add
+   `output: JSON.stringify(payload)` so `bin/forge.js` prints it. Existing
+   `pull` / `bundle` fields retained (back-compat). Registry-path test asserts
+   stdout parses as JSON with the expected keys.
+2. **Bot classification** (`lib/pr-shepherd.js`): replace single `BOT_LOGINS`
+   with `REVIEW_BOT_LOGINS` (coderabbitai, greptile-apps, qodo-merge-pro,
+   sonarqubecloud) + `AUTOMATION_BOT_LOGINS` (github-actions, codecov,
+   dependabot). `actionableComments` now treats a thread with a human OR
+   review-bot comment (not self, not pure-automation) as actionable →
+   unresolved CodeRabbit threads make the pass `NEEDS_REVIEW`, not `MERGE_READY`.
+3. **Adapter reads** (`lib/adapters/pr-state-adapter.js`): add `readReviews`
+   (GraphQL `reviews(last:100){author{login} state submittedAt commit{oid}
+   body}`, latest review per author with its commit oid) and `readIssueComments`
+   (REST `issues/{pr}/comments`, AUTHOR-AGNOSTIC). Add `reviewDecision` to
+   `PR_VIEW_FIELDS` and to the `readState` return.
+4. **Verdict block** (`lib/pr-pull.js` `gatherPullSignal`): compute the
+   fail-closed `verdict` above; attach `verdict` + `evidence` to the payload.
+5. **Checks** (`lib/pr-pull.js`): required checks with conclusion `SKIPPED` go in
+   `skippedRequired[]` and block under `strictSkipped` (default ON). Map
+   `mergeStateStatus` and `reviewDecision` per the precedence.
+6. **Tests** (all via injected gh/adapter deps — no live GitHub):
+   - (a) #365 regression: all threads resolved but latest coderabbitai review
+     `commit.oid !== headOid` → `REVIEW-PENDING`, never CLEAN.
+   - (b) #353 regression: zero threads, one review-bot issue comment
+     "Additional Comments (3)" post-push → `BLOCKED-THREADS`.
+   - (c) 13 unresolved coderabbitai threads + green checks → pass state NOT
+     merge-ready AND verdict `BLOCKED-THREADS`.
+   - (d) fail-closed: a read throws → `UNKNOWN`.
+   - (e) torn read: gh returns a different head oid across gather → not CLEAN.
+   - (f) SKIPPED-required → `BLOCKED-CHECKS`.
+   - (g) output contract from item 1.
+
+## Explicitly NOT rebuilt (already correct)
+
+Fully-paginated `readComments`; required-set null → escalate; `allRequiredGreen`
+presence check; the dryRun read-only pass; the failure-log excerpt/dedupe
+pipeline + token caps; the injected deps. The shepherd's "never merges / never
+resolves threads" invariant stays intact.

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -348,16 +348,71 @@ class PrStateAdapter {
    * @returns {Promise<Array<{ author: string, body: string, createdAt: string }>>}
    */
   async readIssueComments({ owner, repo, pr }) {
-    const query = 'query($o:String!,$n:String!,$pr:Int!,$after:String){repository(owner:$o,name:$n){pullRequest(number:$pr){comments(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{author{login} body createdAt}}}}}';
+    // `author{__typename login}` surfaces the GraphQL actor TYPE ('Bot' vs 'User')
+    // so a non-human direct comment can be detected GENERICALLY — by mechanism,
+    // not by a hardcoded bot-name list — which fails closed for unknown bots.
+    const query = 'query($o:String!,$n:String!,$pr:Int!,$after:String){repository(owner:$o,name:$n){pullRequest(number:$pr){comments(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{author{__typename login} body createdAt}}}}}';
     return this._paginateConnection(
       (after) => this._ghGraphqlPage(query, { owner, repo, pr }, after)
         ?.data?.repository?.pullRequest?.comments,
       (c) => ({
         author: c.author?.login || '',
+        authorTypename: c.author?.__typename || '',
         body: c.body || '',
         createdAt: c.createdAt || '',
       }),
     );
+  }
+
+  /**
+   * Read submitted PR REVIEWS (not inline threads) — the latest review per
+   * author, each with the commit it was submitted against. This is the
+   * review-at-head signal that catches the #365 race: a CodeRabbit review from
+   * an earlier commit whose `commit.oid` no longer matches HEAD is STALE, so the
+   * post-push re-review is still pending. Uses GraphQL because `gh pr view`
+   * cannot return a review's target commit oid. Fully paginated by cursor.
+   *
+   * @param {{ owner: string, repo: string, pr: string }} ctx
+   * @returns {Promise<Array<{ author: string, state: string, submittedAt: string|null, commitOid: string|null, body: string }>>}
+   */
+  async readReviews({ owner, repo, pr }) {
+    const query = 'query($o:String!,$n:String!,$pr:Int!,$after:String){repository(owner:$o,name:$n){pullRequest(number:$pr){reviews(first:100,after:$after){pageInfo{hasNextPage endCursor} nodes{author{__typename login} state submittedAt commit{oid} body}}}}}';
+    const all = this._paginateConnection(
+      (after) => this._ghGraphqlPage(query, { owner, repo, pr }, after)
+        ?.data?.repository?.pullRequest?.reviews,
+      (r) => ({
+        author: String(r.author?.login || '').toLowerCase(),
+        authorTypename: r.author?.__typename || '',
+        state: String(r.state || '').toUpperCase(),
+        submittedAt: r.submittedAt || null,
+        commitOid: r.commit?.oid || null,
+        body: r.body || '',
+      }),
+    );
+    // Keep only the LATEST review per author (first:100 yields oldest→newest, so
+    // a later entry supersedes an earlier one from the same login).
+    const latest = new Map();
+    for (const r of all) {
+      if (!r.author) continue;
+      latest.set(r.author, r);
+    }
+    return Array.from(latest.values());
+  }
+
+  /**
+   * Read the HEAD commit's committed timestamp (epoch ms), or null when
+   * unreadable. Anchors the pull-signal settle window to when the code last
+   * changed — so a freshly-pushed PR whose CI passes BEFORE the review bots have
+   * even run is REVIEW-PENDING, not CLEAN (#365 "never-ran" variant), and a bot
+   * comment older than the last push is treated as stale, not a live blocker.
+   *
+   * @param {{ pr: string }} ctx
+   * @returns {Promise<number|null>} epoch ms of the head commit, or null.
+   */
+  async readHeadCommitTime({ pr }) {
+    const raw = this._gh('gh', ['pr', 'view', String(pr), '--json', 'commits', '-q', '.commits[-1].committedDate']);
+    const t = Date.parse(String(raw || '').trim());
+    return Number.isFinite(t) ? t : null;
   }
 
   /**

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -797,7 +797,13 @@ const KNOWN_GOOD_MSS = new Set(['CLEAN']);
  * @param {object} input
  * @returns {{ verdict: string, evidence: object }}
  */
-function computeVerdict(input) {
+/**
+ * Normalize raw verdict input into a `v` context object carrying the parsed
+ * signals plus a mutable `evidence` accumulator. Each rank predicate reads from
+ * (and annotates) this object; keeping the shape in one place lets computeVerdict
+ * stay a thin dispatch loop (SonarCloud S3776 cognitive-complexity).
+ */
+function buildVerdictContext(input) {
   const {
     headOidStart, headOidEnd,
     mergeStateStatus, mergeable, reviewDecision,
@@ -813,20 +819,16 @@ function computeVerdict(input) {
   } = input || {};
 
   const mss = String(mergeStateStatus || '').toUpperCase();
-  const failing = requiredClass.failing || [];
-  const missing = requiredClass.missing || [];
-  const skipped = requiredClass.skipped || [];
-  const pending = requiredClass.pending || [];
-
+  const rc = requiredClass || {};
   const evidence = {
     headOid: headOidStart || null,
     mergeStateStatus: mss || null,
     unreadable: [...unreadable],
     tornRead: false,
-    failingRequired: failing,
-    missingRequired: missing,
-    skippedRequired: skipped,
-    pendingRequired: pending,
+    failingRequired: rc.failing || [],
+    missingRequired: rc.missing || [],
+    skippedRequired: rc.skipped || [],
+    pendingRequired: rc.pending || [],
     botStatusBlockerCount,
     conflict: false,
     behind,
@@ -836,83 +838,115 @@ function computeVerdict(input) {
     staleReviews: [],
     settleRemainingMs: 0,
   };
-  const V = (verdict) => ({ verdict, evidence });
 
-  // --- Rank 1: UNKNOWN (fail-closed). Unreadable input / required set, missing
-  // head oid, or a torn read (head moved during the gather). ---
-  const torn = Boolean(headOidStart) && Boolean(headOidEnd) && headOidStart !== headOidEnd;
-  evidence.tornRead = torn;
-  if (requiredClass.unreadable && !evidence.unreadable.includes('requiredChecks')) {
-    evidence.unreadable.push('requiredChecks');
+  return {
+    headOidStart, headOidEnd, mss, mergeable, reviewDecision,
+    requiredClass: rc, behind, conflicts,
+    unresolvedThreadCount, botStatusBlockerCount, botDirectComments,
+    reviews, headPushTimeMs, headPushKnown, issueComments,
+    now, settleWindowMs, evidence,
+  };
+}
+
+// --- Rank predicates. Each takes the verdict context `v`, annotates `v.evidence`
+// as needed, and returns a verdict string when its rank fires or `null` to fall
+// through to the next rank. They run in strict precedence order. ---
+
+/** Rank 1: UNKNOWN (fail-closed) — unreadable input/required set, missing head
+ * oid, or a torn read (head moved during the gather). */
+function rankUnknown(v) {
+  const torn = Boolean(v.headOidStart) && Boolean(v.headOidEnd) && v.headOidStart !== v.headOidEnd;
+  v.evidence.tornRead = torn;
+  if (v.requiredClass.unreadable && !v.evidence.unreadable.includes('requiredChecks')) {
+    v.evidence.unreadable.push('requiredChecks');
   }
-  if (!headOidStart && !evidence.unreadable.includes('headOid')) {
-    evidence.unreadable.push('headOid');
+  if (!v.headOidStart && !v.evidence.unreadable.includes('headOid')) {
+    v.evidence.unreadable.push('headOid');
   }
-  if (evidence.unreadable.length > 0 || torn) return V('UNKNOWN');
+  return (v.evidence.unreadable.length > 0 || torn) ? 'UNKNOWN' : null;
+}
 
-  // --- Rank 2: hard merge conflict. ---
-  if ((conflicts && conflicts.conflicted)
-      || String(mergeable || '').toUpperCase() === 'CONFLICTING'
-      || mss === 'DIRTY') {
-    evidence.conflict = true;
-    return V('BLOCKED-CONFLICT');
+/** Rank 2: hard merge conflict. */
+function rankConflict(v) {
+  if ((v.conflicts && v.conflicts.conflicted)
+      || String(v.mergeable || '').toUpperCase() === 'CONFLICTING'
+      || v.mss === 'DIRTY') {
+    v.evidence.conflict = true;
+    return 'BLOCKED-CONFLICT';
   }
+  return null;
+}
 
-  // --- Rank 3: branch behind base. ---
-  if (mss === 'BEHIND' || behind > 0) return V('BEHIND');
+/** Rank 3: branch behind base. */
+function rankBehind(v) {
+  return (v.mss === 'BEHIND' || v.behind > 0) ? 'BEHIND' : null;
+}
 
-  // --- Rank 4: checks. Failing/missing/skipped/pending REQUIRED checks, a
-  // failing bot-status quality gate (Sonar/Vercel/Netlify/Codecov comment picked
-  // up by buildBotStatusBlockers), or an UNSTABLE merge state all block. ---
-  if (failing.length || missing.length || skipped.length || pending.length
-      || botStatusBlockerCount > 0 || mss === 'UNSTABLE') {
-    return V('BLOCKED-CHECKS');
-  }
+/** Rank 4: checks — failing/missing/skipped/pending REQUIRED checks, a failing
+ * bot-status quality gate (buildBotStatusBlockers), or an UNSTABLE merge state. */
+function rankChecks(v) {
+  const e = v.evidence;
+  const blocked = e.failingRequired.length || e.missingRequired.length
+    || e.skippedRequired.length || e.pendingRequired.length
+    || v.botStatusBlockerCount > 0 || v.mss === 'UNSTABLE';
+  return blocked ? 'BLOCKED-CHECKS' : null;
+}
 
-  // --- Rank 5: threads. Unresolved inline threads (RAW, author-agnostic count —
-  // a thread with no id still counts), a fresh non-human direct "Additional
-  // Comments" issue comment (posted AFTER the last head push, i.e. about the
-  // CURRENT code — anchored to the push, NOT to later agent chatter), or a
-  // CHANGES_REQUESTED review decision. `botDirectComments` is already filtered to
-  // actionable (non-human, non-suppressed, non-self) comments upstream. ---
-  const botCommentAnchor = headPushKnown ? headPushTimeMs : 0;
-  const botComments = botDirectComments.filter((c) => {
+/** Rank 5: threads — unresolved inline threads (RAW, author-agnostic count), a
+ * fresh non-human direct comment (posted AFTER the last head push, anchored to
+ * the push not to later agent chatter), or a CHANGES_REQUESTED review decision. */
+function rankThreads(v) {
+  const anchor = v.headPushKnown ? v.headPushTimeMs : 0;
+  const botComments = v.botDirectComments.filter((c) => {
     const t = parseTime(c.createdAt);
-    return t !== null && t > botCommentAnchor;
+    return t !== null && t > anchor;
   });
-  evidence.botComments = botComments.map((c) => c.commentId || null).filter(Boolean);
-  const changesRequested = String(reviewDecision || '').toUpperCase() === 'CHANGES_REQUESTED';
-  evidence.changesRequested = changesRequested;
-  if (unresolvedThreadCount > 0 || botComments.length > 0 || changesRequested) {
-    return V('BLOCKED-THREADS');
-  }
+  v.evidence.botComments = botComments.map((c) => c.commentId || null).filter(Boolean);
+  const changesRequested = String(v.reviewDecision || '').toUpperCase() === 'CHANGES_REQUESTED';
+  v.evidence.changesRequested = changesRequested;
+  const blocked = v.unresolvedThreadCount > 0 || botComments.length > 0 || changesRequested;
+  return blocked ? 'BLOCKED-THREADS' : null;
+}
 
-  // --- Rank 6: review-pending. A code-review-bot review against an OLDER commit
-  // (stale re-review, #365), a REVIEW_REQUIRED decision, or activity that has not
-  // settled (window anchored to the head push, so a fresh green PR that CI passed
-  // before the review bots ran is pending, not clean). ---
-  // Author-agnostic (by mechanism): ANY bot reviewer whose latest review targets
-  // an OLDER commit hasn't re-reviewed the current head → re-review pending.
-  const staleReviews = reviews.filter(
-    (r) => isBotAuthor(r) && r.commitOid && r.commitOid !== headOidStart,
+/** Rank 6: review-pending — an ANY-bot review against an OLDER commit (stale
+ * re-review, #365), a REVIEW_REQUIRED decision, or activity that has not settled
+ * (window anchored to the head push). */
+function rankReviewPending(v) {
+  const staleReviews = v.reviews.filter(
+    (r) => isBotAuthor(r) && r.commitOid && r.commitOid !== v.headOidStart,
   );
-  evidence.staleReviews = staleReviews.map((r) => r.author).filter(Boolean);
+  v.evidence.staleReviews = staleReviews.map((r) => r.author).filter(Boolean);
 
   const anchors = [];
-  if (headPushKnown && headPushTimeMs != null) anchors.push(headPushTimeMs);
-  for (const r of reviews) { const t = parseTime(r.submittedAt); if (t) anchors.push(t); }
-  for (const c of issueComments) { const t = parseTime(c.createdAt); if (t) anchors.push(t); }
+  if (v.headPushKnown && v.headPushTimeMs != null) anchors.push(v.headPushTimeMs);
+  for (const r of v.reviews) { const t = parseTime(r.submittedAt); if (t) anchors.push(t); }
+  for (const c of v.issueComments) { const t = parseTime(c.createdAt); if (t) anchors.push(t); }
   const lastActivity = anchors.length ? Math.max(...anchors) : null;
-  const settleRemaining = lastActivity === null ? 0 : settleWindowMs - (now - lastActivity);
-  evidence.settleRemainingMs = settleRemaining > 0 ? settleRemaining : 0;
+  const settleRemaining = lastActivity === null ? 0 : v.settleWindowMs - (v.now - lastActivity);
+  v.evidence.settleRemainingMs = settleRemaining > 0 ? settleRemaining : 0;
 
-  const reviewRequired = String(reviewDecision || '').toUpperCase() === 'REVIEW_REQUIRED';
-  if (staleReviews.length > 0 || reviewRequired || settleRemaining > 0) return V('REVIEW-PENDING');
+  const reviewRequired = String(v.reviewDecision || '').toUpperCase() === 'REVIEW_REQUIRED';
+  return (staleReviews.length > 0 || reviewRequired || settleRemaining > 0) ? 'REVIEW-PENDING' : null;
+}
 
-  // --- Rank 7: CLEAN — ONLY when the merge state is explicitly good AND the head
-  // push time is known & settled. Anything else fails closed to UNKNOWN. ---
-  if (KNOWN_GOOD_MSS.has(mss) && headPushKnown) return V('CLEAN-MERGEABLE');
-  return V('UNKNOWN');
+/** Rank 7 (terminal): CLEAN only when the merge state is explicitly good AND the
+ * head push time is known & settled — otherwise fail closed to UNKNOWN. */
+function rankClean(v) {
+  return (KNOWN_GOOD_MSS.has(v.mss) && v.headPushKnown) ? 'CLEAN-MERGEABLE' : 'UNKNOWN';
+}
+
+/** Precedence-ordered rank predicates (top wins). */
+const VERDICT_RANKS = [
+  rankUnknown, rankConflict, rankBehind, rankChecks, rankThreads, rankReviewPending,
+];
+
+function computeVerdict(input) {
+  const v = buildVerdictContext(input);
+  for (const rank of VERDICT_RANKS) {
+    const verdict = rank(v);
+    if (verdict) return { verdict, evidence: v.evidence };
+  }
+  return { verdict: rankClean(v), evidence: v.evidence };
 }
 
 /**
@@ -967,7 +1001,6 @@ async function gatherPullSignal(ctx) {
   try {
     pass = await runPass({ ...ctx, adapter, dryRun: true });
   } catch (_err) {
-    void _err;
     pass = { state: 'UNKNOWN', reason: 'Decision pass could not complete — a read failed; see verdict evidence.' };
   }
 
@@ -977,7 +1010,7 @@ async function gatherPullSignal(ctx) {
   try {
     requiredSet = await adapter.readRequiredChecks({ owner, repo, base });
   } catch (_err) {
-    void _err; // unreadable protection → keep null ("unknown"), still diagnose
+    // unreadable protection → keep null ("unknown"), still diagnose
   }
 
   // Fetch logs for failed checks (required first), bounded so matrix dupes can
@@ -1011,7 +1044,7 @@ async function gatherPullSignal(ctx) {
       ? await adapter.readComments({ owner, repo, pr, cwd })
       : [];
   } catch (_err) {
-    void _err; // unreadable threads → keep the empty fix-list, don't sink payload
+    // unreadable threads → keep the empty fix-list, don't sink payload
     unreadable.push('threads'); // fail-closed: cannot confirm threads are clean
   }
   const reviewThreads = buildReviewThreads(threads, self, { maxThreads });
@@ -1027,7 +1060,7 @@ async function gatherPullSignal(ctx) {
       behind = div.behind || 0;
     }
   } catch (_err) {
-    void _err; // unknown divergence → treat as not-behind, keep diagnosing
+    // unknown divergence → treat as not-behind, keep diagnosing
   }
 
   // Predicted merge conflicts (which files) — optional adapter capability.
@@ -1037,7 +1070,7 @@ async function gatherPullSignal(ctx) {
       conflicts = await adapter.detectConflicts({ baseRef: ctx.baseRef, cwd });
     }
   } catch (_err) {
-    void _err; // conflict prediction unsupported → omit, keep diagnosing
+    // conflict prediction unsupported → omit, keep diagnosing
   }
 
   // Bot STATUS COMMENTS (SonarCloud Quality-Gate / Vercel-Netlify deployment /
@@ -1081,7 +1114,6 @@ async function gatherPullSignal(ctx) {
     try {
       reviews = await adapter.readReviews({ owner, repo, pr });
     } catch (_err) {
-      void _err;
       unreadable.push('reviews');
     }
   }
@@ -1092,7 +1124,6 @@ async function gatherPullSignal(ctx) {
       headPushTimeMs = await adapter.readHeadCommitTime({ pr });
       headPushKnown = headPushTimeMs != null;
     } catch (_err) {
-      void _err;
       unreadable.push('headPushTime');
     }
   }
@@ -1102,7 +1133,6 @@ async function gatherPullSignal(ctx) {
     const endState = await adapter.readState(pr);
     headOidEnd = endState.headSha;
   } catch (_err) {
-    void _err;
     unreadable.push('headEnd');
   }
 

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -38,6 +38,10 @@ const DEFAULT_MAX_EXCERPT_LINES = 30;
 // collapse (via dedupe) BEFORE the maxFailures slice — otherwise N identical
 // matrix failures would eat the whole failure budget and hide distinct ones.
 const LOG_FETCH_MULTIPLIER = 3;
+// Merge cannot be declared clean until activity has settled for this long — a
+// re-review or a late reviewer comment inside the window means the PR is still
+// in flight. Mirrors the merge-rules `settle_min` idea (default 10 minutes).
+const DEFAULT_SETTLE_WINDOW_MS = 600000;
 
 /**
  * Bot logins whose review threads ARE actionable fixes (their comments tell you
@@ -644,6 +648,8 @@ function conflictsField(conflicts) {
 function buildPullPayload({
   pr,
   state,
+  verdict,
+  evidence,
   summary,
   reason,
   mergeable = 'UNKNOWN',
@@ -670,6 +676,10 @@ function buildPullPayload({
   return {
     ...prField(pr),
     state,
+    // `verdict` is the trustworthy, fail-closed merge signal (never false-clean);
+    // `state` remains the legacy decision-pass state for back-compat.
+    ...(verdict ? { verdict } : {}),
+    ...(evidence ? { evidence } : {}),
     summary,
     ...(reason ? { reason } : {}),
     mergeable,
@@ -715,6 +725,196 @@ function summarize({ state, failureCount, threadCount, blockers = [] }) {
   return `${state}: ${parts.join(', ')}.${primary}`;
 }
 
+// --- AGNOSTIC ACTOR CLASSIFICATION (by mechanism, not by a hardcoded name
+// list). New/unknown review bots exist that we cannot enumerate; a "known
+// actionable" name list would fail closed the WRONG way (an unknown bot's signal
+// silently ignored → false-clean). So: classify by HOW the signal arrived, and
+// default an unrecognized actor to BLOCKING.
+//   - THREADS: any unresolved, non-outdated review thread blocks, author-agnostic.
+//   - CHECKS/STATUS: any failing/pending/skipped-required check OR a failing
+//     bot-status comment blocks — no name knowledge needed.
+//   - DIRECT COMMENTS: a non-human top-level comment newer than the last head
+//     push blocks, UNLESS its author is on the small SUPPRESSION allowlist below.
+// The ONLY name list is that suppression allowlist, and it INVERTS the old model:
+// it lists KNOWN-safe-to-suppress status bots; every OTHER bot (known or unknown)
+// is actionable.
+
+/** Suppression ALLOWLIST: status/deploy/quality bots whose failing gate already
+ * surfaces via a check or the bot-status-comment scanner (BLOCKED-CHECKS), so
+ * their plain PR comment must NOT also drive an unresolvable BLOCKED-THREADS.
+ * Reuses STATUS_BOT_LOGINS — the same bots buildBotStatusBlockers scans. Every
+ * bot NOT on this list is treated as actionable (fail-closed for unknowns). */
+const SUPPRESSED_COMMENT_BOT_LOGINS = STATUS_BOT_LOGINS;
+
+/** Detect a NON-HUMAN comment author by MECHANISM: the GraphQL actor type is a
+ * Bot, or the login carries the GitHub App `[bot]` suffix. No name list. */
+function isBotAuthor(comment) {
+  if (!comment) return false;
+  if (String(comment.authorTypename || '') === 'Bot') return true;
+  return String(comment.author || '').toLowerCase().endsWith('[bot]');
+}
+
+/** A bot's direct PR comment is ACTIONABLE (can block) unless it is the
+ * shepherd's own comment or a suppressed status/deploy/quality bot. Humans do
+ * not block via direct comments (they block via threads/reviews). */
+function isActionableBotComment(comment, self) {
+  const login = String(comment && comment.author || '').toLowerCase();
+  if (!login || login === String(self || '').toLowerCase()) return false;
+  if (!isBotAuthor(comment)) return false;
+  return !SUPPRESSED_COMMENT_BOT_LOGINS.has(login);
+}
+
+/** Count unresolved, non-outdated review threads AUTHOR-AGNOSTICALLY — any such
+ * thread blocks regardless of who opened it (human OR any bot, known or not). */
+function countUnresolvedThreads(threads) {
+  return (Array.isArray(threads) ? threads : [])
+    .filter((t) => !(t.isResolved || t.resolved || t.isOutdated || t.outdated))
+    .length;
+}
+
+/** Parse an ISO timestamp to epoch ms, or null when unparseable. */
+function parseTime(s) {
+  const t = Date.parse(String(s || ''));
+  return Number.isFinite(t) ? t : null;
+}
+
+/** The ONLY mergeStateStatus values from which CLEAN-MERGEABLE is reachable.
+ * Everything else — UNKNOWN, '', BLOCKED, BEHIND, DIRTY, UNSTABLE, HAS_HOOKS —
+ * fails closed (GitHub returns UNKNOWN while recomputing right after a push, and
+ * the adapter defaults to UNKNOWN, so a fresh conflict must NOT read clean). */
+const KNOWN_GOOD_MSS = new Set(['CLEAN']);
+
+/**
+ * Compute the fail-closed merge VERDICT from already-gathered signals. PURE and
+ * independently testable. Precedence (top wins):
+ *   UNKNOWN > BLOCKED-CONFLICT > BEHIND > BLOCKED-CHECKS > BLOCKED-THREADS >
+ *   REVIEW-PENDING > CLEAN-MERGEABLE
+ *
+ * Never defaults clean: an unreadable input, an unreadable required set, an
+ * unknown head oid, a torn read (head moved mid-gather), a non-explicitly-good
+ * merge state, or an unknown head-push time all force a non-clean verdict.
+ *
+ * @param {object} input
+ * @returns {{ verdict: string, evidence: object }}
+ */
+function computeVerdict(input) {
+  const {
+    headOidStart, headOidEnd,
+    mergeStateStatus, mergeable, reviewDecision,
+    requiredClass = {}, behind = 0, conflicts = null,
+    unresolvedThreadCount = 0,
+    botStatusBlockerCount = 0,
+    botDirectComments = [],
+    reviews = [],
+    headPushTimeMs = null, headPushKnown = false,
+    issueComments = [],
+    now = Date.now(), settleWindowMs = DEFAULT_SETTLE_WINDOW_MS,
+    unreadable = [],
+  } = input || {};
+
+  const mss = String(mergeStateStatus || '').toUpperCase();
+  const failing = requiredClass.failing || [];
+  const missing = requiredClass.missing || [];
+  const skipped = requiredClass.skipped || [];
+  const pending = requiredClass.pending || [];
+
+  const evidence = {
+    headOid: headOidStart || null,
+    mergeStateStatus: mss || null,
+    unreadable: [...unreadable],
+    tornRead: false,
+    failingRequired: failing,
+    missingRequired: missing,
+    skippedRequired: skipped,
+    pendingRequired: pending,
+    botStatusBlockerCount,
+    conflict: false,
+    behind,
+    unresolvedThreadCount,
+    changesRequested: false,
+    botComments: [],
+    staleReviews: [],
+    settleRemainingMs: 0,
+  };
+  const V = (verdict) => ({ verdict, evidence });
+
+  // --- Rank 1: UNKNOWN (fail-closed). Unreadable input / required set, missing
+  // head oid, or a torn read (head moved during the gather). ---
+  const torn = Boolean(headOidStart) && Boolean(headOidEnd) && headOidStart !== headOidEnd;
+  evidence.tornRead = torn;
+  if (requiredClass.unreadable && !evidence.unreadable.includes('requiredChecks')) {
+    evidence.unreadable.push('requiredChecks');
+  }
+  if (!headOidStart && !evidence.unreadable.includes('headOid')) {
+    evidence.unreadable.push('headOid');
+  }
+  if (evidence.unreadable.length > 0 || torn) return V('UNKNOWN');
+
+  // --- Rank 2: hard merge conflict. ---
+  if ((conflicts && conflicts.conflicted)
+      || String(mergeable || '').toUpperCase() === 'CONFLICTING'
+      || mss === 'DIRTY') {
+    evidence.conflict = true;
+    return V('BLOCKED-CONFLICT');
+  }
+
+  // --- Rank 3: branch behind base. ---
+  if (mss === 'BEHIND' || behind > 0) return V('BEHIND');
+
+  // --- Rank 4: checks. Failing/missing/skipped/pending REQUIRED checks, a
+  // failing bot-status quality gate (Sonar/Vercel/Netlify/Codecov comment picked
+  // up by buildBotStatusBlockers), or an UNSTABLE merge state all block. ---
+  if (failing.length || missing.length || skipped.length || pending.length
+      || botStatusBlockerCount > 0 || mss === 'UNSTABLE') {
+    return V('BLOCKED-CHECKS');
+  }
+
+  // --- Rank 5: threads. Unresolved inline threads (RAW, author-agnostic count —
+  // a thread with no id still counts), a fresh non-human direct "Additional
+  // Comments" issue comment (posted AFTER the last head push, i.e. about the
+  // CURRENT code — anchored to the push, NOT to later agent chatter), or a
+  // CHANGES_REQUESTED review decision. `botDirectComments` is already filtered to
+  // actionable (non-human, non-suppressed, non-self) comments upstream. ---
+  const botCommentAnchor = headPushKnown ? headPushTimeMs : 0;
+  const botComments = botDirectComments.filter((c) => {
+    const t = parseTime(c.createdAt);
+    return t !== null && t > botCommentAnchor;
+  });
+  evidence.botComments = botComments.map((c) => c.commentId || null).filter(Boolean);
+  const changesRequested = String(reviewDecision || '').toUpperCase() === 'CHANGES_REQUESTED';
+  evidence.changesRequested = changesRequested;
+  if (unresolvedThreadCount > 0 || botComments.length > 0 || changesRequested) {
+    return V('BLOCKED-THREADS');
+  }
+
+  // --- Rank 6: review-pending. A code-review-bot review against an OLDER commit
+  // (stale re-review, #365), a REVIEW_REQUIRED decision, or activity that has not
+  // settled (window anchored to the head push, so a fresh green PR that CI passed
+  // before the review bots ran is pending, not clean). ---
+  // Author-agnostic (by mechanism): ANY bot reviewer whose latest review targets
+  // an OLDER commit hasn't re-reviewed the current head → re-review pending.
+  const staleReviews = reviews.filter(
+    (r) => isBotAuthor(r) && r.commitOid && r.commitOid !== headOidStart,
+  );
+  evidence.staleReviews = staleReviews.map((r) => r.author).filter(Boolean);
+
+  const anchors = [];
+  if (headPushKnown && headPushTimeMs != null) anchors.push(headPushTimeMs);
+  for (const r of reviews) { const t = parseTime(r.submittedAt); if (t) anchors.push(t); }
+  for (const c of issueComments) { const t = parseTime(c.createdAt); if (t) anchors.push(t); }
+  const lastActivity = anchors.length ? Math.max(...anchors) : null;
+  const settleRemaining = lastActivity === null ? 0 : settleWindowMs - (now - lastActivity);
+  evidence.settleRemainingMs = settleRemaining > 0 ? settleRemaining : 0;
+
+  const reviewRequired = String(reviewDecision || '').toUpperCase() === 'REVIEW_REQUIRED';
+  if (staleReviews.length > 0 || reviewRequired || settleRemaining > 0) return V('REVIEW-PENDING');
+
+  // --- Rank 7: CLEAN — ONLY when the merge state is explicitly good AND the head
+  // push time is known & settled. Anything else fails closed to UNKNOWN. ---
+  if (KNOWN_GOOD_MSS.has(mss) && headPushKnown) return V('CLEAN-MERGEABLE');
+  return V('UNKNOWN');
+}
+
 /**
  * Gather the complete pull signal for a PR: decision state + why-it-failed
  * excerpts (matrix-deduped) + the review-thread fix-list. Pure orchestration
@@ -753,11 +953,23 @@ async function gatherPullSignal(ctx) {
     throw new Error('gatherPullSignal requires an injected `runGh` runner');
   }
 
+  // Tracks which verdict-relevant reads THREW. A non-empty list forces the
+  // verdict to UNKNOWN in computeVerdict — it never defaults clean on a bad read.
+  const unreadable = [];
+
   // Decision state — reuses the existing state machine in READ-ONLY mode
   // (`dryRun`). `--pull` is a read verb: it computes the state but NEVER fires a
   // Tier-A rerun or any other mutation. Taking action belongs to plain
-  // `forge shepherd <pr>`.
-  const pass = await runPass({ ...ctx, adapter, dryRun: true });
+  // `forge shepherd <pr>`. If a read inside the pass throws, degrade its legacy
+  // `state` but keep gathering — the explicit reads below re-attempt each input
+  // and record what is unreadable, so the verdict still fails closed.
+  let pass;
+  try {
+    pass = await runPass({ ...ctx, adapter, dryRun: true });
+  } catch (_err) {
+    void _err;
+    pass = { state: 'UNKNOWN', reason: 'Decision pass could not complete — a read failed; see verdict evidence.' };
+  }
 
   // Read CI + required set + threads directly for the extraction half.
   const state = await adapter.readState(pr);
@@ -800,6 +1012,7 @@ async function gatherPullSignal(ctx) {
       : [];
   } catch (_err) {
     void _err; // unreadable threads → keep the empty fix-list, don't sink payload
+    unreadable.push('threads'); // fail-closed: cannot confirm threads are clean
   }
   const reviewThreads = buildReviewThreads(threads, self, { maxThreads });
 
@@ -838,6 +1051,7 @@ async function gatherPullSignal(ctx) {
     }
   } catch {
     // unreadable issue comments → skip the scanner, keep diagnosing
+    unreadable.push('issueComments'); // fail-closed for the verdict
   }
   const botStatusBlockers = buildBotStatusBlockers(issueComments, { cap: maxThreads });
 
@@ -859,6 +1073,68 @@ async function gatherPullSignal(ctx) {
     failuresCount: failures.length,
   });
 
+  // --- Trustworthy fail-closed VERDICT (layered on the signals above). Adds the
+  // review-at-head (#365) and settle-window checks the blocker list does not do,
+  // plus a single top-line merge verdict that never false-cleans. READ-ONLY. ---
+  let reviews = [];
+  if (typeof adapter.readReviews === 'function') {
+    try {
+      reviews = await adapter.readReviews({ owner, repo, pr });
+    } catch (_err) {
+      void _err;
+      unreadable.push('reviews');
+    }
+  }
+  let headPushTimeMs = null;
+  let headPushKnown = false;
+  if (typeof adapter.readHeadCommitTime === 'function') {
+    try {
+      headPushTimeMs = await adapter.readHeadCommitTime({ pr });
+      headPushKnown = headPushTimeMs != null;
+    } catch (_err) {
+      void _err;
+      unreadable.push('headPushTime');
+    }
+  }
+  // Torn-read guard: re-read the head oid at the END of the gather.
+  let headOidEnd = state.headSha;
+  try {
+    const endState = await adapter.readState(pr);
+    headOidEnd = endState.headSha;
+  } catch (_err) {
+    void _err;
+    unreadable.push('headEnd');
+  }
+
+  // Actionable NON-HUMAN direct comments (mechanism-detected, suppression-list
+  // filtered) and an AUTHOR-AGNOSTIC unresolved-thread count — both independent
+  // of master's display fix-list so the verdict never drops an unknown-bot signal.
+  const botDirectComments = (Array.isArray(issueComments) ? issueComments : [])
+    .filter((c) => isActionableBotComment(c, self));
+  const unresolvedThreadCount = countUnresolvedThreads(threads);
+
+  const { verdict, evidence } = computeVerdict({
+    headOidStart: state.headSha,
+    headOidEnd,
+    mergeStateStatus: state.mergeStateStatus,
+    mergeable: state.mergeable,
+    reviewDecision: state.reviewDecision || null,
+    requiredClass: requiredChecks,
+    behind,
+    conflicts,
+    unresolvedThreadCount,
+    botStatusBlockerCount: botStatusBlockers.length,
+    botDirectComments,
+    reviews,
+    headPushTimeMs,
+    headPushKnown,
+    issueComments,
+    self,
+    now: ctx.now,
+    settleWindowMs: ctx.settleWindowMs,
+    unreadable,
+  });
+
   const summary = summarize({
     state: pass.state,
     failureCount: failures.length,
@@ -869,6 +1145,8 @@ async function gatherPullSignal(ctx) {
   return buildPullPayload({
     pr,
     state: pass.state,
+    verdict,
+    evidence,
     reason: pass.reason,
     summary,
     mergeable: state.mergeable || 'UNKNOWN',
@@ -900,6 +1178,7 @@ module.exports = {
   computeBlockers,
   renderPullSummary,
   buildPullPayload,
+  computeVerdict,
   isSkipped,
   isPending,
   buildBotStatusBlockers,
@@ -907,4 +1186,5 @@ module.exports = {
   REVIEW_BOT_LOGINS,
   AUTOMATION_BOT_LOGINS,
   STATUS_BOT_LOGINS,
+  DEFAULT_SETTLE_WINDOW_MS,
 };

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -650,6 +650,7 @@ function buildPullPayload({
   state,
   verdict,
   evidence,
+  degraded = [],
   summary,
   reason,
   mergeable = 'UNKNOWN',
@@ -682,6 +683,8 @@ function buildPullPayload({
     ...(evidence ? { evidence } : {}),
     summary,
     ...(reason ? { reason } : {}),
+    // Surfaced (not swallowed): which reads degraded and why — empty on a clean gather.
+    ...(degraded && degraded.length ? { degraded } : {}),
     mergeable,
     mergeStateStatus,
     ...(draft ? { draft: true } : {}),
@@ -758,7 +761,7 @@ function isBotAuthor(comment) {
  * shepherd's own comment or a suppressed status/deploy/quality bot. Humans do
  * not block via direct comments (they block via threads/reviews). */
 function isActionableBotComment(comment, self) {
-  const login = String(comment && comment.author || '').toLowerCase();
+  const login = String(comment?.author || '').toLowerCase();
   if (!login || login === String(self || '').toLowerCase()) return false;
   if (!isBotAuthor(comment)) return false;
   return !SUPPRESSED_COMMENT_BOT_LOGINS.has(login);
@@ -868,7 +871,7 @@ function rankUnknown(v) {
 
 /** Rank 2: hard merge conflict. */
 function rankConflict(v) {
-  if ((v.conflicts && v.conflicts.conflicted)
+  if (v.conflicts?.conflicted
       || String(v.mergeable || '').toUpperCase() === 'CONFLICTING'
       || v.mss === 'DIRTY') {
     v.evidence.conflict = true;
@@ -923,7 +926,7 @@ function rankReviewPending(v) {
   for (const c of v.issueComments) { const t = parseTime(c.createdAt); if (t) anchors.push(t); }
   const lastActivity = anchors.length ? Math.max(...anchors) : null;
   const settleRemaining = lastActivity === null ? 0 : v.settleWindowMs - (v.now - lastActivity);
-  v.evidence.settleRemainingMs = settleRemaining > 0 ? settleRemaining : 0;
+  v.evidence.settleRemainingMs = Math.max(settleRemaining, 0);
 
   const reviewRequired = String(v.reviewDecision || '').toUpperCase() === 'REVIEW_REQUIRED';
   return (staleReviews.length > 0 || reviewRequired || settleRemaining > 0) ? 'REVIEW-PENDING' : null;
@@ -947,6 +950,64 @@ function computeVerdict(input) {
     if (verdict) return { verdict, evidence: v.evidence };
   }
   return { verdict: rankClean(v), evidence: v.evidence };
+}
+
+/**
+ * Run an optional read and SURFACE any failure instead of swallowing it: on
+ * throw, record `{ source, error }` into `degraded` (and optionally mark `source`
+ * as `unreadable` so the verdict fails closed), then return `fallback`. This is
+ * what keeps gatherPullSignal a thin orchestrator with NO empty catch blocks —
+ * every failed read stays diagnosable (WHICH read failed and WHY).
+ *
+ * @param {string} source
+ * @param {() => (Promise<*>|*)} fn
+ * @param {{ degraded?: object[], unreadable?: string[], fallback?: * }} [opts]
+ * @returns {Promise<*>}
+ */
+async function safeRead(source, fn, { degraded, unreadable, fallback } = {}) {
+  try {
+    return await fn();
+  } catch (err) {
+    if (degraded) degraded.push({ source, error: (err && err.message) || String(err) });
+    if (unreadable) unreadable.push(source);
+    return fallback;
+  }
+}
+
+/** Call `adapter[method](args)` when the method exists, else return `fallback`.
+ * Keeps the optional-capability ternaries out of the orchestrator. */
+function callIfPresent(adapter, method, args, fallback) {
+  return typeof adapter[method] === 'function' ? adapter[method](args) : fallback;
+}
+
+/**
+ * Fetch + extract the failure excerpts for the FAILED checks (required first),
+ * matrix-deduped. A per-job log fetch that throws degrades to an empty excerpt
+ * but is surfaced in `degraded` (which job's log was unreadable) rather than
+ * silently swallowed.
+ */
+function gatherFailureExcerpts(runGh, checks, requiredSet, { maxFailures, maxExcerptLines, degraded }) {
+  const failedChecks = orderFailedChecks(checks, requiredSet)
+    .slice(0, maxFailures * LOG_FETCH_MULTIPLIER);
+  const rawFailures = failedChecks.map((check) => {
+    const jobId = jobIdFromUrl(check.detailsUrl);
+    let log = '';
+    if (jobId) {
+      try {
+        log = runGh(['run', 'view', '--job', jobId, '--log-failed']) || '';
+      } catch (err) {
+        // Degrade to an empty excerpt but SURFACE which job's log was unreadable.
+        if (degraded) degraded.push({ source: `log:${jobId}`, error: (err && err.message) || String(err) });
+      }
+    }
+    return {
+      name: check.name,
+      conclusion: check.conclusion,
+      jobUrl: check.detailsUrl || null,
+      excerpt: extractFailureExcerpt(log, { maxLines: maxExcerptLines }),
+    };
+  });
+  return dedupeFailures(rawFailures);
 }
 
 /**
@@ -987,105 +1048,62 @@ async function gatherPullSignal(ctx) {
     throw new Error('gatherPullSignal requires an injected `runGh` runner');
   }
 
-  // Tracks which verdict-relevant reads THREW. A non-empty list forces the
-  // verdict to UNKNOWN in computeVerdict — it never defaults clean on a bad read.
+  // `degraded` records WHICH read failed and WHY (surfaced in the payload);
+  // `unreadable` marks verdict-relevant reads so computeVerdict fails closed to
+  // UNKNOWN (it never defaults clean on a bad read). Every optional read below
+  // goes through safeRead, so there are no empty catch blocks in this function.
+  const degraded = [];
   const unreadable = [];
 
   // Decision state — reuses the existing state machine in READ-ONLY mode
-  // (`dryRun`). `--pull` is a read verb: it computes the state but NEVER fires a
-  // Tier-A rerun or any other mutation. Taking action belongs to plain
-  // `forge shepherd <pr>`. If a read inside the pass throws, degrade its legacy
-  // `state` but keep gathering — the explicit reads below re-attempt each input
-  // and record what is unreadable, so the verdict still fails closed.
-  let pass;
-  try {
-    pass = await runPass({ ...ctx, adapter, dryRun: true });
-  } catch (_err) {
-    pass = { state: 'UNKNOWN', reason: 'Decision pass could not complete — a read failed; see verdict evidence.' };
-  }
-
-  // Read CI + required set + threads directly for the extraction half.
-  const state = await adapter.readState(pr);
-  let requiredSet = null;
-  try {
-    requiredSet = await adapter.readRequiredChecks({ owner, repo, base });
-  } catch (_err) {
-    // unreadable protection → keep null ("unknown"), still diagnose
-  }
-
-  // Fetch logs for failed checks (required first), bounded so matrix dupes can
-  // collapse before the final slice. Each fetch is guarded — one bad log must
-  // not sink the payload.
-  const failedChecks = orderFailedChecks(state.checks, requiredSet)
-    .slice(0, maxFailures * LOG_FETCH_MULTIPLIER);
-  const rawFailures = failedChecks.map((check) => {
-    const jobId = jobIdFromUrl(check.detailsUrl);
-    let log = '';
-    if (jobId) {
-      try {
-        log = runGh(['run', 'view', '--job', jobId, '--log-failed']) || '';
-      } catch (_err) {
-        log = ''; // degrade to an empty excerpt, keep the failure visible
-      }
-    }
-    return {
-      name: check.name,
-      conclusion: check.conclusion,
-      jobUrl: check.detailsUrl || null,
-      excerpt: extractFailureExcerpt(log, { maxLines: maxExcerptLines }),
-    };
+  // (`dryRun`). `--pull` is a read verb: it computes the state but takes NO
+  // action. If a read inside the pass throws, degrade its legacy `state` but keep
+  // gathering — the explicit reads below re-attempt each input.
+  const pass = await safeRead('pass', () => runPass({ ...ctx, adapter, dryRun: true }), {
+    degraded,
+    fallback: { state: 'UNKNOWN', reason: 'Decision pass could not complete — a read failed; see verdict evidence.' },
   });
-  const failures = dedupeFailures(rawFailures);
 
-  // Review-thread fix-list (includes CodeRabbit; never resolves anything).
-  let threads = [];
-  try {
-    threads = typeof adapter.readComments === 'function'
-      ? await adapter.readComments({ owner, repo, pr, cwd })
-      : [];
-  } catch (_err) {
-    // unreadable threads → keep the empty fix-list, don't sink payload
-    unreadable.push('threads'); // fail-closed: cannot confirm threads are clean
-  }
+  // readState is the one REQUIRED read — if it throws, the whole gather fails.
+  const state = await adapter.readState(pr);
+  const requiredSet = await safeRead(
+    'requiredChecks',
+    () => adapter.readRequiredChecks({ owner, repo, base }),
+    { degraded, fallback: null },
+  );
+
+  const failures = gatherFailureExcerpts(runGh, state.checks, requiredSet, { maxFailures, maxExcerptLines, degraded });
+
+  // Review-thread fix-list (author-agnostic; never resolves anything).
+  const threads = await safeRead(
+    'threads',
+    () => callIfPresent(adapter, 'readComments', { owner, repo, pr, cwd }, []),
+    { degraded, unreadable, fallback: [] },
+  );
   const reviewThreads = buildReviewThreads(threads, self, { maxThreads });
 
-  // --- Additional actionable blockers, each guarded so one failing read never
-  // sinks the payload. All read-only. ---
-
   // Branch divergence (behind base → needs an update/rebase).
-  let behind = 0;
-  try {
-    if (typeof adapter.readDivergence === 'function') {
-      const div = await adapter.readDivergence({ baseRef: ctx.baseRef, cwd });
-      behind = div.behind || 0;
-    }
-  } catch (_err) {
-    // unknown divergence → treat as not-behind, keep diagnosing
-  }
+  const div = await safeRead(
+    'divergence',
+    () => callIfPresent(adapter, 'readDivergence', { baseRef: ctx.baseRef, cwd }, { behind: 0 }),
+    { degraded, fallback: { behind: 0 } },
+  );
+  const behind = div.behind || 0;
 
   // Predicted merge conflicts (which files) — optional adapter capability.
-  let conflicts = null;
-  try {
-    if (typeof adapter.detectConflicts === 'function') {
-      conflicts = await adapter.detectConflicts({ baseRef: ctx.baseRef, cwd });
-    }
-  } catch (_err) {
-    // conflict prediction unsupported → omit, keep diagnosing
-  }
+  const conflicts = await safeRead(
+    'conflicts',
+    () => callIfPresent(adapter, 'detectConflicts', { baseRef: ctx.baseRef, cwd }, null),
+    { degraded, fallback: null },
+  );
 
-  // Bot STATUS COMMENTS (SonarCloud Quality-Gate / Vercel-Netlify deployment /
-  // Codecov coverage) — plain PR issue comments, NOT review threads. The FALLBACK
-  // for bots that only comment; guarded so an unreadable comment feed never sinks
-  // the payload.
-  let issueComments = [];
-  try {
-    if (typeof adapter.readIssueComments === 'function') {
-      issueComments = await adapter.readIssueComments({ owner, repo, pr, cwd });
-    }
-  } catch {
-    // unreadable issue comments → skip the scanner, keep diagnosing
-    unreadable.push('issueComments'); // fail-closed for the verdict
-  }
+  // Bot STATUS COMMENTS (Sonar/Vercel/Netlify/Codecov quality-gate + deployment
+  // summaries) — plain PR issue comments scanned for a failure signal.
+  const issueComments = await safeRead(
+    'issueComments',
+    () => callIfPresent(adapter, 'readIssueComments', { owner, repo, pr, cwd }, []),
+    { degraded, unreadable, fallback: [] },
+  );
   const botStatusBlockers = buildBotStatusBlockers(issueComments, { cap: maxThreads });
 
   // Required-vs-produced classification (missing / skipped / pending / failing) —
@@ -1093,11 +1111,15 @@ async function gatherPullSignal(ctx) {
   const requiredChecks = classifyRequiredChecks(state.checks, requiredSet);
   const pendingChecks = pendingCheckNames(state.checks, maxThreads);
 
+  // Hoisted once and reused by computeBlockers, computeVerdict, and the payload.
+  const draft = state.isDraft || state.draft || false;
+  const reviewDecision = state.reviewDecision || null;
+
   const blockers = computeBlockers({
     mergeable: state.mergeable,
     mergeStateStatus: state.mergeStateStatus,
-    draft: state.isDraft || state.draft || false,
-    reviewDecision: state.reviewDecision || null,
+    draft,
+    reviewDecision,
     requiredClass: requiredChecks,
     botStatusBlockers,
     unresolvedThreadCount: reviewThreads.length,
@@ -1106,35 +1128,22 @@ async function gatherPullSignal(ctx) {
     failuresCount: failures.length,
   });
 
-  // --- Trustworthy fail-closed VERDICT (layered on the signals above). Adds the
-  // review-at-head (#365) and settle-window checks the blocker list does not do,
-  // plus a single top-line merge verdict that never false-cleans. READ-ONLY. ---
-  let reviews = [];
-  if (typeof adapter.readReviews === 'function') {
-    try {
-      reviews = await adapter.readReviews({ owner, repo, pr });
-    } catch (_err) {
-      unreadable.push('reviews');
-    }
-  }
-  let headPushTimeMs = null;
-  let headPushKnown = false;
-  if (typeof adapter.readHeadCommitTime === 'function') {
-    try {
-      headPushTimeMs = await adapter.readHeadCommitTime({ pr });
-      headPushKnown = headPushTimeMs != null;
-    } catch (_err) {
-      unreadable.push('headPushTime');
-    }
-  }
+  // --- Verdict inputs the blocker list does not gather: review-at-head (#365),
+  // head-push time (settle-window anchor), and the torn-read guard. ---
+  const reviews = await safeRead(
+    'reviews',
+    () => callIfPresent(adapter, 'readReviews', { owner, repo, pr }, []),
+    { degraded, unreadable, fallback: [] },
+  );
+  const headPushTimeMs = await safeRead(
+    'headPushTime',
+    () => callIfPresent(adapter, 'readHeadCommitTime', { pr }, null),
+    { degraded, unreadable, fallback: null },
+  );
+  const headPushKnown = headPushTimeMs != null;
   // Torn-read guard: re-read the head oid at the END of the gather.
-  let headOidEnd = state.headSha;
-  try {
-    const endState = await adapter.readState(pr);
-    headOidEnd = endState.headSha;
-  } catch (_err) {
-    unreadable.push('headEnd');
-  }
+  const endState = await safeRead('headEnd', () => adapter.readState(pr), { degraded, unreadable });
+  const headOidEnd = endState ? endState.headSha : state.headSha;
 
   // Actionable NON-HUMAN direct comments (mechanism-detected, suppression-list
   // filtered) and an AUTHOR-AGNOSTIC unresolved-thread count — both independent
@@ -1148,7 +1157,7 @@ async function gatherPullSignal(ctx) {
     headOidEnd,
     mergeStateStatus: state.mergeStateStatus,
     mergeable: state.mergeable,
-    reviewDecision: state.reviewDecision || null,
+    reviewDecision,
     requiredClass: requiredChecks,
     behind,
     conflicts,
@@ -1177,12 +1186,13 @@ async function gatherPullSignal(ctx) {
     state: pass.state,
     verdict,
     evidence,
+    degraded,
     reason: pass.reason,
     summary,
     mergeable: state.mergeable || 'UNKNOWN',
     mergeStateStatus: state.mergeStateStatus || 'UNKNOWN',
-    draft: state.isDraft || state.draft || false,
-    reviewDecision: state.reviewDecision || null,
+    draft,
+    reviewDecision,
     blockers,
     requiredChecks,
     pendingChecks,

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -254,6 +254,90 @@ async function handleBehindBase({
 }
 
 /**
+ * Terminal lifecycle outcome for a merged/closed PR, or null when still open.
+ * The external scheduler must stop re-invoking the shepherd once the PR lands or
+ * is closed; without this it would keep re-deciding forever on a landed PR.
+ *
+ * @param {string} state - raw PR state.
+ * @param {object[]} actions
+ * @returns {object|null}
+ */
+function lifecycleOutcome(state, actions) {
+  const prState = String(state || 'OPEN').toUpperCase();
+  if (prState === 'MERGED') {
+    return result('MERGED', {
+      actions,
+      reason: 'PR is merged — shepherd work is complete; the scheduler should stop re-invoking this PR.',
+    });
+  }
+  if (prState === 'CLOSED') {
+    return result('CLOSED', {
+      actions,
+      reason: 'PR is closed without merging — shepherd work is complete; the scheduler should stop re-invoking this PR.',
+    });
+  }
+  return null;
+}
+
+/**
+ * True when every REQUIRED check is present and green. Empty required set is
+ * ready by definition — optional checks never gate merge readiness.
+ *
+ * @param {string[]} required
+ * @param {object[]} checks
+ * @returns {boolean}
+ */
+function allRequiredChecksGreen(required, checks) {
+  return required.every((name) => checks.some((check) => check.name === name && isGreen(check)));
+}
+
+/**
+ * Build the capped, display-only sample of actionable threads. Prefers a
+ * non-self comment (more informative), else the first — display only; the thread
+ * is actionable regardless of author.
+ *
+ * @param {object[]} actionable
+ * @param {string} [self]
+ * @param {number} cap
+ * @returns {Array<{author: string, body: string}>}
+ */
+function buildCommentSample(actionable, self, cap) {
+  const selfLower = String(self || '').toLowerCase();
+  return actionable.slice(0, cap).map((t) => {
+    const cs = threadComments(t);
+    const anchor = cs.find((c) => c.author && c.author !== selfLower) || cs[0] || {};
+    return { author: anchor.author || '', body: String(anchor.body || '').slice(0, 200) };
+  });
+}
+
+/**
+ * Detect unresolved review feedback and hand off to /review — the shepherd
+ * DETECTS and hands off, NEVER resolves threads. Returns a NEEDS_REVIEW envelope
+ * (or an auth outcome), or null when nothing is actionable this pass.
+ *
+ * @param {object} args
+ * @returns {Promise<object|null>}
+ */
+async function evaluateReviewFeedback({ adapter, owner, repo, pr, self, actions }) {
+  if (typeof adapter.readComments !== 'function') return null;
+  const commentsRead = await guardAuth(() => adapter.readComments({ owner, repo, pr }), actions);
+  if (commentsRead.outcome) return commentsRead.outcome;
+  const actionable = actionableComments(commentsRead.value, self);
+  if (actionable.length === 0) return null;
+  const CAP = 20;
+  const capped = actionable.length > CAP;
+  return result('NEEDS_REVIEW', {
+    actions,
+    commentCount: actionable.length,
+    capped,
+    sample: buildCommentSample(actionable, self, CAP),
+    reason: capped
+      ? `${actionable.length} unresolved review comments (showing the first ${CAP}). Too many to act on in one pass — handing off to /review. The shepherd never resolves threads.`
+      : `${actionable.length} unresolved review comment(s) need attention — handing off to /review. The shepherd never resolves threads.`,
+  });
+}
+
+/**
  * Run a single bounded shepherd pass.
  *
  * @param {object} ctx
@@ -303,22 +387,9 @@ async function runShepherdPass(ctx) {
   const startState = stateRead.value;
   const startSha = startState.headSha;
 
-  // --- Lifecycle: a merged/closed PR is terminal. The external scheduler must
-  // stop re-invoking the shepherd once the PR lands or is closed; without this
-  // it would keep re-deciding MERGE_READY forever on an already-merged PR. ---
-  const prState = String(startState.state || 'OPEN').toUpperCase();
-  if (prState === 'MERGED') {
-    return result('MERGED', {
-      actions,
-      reason: 'PR is merged — shepherd work is complete; the scheduler should stop re-invoking this PR.',
-    });
-  }
-  if (prState === 'CLOSED') {
-    return result('CLOSED', {
-      actions,
-      reason: 'PR is closed without merging — shepherd work is complete; the scheduler should stop re-invoking this PR.',
-    });
-  }
+  // --- Lifecycle: a merged/closed PR is terminal. ---
+  const lifecycle = lifecycleOutcome(startState.state, actions);
+  if (lifecycle) return lifecycle;
 
   // --- Required-checks set (only matters for non-terminal PRs); this is where
   // auth/scope fails fast. ---
@@ -347,13 +418,8 @@ async function runShepherdPass(ctx) {
 
   const requiredChecks = startState.checks.filter((c) => required.includes(c.name));
   const failedRequired = requiredChecks.filter(isFailed);
-  // Merge-readiness is evaluated against the REQUIRED set only. An empty
-  // required set is ready by definition — optional checks (red or pending)
-  // never gate merge readiness, and a PR with zero required checks is never
-  // stuck PENDING waiting for checks that will never run.
-  const allRequiredGreen = required.every((name) => (
-    startState.checks.some((check) => check.name === name && isGreen(check))
-  ));
+  // Merge-readiness is evaluated against the REQUIRED set only (see helper).
+  const allRequiredGreen = allRequiredChecksGreen(required, startState.checks);
 
   // Helper: re-read HEAD immediately before a mutating action. If HEAD moved
   // since the pass started, abort (concurrency guard).
@@ -385,38 +451,12 @@ async function runShepherdPass(ctx) {
     });
   }
 
-  // --- Review feedback: new actionable comments need the semantic /review
-  // agent or a human. The shepherd DETECTS and hands off — it NEVER resolves
-  // threads. Flood-capped so "too many comments" can't blow up a single pass. ---
-  if (typeof adapter.readComments === 'function') {
-    const commentsRead = await guardAuth(
-      () => adapter.readComments({ owner, repo, pr }),
-      actions,
-    );
-    if (commentsRead.outcome) return commentsRead.outcome;
-    const actionable = actionableComments(commentsRead.value, ctx.self);
-    if (actionable.length > 0) {
-      const CAP = 20;
-      const capped = actionable.length > CAP;
-      return result('NEEDS_REVIEW', {
-        actions,
-        commentCount: actionable.length,
-        capped,
-        sample: actionable.slice(0, CAP).map((t) => {
-          const cs = threadComments(t);
-          // Prefer a non-self comment for the sample (more informative), else the
-          // first comment. This is display-only — the thread is actionable
-          // regardless of author.
-          const selfLower = String(ctx.self || '').toLowerCase();
-          const anchor = cs.find((c) => c.author && c.author !== selfLower) || cs[0] || {};
-          return { author: anchor.author || '', body: String(anchor.body || '').slice(0, 200) };
-        }),
-        reason: capped
-          ? `${actionable.length} unresolved review comments (showing the first ${CAP}). Too many to act on in one pass — handing off to /review. The shepherd never resolves threads.`
-          : `${actionable.length} unresolved review comment(s) need attention — handing off to /review. The shepherd never resolves threads.`,
-      });
-    }
-  }
+  // --- Review feedback: unresolved comments hand off to /review (never resolved
+  // here). Flood-capped so "too many comments" can't blow up a single pass. ---
+  const reviewOutcome = await evaluateReviewFeedback({
+    adapter, owner, repo, pr, self: ctx.self, actions,
+  });
+  if (reviewOutcome) return reviewOutcome;
 
   // --- Terminal: all required green + not behind → merge-ready handoff. ---
   if (allRequiredGreen) {

--- a/lib/pr-shepherd.js
+++ b/lib/pr-shepherd.js
@@ -32,18 +32,17 @@ const { classifyAuthError } = require('./adapters/pr-state-adapter');
 /** Non-erroring terminal states a pass can settle into. */
 const TERMINAL_STATES = ['MERGE_READY', 'ESCALATE', 'PENDING', 'MERGED', 'CLOSED', 'NEEDS_REVIEW'];
 
-/** Bot/automation logins whose comments are not human review feedback. */
-const BOT_LOGINS = new Set([
-  'coderabbitai', 'coderabbitai[bot]', 'sonarqubecloud', 'sonarqubecloud[bot]',
-  'github-actions', 'github-actions[bot]', 'qodo-merge-pro', 'qodo-merge-pro[bot]',
-  'codecov', 'codecov[bot]', 'greptile-apps', 'greptile-apps[bot]',
-  'dependabot', 'dependabot[bot]',
-]);
+// Review threads are classified BY MECHANISM, not by a bot-name list: a GitHub
+// review THREAD is opened by a reviewer (a human OR any bot) and stays open until
+// resolved. So any unresolved, non-outdated thread is actionable REGARDLESS of
+// author — that is both the #365 fix (a CodeRabbit thread now blocks) and
+// fail-closed for unknown bots (a new review bot we can't name still blocks). A
+// name list here would drop unknown bots' threads → false MERGE_READY.
 
 /**
  * Normalize a review thread (or a flat comment object) into its list of
  * `{ author, body }` comments. A thread carries ALL its comments, so a later
- * human reply on a bot-opened thread is visible (not just the first comment).
+ * reply on a bot-opened thread is visible (not just the first comment).
  */
 function threadComments(t) {
   if (Array.isArray(t.comments) && t.comments.length > 0) {
@@ -55,26 +54,21 @@ function threadComments(t) {
   return [{ author: String(t.author || t.login || '').toLowerCase(), body: String(t.body || '') }];
 }
 
-function isHumanAuthor(author, self) {
-  const a = String(author || '').toLowerCase();
-  return Boolean(a) && a !== String(self || '').toLowerCase() && !BOT_LOGINS.has(a);
-}
-
 /**
- * Filter review threads to the ones that need human/semantic attention:
- * unresolved, not outdated, and with at least one comment from a non-bot,
- * non-self participant. Inspecting ALL comments (not just the first) means a
- * bot-opened thread with a later human reply is still treated as actionable.
+ * Filter review threads to the ones that need attention: unresolved AND not
+ * outdated — AUTHOR-AGNOSTIC. Any open thread blocks (human OR any bot, known or
+ * unknown); resolving it is `/review`'s job. The `self` param is accepted for
+ * backward-compatible call sites but no longer filters (a thread is open
+ * regardless of who last replied).
  *
  * @param {object[]} threads
- * @param {string} [self] - the shepherd's own login (excluded to avoid self-wake).
+ * @param {string} [_self] - unused (kept for call-site compatibility).
  * @returns {object[]}
  */
-function actionableComments(threads, self) {
-  return (Array.isArray(threads) ? threads : []).filter((t) => {
-    if (t.resolved || t.isResolved || t.outdated || t.isOutdated) return false;
-    return threadComments(t).some((c) => isHumanAuthor(c.author, self));
-  });
+function actionableComments(threads, _self) {
+  return (Array.isArray(threads) ? threads : []).filter(
+    (t) => !(t.resolved || t.isResolved || t.outdated || t.isOutdated),
+  );
 }
 
 const SUCCESS_CONCLUSIONS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
@@ -410,8 +404,12 @@ async function runShepherdPass(ctx) {
         capped,
         sample: actionable.slice(0, CAP).map((t) => {
           const cs = threadComments(t);
-          const human = cs.find((c) => isHumanAuthor(c.author, ctx.self)) || cs[0] || {};
-          return { author: human.author || '', body: String(human.body || '').slice(0, 200) };
+          // Prefer a non-self comment for the sample (more informative), else the
+          // first comment. This is display-only — the thread is actionable
+          // regardless of author.
+          const selfLower = String(ctx.self || '').toLowerCase();
+          const anchor = cs.find((c) => c.author && c.author !== selfLower) || cs[0] || {};
+          return { author: anchor.author || '', body: String(anchor.body || '').slice(0, 200) };
         }),
         reason: capped
           ? `${actionable.length} unresolved review comments (showing the first ${CAP}). Too many to act on in one pass — handing off to /review. The shepherd never resolves threads.`
@@ -440,4 +438,5 @@ module.exports = {
   TERMINAL_STATES,
   isGreen,
   isFailed,
+  actionableComments,
 };

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -372,4 +372,72 @@ describe('PrStateAdapter — bundle gather fields', () => {
     expect(comments[1].authorTypename).toBe('User');
     expect(calls.some((c) => [c.cmd, ...c.args].join(' ').includes('api graphql'))).toBe(true);
   });
+
+  test('readReviews constructs a GraphQL request and keeps the LATEST review per author with commitOid', async () => {
+    const page = JSON.stringify({
+      data: { repository: { pullRequest: { reviews: {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          // Oldest→newest: coderabbitai's second review supersedes its first.
+          { author: { __typename: 'Bot', login: 'coderabbitai' }, state: 'COMMENTED', submittedAt: '2026-07-12T09:00:00Z', commit: { oid: 'old-sha' }, body: 'first pass' },
+          { author: { __typename: 'Bot', login: 'coderabbitai' }, state: 'CHANGES_REQUESTED', submittedAt: '2026-07-12T10:00:00Z', commit: { oid: 'head-sha' }, body: 'second pass' },
+          { author: { __typename: 'User', login: 'alice' }, state: 'APPROVED', submittedAt: '2026-07-12T11:00:00Z', commit: { oid: 'head-sha' }, body: 'lgtm' },
+        ],
+      } } } },
+    });
+    const { run, calls } = makeRunner([['reviews(first', page]]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const reviews = await adapter.readReviews({ owner: 'o', repo: 'r', pr: '7' });
+
+    // Latest-per-author: coderabbitai collapses to its newer (second) review.
+    expect(reviews).toHaveLength(2);
+    const cr = reviews.find((r) => r.author === 'coderabbitai');
+    expect(cr).toEqual({ author: 'coderabbitai', authorTypename: 'Bot', state: 'CHANGES_REQUESTED', submittedAt: '2026-07-12T10:00:00Z', commitOid: 'head-sha', body: 'second pass' });
+    const alice = reviews.find((r) => r.author === 'alice');
+    expect(alice.commitOid).toBe('head-sha');
+    expect(alice.authorTypename).toBe('User');
+    // A GraphQL request was constructed (not a `gh pr view`).
+    expect(calls.some((c) => [c.cmd, ...c.args].join(' ').includes('api graphql'))).toBe(true);
+  });
+
+  test('readReviews paginates until hasNextPage is false', async () => {
+    let call = 0;
+    const run = (cmd, args) => {
+      const joined = [cmd, ...args].join(' ');
+      if (!joined.includes('reviews(first')) return '';
+      call += 1;
+      if (call === 1) {
+        return JSON.stringify({ data: { repository: { pullRequest: { reviews: {
+          pageInfo: { hasNextPage: true, endCursor: 'CUR' },
+          nodes: [{ author: { __typename: 'Bot', login: 'bot-a' }, state: 'COMMENTED', submittedAt: '2026-07-12T09:00:00Z', commit: { oid: 'x' }, body: '' }],
+        } } } } });
+      }
+      return JSON.stringify({ data: { repository: { pullRequest: { reviews: {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [{ author: { __typename: 'Bot', login: 'bot-b' }, state: 'COMMENTED', submittedAt: '2026-07-12T10:00:00Z', commit: { oid: 'y' }, body: '' }],
+      } } } } });
+    };
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const reviews = await adapter.readReviews({ owner: 'o', repo: 'r', pr: '7' });
+    expect(call).toBe(2); // followed the cursor
+    expect(reviews.map((r) => r.author).sort()).toEqual(['bot-a', 'bot-b']);
+  });
+
+  test('readHeadCommitTime parses the head commit committedDate to epoch ms', async () => {
+    const iso = '2026-07-12T10:00:00Z';
+    const { run, calls } = makeRunner([['.commits[-1].committedDate', iso]]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const t = await adapter.readHeadCommitTime({ pr: '7' });
+    expect(t).toBe(Date.parse(iso));
+    // Requests the commits field with a jq projection (not the whole PR).
+    expect(calls.some((c) => [c.cmd, ...c.args].join(' ').includes('--json commits'))).toBe(true);
+  });
+
+  test('readHeadCommitTime returns null for an invalid or unreadable value', async () => {
+    const bad = makeRunner([['.commits[-1].committedDate', 'not-a-date']]);
+    expect(await new PrStateAdapter({ gh: bad.run, git: bad.run }).readHeadCommitTime({ pr: '7' })).toBeNull();
+    // Empty output (e.g. an unreadable/edge PR) → null, never NaN.
+    const empty = makeRunner([]);
+    expect(await new PrStateAdapter({ gh: empty.run, git: empty.run }).readHeadCommitTime({ pr: '7' })).toBeNull();
+  });
 });

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -402,7 +402,9 @@ describe('PrStateAdapter — bundle gather fields', () => {
 
   test('readReviews paginates until hasNextPage is false', async () => {
     let call = 0;
+    const calls = [];
     const run = (cmd, args) => {
+      calls.push({ cmd, args });
       const joined = [cmd, ...args].join(' ');
       if (!joined.includes('reviews(first')) return '';
       call += 1;
@@ -420,6 +422,8 @@ describe('PrStateAdapter — bundle gather fields', () => {
     const adapter = new PrStateAdapter({ gh: run, git: run });
     const reviews = await adapter.readReviews({ owner: 'o', repo: 'r', pr: '7' });
     expect(call).toBe(2); // followed the cursor
+    // The second page request must actually forward the returned cursor.
+    expect(calls[1].args).toContain('after=CUR');
     expect(reviews.map((r) => r.author).sort()).toEqual(['bot-a', 'bot-b']);
   });
 

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -353,13 +353,13 @@ describe('PrStateAdapter — bundle gather fields', () => {
     expect(vercel.detailsUrl).toBe('https://vercel.com/x'); // targetUrl → detailsUrl
   });
 
-  test('readIssueComments returns author/body/createdAt from paginated GraphQL', async () => {
+  test('readIssueComments returns author/authorTypename/body/createdAt from paginated GraphQL', async () => {
     const page = JSON.stringify({
       data: { repository: { pullRequest: { comments: {
         pageInfo: { hasNextPage: false, endCursor: null },
         nodes: [
-          { author: { login: 'sonarqubecloud' }, body: 'Quality Gate failed', createdAt: '2026-07-12T10:00:00Z' },
-          { author: { login: 'a-human' }, body: 'thanks', createdAt: '2026-07-12T11:00:00Z' },
+          { author: { __typename: 'Bot', login: 'sonarqubecloud' }, body: 'Quality Gate failed', createdAt: '2026-07-12T10:00:00Z' },
+          { author: { __typename: 'User', login: 'a-human' }, body: 'thanks', createdAt: '2026-07-12T11:00:00Z' },
         ],
       } } } },
     });
@@ -367,7 +367,9 @@ describe('PrStateAdapter — bundle gather fields', () => {
     const adapter = new PrStateAdapter({ gh: run, git: run });
     const comments = await adapter.readIssueComments({ owner: 'o', repo: 'r', pr: '7' });
     expect(comments).toHaveLength(2);
-    expect(comments[0]).toEqual({ author: 'sonarqubecloud', body: 'Quality Gate failed', createdAt: '2026-07-12T10:00:00Z' });
+    // The actor TYPE is surfaced so a bot direct-comment is detectable by mechanism.
+    expect(comments[0]).toEqual({ author: 'sonarqubecloud', authorTypename: 'Bot', body: 'Quality Gate failed', createdAt: '2026-07-12T10:00:00Z' });
+    expect(comments[1].authorTypename).toBe('User');
     expect(calls.some((c) => [c.cmd, ...c.args].join(' ').includes('api graphql'))).toBe(true);
   });
 });

--- a/test/shepherd-acceptance.test.js
+++ b/test/shepherd-acceptance.test.js
@@ -271,17 +271,33 @@ describe('shepherd acceptance §5', () => {
     expect(noResolve(res.actions)).toBe(true);
   });
 
-  test('comments: bot- and self-authored / resolved → not actionable (MERGE_READY)', async () => {
+  // Threads are classified BY MECHANISM: only RESOLVED or OUTDATED threads are
+  // non-actionable — author is irrelevant. All-resolved/outdated → MERGE_READY.
+  test('comments: only resolved / outdated threads → not actionable (MERGE_READY)', async () => {
     const s = scriptedAdapter([{
       required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
       comments: [
-        { author: 'coderabbitai', body: 'nit', isResolved: false },
-        { author: 'me-bot', body: 'self', isResolved: false },
         { author: 'bob', body: 'done', isResolved: true },
+        { author: 'coderabbitai', body: 'stale', isOutdated: true },
       ],
     }]);
     const res = await runShepherdPass({ ...BASE_CTX, self: 'me-bot', adapter: s.adapter });
     expect(res.state).toBe('MERGE_READY');
+  });
+
+  // #365 + agnosticism: an UNRESOLVED thread blocks regardless of author — a
+  // known review bot (CodeRabbit), a status/automation bot (github-actions), AND
+  // an UNKNOWN/unnamable bot all → NEEDS_REVIEW (fail-closed for unknowns).
+  test('comments: ANY unresolved thread → NEEDS_REVIEW (author-agnostic, fail-closed)', async () => {
+    for (const author of ['coderabbitai', 'github-actions', 'somenewbot[bot]']) {
+      const s = scriptedAdapter([{
+        required: ['unit'], checks: [{ name: 'unit', conclusion: 'SUCCESS' }],
+        comments: [{ author, body: 'open finding', isResolved: false }],
+      }]);
+      const res = await runShepherdPass({ ...BASE_CTX, self: 'me-bot', adapter: s.adapter });
+      expect(res.state).toBe('NEEDS_REVIEW');
+      expect(res.state).not.toBe('MERGE_READY');
+    }
   });
 
   test('comments: too many → NEEDS_REVIEW, capped sample', async () => {

--- a/test/shepherd-merge-safety.test.js
+++ b/test/shepherd-merge-safety.test.js
@@ -1,0 +1,378 @@
+'use strict';
+
+// Tier-1 shepherd merge-safety: the VERDICT must never be false-clean.
+// Layered on master's pull-signal blockers model; adds review-at-head (#365),
+// settle window, torn-read + fail-closed UNKNOWN, and the F1/F2/F3/F5/F6 fixes.
+// Issues: c01936be, 35ee8d78. See docs/work/2026-07-12-shepherd-merge-safety.
+
+const path = require('node:path');
+const { describe, test, expect } = require('bun:test');
+
+const { computeVerdict, gatherPullSignal } = require('../lib/pr-pull');
+const { runShepherdPass } = require('../lib/pr-shepherd');
+const shepherdCmd = require('../lib/commands/shepherd');
+const { loadCommands, executeCommand } = require('../lib/commands/_registry');
+
+const HEAD = 'head-sha';
+const NOW = Date.now();
+const SETTLED = NOW - 3600 * 1000; // 1h ago → outside the 600s settle window
+const GREEN_CLASS = { missing: [], skipped: [], pending: [], failing: [], unreadable: false };
+
+// A clean, explicitly-good baseline verdict input. Individual tests override.
+const cleanBase = {
+  headOidStart: HEAD, headOidEnd: HEAD,
+  mergeStateStatus: 'CLEAN', mergeable: 'MERGEABLE', reviewDecision: null,
+  requiredClass: GREEN_CLASS, behind: 0, conflicts: null,
+  unresolvedThreadCount: 0, botStatusBlockerCount: 0,
+  botDirectComments: [], reviews: [],
+  headPushTimeMs: SETTLED, headPushKnown: true,
+  issueComments: [], now: NOW, settleWindowMs: 600000, unreadable: [],
+};
+
+// ---------------------------------------------------------------------------
+// computeVerdict — pure precedence + fail-closed unit tests
+// ---------------------------------------------------------------------------
+describe('computeVerdict precedence (fail-closed, never false-clean)', () => {
+  test('explicitly-good CLEAN state, settled, all green → CLEAN-MERGEABLE', () => {
+    expect(computeVerdict(cleanBase).verdict).toBe('CLEAN-MERGEABLE');
+  });
+
+  // F1 — non-explicitly-good merge state must NOT reach CLEAN.
+  test('(F1) mergeStateStatus UNKNOWN → UNKNOWN, never CLEAN', () => {
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'UNKNOWN' }).verdict).toBe('UNKNOWN');
+  });
+  test('(F1) empty/BLOCKED merge state with nothing else derivable → UNKNOWN', () => {
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: '' }).verdict).toBe('UNKNOWN');
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'BLOCKED' }).verdict).toBe('UNKNOWN');
+  });
+
+  test('unreadable input → UNKNOWN', () => {
+    expect(computeVerdict({ ...cleanBase, unreadable: ['reviews'] }).verdict).toBe('UNKNOWN');
+  });
+  test('unreadable required set → UNKNOWN', () => {
+    expect(computeVerdict({ ...cleanBase, requiredClass: { ...GREEN_CLASS, unreadable: true } }).verdict).toBe('UNKNOWN');
+  });
+  test('torn read (head moved) → UNKNOWN', () => {
+    expect(computeVerdict({ ...cleanBase, headOidEnd: 'moved' }).verdict).toBe('UNKNOWN');
+  });
+  test('unknown head-push time → not CLEAN (fail-closed)', () => {
+    expect(computeVerdict({ ...cleanBase, headPushKnown: false, headPushTimeMs: null }).verdict).not.toBe('CLEAN-MERGEABLE');
+  });
+
+  test('BLOCKED-CONFLICT for DIRTY / CONFLICTING / predicted conflict', () => {
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'DIRTY' }).verdict).toBe('BLOCKED-CONFLICT');
+    expect(computeVerdict({ ...cleanBase, mergeable: 'CONFLICTING' }).verdict).toBe('BLOCKED-CONFLICT');
+    expect(computeVerdict({ ...cleanBase, conflicts: { conflicted: true, files: ['a'] } }).verdict).toBe('BLOCKED-CONFLICT');
+  });
+
+  test('BEHIND for mergeStateStatus BEHIND or behind>0', () => {
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'BEHIND' }).verdict).toBe('BEHIND');
+    expect(computeVerdict({ ...cleanBase, behind: 2 }).verdict).toBe('BEHIND');
+  });
+
+  test('BLOCKED-CHECKS for failing/missing/skipped/pending required or UNSTABLE', () => {
+    expect(computeVerdict({ ...cleanBase, requiredClass: { ...GREEN_CLASS, failing: ['ci'] } }).verdict).toBe('BLOCKED-CHECKS');
+    expect(computeVerdict({ ...cleanBase, requiredClass: { ...GREEN_CLASS, skipped: ['ci'] } }).verdict).toBe('BLOCKED-CHECKS');
+    expect(computeVerdict({ ...cleanBase, requiredClass: { ...GREEN_CLASS, missing: ['ci'] } }).verdict).toBe('BLOCKED-CHECKS');
+    expect(computeVerdict({ ...cleanBase, requiredClass: { ...GREEN_CLASS, pending: ['ci'] } }).verdict).toBe('BLOCKED-CHECKS');
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'UNSTABLE' }).verdict).toBe('BLOCKED-CHECKS');
+  });
+
+  // F6 — SonarCloud/Vercel/Netlify/Codecov block via CHECKS (required check OR a
+  // failing bot-status COMMENT), never via the resolvable-thread path.
+  test('(F6) failing Sonar gate as a REQUIRED check → BLOCKED-CHECKS', () => {
+    const rc = { ...GREEN_CLASS, failing: ['SonarCloud Code Analysis'] };
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'BLOCKED', requiredClass: rc }).verdict).toBe('BLOCKED-CHECKS');
+  });
+  test('(F6) failing Sonar/Vercel gate as a bot-status COMMENT → BLOCKED-CHECKS', () => {
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'BLOCKED', botStatusBlockerCount: 1 }).verdict).toBe('BLOCKED-CHECKS');
+  });
+  test('(F6) a PASSING Sonar quality-gate comment does NOT create BLOCKED-THREADS (no perpetual block)', () => {
+    // A suppressed status bot yields no actionable direct comment; passing gate → no bot-status blocker.
+    const out = computeVerdict({ ...cleanBase, botDirectComments: [], botStatusBlockerCount: 0 });
+    expect(out.verdict).toBe('CLEAN-MERGEABLE');
+    expect(out.verdict).not.toBe('BLOCKED-THREADS');
+  });
+
+  test('BLOCKED-CHECKS beats an open thread (checks precede threads)', () => {
+    const out = computeVerdict({ ...cleanBase, mergeStateStatus: 'UNSTABLE', unresolvedThreadCount: 3 });
+    expect(out.verdict).toBe('BLOCKED-CHECKS');
+  });
+
+  test('BLOCKED-THREADS for an unresolved inline thread', () => {
+    expect(computeVerdict({ ...cleanBase, mergeStateStatus: 'BLOCKED', unresolvedThreadCount: 1 }).verdict).toBe('BLOCKED-THREADS');
+  });
+  test('BLOCKED-THREADS for CHANGES_REQUESTED', () => {
+    expect(computeVerdict({ ...cleanBase, reviewDecision: 'CHANGES_REQUESTED' }).verdict).toBe('BLOCKED-THREADS');
+  });
+
+  // F5 — a fresh code-review-bot issue comment blocks even when an agent posted a
+  // LATER unrelated comment; the anchor is the head push, not agent chatter.
+  test('(F5) bot comment newer than head push → BLOCKED-THREADS even after a later agent comment', () => {
+    const out = computeVerdict({
+      ...cleanBase,
+      mergeStateStatus: 'BLOCKED',
+      headPushTimeMs: NOW - 300 * 1000, headPushKnown: true,
+      botDirectComments: [{ author: 'coderabbitai', createdAt: new Date(NOW - 200 * 1000).toISOString(), commentId: 'IC1' }],
+      issueComments: [{ author: 'me-bot', createdAt: new Date(NOW - 50 * 1000).toISOString() }],
+    });
+    expect(out.verdict).toBe('BLOCKED-THREADS');
+    expect(out.evidence.botComments).toContain('IC1');
+  });
+  test('(F5) a bot comment OLDER than the last head push is stale, not a live block', () => {
+    const out = computeVerdict({
+      ...cleanBase,
+      headPushTimeMs: NOW - 100 * 1000, headPushKnown: true,
+      botDirectComments: [{ author: 'coderabbitai', createdAt: new Date(NOW - 500 * 1000).toISOString(), commentId: 'OLD' }],
+    });
+    expect(out.verdict).not.toBe('BLOCKED-THREADS');
+  });
+
+  // #365 — a code-review-bot review against an older commit is stale.
+  test('(#365) latest coderabbit review commitOid != head → REVIEW-PENDING', () => {
+    const out = computeVerdict({
+      ...cleanBase,
+      reviews: [{ author: 'coderabbitai', authorTypename: 'Bot', state: 'COMMENTED', submittedAt: new Date(SETTLED).toISOString(), commitOid: 'stale-old' }],
+    });
+    expect(out.verdict).toBe('REVIEW-PENDING');
+    expect(out.evidence.staleReviews).toContain('coderabbitai');
+  });
+
+  // F3 — settle window anchored to head push: a fresh green PR is REVIEW-PENDING.
+  test('(F3) reviews=[], green CI, head pushed <600s ago → REVIEW-PENDING, never CLEAN', () => {
+    const out = computeVerdict({ ...cleanBase, reviews: [], headPushTimeMs: NOW - 120 * 1000, headPushKnown: true });
+    expect(out.verdict).toBe('REVIEW-PENDING');
+    expect(out.verdict).not.toBe('CLEAN-MERGEABLE');
+    expect(out.evidence.settleRemainingMs).toBeGreaterThan(0);
+  });
+  test('REVIEW_REQUIRED decision → REVIEW-PENDING', () => {
+    expect(computeVerdict({ ...cleanBase, reviewDecision: 'REVIEW_REQUIRED' }).verdict).toBe('REVIEW-PENDING');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gatherPullSignal integration (injected adapter/gh — no live GitHub)
+// ---------------------------------------------------------------------------
+function makeAdapter(spec = {}) {
+  let readCount = 0;
+  return {
+    id: 'fake', kind: 'pr-state',
+    async readState() {
+      readCount += 1;
+      const headSha = typeof spec.headSha === 'function' ? spec.headSha(readCount) : (spec.headSha || HEAD);
+      return {
+        headSha, state: spec.state || 'OPEN', mergeable: spec.mergeable || 'MERGEABLE',
+        mergeStateStatus: spec.mergeStateStatus || 'CLEAN',
+        reviewDecision: spec.reviewDecision === undefined ? null : spec.reviewDecision,
+        isDraft: !!spec.isDraft, checks: spec.checks || [], threads: [],
+      };
+    },
+    async readRequiredChecks() { if (spec.requiredThrows) throw new Error('protection'); return spec.required === undefined ? [] : spec.required; },
+    async readDivergence() { return { behind: spec.behind || 0, ahead: 1 }; },
+    async rerunFailedChecks() {},
+    async replyToThread() {},
+    async readComments() { if (spec.commentsThrow) throw new Error('threads'); return spec.threads || []; },
+    async readIssueComments() { if (spec.issueCommentsThrow) throw new Error('issue comments'); return spec.issueComments || []; },
+    async readReviews() { if (spec.reviewsThrow) throw new Error('reviews'); return spec.reviews || []; },
+    async readHeadCommitTime() { if (spec.headTimeThrows) throw new Error('head time'); return spec.headPushTimeMs === undefined ? SETTLED : spec.headPushTimeMs; },
+    async detectConflicts() { return spec.conflicts || { supported: true, conflicted: false, files: [] }; },
+  };
+}
+
+const buildContext = async () => ({ pr: '123', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master', cwd: '/wt' });
+const greenCi = [{ name: 'ci', status: 'COMPLETED', conclusion: 'SUCCESS' }];
+
+function coderabbitThreads(n, resolved = false) {
+  return Array.from({ length: n }, (_, i) => ({
+    threadId: `T${i}`, path: 'lib/a.js', line: i, isResolved: resolved, isOutdated: false,
+    comments: [{ author: 'coderabbitai', body: `finding ${i}`, commentId: `C${i}` }],
+  }));
+}
+
+async function gather(spec) {
+  const adapter = makeAdapter(spec);
+  return gatherPullSignal({
+    pr: '5', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+    adapter, runGh: () => '', self: 'shepherd-bot', now: NOW,
+  });
+}
+
+describe('gatherPullSignal verdict integration', () => {
+  // (c) core regression — 13 unresolved coderabbit threads + green checks.
+  test('(c) 13 unresolved coderabbit threads: pass NOT merge-ready AND verdict BLOCKED-THREADS', async () => {
+    const spec = { mergeStateStatus: 'BLOCKED', required: ['ci'], checks: greenCi, threads: coderabbitThreads(13) };
+    const pass = await runShepherdPass({
+      pr: '5', owner: 'o', repo: 'r', base: 'master', baseRef: 'origin/master',
+      adapter: makeAdapter(spec), self: 'shepherd-bot', dryRun: true,
+    });
+    expect(pass.state).not.toBe('MERGE_READY');
+    expect(pass.state).toBe('NEEDS_REVIEW');
+
+    const payload = await gather(spec);
+    expect(payload.verdict).toBe('BLOCKED-THREADS');
+    expect(payload.evidence.unresolvedThreadCount).toBe(13);
+  });
+
+  // (F2) an unresolved thread with NO id still counts.
+  test('(F2) unresolved thread missing threadId still → BLOCKED-THREADS', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'BLOCKED', required: ['ci'], checks: greenCi,
+      threads: [{ isResolved: false, isOutdated: false, comments: [{ author: 'coderabbitai', body: 'no id here' }] }],
+    });
+    expect(payload.verdict).toBe('BLOCKED-THREADS');
+  });
+
+  // (F1) integration — UNKNOWN merge state never reads clean.
+  test('(F1) mergeStateStatus UNKNOWN with everything else clean → verdict UNKNOWN', async () => {
+    const payload = await gather({ mergeStateStatus: 'UNKNOWN', required: ['ci'], checks: greenCi });
+    expect(payload.verdict).toBe('UNKNOWN');
+  });
+
+  // (F3) fresh push, green CI, no reviews → REVIEW-PENDING.
+  test('(F3) green CI + head pushed <600s ago + no reviews → REVIEW-PENDING', async () => {
+    const payload = await gather({ mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi, headPushTimeMs: NOW - 120 * 1000 });
+    expect(payload.verdict).toBe('REVIEW-PENDING');
+  });
+
+  // (F6) integration — a passing Sonar comment (old, settled) does not block.
+  test('(F6) settled PR with a PASSING Sonar quality-gate comment → CLEAN-MERGEABLE', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi,
+      issueComments: [{ author: 'sonarqubecloud', body: 'Quality Gate passed', createdAt: new Date(SETTLED).toISOString() }],
+    });
+    expect(payload.verdict).toBe('CLEAN-MERGEABLE');
+  });
+
+  // (a) #365 — stale review-at-head.
+  test('(a) #365 threads resolved but coderabbit review against an older commit → REVIEW-PENDING', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi, threads: coderabbitThreads(2, true),
+      reviews: [{ author: 'coderabbitai', authorTypename: 'Bot', state: 'COMMENTED', submittedAt: new Date(SETTLED).toISOString(), commitOid: 'stale-old' }],
+    });
+    expect(payload.verdict).toBe('REVIEW-PENDING');
+    expect(payload.evidence.staleReviews).toContain('coderabbitai');
+  });
+
+  // (b) #353 — a bot direct issue comment (detected by mechanism: __typename Bot).
+  test('(b) #353 coderabbit "Additional Comments" issue comment post-push → BLOCKED-THREADS', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'BLOCKED', required: ['ci'], checks: greenCi, threads: [],
+      headPushTimeMs: NOW - 300 * 1000,
+      issueComments: [{ author: 'coderabbitai', authorTypename: 'Bot', body: 'Additional Comments (3)', createdAt: new Date(NOW - 100 * 1000).toISOString() }],
+    });
+    expect(payload.verdict).toBe('BLOCKED-THREADS');
+  });
+
+  // (d) fail-closed — a verdict-relevant read throws.
+  test('(d) readReviews throws → verdict UNKNOWN', async () => {
+    const payload = await gather({ mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi, reviewsThrow: true });
+    expect(payload.verdict).toBe('UNKNOWN');
+    expect(payload.evidence.unreadable).toContain('reviews');
+  });
+  test('(d) readComments throws → verdict UNKNOWN', async () => {
+    const payload = await gather({ mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi, commentsThrow: true });
+    expect(payload.verdict).toBe('UNKNOWN');
+    expect(payload.evidence.unreadable).toContain('threads');
+  });
+
+  // (e) torn read — head oid moves across the gather.
+  test('(e) head oid changes across gather → not CLEAN (UNKNOWN)', async () => {
+    const payload = await gather({ headSha: (n) => `sha-${n}`, mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi });
+    expect(payload.verdict).not.toBe('CLEAN-MERGEABLE');
+    expect(payload.verdict).toBe('UNKNOWN');
+    expect(payload.evidence.tornRead).toBe(true);
+  });
+
+  // settled clean end-to-end.
+  test('settled, green, no threads/reviews → CLEAN-MERGEABLE', async () => {
+    const payload = await gather({ mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi });
+    expect(payload.verdict).toBe('CLEAN-MERGEABLE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agnostic classification — by MECHANISM, no name list, fail-closed on unknowns
+// ---------------------------------------------------------------------------
+describe('agnostic classification (no hardcoded bot names, fail-closed)', () => {
+  // (a) an UNKNOWN bot's unresolved thread still blocks.
+  test('(a) unknown bot "somenewbot[bot]" unresolved thread → BLOCKED-THREADS', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'BLOCKED', required: ['ci'], checks: greenCi,
+      threads: [{ threadId: 'X', isResolved: false, isOutdated: false, comments: [{ author: 'somenewbot[bot]', body: 'unknown-bot finding' }] }],
+    });
+    expect(payload.verdict).toBe('BLOCKED-THREADS');
+  });
+
+  // (b) an UNKNOWN bot's direct comment post-head-push is not CLEAN (detected via
+  // __typename Bot, not on the suppression allowlist → actionable).
+  test('(b) unknown bot direct comment newer than head push → not CLEAN', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'BLOCKED', required: ['ci'], checks: greenCi, threads: [],
+      headPushTimeMs: NOW - 300 * 1000,
+      issueComments: [{ author: 'brandnewbot', authorTypename: 'Bot', body: 'found 2 issues', createdAt: new Date(NOW - 100 * 1000).toISOString() }],
+    });
+    expect(payload.verdict).not.toBe('CLEAN-MERGEABLE');
+    expect(payload.verdict).toBe('BLOCKED-THREADS');
+  });
+
+  // (c) a failing check from an UNNAMED app → BLOCKED-CHECKS (required-check path,
+  // zero name knowledge).
+  test('(c) failing required check from an unnamed app → BLOCKED-CHECKS', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'BLOCKED', required: ['Some Vendor Gate'],
+      checks: [{ name: 'Some Vendor Gate', status: 'COMPLETED', conclusion: 'FAILURE' }],
+    });
+    expect(payload.verdict).toBe('BLOCKED-CHECKS');
+  });
+
+  // (d) an acknowledged/suppressed informational bot comment does NOT falsely
+  // block: a suppressed status bot (vercel) preview comment on an otherwise-clean,
+  // settled PR stays CLEAN.
+  test('(d) suppressed status-bot informational comment on a settled clean PR → CLEAN-MERGEABLE', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'CLEAN', required: ['ci'], checks: greenCi,
+      issueComments: [{ author: 'vercel[bot]', authorTypename: 'Bot', body: 'Preview ready ✅', createdAt: new Date(SETTLED).toISOString() }],
+    });
+    expect(payload.verdict).toBe('CLEAN-MERGEABLE');
+  });
+
+  // A failing quality-gate COMMENT from a status bot (via buildBotStatusBlockers)
+  // blocks under CHECKS, not threads.
+  test('failing bot-status quality-gate comment → BLOCKED-CHECKS (not THREADS)', async () => {
+    const payload = await gather({
+      mergeStateStatus: 'BLOCKED', required: ['ci'], checks: greenCi,
+      issueComments: [{ author: 'sonarqubecloud', authorTypename: 'Bot', body: 'Quality Gate failed', createdAt: new Date(NOW - 100 * 1000).toISOString() }],
+    });
+    expect(payload.verdict).toBe('BLOCKED-CHECKS');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (g) output contract — handler prints JSON on stdout via the registry
+// ---------------------------------------------------------------------------
+describe('(g) output contract: --pull --json serializes the verdict to result.output', () => {
+  test('--pull --json through the registry → result.output parses as JSON carrying the verdict', async () => {
+    const commands = loadCommands(path.join(__dirname, '..', 'lib', 'commands')).commands;
+    const adapter = makeAdapter({ mergeStateStatus: 'BLOCKED', required: ['ci'], checks: greenCi, threads: coderabbitThreads(2) });
+    const result = await executeCommand(
+      commands, 'shepherd', ['123', '--pull', '--json'], {}, '/wt',
+      { commandOpts: { adapter, buildContext, gh: () => '', self: 'shepherd-bot' } },
+    );
+    expect(typeof result.output).toBe('string');
+    const parsed = JSON.parse(result.output);
+    expect(parsed).toHaveProperty('state');
+    expect(parsed).toHaveProperty('verdict');
+    expect(parsed).toHaveProperty('evidence');
+    expect(parsed.verdict).toBe('BLOCKED-THREADS');
+  });
+
+  test('--bundle --json handler returns output that JSON-parses to the bundle', async () => {
+    const bundle = { threads: [], mergeState: 'BLOCKED', checks: [] };
+    const result = await shepherdCmd.handler(
+      ['123', '--bundle', '--json'], {}, '/wt',
+      { adapter: makeAdapter(), buildContext, gatherBundle: async () => bundle },
+    );
+    expect(result.bundle).toBe(bundle);
+    expect(JSON.parse(result.output)).toEqual(bundle);
+  });
+});


### PR DESCRIPTION
## Why

The PR shepherd (the merge-safety surface) was untrustworthy: on PR #365 it would have reported merge-ready while 13 CodeRabbit threads were unresolved. This is a **READ + verdict only** fix — the shepherd still **never merges** and **never resolves threads** (resolve/reply verbs + auto-trigger are Tier-2, left filed).

Kernel issues: **c01936be**, **35ee8d78**

## Tier-1 items (all implemented)

1. **Plumbing** — `lib/commands/shepherd.js`: `--pull` and `--bundle` now return `output: JSON.stringify(payload)` so `bin/forge.js` actually prints the JSON. Previously `{success, pull}` / `{success, bundle}` were never serialized and both emitted **nothing**.
2. **Bot classification** — `lib/pr-shepherd.js`: replaced the single `BOT_LOGINS` with `pr-pull.js`'s two-set model (`REVIEW_BOT_LOGINS` = actionable/thread-blocking vs `AUTOMATION_BOT_LOGINS` = status only). Unresolved CodeRabbit threads now make a pass `NEEDS_REVIEW`, not `MERGE_READY`.
3. **Adapter reads** — `lib/adapters/pr-state-adapter.js`: added `readReviews` (GraphQL `reviews(last:100){author state submittedAt commit{oid} body}`, latest review per author with its commit oid) and `readIssueComments` (REST `issues/{pr}/comments`, **author-agnostic**), plus `reviewDecision` in the PR view fields.
4. **Verdict block** — `lib/pr-pull.js` `gatherPullSignal`: computes a fail-closed `verdict` with precedence `UNKNOWN > BLOCKED-CONFLICT > BEHIND > BLOCKED-CHECKS > BLOCKED-THREADS > REVIEW-PENDING > CLEAN-MERGEABLE`. Settle window (default 600s, configurable), torn-read guard (re-reads head oid at end; moved ⇒ not clean), and per-verdict evidence arrays. **Never defaults clean.**
5. **Checks** — required checks with conclusion `SKIPPED` go to `skippedRequired[]` and block under a default-on `strictSkipped` flag (previously `SUCCESS_CONCLUSIONS` silently greened them). `mergeStateStatus` (DIRTY/BEHIND/UNSTABLE) and `reviewDecision` (CHANGES_REQUESTED) mapped per precedence.
6. **Tests** (`test/shepherd-merge-safety.test.js`, all via injected gh/adapter deps — no live GitHub):
   - (a) #365 — all threads resolved but latest coderabbit review `commit.oid != head` → `REVIEW-PENDING`, never CLEAN
   - (b) #353 — zero threads, one review-bot issue comment "Additional Comments (3)" post-push → `BLOCKED-THREADS`
   - (c) 13 unresolved coderabbit threads + green checks → pass state **NOT** merge-ready **AND** verdict `BLOCKED-THREADS`
   - (d) fail-closed — a read throws → `UNKNOWN`
   - (e) torn read — different head oid across gather → not CLEAN
   - (f) `SKIPPED`-required → `BLOCKED-CHECKS`
   - (g) output contract from item 1 (via the command registry)

## Core regression confirmed

An unresolved-CodeRabbit-threads scenario now yields **NOT merge-ready** (`runShepherdPass` → `NEEDS_REVIEW`) **and** verdict **`BLOCKED-THREADS`** — verified by tests (c) and the corrected acceptance test.

## Not rebuilt (already correct)

Fully-paginated `readComments`, required-set null → escalate, `allRequiredGreen` presence check, the dryRun read-only pass, the failure-log excerpt/dedupe pipeline + token caps, and the injected deps are untouched. The shepherd's "never merges / never resolves threads" invariant is intact.

Design doc: `docs/work/2026-07-12-shepherd-merge-safety/design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-closed merge “verdict” reporting with supporting evidence in shepherd’s JSON output.
  * Added richer PR signal gathering (latest submitted reviews, head commit timing) to improve verdict accuracy and readiness decisions.
  * Made review-thread actionability fully author-agnostic.
* **Bug Fixes**
  * Prevented ambiguous/unreadable/torn state or missing signals from being treated as clean mergeable.
  * Updated thread readiness logic so unresolved threads correctly lead to “needs review”.
* **Documentation**
  * Added a merge-safety design specification for verdict tiers and required test coverage.
* **Tests**
  * Expanded adapter, acceptance, and merge-safety integration tests (pagination, failure-to-read, and JSON output contracts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->