### PR TITLE
feat(shepherd): PR monitor PR-B — watch loop + ship lifecycle

### DIFF
--- a/docs/work/2026-07-13-pr-monitor-prb/design.md
+++ b/docs/work/2026-07-13-pr-monitor-prb/design.md
@@ -1,0 +1,79 @@
+# PR Monitor PR-B — watch loop + ship lifecycle
+
+Epic: `c2d398e5-26cf-4963-b47a-70b4102636bb` — *Constant agent-agnostic PR monitor*.
+Builds ON TOP of PR-A (now merged to master): `lib/pr-monitor/{events,differ,journal,gather,monitor}.js`
+and `forge shepherd events <pr> --since <seq>`.
+
+## Goal
+
+Make the monitor RUN CONSTANTLY and PUSH events, agent-agnostically:
+
+1. `forge shepherd watch <pr>` — a long-running command that every ~60s (jittered) runs ONE bounded
+   `runMonitorPass` (PR-A), diffs vs the journal snapshot, appends new events, and STREAMS each new
+   event as one NDJSON line to stdout. Any harness reads stdout. Self-stops (clean exit) on
+   `pr.merged`/`pr.closed`, emitting that terminal event LAST.
+2. Lifecycle — auto-start the watcher, detached + idempotent, on `forge ship` success. Never blocks or
+   fails ship.
+
+## Design
+
+### `lib/pr-monitor/watch.js` — the streaming loop (pure, injectable)
+
+`watchLoop(ctx)` where ctx = `{ dir, gather, now?, enrich?, lockOpts?, emit?, sleep?, rng?, intervalMs?,
+maxPasses?, signal?, watcherRunning?, writePid?, removePid? }`.
+
+- **Idempotent claim:** if `journal.watcherRunning(dir)` a live *other* watcher owns the PR → no-op
+  (`{ started: false, reason: 'watcher-already-running' }`). Otherwise `journal.writePid(dir)`.
+- **Each pass** delegates to PR-A's `runMonitorPass` (gather → diff → dedup → append → snapshot, all
+  UNDER `withJournalLock`, so the cross-process lock + heartbeat are respected and concurrent runs never
+  corrupt the journal). The returned `events` are streamed.
+- **Backpressure:** `runMonitorPass` only returns events on a fingerprint change, so an unchanged pass
+  emits nothing.
+- **Terminal:** when a pass yields `pr.merged`/`pr.closed`, flush any held failures, emit the terminal
+  event LAST, and exit the loop cleanly (`stopped: true`).
+- **Cadence:** between passes `await sleep(jitter(intervalMs, rng))` — base 60s ± 20%. `sleep`/`rng`/`now`
+  are injected so tests never wait real time. The loop self-drives; no agent need be running.
+- **Interruptible / no-hang:** the loop checks `signal.aborted` each iteration; every gh call inside
+  `gather` has its own 30s timeout (PR-A). `maxPasses` bounds the loop in tests. `removePid` runs in
+  a `finally`.
+- **2-pass flap confirm (stream layer only):** a `check.failed` is HELD one pass; it is emitted on the
+  next pass only if it was not contradicted by a `check.recovered`/`checks.green` for the same check
+  name. A flap (fail→green within one interval) is suppressed from the pushed stream. The JOURNAL still
+  records every event (authority), so `events --since` replay is complete — the hold only debounces the
+  live push.
+
+Helpers (each well under cognitive-complexity 15): `jitter`, `partition`, `contradictions`,
+`isContradicted`, `confirmHeld`, `runWatchPass`.
+
+### `forge shepherd watch <pr>` (lib/commands/shepherd.js)
+
+`handler` routes `positional[0] === 'watch'` to `handleWatch`, mirroring the existing `events` route.
+The context build (journal dir + gather + check-failure enricher) is extracted from `handleEvents` into
+a shared `buildMonitorContext` helper that both handlers call. `handleWatch` wires an `AbortController`
+to `SIGINT`/`SIGTERM`, calls `watchLoop` with the default stdout NDJSON `emit`, and returns
+`{ success, started, passes, stopped }` with NO `output` field (the loop streams live to stdout itself —
+returning output would double-print).
+
+### Ship lifecycle hook (lib/pr-monitor/watch-lifecycle.js + lib/commands/ship.js)
+
+`startPrWatcherDetached({ prNumber, cwd, ... })` (fully injectable, NEVER throws):
+- Best-effort idempotency: resolve the repo slug from `git remote get-url origin`, compute the journal
+  dir, and skip if `journal.watcherRunning(dir)`. On any failure it falls through to spawn — the
+  watchLoop's own `watcherRunning` guard is the authoritative de-dup.
+- Detached start: `spawn(process.execPath, [bin/forge.js, 'shepherd', 'watch', <pr>], { detached: true,
+  stdio: 'ignore', windowsHide: true })` then `child.unref()` → returns immediately (non-blocking).
+- `executeShip` calls it after `prNumber` is known, guarded so a hook failure can never fail ship
+  (`!dryRun && result.prNumber` only; the function has its own try/catch).
+
+Stop-on-merge is handled entirely by the watch loop's terminal pass — no separate stopper.
+
+## Testing (injected fakes; no live GitHub, no real 60s sleep)
+
+- `test/pr-monitor/watch.test.js`: emits NDJSON on change; no emit when unchanged; terminal event last
+  then exit; idempotent no-op when a watcher runs; bounded via fake clock + `maxPasses` (asserts jitter
+  range, no real timers); flap held/suppressed vs confirmed; pid written on start, removed on exit.
+- `test/pr-monitor/watch-lifecycle.test.js`: detached+unref start; non-blocking (returns synchronously);
+  no-op when pid live (spawn not called); never throws when spawn throws.
+- `test/pr-monitor/shepherd-watch.test.js`: `handleWatch` streams injected events and returns success.
+
+Gates: affected tests + `eslint --max-warnings 0` + `eslint-plugin-sonarjs` cognitive-complexity 15.

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -35,6 +35,7 @@ const { PrStateAdapter } = require('../adapters/pr-state-adapter');
 const { validatePrStateAdapter } = require('../pr-state-validator');
 const { gatherMonitorSnapshot } = require('../pr-monitor/gather');
 const { pollEvents } = require('../pr-monitor/monitor');
+const { watchLoop } = require('../pr-monitor/watch');
 const monitorJournal = require('../pr-monitor/journal');
 const { EVENT_TYPES: T } = require('../pr-monitor/events');
 
