### PR TITLE
test(dist): guard compiled-binary bundling of production deps (issue 53770b23)

### DIFF
--- a/test/binary-dep-bundling.test.js
+++ b/test/binary-dep-bundling.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// Regression guard for issue 53770b23 — "dynamic require(...) not bundled by
+// bun compile, so a production dependency is missing at runtime in the single
+// binary".
+//
+// bun's `--compile` bundler only follows requires it can resolve statically
+// (string-literal specifiers). A production dependency that is reachable ONLY
+// through a dynamic require — `require(variable)`, `require(path.join(...))`,
+// template-literal specifiers — is silently excluded from the compiled binary
+// and blows up at runtime with "Cannot find module".
+//
+// This test walks the runtime source (bin/ + lib/, excluding node_modules and
+// generated files) and asserts every production dependency in package.json is
+// required via at least one static string-literal `require('<dep>')`. That is
+// the invariant that keeps the dependency bundleable — it is what currently
+// keeps `fastest-levenshtein` (via lib/context-merge.js) inside the binary.
+//
+// Fast + deterministic: pure filesystem scan, no compile step.
+
+const { test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO = path.resolve(__dirname, '..');
+const SCAN_ROOTS = ['bin', 'lib'];
+
+const pkg = JSON.parse(fs.readFileSync(path.join(REPO, 'package.json'), 'utf8'));
+const PROD_DEPS = Object.keys(pkg.dependencies || {});
+
+/** Recursively collect *.js / *.mjs / *.cjs files under a root (skip generated). */
+function collectSourceFiles(root) {
+  const out = [];
+  const abs = path.join(REPO, root);
+  if (!fs.existsSync(abs)) return out;
+  const walk = (dir) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (e.name === 'node_modules') continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+      } else if (/\.(js|mjs|cjs)$/.test(e.name) && !e.name.includes('.generated.')) {
+        out.push(full);
+      }
+    }
+  };
+  walk(abs);
+  return out;
+}
+
+const SOURCE = collectSourceFiles(SCAN_ROOTS[0])
+  .concat(collectSourceFiles(SCAN_ROOTS[1]))
+  .map((f) => fs.readFileSync(f, 'utf8'))
+  .join('\n');
+
+/** True if `dep` is imported via a static string-literal require/import anywhere. */
+function hasStaticImport(dep) {
+  const d = dep.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const patterns = [
+    new RegExp(`require\\(\\s*['"]${d}['"]`),
+    new RegExp(`from\\s+['"]${d}['"]`),
+    new RegExp(`import\\(\\s*['"]${d}['"]`),
+  ];
+  return patterns.some((re) => re.test(SOURCE));
+}
+
+test('production dependencies are statically requireable (bundleable by bun --compile)', () => {
+  expect(PROD_DEPS.length).toBeGreaterThan(0);
+  const missing = PROD_DEPS.filter((dep) => !hasStaticImport(dep));
+  // Any production dep reachable only via a dynamic require would land here and
+  // is a compiled-binary "Cannot find module" crash waiting to happen.
+  expect(missing).toEqual([]);
+});
+
+test('fastest-levenshtein (context-merge path) is statically bundleable', () => {
+  // Named explicitly because it is the dependency issue 53770b23 flagged.
+  expect(hasStaticImport('fastest-levenshtein')).toBe(true);
+});


### PR DESCRIPTION
## Finding: the reported crash does NOT reproduce

Issue `53770b23` predicted the single binary crashes at startup because `lib/context-merge.js` -> `fastest-levenshtein` is loaded via a dynamic `require(path.join(packageDir,'lib',…))` that `bun build --compile` cannot bundle.

I built and ran the real binary (Bun 1.3.6, Windows) in an isolated worktree. **It starts and runs cleanly** — there is no missing-module crash:

- `forge-bin.exe --version` → `Forge v0.1.0-beta.1`
- `forge-bin.exe ready` → works
- `forge-bin.exe setup --quick` in a throwaway git project → full setup, exit 0
- Compiled probe calling `contextMerge.semanticMerge()` (which does `require('fastest-levenshtein')`) → runs, marker preserved
- `bun scripts/parity-check.mjs` → **PARITY OK — 220 files byte-identical** between npm and compiled binary

**Root cause of the false alarm:** `fastest-levenshtein` is imported as a *bare string-literal* `require('fastest-levenshtein')`, and `context-merge` is reached only through **static** requires (`bin/forge.js`, `lib/commands/setup.js`, and the static `lib/commands/_manifest.js` command chain). bun statically follows all of those and bundles the dep (393 modules). The dynamic `require(path.join(commandsDir,file))` in `_registry.js` is a dev/extension fallback only — the compiled path uses the static manifest. So the premise (dep hidden behind a dynamic require) is not true on current master.

## What this PR adds

A fast, no-compile **regression guard** (`test/binary-dep-bundling.test.js`) asserting every `package.json` production dependency stays reachable via a static `require('<dep>')` — the invariant that keeps them bundleable. If a future change ever hides a production dep behind a dynamic require, this test fails deterministically instead of the compiled binary crashing at runtime.

Recommend **closing issue 53770b23** as already-resolved, with this guard preventing regression.

Refs: 53770b23-a2c5-406f-a9b2-be30c14465e3

🤖 Generated with [Claude Code](https://claude.com/claude-code)