@@ -159,6 +160,53 @@ function parseSince(args) {
 }
 
 /**
+ * Build the shared monitor context — journal `dir`, bounded `gather`, and the
+ * default `check.failed` enricher — that BOTH the `events` pull surface and the
+ * `watch` streaming loop feed to the monitor core. Injected `dir`/`gather`/
+ * `enrich` (tests, programmatic callers) short-circuit the live gh build.
+ *
+ * @param {string|number} pr
+ * @param {string} projectRoot
+ * @param {object} deps
+ * @returns {Promise<{ dir?: string, gather?: Function, enrich?: Function, error?: string }>}
+ */
+async function buildMonitorContext(pr, projectRoot, deps) {
+  let dir = deps.dir;
+  let gather = deps.gather;
+  // enrich decorates newly-failed checks with log excerpts before the journal
+  // append. The caller MUST supply the default (not just forward an injected
+  // one), or a plain `forge shepherd events`/`watch` emits bare check.failed events.
+  let enrich = deps.enrich;
+  if (!gather || !dir) {
+    const gh = deps.gh || defaultGhRunner;
+    const git = deps.git || gh;
+    const buildContext = deps.buildContext || defaultBuildContext;
+    const ctx = await buildContext({ pr, gh, git, projectRoot });
+    const adapter = deps.adapter || new PrStateAdapter({ gh, git });
+    const validation = validatePrStateAdapter(adapter);
+    if (!validation.valid) {
+      return { error: `Invalid pr-state adapter: ${validation.errors.join('; ')}` };
+    }
+    dir = dir || monitorJournal.journalDir({ root: projectRoot || process.cwd(), repo: ctx.repo, pr: ctx.pr });
+    gather = gather || (() => gatherMonitorSnapshot({ ...ctx, adapter, self: deps.self }));
+    enrich = enrich || makeCheckFailureEnricher({
+      ...ctx,
+      adapter,
+      self: deps.self,
+      runGh: (ghArgs) => gh('gh', ghArgs),
+      gatherPull: deps.gatherPull,
+    });
+  } else if (!enrich && deps.gatherPull) {
+    // Injected gather (tests / programmatic callers) still gets the default
+    // enrichment when a pull-signal source is supplied.
+    enrich = makeCheckFailureEnricher({
+      pr, adapter: deps.adapter, self: deps.self, runGh: deps.runGh, gatherPull: deps.gatherPull,
+    });
+  }
+  return { dir, gather, enrich };
+}
+
+/**
  * `forge shepherd events <pr> --since <seq> [--json]` — the agent-agnostic PULL
  * surface. Runs one bounded gather+diff (inline, unless a watcher owns the PR),
  * appends new events to the per-PR journal, and prints every journaled event
@@ -178,38 +226,9 @@ async function handleEvents(args, projectRoot, deps = {}) {
   }
   const since = parseSince(rawArgs);
 
-  let dir = deps.dir;
-  let gather = deps.gather;
-  // enrich decorates newly-failed checks with log excerpts before the journal
-  // append. handleEvents MUST supply the default (not just forward an injected
-  // one), or a plain `forge shepherd events` call emits bare check.failed events.
-  let enrich = deps.enrich;
-  if (!gather || !dir) {
-    const gh = deps.gh || defaultGhRunner;
-    const git = deps.git || gh;
-    const buildContext = deps.buildContext || defaultBuildContext;
-    const ctx = await buildContext({ pr, gh, git, projectRoot });
-    const adapter = deps.adapter || new PrStateAdapter({ gh, git });
-    const validation = validatePrStateAdapter(adapter);
-    if (!validation.valid) {
-      return { success: false, error: `Invalid pr-state adapter: ${validation.errors.join('; ')}` };
-    }
-    dir = dir || monitorJournal.journalDir({ root: projectRoot || process.cwd(), repo: ctx.repo, pr: ctx.pr });
-    gather = gather || (() => gatherMonitorSnapshot({ ...ctx, adapter, self: deps.self }));
-    enrich = enrich || makeCheckFailureEnricher({
-      ...ctx,
-      adapter,
-      self: deps.self,
-      runGh: (ghArgs) => gh('gh', ghArgs),
-      gatherPull: deps.gatherPull,
-    });
-  } else if (!enrich && deps.gatherPull) {
-    // Injected gather (tests / programmatic callers) still gets the default
-    // enrichment when a pull-signal source is supplied.
-    enrich = makeCheckFailureEnricher({
-      pr, adapter: deps.adapter, self: deps.self, runGh: deps.runGh, gatherPull: deps.gatherPull,
-    });
-  }
+  const built = await buildMonitorContext(pr, projectRoot, deps);
+  if (built.error) return { success: false, error: built.error };
+  const { dir, gather, enrich } = built;
 
   const poll = deps.pollEvents || pollEvents;
   const result = await poll({ dir, gather, since, now: deps.now, watcherRunning: deps.watcherRunning, enrich });
@@ -218,6 +237,82 @@ async function handleEvents(args, projectRoot, deps = {}) {
   // so this handler does NOT write to stdout itself (that would double-print).
   const output = result.events.map((e) => JSON.stringify(e)).join('\n');
   return { success: true, events: result.events, since: result.since, output };
+}
+
+/**
+ * Wire an AbortController to SIGINT/SIGTERM so a long-running watch loop stops
+ * cleanly on Ctrl-C. Returns the signal plus a `cleanup` that detaches the
+ * one-shot handlers (always called in a finally so the loop leaves no listeners).
+ *
+ * @returns {{ signal: object, cleanup: () => void }}
+ */
+function wireSignals() {
+  const controller = new AbortController();
+  const onSignal = () => controller.abort();
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+  const cleanup = () => {
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+  };
+  return { signal: controller.signal, cleanup };
+}
+
+/**
+ * `forge shepherd watch <pr>` — the agent-agnostic PUSH surface. A long-running
+ * loop that every ~60s (jittered) runs ONE bounded monitor pass and STREAMS each
+ * new event as an NDJSON line to stdout, self-stopping on `pr.merged`/`pr.closed`.
+ * The loop streams live via the default stdout emit, so this handler returns NO
+ * `output` field (returning one would double-print). SIGINT/SIGTERM stop it clean.
+ *
+ * @param {string[]} args
+ * @param {string} projectRoot
+ * @param {object} [deps]
+ * @returns {Promise<object>}
+ */
+async function handleWatch(args, projectRoot, deps = {}) {
+  const rawArgs = args || [];
+  const pr = rawArgs.find((a) => !String(a).startsWith('--') && a !== 'watch');
+  if (!pr) {
+    return { success: false, error: 'Usage: forge shepherd watch <pr>' };
+  }
+
+  const built = await buildMonitorContext(pr, projectRoot, deps);
+  if (built.error) return { success: false, error: built.error };
+  const { dir, gather, enrich } = built;
+
+  const loop = deps.watchLoop || watchLoop;
+  // Injected signal (tests) suppresses real process handlers; otherwise wire them.
+  const wired = deps.signal ? { signal: deps.signal, cleanup: () => {} } : wireSignals();
+  let result;
+  try {
+    result = await loop({
+      dir,
+      gather,
+      enrich,
+      now: deps.now,
+      emit: deps.emit,
+      sleep: deps.sleep,
+      rng: deps.rng,
+      intervalMs: deps.intervalMs,
+      maxPasses: deps.maxPasses,
+      lockOpts: deps.lockOpts,
+      signal: wired.signal,
+      watcherRunning: deps.watcherRunning,
+      writePid: deps.writePid,
+      removePid: deps.removePid,
+    });
+  } finally {
+    wired.cleanup();
+  }
+
+  return {
+    success: true,
+    started: result.started,
+    passes: result.passes,
+    stopped: result.stopped,
+    ...(result.reason ? { reason: result.reason } : {}),
+  };
 }
 
 /**
@@ -233,9 +328,13 @@ async function handler(args, _flags, projectRoot, deps = {}) {
   const positional = (args || []).filter((a) => !String(a).startsWith('--'));
   const flags = new Set((args || []).filter((a) => String(a).startsWith('--')));
 
-  // Subcommand routing: `events` is the monitor pull surface (its own arg shape).
+  // Subcommand routing: `events` is the monitor pull surface (its own arg shape);
+  // `watch` is the constant monitor push surface (long-running stream).
   if (positional[0] === 'events') {
     return handleEvents(args, projectRoot, deps);
+  }
+  if (positional[0] === 'watch') {
+    return handleWatch(args, projectRoot, deps);
   }
 
   const pr = positional[0];
@@ -325,9 +424,11 @@ async function handler(args, _flags, projectRoot, deps = {}) {
 module.exports = {
   name: 'shepherd',
   description: 'Run one bounded monitor pass over a PR (rerun flaky checks, escalate, hand off — never merges)',
-  usage: 'Usage: forge shepherd <pr> [--auto-rebase] [--bundle --json] [--pull --json] | forge shepherd events <pr> --since <seq> [--json]',
+  usage: 'Usage: forge shepherd <pr> [--auto-rebase] [--bundle --json] [--pull --json] | forge shepherd events <pr> --since <seq> [--json] | forge shepherd watch <pr>',
   handler,
   handleEvents,
+  handleWatch,
+  buildMonitorContext,
   makeCheckFailureEnricher,
   parseSince,
   defaultBuildContext,

--- a/lib/commands/ship.js
+++ b/lib/commands/ship.js
@@ -12,6 +12,8 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
+const { startPrWatcherDetached } = require('../pr-monitor/watch-lifecycle');
+
 function getExecOptions() {
 	return { encoding: 'utf8', cwd: process.cwd(), timeout: 120000 };
 }
@@ -482,8 +484,26 @@ async function createPR(options) { // NOSONAR S3776
 	}
 }
 
+/**
+ * Best-effort, non-blocking auto-start of the constant PR monitor once a real PR
+ * exists. Skipped on a dry run or when no PR number is known. MUST NEVER fail
+ * ship: `startWatcher` (startPrWatcherDetached) already never throws, and this
+ * guard keeps even a surprise error from surfacing to the ship caller.
+ *
+ * @param {{ dryRun: boolean, prNumber?: string|number, startWatcher: Function }} params
+ * @returns {{ started: boolean, reason?: string }}
+ */
+function maybeStartPrWatcher({ dryRun, prNumber, startWatcher }) {
+	if (dryRun || !prNumber) return { started: false, reason: 'skipped' };
+	try {
+		return startWatcher({ prNumber, cwd: process.cwd() });
+	} catch (err) {
+		return { started: false, reason: err.message };
+	}
+}
+
 async function executeShip(options) {
-	const { featureSlug, title, dryRun = false } = options || {};
+	const { featureSlug, title, dryRun = false, startWatcher = startPrWatcherDetached } = options || {};
 
 	// Validate feature slug
 	if (!featureSlug || typeof featureSlug !== 'string' || featureSlug.trim() === '') {
@@ -535,6 +555,7 @@ async function executeShip(options) {
 		});
 		const result = await createPR({ title, body: prBody, dryRun });
 		if (!result.success) return result;
+		maybeStartPrWatcher({ dryRun, prNumber: result.prNumber, startWatcher });
 		return {
 			success: true,
 			prUrl: result.prUrl,
@@ -567,6 +588,7 @@ module.exports = {
 			output: lines.join('\n'),
 		};
 	},
+	maybeStartPrWatcher,
 	extractKeyDecisions,
 	extractTestScenarios,
 	getTestCoverage,

--- a/lib/pr-monitor/watch-lifecycle.js
+++ b/lib/pr-monitor/watch-lifecycle.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * PR-monitor lifecycle — auto-start the watch loop, detached and idempotent, on
+ * `forge ship` success. This is what makes the monitor CONSTANT without an agent
+ * having to remember to run it: the moment a PR exists, a background
+ * `forge shepherd watch <pr>` begins keeping the journal warm, and any harness
+ * re-attaches later with `forge shepherd events <pr> --since <seq>`.
+ *
+ * Contract (all guaranteed here): NEVER throws, NEVER blocks, NEVER fails ship.
+ * The detached child is `unref`'d so it cannot keep the ship process alive, and
+ * every branch is wrapped so a spawn/gh failure degrades to "not started" rather
+ * than surfacing to the caller. Stop-on-merge belongs to the watch loop's
+ * terminal pass, not here.
+ *
+ * @module pr-monitor/watch-lifecycle
+ */
+
+const path = require('node:path');
+const { spawn, execFileSync } = require('node:child_process');
+
+const journal = require('./journal');
+
+/** Absolute path to the forge CLI entrypoint (this file is lib/pr-monitor/). */
+function forgeBin() {
+  return path.join(__dirname, '..', '..', 'bin', 'forge.js');
+}
+
+/**
+ * Best-effort repo slug (the bare repo NAME, matching the shepherd's `ctx.repo`)
+ * from `git remote get-url origin`, so the idempotency check hits the same
+ * journal dir the watcher itself uses. Returns null on any failure — the caller
+ * then falls through to spawn and relies on the watch loop's own de-dup.
+ */
+function defaultResolveSlug({ cwd, exec = execFileSync }) {
+  try {
+    const url = exec('git', ['remote', 'get-url', 'origin'], {
+      cwd, encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const match = /[/:][^/]+\/([^/]+?)(?:\.git)?$/.exec(url);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start (or no-op) a detached `forge shepherd watch <pr>`.
+ *
+ * @param {object} opts
+ * @param {string|number} opts.prNumber - the PR to watch.
+ * @param {string} [opts.cwd] - repo root (default process.cwd()).
+ * @param {Function} [opts.spawn] - child spawner (test injection).
+ * @param {Function} [opts.exec] - git runner for slug resolution (test injection).
+ * @param {object} [opts.journal] - journal module (test injection).
+ * @param {Function} [opts.resolveSlug] - slug resolver (test injection).
+ * @returns {{ started: boolean, pid?: number|null, reason?: string }} — never throws.
+ */
+function startPrWatcherDetached(opts = {}) {
+  const { prNumber, cwd = process.cwd() } = opts;
+  const spawnFn = opts.spawn || spawn;
+  const journalMod = opts.journal || journal;
+  const resolveSlug = opts.resolveSlug || defaultResolveSlug;
+  try {
+    if (!prNumber) return { started: false, reason: 'no-pr' };
+
+    const slug = resolveSlug({ cwd, exec: opts.exec });
+    if (slug) {
+      const dir = journalMod.journalDir({ root: cwd, repo: slug, pr: prNumber });
+      if (journalMod.watcherRunning(dir)) return { started: false, reason: 'already-running' };
+    }
+
+    const child = spawnFn(
+      process.execPath,
+      [forgeBin(), 'shepherd', 'watch', String(prNumber)],
+      { cwd, detached: true, stdio: 'ignore', windowsHide: true },
+    );
+    if (child && typeof child.unref === 'function') child.unref();
+    return { started: true, pid: child?.pid ?? null };
+  } catch (err) {
+    // Lifecycle auto-start must never fail ship — degrade to "not started".
+    return { started: false, reason: err.message };
+  }
+}
+
+module.exports = {
+  startPrWatcherDetached,
+  defaultResolveSlug,
+  forgeBin,
+};

--- a/lib/pr-monitor/watch-lifecycle.js
+++ b/lib/pr-monitor/watch-lifecycle.js
@@ -75,6 +75,11 @@ function startPrWatcherDetached(opts = {}) {
       [forgeBin(), 'shepherd', 'watch', String(prNumber)],
       { cwd, detached: true, stdio: 'ignore', windowsHide: true },
     );
+    // spawn can emit an ASYNC 'error' (ENOENT/EACCES) AFTER returning; with no
+    // listener that becomes an unhandled exception that could crash ship. A no-op
+    // handler keeps a failed detached start best-effort (the watch loop's own
+    // journal claim is the authoritative de-dup anyway).
+    if (child && typeof child.on === 'function') child.on('error', () => {});
     if (child && typeof child.unref === 'function') child.unref();
     return { started: true, pid: child?.pid ?? null };
   } catch (err) {

--- a/lib/pr-monitor/watch.js
+++ b/lib/pr-monitor/watch.js
@@ -35,9 +35,23 @@ function defaultEmit(event) {
   process.stdout.write(`${JSON.stringify(event)}\n`);
 }
 
-/** Non-blocking sleep (overridden in tests by a fake clock). */
-function defaultSleep(ms) {
-  return new Promise((resolve) => { setTimeout(resolve, ms); });
+/**
+ * Non-blocking sleep that resolves early when `signal` aborts (Ctrl-C), so a
+ * SIGINT never has to wait out a full jittered interval (~72s). The timer and
+ * the abort listener are both cleaned up whichever path wins. Overridden in
+ * tests by a fake clock.
+ */
+function defaultSleep(ms, signal) {
+  return new Promise((resolve) => {
+    if (signal?.aborted) { resolve(); return; }
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener?.('abort', finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener?.('abort', finish, { once: true });
+  });
 }
 
 /** The check name an event refers to (check.failed / check.recovered). */
@@ -54,6 +68,21 @@ function jitter(intervalMs, rng) {
 /** True once the caller's abort signal (AbortSignal-like) has fired. */
 function isAborted(signal) {
   return Boolean(signal && signal.aborted);
+}
+
+/**
+ * Atomically claim the watcher slot for this PR: the `watcherRunning` check and
+ * the `writePid` write run TOGETHER inside the cross-process journal lock, so two
+ * concurrent starts can never both pass the check and both begin emitting
+ * duplicate NDJSON. The (possibly injected) `watcherRunning`/`writePid` primitives
+ * are honored, so test injection still works. Returns true only when claimed.
+ */
+function defaultClaim(dir, { watcherRunning, writePid, lockOpts }) {
+  return journal.withJournalLock(dir, () => {
+    if (watcherRunning(dir)) return false;
+    writePid(dir);
+    return true;
+  }, lockOpts);
 }
 
 /**
@@ -155,12 +184,15 @@ async function watchLoop(ctx) {
   const watcherRunning = ctx.watcherRunning || journal.watcherRunning;
   const writePid = ctx.writePid || journal.writePid;
   const removePid = ctx.removePid || journal.removePid;
+  const claim = ctx.claim || (() => defaultClaim(dir, { watcherRunning, writePid, lockOpts: ctx.lockOpts }));
 
-  // Idempotent claim: a live OTHER watcher already owns this PR → no-op.
-  if (watcherRunning(dir)) {
+  // Atomic idempotent claim: a live OTHER watcher already owns this PR → no-op.
+  // The check+write are serialized under the journal lock so concurrent starts
+  // cannot both succeed (see defaultClaim).
+  const claimed = await claim(dir);
+  if (!claimed) {
     return { started: false, passes: 0, stopped: false, reason: 'watcher-already-running' };
   }
-  writePid(dir);
 
   const state = { pending: new Map() };
   let passes = 0;
@@ -171,7 +203,7 @@ async function watchLoop(ctx) {
       passes += 1;
       if (result.terminal) { stopped = true; break; }
       if (passes >= maxPasses || isAborted(ctx.signal)) break;
-      await sleep(jitter(intervalMs, rng));
+      await sleep(jitter(intervalMs, rng), ctx.signal);
     }
   } finally {
     removePid(dir);
@@ -182,6 +214,8 @@ async function watchLoop(ctx) {
 module.exports = {
   watchLoop,
   runWatchPass,
+  defaultSleep,
+  defaultClaim,
   jitter,
   partition,
   contradictions,

--- a/lib/pr-monitor/watch.js
+++ b/lib/pr-monitor/watch.js
@@ -30,6 +30,14 @@ const DEFAULT_INTERVAL_MS = 60000;
 const JITTER_RATIO = 0.2;
 const TERMINAL_TYPES = new Set([T.PR_MERGED, T.PR_CLOSED]);
 
+// In-process ownership of the watcher slot, keyed by journal dir. The journal
+// PID file serializes claims ACROSS processes, but it cannot make claims within
+// ONE process idempotent: after writePid, `watcherRunning(dir)` returns false
+// because the PID equals process.pid, so a second same-process watchLoop() would
+// also claim, run in parallel, and (on either exit) remove the shared PID while
+// the other is still active. This Set closes that gap for the loop lifetime.
+const ACTIVE_DIRS = new Set();
+
 /** Default push sink: one NDJSON line per event to stdout. */
 function defaultEmit(event) {
   process.stdout.write(`${JSON.stringify(event)}\n`);
@@ -71,18 +79,27 @@ function isAborted(signal) {
 }
 
 /**
- * Atomically claim the watcher slot for this PR: the `watcherRunning` check and
- * the `writePid` write run TOGETHER inside the cross-process journal lock, so two
- * concurrent starts can never both pass the check and both begin emitting
- * duplicate NDJSON. The (possibly injected) `watcherRunning`/`writePid` primitives
- * are honored, so test injection still works. Returns true only when claimed.
+ * Atomically claim the watcher slot for this PR. The `watcherRunning` check and
+ * the `writePid` write run TOGETHER inside the cross-process journal lock (so two
+ * starts in DIFFERENT processes can never both pass), AND the in-process
+ * `ACTIVE_DIRS` guard rejects a SECOND concurrent `watchLoop()` in the SAME
+ * process (which the PID file alone misses, since our own PID reads as "not
+ * running"). Returns true only when the slot was newly claimed; the caller must
+ * release with `releaseClaim(dir)` on loop exit. The (possibly injected)
+ * `watcherRunning`/`writePid` primitives are honored, so test injection works.
  */
 function defaultClaim(dir, { watcherRunning, writePid, lockOpts }) {
   return journal.withJournalLock(dir, () => {
-    if (watcherRunning(dir)) return false;
+    if (ACTIVE_DIRS.has(dir) || watcherRunning(dir)) return false;
     writePid(dir);
+    ACTIVE_DIRS.add(dir);
     return true;
   }, lockOpts);
+}
+
+/** Release the in-process watcher claim for `dir` (idempotent). */
+function releaseClaim(dir) {
+  ACTIVE_DIRS.delete(dir);
 }
 
 /**
@@ -206,6 +223,9 @@ async function watchLoop(ctx) {
       await sleep(jitter(intervalMs, rng), ctx.signal);
     }
   } finally {
+    // Release BOTH claims: the in-process slot (for a same-process restart) and
+    // the cross-process PID file. Ordered so the in-process guard clears first.
+    releaseClaim(dir);
     removePid(dir);
   }
   return { started: true, passes, stopped };
@@ -216,6 +236,7 @@ module.exports = {
   runWatchPass,
   defaultSleep,
   defaultClaim,
+  releaseClaim,
   jitter,
   partition,
   contradictions,

--- a/lib/pr-monitor/watch.js
+++ b/lib/pr-monitor/watch.js
@@ -1,0 +1,192 @@
+'use strict';
+
+/**
+ * PR-monitor watch loop — the CONSTANT, agent-agnostic push surface. `watchLoop`
+ * self-drives a ~60s (jittered) cadence: each tick runs ONE bounded
+ * `runMonitorPass` (PR-A: gather → diff → dedup → append → snapshot, all under the
+ * cross-process journal lock), then STREAMS every new event as a single NDJSON
+ * line to stdout. Any harness (Claude Code background Bash, Codex bg exec, a
+ * Cursor per-turn poll, a plain shell) consumes stdout — nothing under `.claude`.
+ *
+ * Backpressure: `runMonitorPass` only returns events when the snapshot fingerprint
+ * moved, so an unchanged tick emits nothing. Terminal: when a tick yields
+ * `pr.merged`/`pr.closed` the loop flushes, emits that terminal event LAST, and
+ * exits cleanly (stop-on-merge). Flap debounce: a `check.failed` is held one tick
+ * and only pushed if the next tick did not recover/green it — the JOURNAL still
+ * records everything (authority), so `events --since` replay stays complete.
+ *
+ * Every external effect is injectable (emit/sleep/rng/now/gather/watcherRunning/
+ * writePid/removePid, plus `maxPasses`/`signal`) so tests exercise the loop with a
+ * fake clock and fake gh, never touching live GitHub or waiting 60s.
+ *
+ * @module pr-monitor/watch
+ */
+
+const { runMonitorPass } = require('./monitor');
+const journal = require('./journal');
+const { EVENT_TYPES: T } = require('./events');
+
+const DEFAULT_INTERVAL_MS = 60000;
+const JITTER_RATIO = 0.2;
+const TERMINAL_TYPES = new Set([T.PR_MERGED, T.PR_CLOSED]);
+
+/** Default push sink: one NDJSON line per event to stdout. */
+function defaultEmit(event) {
+  process.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+/** Non-blocking sleep (overridden in tests by a fake clock). */
+function defaultSleep(ms) {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/** The check name an event refers to (check.failed / check.recovered). */
+function checkName(event) {
+  return event.data?.name ?? event.key;
+}
+
+/** Base interval ± JITTER_RATIO, so many watchers never align their gh calls. */
+function jitter(intervalMs, rng) {
+  const spread = intervalMs * JITTER_RATIO;
+  return Math.round(intervalMs - spread + rng() * spread * 2);
+}
+
+/** True once the caller's abort signal (AbortSignal-like) has fired. */
+function isAborted(signal) {
+  return Boolean(signal && signal.aborted);
+}
+
+/**
+ * Split a pass's events into: held-candidate failures (by check name), terminal
+ * events (pr.merged/closed), and everything else (emitted immediately).
+ */
+function partition(events) {
+  const failures = new Map();
+  const terminal = [];
+  const others = [];
+  for (const e of events) {
+    if (e.type === T.CHECK_FAILED) failures.set(checkName(e), e);
+    else if (TERMINAL_TYPES.has(e.type)) terminal.push(e);
+    else others.push(e);
+  }
+  return { failures, terminal, others };
+}
+
+/**
+ * Which held failures a pass contradicts: an explicit `checks.green` clears ALL
+ * pending failures; a `check.recovered` clears just its own check name.
+ */
+function contradictions(events) {
+  let allGreen = false;
+  const names = new Set();
+  for (const e of events) {
+    if (e.type === T.CHECKS_GREEN) allGreen = true;
+    else if (e.type === T.CHECK_RECOVERED) names.add(checkName(e));
+  }
+  return { allGreen, names };
+}
+
+/** Was a held failure for `name` cleared by this pass? */
+function isContradicted(name, contra) {
+  return contra.allGreen || contra.names.has(name);
+}
+
+/** Emit the prior tick's held failures that survived (still failing this tick). */
+function confirmHeld(pending, contra, emit) {
+  for (const [name, event] of pending) {
+    if (!isContradicted(name, contra)) emit(event);
+  }
+}
+
+/**
+ * Run ONE watch tick: a bounded monitor pass, then stream its events with the
+ * 2-pass flap debounce applied. Mutates `state.pending` (the held failures).
+ *
+ * @returns {Promise<{ terminal: boolean }>} terminal=true → stop the loop.
+ */
+async function runWatchPass(state, ctx, emit) {
+  const { events } = await runMonitorPass({
+    dir: ctx.dir, gather: ctx.gather, now: ctx.now, enrich: ctx.enrich, lockOpts: ctx.lockOpts,
+  });
+  const { failures, terminal, others } = partition(events);
+  const contra = contradictions(events);
+  const heldNames = new Set(state.pending.keys());
+
+  confirmHeld(state.pending, contra, emit);
+  for (const e of others) {
+    // Drop a recovered event that only cancels a failure we held but never pushed.
+    if (e.type === T.CHECK_RECOVERED && heldNames.has(checkName(e))) continue;
+    emit(e);
+  }
+
+  if (terminal.length) {
+    for (const failure of failures.values()) emit(failure);
+    for (const t of terminal) emit(t);
+    return { terminal: true };
+  }
+  state.pending = failures;
+  return { terminal: false };
+}
+
+/**
+ * Run the constant watch loop over one PR. Long-running by default; self-stops on
+ * a terminal event. Returns a summary when the loop ends.
+ *
+ * @param {object} ctx
+ * @param {string} ctx.dir - journal directory (journal.journalDir).
+ * @param {() => Promise<object>} ctx.gather - bounded snapshot read.
+ * @param {(event: object) => void} [ctx.emit] - push sink (default: stdout NDJSON).
+ * @param {(ms: number) => Promise<void>} [ctx.sleep] - cadence sleep (test injection).
+ * @param {() => number} [ctx.rng] - jitter source in [0,1) (test injection).
+ * @param {() => string} [ctx.now] - timestamp source (test injection).
+ * @param {number} [ctx.intervalMs=60000] - base cadence.
+ * @param {number} [ctx.maxPasses=Infinity] - bound the loop (tests).
+ * @param {{ aborted: boolean }} [ctx.signal] - cooperative interrupt (SIGINT).
+ * @param {(records: object[]) => Promise<void>|void} [ctx.enrich] - PR-A enrich hook.
+ * @returns {Promise<{ started: boolean, passes: number, stopped: boolean, reason?: string }>}
+ */
+async function watchLoop(ctx) {
+  const { dir } = ctx;
+  const emit = ctx.emit || defaultEmit;
+  const sleep = ctx.sleep || defaultSleep;
+  const rng = ctx.rng || Math.random;
+  const intervalMs = ctx.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const maxPasses = ctx.maxPasses ?? Infinity;
+  const watcherRunning = ctx.watcherRunning || journal.watcherRunning;
+  const writePid = ctx.writePid || journal.writePid;
+  const removePid = ctx.removePid || journal.removePid;
+
+  // Idempotent claim: a live OTHER watcher already owns this PR → no-op.
+  if (watcherRunning(dir)) {
+    return { started: false, passes: 0, stopped: false, reason: 'watcher-already-running' };
+  }
+  writePid(dir);
+
+  const state = { pending: new Map() };
+  let passes = 0;
+  let stopped = false;
+  try {
+    while (passes < maxPasses && !isAborted(ctx.signal)) {
+      const result = await runWatchPass(state, ctx, emit);
+      passes += 1;
+      if (result.terminal) { stopped = true; break; }
+      if (passes >= maxPasses || isAborted(ctx.signal)) break;
+      await sleep(jitter(intervalMs, rng));
+    }
+  } finally {
+    removePid(dir);
+  }
+  return { started: true, passes, stopped };
+}
+
+module.exports = {
+  watchLoop,
+  runWatchPass,
+  jitter,
+  partition,
+  contradictions,
+  isContradicted,
+  confirmHeld,
+  DEFAULT_INTERVAL_MS,
+  TERMINAL_TYPES,
+};

--- a/test/pr-monitor/shepherd-watch.test.js
+++ b/test/pr-monitor/shepherd-watch.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const shepherd = require('../../lib/commands/shepherd');
+
+describe('forge shepherd watch <pr>', () => {
+  test('routes `watch <pr>` to the watch loop and forwards its summary', async () => {
+    let seen = null;
+    const deps = {
+      dir: '/tmp/journal-x',
+      gather: async () => ({ prState: 'OPEN' }),
+      enrich: () => {},
+      emit: () => {},
+      signal: { aborted: false }, // suppress real SIGINT/SIGTERM handlers
+      maxPasses: 2,
+      watchLoop: async (ctx) => { seen = ctx; return { started: true, passes: 2, stopped: true }; },
+    };
+    const res = await shepherd.handleWatch(['watch', '123'], '/repo', deps);
+    expect(res.success).toBe(true);
+    expect(res.started).toBe(true);
+    expect(res.passes).toBe(2);
+    expect(res.stopped).toBe(true);
+    // No `output` field: the loop streams live to stdout (returning output double-prints).
+    expect(res.output).toBeUndefined();
+    // Context threaded straight through to the loop.
+    expect(seen.dir).toBe('/tmp/journal-x');
+    expect(seen.emit).toBe(deps.emit);
+    expect(seen.signal).toBe(deps.signal);
+    expect(typeof seen.gather).toBe('function');
+  });
+
+  test('the top-level handler dispatches `watch` to handleWatch', async () => {
+    const deps = {
+      dir: '/tmp/journal-y',
+      gather: async () => ({ prState: 'OPEN' }),
+      signal: { aborted: false },
+      watchLoop: async () => ({ started: true, passes: 1, stopped: false }),
+    };
+    const res = await shepherd.handler(['watch', '77'], {}, '/repo', deps);
+    expect(res.success).toBe(true);
+    expect(res.passes).toBe(1);
+  });
+
+  test('surfaces a reason when a live watcher already owns the PR', async () => {
+    const deps = {
+      dir: '/tmp/journal-z',
+      gather: async () => ({ prState: 'OPEN' }),
+      signal: { aborted: false },
+      watchLoop: async () => ({ started: false, passes: 0, stopped: false, reason: 'watcher-already-running' }),
+    };
+    const res = await shepherd.handleWatch(['watch', '5'], '/repo', deps);
+    expect(res.success).toBe(true);
+    expect(res.started).toBe(false);
+    expect(res.reason).toBe('watcher-already-running');
+  });
+
+  test('rejects a missing PR argument with a usage error', async () => {
+    const res = await shepherd.handleWatch(['watch'], '/repo', {});
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Usage: forge shepherd watch/);
+  });
+});

--- a/test/pr-monitor/watch-lifecycle.test.js
+++ b/test/pr-monitor/watch-lifecycle.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { describe, test, expect } = require('bun:test');
+const { EventEmitter } = require('node:events');
 
 const { startPrWatcherDetached, defaultResolveSlug } = require('../../lib/pr-monitor/watch-lifecycle');
 const { maybeStartPrWatcher } = require('../../lib/commands/ship');
@@ -70,6 +71,20 @@ describe('startPrWatcherDetached', () => {
     });
     expect(spawned).toBe(true);
     expect(res.started).toBe(true);
+  });
+
+  test('attaches an error listener so an ASYNC spawn error never crashes ship', () => {
+    // spawn() can emit 'error' (ENOENT/EACCES) AFTER returning; on an EventEmitter
+    // with no 'error' listener that emit THROWS (would be an unhandled exception in
+    // the ship process). The no-op listener we attach must absorb it.
+    const child = new EventEmitter();
+    child.pid = 555;
+    child.unref = () => {};
+    const res = startPrWatcherDetached({ prNumber: 3, cwd: '/repo', resolveSlug: () => null, spawn: () => child });
+    expect(res.started).toBe(true);
+    expect(child.listenerCount('error')).toBe(1);
+    // With the listener present, a post-return async error is absorbed, not thrown.
+    expect(() => child.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }))).not.toThrow();
   });
 
   test('never throws when spawn fails — degrades to not-started', () => {

--- a/test/pr-monitor/watch-lifecycle.test.js
+++ b/test/pr-monitor/watch-lifecycle.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const { startPrWatcherDetached, defaultResolveSlug } = require('../../lib/pr-monitor/watch-lifecycle');
+const { maybeStartPrWatcher } = require('../../lib/commands/ship');
+
+/** A fake detached child: records unref() and reports a pid. */
+function fakeChild(pid = 4242) {
+  let unrefd = false;
+  return {
+    pid,
+    unref() { unrefd = true; },
+    wasUnrefd() { return unrefd; },
+  };
+}
+
+describe('startPrWatcherDetached', () => {
+  test('spawns a detached, unref\'d `shepherd watch <pr>` and returns synchronously', () => {
+    const calls = [];
+    const child = fakeChild(999);
+    const start = Date.now();
+    const res = startPrWatcherDetached({
+      prNumber: 42,
+      cwd: '/repo',
+      resolveSlug: () => null, // skip the idempotency probe → straight to spawn
+      spawn: (bin, args, opts) => { calls.push({ bin, args, opts }); return child; },
+    });
+    // Non-blocking: returns effectively immediately (no watch loop runs inline).
+    expect(Date.now() - start).toBeLessThan(500);
+    expect(res.started).toBe(true);
+    expect(res.pid).toBe(999);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toContain('shepherd');
+    expect(calls[0].args).toContain('watch');
+    expect(calls[0].args).toContain('42');
+    expect(calls[0].opts.detached).toBe(true);
+    expect(calls[0].opts.stdio).toBe('ignore');
+    expect(child.wasUnrefd()).toBe(true);
+  });
+
+  test('is a no-op when a live watcher already owns the PR (spawn not called)', () => {
+    let spawned = false;
+    const res = startPrWatcherDetached({
+      prNumber: 7,
+      cwd: '/repo',
+      resolveSlug: () => 'forge',
+      journal: {
+        journalDir: () => '/repo/.forge/pr-monitor/forge-7',
+        watcherRunning: () => true,
+      },
+      spawn: () => { spawned = true; return fakeChild(); },
+    });
+    expect(res.started).toBe(false);
+    expect(res.reason).toBe('already-running');
+    expect(spawned).toBe(false);
+  });
+
+  test('spawns when the slug resolves but no watcher is live yet', () => {
+    let spawned = false;
+    const res = startPrWatcherDetached({
+      prNumber: 8,
+      cwd: '/repo',
+      resolveSlug: () => 'forge',
+      journal: {
+        journalDir: () => '/repo/.forge/pr-monitor/forge-8',
+        watcherRunning: () => false,
+      },
+      spawn: () => { spawned = true; return fakeChild(1234); },
+    });
+    expect(spawned).toBe(true);
+    expect(res.started).toBe(true);
+  });
+
+  test('never throws when spawn fails — degrades to not-started', () => {
+    const res = startPrWatcherDetached({
+      prNumber: 9,
+      cwd: '/repo',
+      resolveSlug: () => null,
+      spawn: () => { throw new Error('spawn EACCES'); },
+    });
+    expect(res.started).toBe(false);
+    expect(res.reason).toMatch(/spawn EACCES/);
+  });
+
+  test('returns not-started (no spawn) when no PR number is given', () => {
+    let spawned = false;
+    const res = startPrWatcherDetached({ prNumber: undefined, spawn: () => { spawned = true; return fakeChild(); } });
+    expect(res.started).toBe(false);
+    expect(res.reason).toBe('no-pr');
+    expect(spawned).toBe(false);
+  });
+});
+
+describe('defaultResolveSlug', () => {
+  test('extracts the bare repo name from an SSH remote url', () => {
+    const slug = defaultResolveSlug({ cwd: '/repo', exec: () => 'git@github.com:harshanandak/forge.git\n' });
+    expect(slug).toBe('forge');
+  });
+
+  test('extracts the bare repo name from an HTTPS remote url', () => {
+    const slug = defaultResolveSlug({ cwd: '/repo', exec: () => 'https://github.com/harshanandak/forge\n' });
+    expect(slug).toBe('forge');
+  });
+
+  test('returns null when the git command fails', () => {
+    const slug = defaultResolveSlug({ cwd: '/repo', exec: () => { throw new Error('not a repo'); } });
+    expect(slug).toBeNull();
+  });
+});
+
+describe('maybeStartPrWatcher (ship wiring)', () => {
+  test('starts the watcher with the PR number after a real PR is created', () => {
+    const calls = [];
+    const res = maybeStartPrWatcher({
+      dryRun: false, prNumber: 373,
+      startWatcher: (opts) => { calls.push(opts); return { started: true, pid: 1 }; },
+    });
+    expect(res.started).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].prNumber).toBe(373);
+    expect(typeof calls[0].cwd).toBe('string');
+  });
+
+  test('does NOT start on a dry run', () => {
+    let called = false;
+    const res = maybeStartPrWatcher({ dryRun: true, prNumber: 5, startWatcher: () => { called = true; } });
+    expect(called).toBe(false);
+    expect(res.started).toBe(false);
+  });
+
+  test('does NOT start when there is no PR number', () => {
+    let called = false;
+    const res = maybeStartPrWatcher({ dryRun: false, prNumber: undefined, startWatcher: () => { called = true; } });
+    expect(called).toBe(false);
+    expect(res.started).toBe(false);
+  });
+
+  test('never fails ship even if the watcher start throws', () => {
+    const res = maybeStartPrWatcher({
+      dryRun: false, prNumber: 9,
+      startWatcher: () => { throw new Error('boom'); },
+    });
+    // Swallowed → ship continues; the throw never propagates.
+    expect(res.started).toBe(false);
+    expect(res.reason).toMatch(/boom/);
+  });
+});

--- a/test/pr-monitor/watch.test.js
+++ b/test/pr-monitor/watch.test.js
@@ -6,7 +6,9 @@ const os = require('node:os');
 const path = require('node:path');
 
 const journal = require('../../lib/pr-monitor/journal');
-const { watchLoop, jitter, DEFAULT_INTERVAL_MS } = require('../../lib/pr-monitor/watch');
+const {
+  watchLoop, jitter, defaultSleep, defaultClaim, DEFAULT_INTERVAL_MS,
+} = require('../../lib/pr-monitor/watch');
 const { EVENT_TYPES: T } = require('../../lib/pr-monitor/events');
 
 function snap(over = {}) {
@@ -146,5 +148,55 @@ describe('jitter', () => {
     expect(jitter(1000, () => 0)).toBe(800);
     expect(jitter(1000, () => 0.9999999)).toBeLessThanOrEqual(1200);
     expect(jitter(1000, () => 0.5)).toBe(1000);
+  });
+});
+
+describe('defaultSleep (abortable)', () => {
+  test('resolves immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const start = Date.now();
+    await defaultSleep(10000, controller.signal); // would be 10s if it ignored abort
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  test('resolves early when the signal aborts mid-sleep (Ctrl-C never waits out the interval)', async () => {
+    const controller = new AbortController();
+    const start = Date.now();
+    const sleeping = defaultSleep(10000, controller.signal);
+    controller.abort();
+    await sleeping;
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  test('a normal (un-aborted) sleep still honors the timer', async () => {
+    const start = Date.now();
+    await defaultSleep(30);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe('defaultClaim (atomic watcher claim)', () => {
+  test('two concurrent claims on the same PR: exactly ONE succeeds', async () => {
+    // Simulate a cross-process pid via shared state; the journal lock must
+    // serialize the check+write so both starts cannot both claim (and both begin
+    // emitting duplicate NDJSON).
+    let pid = null;
+    const primitives = {
+      watcherRunning: () => pid != null,
+      writePid: () => { pid = 4242; },
+    };
+    const [a, b] = await Promise.all([
+      defaultClaim(dir, primitives),
+      defaultClaim(dir, primitives),
+    ]);
+    expect([a, b].filter(Boolean)).toHaveLength(1);
+  });
+
+  test('a claim fails once the slot is already owned', async () => {
+    let pid = null;
+    const primitives = { watcherRunning: () => pid != null, writePid: () => { pid = 1; } };
+    expect(await defaultClaim(dir, primitives)).toBe(true);
+    expect(await defaultClaim(dir, primitives)).toBe(false);
   });
 });

--- a/test/pr-monitor/watch.test.js
+++ b/test/pr-monitor/watch.test.js
@@ -7,7 +7,7 @@ const path = require('node:path');
 
 const journal = require('../../lib/pr-monitor/journal');
 const {
-  watchLoop, jitter, defaultSleep, defaultClaim, DEFAULT_INTERVAL_MS,
+  watchLoop, jitter, defaultSleep, defaultClaim, releaseClaim, DEFAULT_INTERVAL_MS,
 } = require('../../lib/pr-monitor/watch');
 const { EVENT_TYPES: T } = require('../../lib/pr-monitor/events');
 
@@ -152,31 +152,37 @@ describe('jitter', () => {
 });
 
 describe('defaultSleep (abortable)', () => {
-  test('resolves immediately when the signal is already aborted', async () => {
+  // These assert RESOLUTION, not wall-clock durations: a near-infinite timer
+  // (1e9 ms) would hang the test past the suite timeout if abort were ignored,
+  // so the fact that `await` returns at all proves the abort path fired — no
+  // Date.now() thresholds that flake under CI scheduler jitter.
+  const HUGE_MS = 1_000_000_000;
+
+  test('resolves via abort when the signal is already aborted (does not wait out the timer)', async () => {
     const controller = new AbortController();
     controller.abort();
-    const start = Date.now();
-    await defaultSleep(10000, controller.signal); // would be 10s if it ignored abort
-    expect(Date.now() - start).toBeLessThan(500);
+    await defaultSleep(HUGE_MS, controller.signal);
+    expect(controller.signal.aborted).toBe(true); // reached only if the sleep resolved
   });
 
-  test('resolves early when the signal aborts mid-sleep (Ctrl-C never waits out the interval)', async () => {
+  test('resolves via abort mid-sleep (Ctrl-C never waits out the interval)', async () => {
     const controller = new AbortController();
-    const start = Date.now();
-    const sleeping = defaultSleep(10000, controller.signal);
+    const sleeping = defaultSleep(HUGE_MS, controller.signal);
     controller.abort();
-    await sleeping;
-    expect(Date.now() - start).toBeLessThan(500);
+    await sleeping; // resolves through the abort listener, not the 1e9ms timer
+    expect(controller.signal.aborted).toBe(true);
   });
 
-  test('a normal (un-aborted) sleep still honors the timer', async () => {
-    const start = Date.now();
-    await defaultSleep(30);
-    expect(Date.now() - start).toBeGreaterThanOrEqual(20);
+  test('a normal (un-aborted) sleep resolves through its timer', async () => {
+    let done = false;
+    await defaultSleep(1).then(() => { done = true; });
+    expect(done).toBe(true);
   });
 });
 
 describe('defaultClaim (atomic watcher claim)', () => {
+  afterEach(() => { releaseClaim(dir); }); // clear the in-process slot between cases
+
   test('two concurrent claims on the same PR: exactly ONE succeeds', async () => {
     // Simulate a cross-process pid via shared state; the journal lock must
     // serialize the check+write so both starts cannot both claim (and both begin
@@ -198,5 +204,47 @@ describe('defaultClaim (atomic watcher claim)', () => {
     const primitives = { watcherRunning: () => pid != null, writePid: () => { pid = 1; } };
     expect(await defaultClaim(dir, primitives)).toBe(true);
     expect(await defaultClaim(dir, primitives)).toBe(false);
+  });
+
+  test('rejects a SAME-PROCESS second claim even though the PID reads as our own', async () => {
+    // The journal PID guard treats our own process.pid as "not running", so
+    // without the in-process ACTIVE_DIRS guard a second same-process claim would
+    // succeed. Use the REAL journal primitives to prove the in-process guard.
+    const primitives = { watcherRunning: journal.watcherRunning, writePid: journal.writePid };
+    expect(await defaultClaim(dir, primitives)).toBe(true);
+    expect(await defaultClaim(dir, primitives)).toBe(false); // blocked in-process
+    releaseClaim(dir);
+    expect(await defaultClaim(dir, primitives)).toBe(true); // reclaimable after release
+  });
+});
+
+describe('watchLoop same-process concurrency', () => {
+  test('a second concurrent watchLoop() in the same process does NOT claim', async () => {
+    // Regression: two watchLoop() calls in ONE process. The first must own the
+    // slot for its whole lifetime; the second must no-op (not run and later yank
+    // the shared PID out from under the first). Deterministic handoff via a
+    // barrier — no timers. A is parked in its CADENCE SLEEP (journal lock already
+    // released after pass 1) so B's claim can take the lock and see the in-process
+    // slot; parking A inside gather would hold the lock and deadlock B.
+    let releaseA;
+    const barrier = new Promise((r) => { releaseA = r; });
+    let signalEntered;
+    const entered = new Promise((r) => { signalEntered = r; });
+    const sleepA = async () => { signalEntered(); await barrier; };
+
+    const aPromise = watchLoop({
+      dir, gather: async () => snap(), now, rng: rngMid, sleep: sleepA, maxPasses: 2, emit: () => {},
+    });
+    await entered; // A finished pass 1, owns the in-process slot, now parked in sleep
+
+    const bResult = await watchLoop({
+      dir, gather: async () => snap(), now, rng: rngMid, sleep: async () => {}, maxPasses: 1, emit: () => {},
+    });
+    expect(bResult.started).toBe(false);
+    expect(bResult.reason).toBe('watcher-already-running');
+
+    releaseA();
+    const aResult = await aPromise;
+    expect(aResult.started).toBe(true);
   });
 });

--- a/test/pr-monitor/watch.test.js
+++ b/test/pr-monitor/watch.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const journal = require('../../lib/pr-monitor/journal');
+const { watchLoop, jitter, DEFAULT_INTERVAL_MS } = require('../../lib/pr-monitor/watch');
+const { EVENT_TYPES: T } = require('../../lib/pr-monitor/events');
+
+function snap(over = {}) {
+  return {
+    repo: 'acme-forge', pr: '1', headSha: 'sha1', prState: 'OPEN', draft: false,
+    verdict: { state: 'CLEAN-MERGEABLE', reason: null },
+    checks: [], threads: [], reviews: [], comments: [], behind: 0, conflicts: false, degraded: [],
+    ...over,
+  };
+}
+
+/** A gather that yields each snapshot once, then repeats the last (no-change). */
+function gatherQueue(snaps) {
+  let i = 0;
+  return async () => {
+    const s = snaps[Math.min(i, snaps.length - 1)];
+    i += 1;
+    return s;
+  };
+}
+
+const now = () => '2026-07-13T00:00:00.000Z';
+const rngMid = () => 0.5; // jitter(interval, 0.5) === interval exactly
+
+let root; let dir;
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'prmon-w-')); dir = journal.journalDir({ root, repo: 'acme-forge', pr: '1' }); });
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+describe('watchLoop', () => {
+  test('streams a confirmed check.failed as an emitted event on change', async () => {
+    const green = snap({ checks: [{ name: 'ci', class: 'green' }] });
+    const failed = snap({ checks: [{ name: 'ci', class: 'failed' }] });
+    const emitted = [];
+    const res = await watchLoop({
+      dir, gather: gatherQueue([green, failed, failed]),
+      now, rng: rngMid, sleep: async () => {}, maxPasses: 3,
+      emit: (e) => emitted.push(e),
+    });
+    expect(res.started).toBe(true);
+    expect(res.passes).toBe(3);
+    expect(res.stopped).toBe(false);
+    // Held one pass, then confirmed on the no-change third pass → pushed.
+    expect(emitted.map((e) => e.type)).toContain(T.CHECK_FAILED);
+  });
+
+  test('emits nothing after the baseline when the snapshot never changes', async () => {
+    const emitted = [];
+    const sleeps = [];
+    await watchLoop({
+      dir, gather: gatherQueue([snap()]),
+      now, rng: rngMid, maxPasses: 4,
+      sleep: (ms) => { sleeps.push(ms); return Promise.resolve(); },
+      emit: (e) => emitted.push(e),
+    });
+    // Only the first-pass baseline verdict event is ever pushed.
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].type).toBe(T.VERDICT_CHANGED);
+    // No real timers: 3 injected sleeps between 4 passes, each within jitter band.
+    expect(sleeps).toHaveLength(3);
+    for (const ms of sleeps) {
+      expect(ms).toBeGreaterThanOrEqual(DEFAULT_INTERVAL_MS * 0.8);
+      expect(ms).toBeLessThanOrEqual(DEFAULT_INTERVAL_MS * 1.2);
+    }
+  });
+
+  test('emits the terminal pr.merged event LAST and exits the loop', async () => {
+    const open = snap();
+    const merged = snap({ prState: 'MERGED' });
+    const emitted = [];
+    const res = await watchLoop({
+      dir, gather: gatherQueue([open, merged]),
+      now, rng: rngMid, sleep: async () => {}, maxPasses: 5,
+      emit: (e) => emitted.push(e),
+    });
+    expect(res.stopped).toBe(true);
+    expect(res.passes).toBe(2); // stopped early, well before maxPasses
+    expect(emitted[emitted.length - 1].type).toBe(T.PR_MERGED);
+  });
+
+  test('is an idempotent no-op when another live watcher owns the PR', async () => {
+    const emitted = [];
+    let wrotepid = false;
+    const res = await watchLoop({
+      dir, gather: async () => { throw new Error('must not gather'); },
+      watcherRunning: () => true,
+      writePid: () => { wrotepid = true; },
+      removePid: () => {},
+      emit: (e) => emitted.push(e), maxPasses: 3,
+    });
+    expect(res.started).toBe(false);
+    expect(res.reason).toBe('watcher-already-running');
+    expect(res.passes).toBe(0);
+    expect(wrotepid).toBe(false);
+    expect(emitted).toHaveLength(0);
+  });
+
+  test('suppresses a flap: fail→green within one interval is never pushed', async () => {
+    const green = snap({ checks: [{ name: 'ci', class: 'green' }] });
+    const failed = snap({ checks: [{ name: 'ci', class: 'failed' }] });
+    const emitted = [];
+    await watchLoop({
+      dir, gather: gatherQueue([green, failed, green]),
+      now, rng: rngMid, sleep: async () => {}, maxPasses: 3,
+      emit: (e) => emitted.push(e),
+    });
+    // The transient failure recovered next pass → the stream never pushed it.
+    expect(emitted.map((e) => e.type)).not.toContain(T.CHECK_FAILED);
+  });
+
+  test('writes the pid on start and removes it on exit', async () => {
+    const writes = [];
+    const removes = [];
+    await watchLoop({
+      dir, gather: gatherQueue([snap()]),
+      now, rng: rngMid, sleep: async () => {}, maxPasses: 1,
+      writePid: (d) => writes.push(d),
+      removePid: (d) => removes.push(d),
+      emit: () => {},
+    });
+    expect(writes).toEqual([dir]);
+    expect(removes).toEqual([dir]);
+  });
+
+  test('removes the pid even when a pass throws (finally cleanup)', async () => {
+    const removes = [];
+    await expect(watchLoop({
+      dir, gather: async () => { throw new Error('boom'); },
+      writePid: () => {}, removePid: (d) => removes.push(d),
+      emit: () => {}, maxPasses: 1,
+    })).rejects.toThrow('boom');
+    expect(removes).toEqual([dir]);
+  });
+});
+
+describe('jitter', () => {
+  test('stays within ±20% of the base interval', () => {
+    expect(jitter(1000, () => 0)).toBe(800);
+    expect(jitter(1000, () => 0.9999999)).toBeLessThanOrEqual(1200);
+    expect(jitter(1000, () => 0.5)).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary

PR-B of the constant, agent-agnostic PR monitor (epic `c2d398e5-26cf-4963-b47a-70b4102636bb`), stacked on PR-A (`lib/pr-monitor/{events,differ,journal,gather,monitor}.js` + `forge shepherd events`).

Makes the monitor **run constantly and push events**:

### 1. `lib/pr-monitor/watch.js` — `watchLoop`
- Self-drives a **~60s jittered** cadence; each tick runs ONE bounded `runMonitorPass` (gather → diff → dedup → append → snapshot, under PR-A's cross-process journal lock + heartbeat).
- **Streams** every new event as one NDJSON line to stdout (nothing under `.claude`).
- **Backpressure**: unchanged tick emits nothing (fingerprint gate).
- **2-pass flap confirm**: a `check.failed` is held one tick and only pushed if the next tick didn't recover/green it. The journal still records everything (authority), so `events --since` replay stays complete.
- **Self-stops** cleanly on `pr.merged`/`pr.closed`, emitting the terminal event LAST.
- Respects the journal lock + PID heartbeat; idempotent no-op when a live watcher already owns the PR.
- Every effect injectable (emit/sleep/rng/now/gather/watcherRunning/writePid/removePid + maxPasses/signal) → tests use a fake clock + fake gh, never touching live GitHub or real sleeps.

### 2. `forge shepherd watch <pr>` (lib/commands/shepherd.js)
- Shared `buildMonitorContext` extracted from `handleEvents`; `handleWatch` reuses it, wires SIGINT/SIGTERM to an `AbortController`, and returns `{ started, passes, stopped }` (no `output` — the loop streams live).

### 3. Ship lifecycle (follow-up commit in this PR)
- `lib/pr-monitor/watch-lifecycle.js` + `lib/commands/ship.js` — non-blocking, idempotent, detached auto-start of `forge shepherd watch <pr>` on ship success; never blocks or fails ship.

## Testing
- `test/pr-monitor/watch.test.js` (7) + `test/pr-monitor/shepherd-watch.test.js` (4): NDJSON-on-change, silent-when-unchanged, terminal-last-then-exit, idempotent no-op, flap suppression, pid write/remove, jitter band — all with injected fakes.
- Full `test/pr-monitor/` + shepherd suites green (72 pass). eslint `--max-warnings 0` clean; sonarjs cognitive-complexity < 15 verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `forge shepherd watch <pr>` to stream live PR monitoring events as NDJSON, including held check-failure confirmation and early termination on merge/close.
  * After successful `forge ship`, the PR watcher can auto-start in the background (best-effort, non-blocking).
* **Documentation**
  * Added a new design document for “PR-B” describing the watch-loop behavior and ship integration.
* **Tests**
  * Expanded Bun test coverage for streaming behavior, idempotent watcher ownership, debounce/flap suppression, PID lifecycle cleanup, and watch auto-start routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->