### PR TITLE
feat(dashboard): Workflow customization cockpit (read view + copy-as-command)

### DIFF
--- a/docs/work/2026-07-13-cockpit/design.md
+++ b/docs/work/2026-07-13-cockpit/design.md
@@ -1,0 +1,93 @@
+# Workflow customization cockpit — Tier-1 read view + copy-as-command
+
+Issue: `84970f9d-878c-4577-9000-adbceefc0128` · Epic: `363954dd-f6e1-4463-870c-c020c06db2aa`
+
+## Intent
+
+Turn the read-only Forge dashboard (a static `file://` SPA — no server) into a
+**customization cockpit** that SHOWS the configurable workflow architecture and
+lets users copy the exact `forge …` command to change it. Because there is no
+server, "customize" in Tier-1 = **copy-as-command**. The Tier-2 write path
+(`forge serve` config-intent) is filed separately (`9f2f0320`) and drops into the
+same `DataSource` seam without render changes.
+
+## Design (3 parts)
+
+### 1. Snapshot bake (`web/dashboard/generate-snapshot.mjs`)
+
+Add a point-in-time `snapshot.workflow` object, sourced from `lib/` via
+`createRequire` (the generator is ESM), degrading to `null` under `tryRun` if a
+module fails to load:
+
+- **Resolved runtime graph** (`getResolvedRuntimeGraph`): `phases`, `roles`,
+  `gates`, `rails`, `evidence`, `artifacts`, `adapters`, `actions`, `edges`,
+  `planSubSkills` (`graph.planning.subSkills` — the 5 `/plan` sub-skills), and
+  `config` (`.forge/config.yaml` load state).
+- **`stageOrder` / `roleIds`** = `[...ROLE_IDS]` (`plan,dev,validate,ship,review,verify`)
+  — the fixed, closed role set and the canonical 6-stage rail order.
+- **Raw config** via `loadRawConfig(ROOT)` → `rawConfig` (`null` + `configPresent:false`
+  when `.forge/config.yaml` is absent → "all defaults").
+- **PROFILES** imported from `lib/workflow-profiles.js` (6 profiles × stages +
+  classification keywords).
+- **Skills catalog**: walk `skillSearchDirs(ROOT)` precedence (`.skills` > `skills`
+  > packaged), first hit wins; attach `skills-lock.json` `source`/`sourceType`/`hash`
+  per skill; bake the per-harness render matrix `SESSION_START_SUPPORT` from
+  `hook-renderer.js` (only Claude has SessionStart injection — honest).
+- **Lint** via `lintRuntimeGraphConfig` → `{ok, errors, warnings}` (surface
+  unknown-key warnings).
+- **seams**: review/verify phase gap, PROFILES-edit (`8e7e5ad6`), Tier-2 write
+  (`9f2f0320`), comment-back (`e244f12d`).
+
+### 2. Cockpit view (`web/dashboard/app.js`)
+
+A new top-level **Workflow** view in `VIEWS`, matching the existing mono /
+Swiss-brutalist dark-default skin and a11y patterns (`data-act` delegation,
+`esc`, `icon()`, `seamId()`), rendering:
+
+- **Stage rail** — 6 cards from `stageOrder`, each joining its `role → skill`
+  binding and (where a phase record exists) its gates, evidence, artifacts, and —
+  for `plan` — its 5 sub-skills. review/verify show the role binding + an explicit
+  SEAM note (no phase record yet).
+- **Gates panel** — 4 stage gates + 3 human gates (intent / plan-approval /
+  merge) + `gate.issue_verify`, each with enabled / **LOCKED** state (locked =
+  greyed + why, mirroring `gate.js` `Cannot disable locked gate`; never rendered
+  as toggleable). **Rails** shown separately (all locked except
+  `rail.kernel_tracking`).
+- **Skills catalog** — which copy wins (user `.skills` > project `skills` >
+  packaged), lock hash/source, and the per-harness render matrix.
+- **Profiles × stage + keyword matrix** — marked read-only / SEAM (config can't
+  edit profiles yet).
+- **Honesty badges** on every item: `configSource` package-default vs override →
+  `customized` badge; lint warnings surfaced; fixed things (closed `ROLE_IDS`,
+  stage list, locked rails) labelled `fixed`.
+
+### 3. Copy-as-command
+
+On every CONFIGURABLE item, render the exact command string with a copy button —
+the Tier-1 write path:
+
+- unlocked gate → `forge gate disable <id>` / `forge gate enable <id>`
+- role → skill binding → `forge role <stage> --use <skill>`
+
+Copy uses `navigator.clipboard` with a `document.execCommand('copy')` fallback for
+`file://`. Locked gates and rails render NO command (they are fixed). Everything
+flows through the existing `DataSource` seam so the Tier-2 server drops in later
+without touching render code.
+
+## Honest SEAMs (data the graph does not expose — surfaced, not faked)
+
+- **review / verify have no phase record.** The runtime graph exposes `phases`
+  only for `plan/dev/validate/ship` (4), but `ROLE_IDS` has 6. review/verify are
+  rendered from their `role → skill` binding with an explicit "no runtime phase
+  yet" note — their gates/evidence are not invented.
+- **PROFILES are read-only** (`8e7e5ad6`) — no config surface edits them yet.
+- **Tier-1 has no write endpoint** — copy-as-command only; Tier-2 = `9f2f0320`.
+
+## Verification
+
+- Regenerate the snapshot; assert `data.json` has `workflow` with all baked
+  fields; `node --check web/dashboard/app.js`.
+- `bun test web/dashboard/app.test.js` — new tests for the pure cockpit helpers
+  and the snapshot integrity of `workflow`.
+- `eslint . --max-warnings 0`; sonarjs cognitive-complexity < 15 (view split into
+  small pure helpers).

--- a/web/dashboard/app.js
+++ b/web/dashboard/app.js
@@ -65,6 +65,7 @@ function icon(name) {
     workspaces: '<rect x="3" y="4" width="18" height="14"/><path d="M3 9h18M8 4v5"/>',
     memory: '<circle cx="6" cy="6" r="2"/><circle cx="18" cy="7" r="2"/><circle cx="9" cy="17" r="2"/><path d="M8 6h8M7 8l1.5 7M16 9l-6 7"/>',
     backlog: '<path d="M3 4h18v6H3zM3 14h18v6H3"/><path d="M7 7h4M7 17h4"/>',
+    workflow: '<circle cx="5" cy="6" r="2"/><circle cx="5" cy="18" r="2"/><circle cx="19" cy="12" r="2"/><path d="M7 6h6a2 2 0 0 1 2 2v2M7 18h6a2 2 0 0 0 2-2v-2"/>',
   }[name] || '';
   return `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="square" stroke-linejoin="miter">${p}</svg>`;
 }
@@ -228,6 +229,7 @@ function card(i) {
  * ========================================================================== */
 const VIEWS = [
   { id: 'overview', title: 'Overview', flush: false, render: renderOverview },
+  { id: 'workflow', title: 'Workflow', flush: false, render: renderWorkflow },
   { id: 'board', title: 'Work Board', flush: true, render: renderBoard },
   { id: 'epics', title: 'Epics', flush: false, render: renderEpics },
   { id: 'workspaces', title: 'Workspaces', flush: false, render: renderWorkspaces },
@@ -858,6 +860,195 @@ function restoreOverlayFocus() {
 /* ============================================================================
  * Router — every entity is a URL; the detail overlay is route-driven.
  * ========================================================================== */
+/* ============================================================================
+ * WORKFLOW COCKPIT (84970f9d) — read view + copy-as-command.
+ * Renders the CONFIGURABLE workflow architecture from snapshot.workflow (baked by
+ * generate-snapshot.mjs). Every configurable item carries the exact `forge …`
+ * command + a copy button — the Tier-1 write path (no server; Tier-2 = 9f2f0320).
+ * Pure model helpers below are DOM-free and unit-tested.
+ * ========================================================================== */
+const HUMAN_GATE_IDS = new Set(['gate.intent', 'gate.plan-approval', 'gate.merge']);
+const VERIFY_GATE_IDS = new Set(['gate.issue_verify']);
+const shortId = (id) => String(id || '').replace(/^(gate|evidence|artifact|rail|action|role|adapter)\./, '');
+
+// Which of the three closed buckets a gate belongs to.
+function gateBucket(gate) {
+  if (HUMAN_GATE_IDS.has(gate.id)) return 'human';
+  if (VERIFY_GATE_IDS.has(gate.id)) return 'verify';
+  return 'stage';
+}
+// Honesty: an item is "customized" only when its configSource is a real override.
+function isCustomized(configSource) {
+  return !!configSource && configSource !== 'package-defaults' && configSource !== 'package-default';
+}
+// Exact copy-as-command for a gate toggle — null when locked (fixed, not configurable).
+function gateCommand(gate) {
+  if (gate.locked) return null;
+  return gate.enabled === false ? `forge gate enable ${gate.id}` : `forge gate disable ${gate.id}`;
+}
+// Exact copy-as-command for a role → skill binding.
+function roleCommand(role) {
+  return `forge role ${role.role} --use ${role.skill}`;
+}
+// The 6-stage rail: role binding (always) joined with its phase record (only the
+// 4 plan/dev/validate/ship phases exist today — review/verify are role-only).
+function stageRailModel(wf) {
+  const phaseById = new Map((wf.phases || []).map((p) => [p.id, p]));
+  const roleByStage = new Map((wf.roles || []).map((r) => [r.role, r]));
+  return (wf.stageOrder || []).map((id) => ({ id, role: roleByStage.get(id) || null, phase: phaseById.get(id) || null }));
+}
+
+/* ---------- cockpit render (DOM-facing) ---------- */
+const cmdChip = (cmd) => `<button class="cmdchip" data-act="copy" data-cmd="${esc(cmd)}" title="Copy command"><code>${esc(cmd)}</code><span class="cmdchip__ico" aria-hidden="true">⧉</span></button>`;
+const cfgBadge = (src) => (isCustomized(src)
+  ? '<span class="wbadge wbadge--custom" title="overridden in .forge/config.yaml">customized</span>'
+  : '<span class="wbadge wbadge--default" title="shipped default — no override">default</span>');
+const fixedBadge = (why) => `<span class="wbadge wbadge--fixed" title="${esc(why)}">fixed</span>`;
+const lockedBadge = (why) => `<span class="wbadge wbadge--locked" title="${esc(why)}">locked</span>`;
+const wtags = (ids, extra) => (ids || []).map((x) => `<span class="wtag ${extra || ''}">${esc(shortId(x))}</span>`).join('');
+const wseam = (key) => esc((State.snapshot.workflow.seams || {})[key] || 'SEAM');
+
+function planSubSkillsBlock(wf) {
+  const subs = wf.planSubSkills || [];
+  if (!subs.length) return '';
+  const items = subs.map((s) => `<li>${esc(s.label || shortId(s.id))}</li>`).join('');
+  return `<div class="stage__row"><span class="wk">/plan sub-skills</span><ol class="wsubs">${items}</ol></div>`;
+}
+function stageCard(node, idx, wf) {
+  const { id, role, phase } = node;
+  const skill = role ? role.skill : null;
+  const cmd = role ? `<div class="stage__cmd">${cmdChip(roleCommand(role))}</div>` : '';
+  const gates = phase ? `<div class="stage__row"><span class="wk">gates</span>${wtags(phase.gates)}</div>` : '';
+  const ev = phase ? `<div class="stage__row"><span class="wk">evidence</span>${wtags(phase.evidence, 'wtag--ev')}</div>` : '';
+  const art = phase ? `<div class="stage__row"><span class="wk">artifacts</span>${wtags(phase.artifacts, 'wtag--art')}</div>` : '';
+  const sub = id === 'plan' ? planSubSkillsBlock(wf) : '';
+  const seam = phase ? '' : `<div class="wseam">role-only stage — no runtime phase record yet · ${wseam('reviewVerifyPhases')}</div>`;
+  return `<div class="stage ${phase ? '' : 'stage--roleonly'}">
+    <div class="stage__hd"><span class="stage__n">${idx + 1}</span><span class="stage__id">/${esc(id)}</span></div>
+    <div class="stage__role">role <b>${esc(id)}</b> → skill <b>${esc(skill || '—')}</b> ${role ? cfgBadge(role.configSource) : ''}</div>
+    ${cmd}${gates}${ev}${art}${sub}${seam}
+  </div>`;
+}
+function gateStateBadge(gate) {
+  if (gate.locked) return lockedBadge(`Cannot disable locked gate '${gate.id}'`);
+  return gate.enabled === false ? '<span class="wbadge wbadge--off">disabled</span>' : '<span class="wbadge wbadge--on">enabled</span>';
+}
+function gateRow(gate) {
+  const cmd = gateCommand(gate);
+  const phase = gate.phase ? `<span class="wk">${esc(gate.phase)}</span>` : '';
+  const cmdHtml = cmd ? `<div class="grow__cmd">${cmdChip(cmd)}</div>` : '<div class="grow__cmd wmute">fixed — not toggleable</div>';
+  return `<div class="grow ${gate.locked ? 'grow--locked' : ''}">
+    <div class="grow__main"><code class="gid">${esc(gate.id)}</code><span class="glabel">${esc(gate.label || '')}</span></div>
+    <div class="grow__meta">${phase}${cfgBadge(gate.configSource)}${gateStateBadge(gate)}</div>
+    ${cmdHtml}
+  </div>`;
+}
+function gateGroupHtml(title, list, note) {
+  if (!list.length) return '';
+  return `<div class="gategrp"><div class="gategrp__t">${esc(title)} <span class="wmute">${esc(note)}</span></div>${list.map(gateRow).join('')}</div>`;
+}
+function gatesPanel(wf) {
+  const gates = wf.gates || [];
+  const stage = gates.filter((g) => gateBucket(g) === 'stage');
+  const human = gates.filter((g) => gateBucket(g) === 'human');
+  const verify = gates.filter((g) => gateBucket(g) === 'verify');
+  return `<div class="wpanel"><div class="wpanel__hd">Gates <span class="wmute">${stage.length} stage · ${human.length} human · ${verify.length} write-verify</span></div>${gateGroupHtml('Stage gates', stage, 'phase entry/exit')}${gateGroupHtml('Human gates', human, 'approval events')}${gateGroupHtml('Write verification', verify, 'check-after-write')}</div>`;
+}
+function railRow(rail) {
+  const state = rail.locked ? lockedBadge('fixed L1 guardrail — cannot disable') : '<span class="wbadge wbadge--on">enabled</span>';
+  const cmdHtml = rail.locked ? '<div class="grow__cmd wmute">fixed — cannot disable</div>' : `<div class="grow__cmd">${cmdChip(`forge gate disable ${rail.id}`)}</div>`;
+  return `<div class="grow ${rail.locked ? 'grow--locked' : ''}">
+    <div class="grow__main"><code class="gid">${esc(rail.id)}</code><span class="glabel">${esc(rail.label || '')}</span></div>
+    <div class="grow__meta"><span class="wk">${esc(rail.layer || 'L1')}</span>${state}</div>
+    ${cmdHtml}
+  </div>`;
+}
+function railsPanel(wf) {
+  return `<div class="wpanel"><div class="wpanel__hd">Rails <span class="wmute">L1 — all locked except rail.kernel_tracking</span></div>${(wf.rails || []).map(railRow).join('')}</div>`;
+}
+function skillRow(sk) {
+  const lock = sk.lock ? `<span class="wtag" title="${esc(sk.lock.source)} · ${esc(sk.lock.sourceType)}">lock ${esc(sk.lock.hash)}</span>` : '<span class="wmute">no lock entry</span>';
+  return `<div class="skrow"><code class="skname">${esc(sk.name)}</code><span class="wbadge wbadge--win" title="wins precedence: user .skills &gt; project skills &gt; packaged">${esc(sk.winner)}</span>${lock}</div>`;
+}
+function harnessMatrixHtml(wf) {
+  return Object.entries(wf.harnessMatrix || {}).map(([h, v]) => `<span class="hchip ${v.rendered ? 'hchip--on' : 'hchip--off'}" title="${esc(v.reason || 'SessionStart injection')}">${esc(h)} ${v.rendered ? '✓' : '✕'}</span>`).join('');
+}
+function skillsCatalog(wf) {
+  const dirs = (wf.skillDirs || []).map((d) => `<span class="wtag ${d.exists ? '' : 'wtag--muted'}">${esc(d.label)}${d.exists ? '' : ' (absent)'}</span>`).join(' › ');
+  return `<div class="wpanel"><div class="wpanel__hd">Skills catalog <span class="wmute">precedence ${dirs}</span></div>
+    <div class="wpanel__sub">SessionStart render: ${harnessMatrixHtml(wf)} <span class="wmute">— only Claude injects context (honest)</span></div>
+    <div class="sklist">${(wf.skills || []).map(skillRow).join('')}</div></div>`;
+}
+function profileRow(name, p) {
+  const kw = (p.keywords || []).map((k) => `<span class="wtag wtag--kw">${esc(k)}</span>`).join('');
+  return `<div class="profrow"><div class="profrow__hd"><b>${esc(p.name || name)}</b> <span class="wmute">tdd:${esc(p.tdd || '—')} · research:${esc(p.research || '—')}</span></div>
+    <div class="profrow__stages">${esc((p.stages || []).join(' → '))}</div>
+    ${kw ? `<div class="profrow__kw"><span class="wk">keywords</span>${kw}</div>` : ''}</div>`;
+}
+function profilesMatrix(wf) {
+  const rows = Object.entries(wf.profiles || {}).map(([k, p]) => profileRow(k, p)).join('');
+  return `<div class="wpanel wpanel--seam"><div class="wpanel__hd">Profiles × stage <span class="wbadge wbadge--fixed">read-only</span> <span class="wmute">${wseam('profilesEdit')}</span></div>${rows}</div>`;
+}
+function lintBanner(wf) {
+  const warns = (wf.lint && wf.lint.warnings) || [];
+  const errs = (wf.lint && wf.lint.errors) || [];
+  if (!warns.length && !errs.length) return '<div class="wnote wnote--ok">config lint clean — no unknown keys</div>';
+  const li = (x) => `<li>${esc(x.code ? x.code + ': ' : '')}${esc(x.message || String(x))}</li>`;
+  return `<div class="wnote wnote--warn"><b>config lint</b><ul>${errs.map(li).join('')}${warns.map(li).join('')}</ul></div>`;
+}
+function configBadge(wf) {
+  return wf.configPresent
+    ? '<span class="wbadge wbadge--custom">.forge/config.yaml present</span>'
+    : '<span class="wbadge wbadge--default">no .forge/config.yaml — all defaults</span>';
+}
+// Reserved placeholder for an extensibility surface not yet baked. The cockpit's
+// north star is a control plane over EVERY surface (skills, gates, roles, hooks,
+// MCP, rules); these sections keep the layout so a follow-up bake slots in without
+// a redesign — honest "follow-up", never faked data.
+function surfacePlaceholder(title, covers, ref) {
+  return `<div class="wpanel wpanel--future">
+    <div class="wpanel__hd">${esc(title)} <span class="wbadge wbadge--soon">follow-up</span></div>
+    <div class="wpanel__sub">${esc(covers)}</div>
+    <div class="wseam">Not baked yet — reserved section so a follow-up slots in without a redesign · ${esc(ref)}</div>
+  </div>`;
+}
+function futureSurfaces(wf) {
+  const s = wf.seams || {};
+  return `<div class="wgrid wgrid--3">
+    ${surfacePlaceholder('Hooks', 'Enforcement + SessionStart hooks per harness (PreToolUse, protected-path, tdd-gate).', s.hooksSurface || 'follow-up')}
+    ${surfacePlaceholder('MCP servers', 'Configured MCP servers and which harness they attach to.', s.mcpSurface || 'follow-up')}
+    ${surfacePlaceholder('Rules', 'Rendered rules (rules/*.md → per-harness ports, e.g. kernel-tracking).', s.rulesSurface || 'follow-up')}
+  </div>`;
+}
+// Control-state legend: today the graph exposes enabled/disabled; the target model
+// is tri-state (mandatory / optional / permission-based) — rendered honestly.
+function controlStateNote(wf) {
+  const tri = (wf.seams && wf.seams.tristate) || 'target control state is tri-state (mandatory / optional / permission)';
+  return `<div class="wnote wnote--tri"><b>control state</b> — today: <span class="wbadge wbadge--on">enabled</span> / <span class="wbadge wbadge--off">disabled</span>. Target: <span class="wbadge wbadge--tri">mandatory</span> <span class="wbadge wbadge--tri">optional</span> <span class="wbadge wbadge--tri">permission</span>. <span class="wmute">${esc(tri)}</span></div>`;
+}
+function renderWorkflow() {
+  const wf = State.snapshot.workflow;
+  if (!wf) return '<div class="empty-state"><h4>No workflow surface baked</h4><p>Run node web/dashboard/generate-snapshot.mjs to bake the cockpit surface.</p></div>';
+  const rail = stageRailModel(wf).map((n, i) => stageCard(n, i, wf)).join('');
+  const order = (wf.stageOrder || []).join(' → ');
+  const writeRef = esc((wf.seams && wf.seams.writePath || '9f2f0320').split(' ')[0]);
+  return `<div class="fade-in wcockpit">
+    <div class="viewhead"><span class="crumb">Control plane over the configurable workflow — one section per surface, each item shows how to customize it. Read-only page; the write path is Tier-2 (${writeRef}).</span> ${configBadge(wf)}</div>
+    ${lintBanner(wf)}
+    <div class="section-title">Chain · stages + roles <span class="wmute">${esc(order)} · ${fixedBadge('ROLE_IDS is a closed, fixed set — new stages are not user-addable in Tier-1')}</span></div>
+    <div class="stagerail">${rail}</div>
+    <div class="section-title">Gates + rails</div>
+    ${controlStateNote(wf)}
+    <div class="wgrid">${gatesPanel(wf)}${railsPanel(wf)}</div>
+    <div class="section-title">Skills</div>
+    ${skillsCatalog(wf)}
+    <div class="section-title">Profiles</div>
+    ${profilesMatrix(wf)}
+    <div class="section-title">More surfaces <span class="wmute">north-star control plane — reserved, baked in a follow-up</span></div>
+    ${futureSurfaces(wf)}
+  </div>`;
+}
+
 const VIEW_IDS = new Set(VIEWS.map((v) => v.id));
 const ENTITY_KINDS = new Set(['issue', 'epic', 'decision', 'work']);
 function parseHash() {
@@ -940,6 +1131,35 @@ function handleAct(t) {
   else if (act === 'board-mode') { State.board.mode = t.dataset.mode === 'table' ? 'table' : 'kanban'; try { localStorage.setItem('forge-board-mode', State.board.mode); } catch (_e) { /* private mode */ } rerender(); }
   else if (act === 'toggle-workgroup') { const id = t.dataset.id; State.board.tableCollapsed.has(id) ? State.board.tableCollapsed.delete(id) : State.board.tableCollapsed.add(id); rerender(); }
   else if (act === 'toggle-area') { const id = t.dataset.id; State.archExpanded.has(id) ? State.archExpanded.delete(id) : State.archExpanded.add(id); rerender(); }
+  else if (act === 'copy') { copyCommand(t); }
+}
+// Copy-as-command (the Tier-1 write path): clipboard with a file:// execCommand
+// fallback, plus a brief "copied" flash. No server, no config write here.
+function copyCommand(el) {
+  const cmd = el.dataset.cmd || '';
+  const ico = el.querySelector('.cmdchip__ico');
+  const flash = () => {
+    el.classList.add('copied');
+    const prev = ico ? ico.textContent : '';
+    if (ico) ico.textContent = '✓';
+    setTimeout(() => { el.classList.remove('copied'); if (ico) ico.textContent = prev; }, 1200);
+  };
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(cmd).then(flash).catch(() => fallbackCopy(cmd, flash));
+      return;
+    }
+  } catch (_e) { /* clipboard API unavailable — fall through */ }
+  fallbackCopy(cmd, flash);
+}
+function fallbackCopy(text, done) {
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text; ta.setAttribute('readonly', '');
+    ta.style.position = 'absolute'; ta.style.left = '-9999px';
+    document.body.appendChild(ta); ta.select();
+    document.execCommand('copy'); document.body.removeChild(ta); done();
+  } catch (_e) { /* clipboard unavailable in this context */ }
 }
 function onViewClick(e) {
   const t = e.target.closest('[data-act]'); if (!t) return;
@@ -1055,5 +1275,5 @@ async function boot() {
 }
 if (typeof document !== 'undefined') boot();
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { columnOf, matchesFilter, relTime, epicRollup, epicHealth, isLive, lifecyclePhase, wtSummary, renderMarkdown, isActivationKey, needsButtonSemantics, State };
+  module.exports = { columnOf, matchesFilter, relTime, epicRollup, epicHealth, isLive, lifecyclePhase, wtSummary, renderMarkdown, isActivationKey, needsButtonSemantics, State, gateBucket, isCustomized, gateCommand, roleCommand, stageRailModel, shortId };
 }

--- a/web/dashboard/app.js
+++ b/web/dashboard/app.js
@@ -890,6 +890,11 @@ function gateCommand(gate) {
 function roleCommand(role) {
   return `forge role ${role.role} --use ${role.skill}`;
 }
+// A role bound to its own default skill with no override — copying `forge role dev
+// --use dev` is a self-noop, so the cockpit shows a customize template instead.
+function isDefaultBinding(role) {
+  return !!role && role.skill === role.role && !isCustomized(role.configSource);
+}
 // The 6-stage rail: role binding (always) joined with its phase record (only the
 // 4 plan/dev/validate/ship phases exist today — review/verify are role-only).
 function stageRailModel(wf) {
@@ -899,7 +904,7 @@ function stageRailModel(wf) {
 }
 
 /* ---------- cockpit render (DOM-facing) ---------- */
-const cmdChip = (cmd) => `<button class="cmdchip" data-act="copy" data-cmd="${esc(cmd)}" title="Copy command"><code>${esc(cmd)}</code><span class="cmdchip__ico" aria-hidden="true">⧉</span></button>`;
+const cmdChip = (cmd) => `<button class="cmdchip" data-act="copy" data-cmd="${esc(cmd)}" title="Copy command"><code>${esc(cmd)}</code><span class="cmdchip__ico" aria-hidden="true">⧉</span><span class="cmdchip__sr" aria-live="polite"></span></button>`;
 const cfgBadge = (src) => (isCustomized(src)
   ? '<span class="wbadge wbadge--custom" title="overridden in .forge/config.yaml">customized</span>'
   : '<span class="wbadge wbadge--default" title="shipped default — no override">default</span>');
@@ -914,24 +919,30 @@ function planSubSkillsBlock(wf) {
   const items = subs.map((s) => `<li>${esc(s.label || shortId(s.id))}</li>`).join('');
   return `<div class="stage__row"><span class="wk">/plan sub-skills</span><ol class="wsubs">${items}</ol></div>`;
 }
+function roleCmdHtml(role, id) {
+  if (!role) return '';
+  if (isDefaultBinding(role)) return `<div class="stage__cmd wmute">default binding — customize: <code>forge role ${esc(id)} --use &lt;skill&gt;</code></div>`;
+  return `<div class="stage__cmd">${cmdChip(roleCommand(role))}</div>`;
+}
 function stageCard(node, idx, wf) {
   const { id, role, phase } = node;
   const skill = role ? role.skill : null;
-  const cmd = role ? `<div class="stage__cmd">${cmdChip(roleCommand(role))}</div>` : '';
+  const phaseState = phase ? `${cfgBadge(phase.configSource)}${gateStateBadge(phase)}` : '';
   const gates = phase ? `<div class="stage__row"><span class="wk">gates</span>${wtags(phase.gates)}</div>` : '';
   const ev = phase ? `<div class="stage__row"><span class="wk">evidence</span>${wtags(phase.evidence, 'wtag--ev')}</div>` : '';
   const art = phase ? `<div class="stage__row"><span class="wk">artifacts</span>${wtags(phase.artifacts, 'wtag--art')}</div>` : '';
   const sub = id === 'plan' ? planSubSkillsBlock(wf) : '';
   const seam = phase ? '' : `<div class="wseam">role-only stage — no runtime phase record yet · ${wseam('reviewVerifyPhases')}</div>`;
   return `<div class="stage ${phase ? '' : 'stage--roleonly'}">
-    <div class="stage__hd"><span class="stage__n">${idx + 1}</span><span class="stage__id">/${esc(id)}</span></div>
+    <div class="stage__hd"><span class="stage__n">${idx + 1}</span><span class="stage__id">/${esc(id)}</span>${phaseState}</div>
     <div class="stage__role">role <b>${esc(id)}</b> → skill <b>${esc(skill || '—')}</b> ${role ? cfgBadge(role.configSource) : ''}</div>
-    ${cmd}${gates}${ev}${art}${sub}${seam}
+    ${roleCmdHtml(role, id)}${gates}${ev}${art}${sub}${seam}
   </div>`;
 }
-function gateStateBadge(gate) {
-  if (gate.locked) return lockedBadge(`Cannot disable locked gate '${gate.id}'`);
-  return gate.enabled === false ? '<span class="wbadge wbadge--off">disabled</span>' : '<span class="wbadge wbadge--on">enabled</span>';
+// Shared state badge for gates, rails, and phases — all carry enabled/locked.
+function gateStateBadge(item) {
+  if (item.locked) return lockedBadge(`Cannot disable locked '${item.id}'`);
+  return item.enabled === false ? '<span class="wbadge wbadge--off">disabled</span>' : '<span class="wbadge wbadge--on">enabled</span>';
 }
 function gateRow(gate) {
   const cmd = gateCommand(gate);
@@ -954,29 +965,42 @@ function gatesPanel(wf) {
   const verify = gates.filter((g) => gateBucket(g) === 'verify');
   return `<div class="wpanel"><div class="wpanel__hd">Gates <span class="wmute">${stage.length} stage · ${human.length} human · ${verify.length} write-verify</span></div>${gateGroupHtml('Stage gates', stage, 'phase entry/exit')}${gateGroupHtml('Human gates', human, 'approval events')}${gateGroupHtml('Write verification', verify, 'check-after-write')}</div>`;
 }
+// Rails reuse the SAME helpers as gates so their state, command (enable vs
+// disable), and customized badge all track the real resolved config — never a
+// hardcoded "enabled" that goes stale after `forge gate disable rail.kernel_tracking`.
 function railRow(rail) {
-  const state = rail.locked ? lockedBadge('fixed L1 guardrail — cannot disable') : '<span class="wbadge wbadge--on">enabled</span>';
-  const cmdHtml = rail.locked ? '<div class="grow__cmd wmute">fixed — cannot disable</div>' : `<div class="grow__cmd">${cmdChip(`forge gate disable ${rail.id}`)}</div>`;
+  const cmd = gateCommand(rail);
+  const cmdHtml = cmd ? `<div class="grow__cmd">${cmdChip(cmd)}</div>` : '<div class="grow__cmd wmute">fixed — cannot disable</div>';
   return `<div class="grow ${rail.locked ? 'grow--locked' : ''}">
     <div class="grow__main"><code class="gid">${esc(rail.id)}</code><span class="glabel">${esc(rail.label || '')}</span></div>
-    <div class="grow__meta"><span class="wk">${esc(rail.layer || 'L1')}</span>${state}</div>
+    <div class="grow__meta"><span class="wk">${esc(rail.layer || 'L1')}</span>${cfgBadge(rail.configSource)}${gateStateBadge(rail)}</div>
     ${cmdHtml}
   </div>`;
 }
 function railsPanel(wf) {
-  return `<div class="wpanel"><div class="wpanel__hd">Rails <span class="wmute">L1 — all locked except rail.kernel_tracking</span></div>${(wf.rails || []).map(railRow).join('')}</div>`;
+  const rails = wf.rails || [];
+  const unlocked = rails.filter((r) => !r.locked).map((r) => r.id);
+  const note = unlocked.length ? `L1 — unlocked: ${unlocked.join(', ')}` : 'L1 — all locked';
+  return `<div class="wpanel"><div class="wpanel__hd">Rails <span class="wmute">${esc(note)}</span></div>${rails.map(railRow).join('')}</div>`;
 }
 function skillRow(sk) {
   const lock = sk.lock ? `<span class="wtag" title="${esc(sk.lock.source)} · ${esc(sk.lock.sourceType)}">lock ${esc(sk.lock.hash)}</span>` : '<span class="wmute">no lock entry</span>';
   return `<div class="skrow"><code class="skname">${esc(sk.name)}</code><span class="wbadge wbadge--win" title="wins precedence: user .skills &gt; project skills &gt; packaged">${esc(sk.winner)}</span>${lock}</div>`;
+}
+// Harnesses that actually inject context at SessionStart — DERIVED from the baked
+// matrix, not hardcoded, so it stays honest if the capability matrix changes.
+function renderingHarnesses(wf) {
+  return Object.entries(wf.harnessMatrix || {}).filter(([, v]) => v.rendered).map(([h]) => h);
 }
 function harnessMatrixHtml(wf) {
   return Object.entries(wf.harnessMatrix || {}).map(([h, v]) => `<span class="hchip ${v.rendered ? 'hchip--on' : 'hchip--off'}" title="${esc(v.reason || 'SessionStart injection')}">${esc(h)} ${v.rendered ? '✓' : '✕'}</span>`).join('');
 }
 function skillsCatalog(wf) {
   const dirs = (wf.skillDirs || []).map((d) => `<span class="wtag ${d.exists ? '' : 'wtag--muted'}">${esc(d.label)}${d.exists ? '' : ' (absent)'}</span>`).join(' › ');
+  const renders = renderingHarnesses(wf);
+  const note = renders.length ? `only ${renders.join(', ')} inject${renders.length === 1 ? 's' : ''} context` : 'no harness injects context';
   return `<div class="wpanel"><div class="wpanel__hd">Skills catalog <span class="wmute">precedence ${dirs}</span></div>
-    <div class="wpanel__sub">SessionStart render: ${harnessMatrixHtml(wf)} <span class="wmute">— only Claude injects context (honest)</span></div>
+    <div class="wpanel__sub">SessionStart render: ${harnessMatrixHtml(wf)} <span class="wmute">— ${esc(note)} (derived)</span></div>
     <div class="sklist">${(wf.skills || []).map(skillRow).join('')}</div></div>`;
 }
 function profileRow(name, p) {
@@ -1138,11 +1162,13 @@ function handleAct(t) {
 function copyCommand(el) {
   const cmd = el.dataset.cmd || '';
   const ico = el.querySelector('.cmdchip__ico');
+  const sr = el.querySelector('.cmdchip__sr');
   const flash = () => {
     el.classList.add('copied');
     const prev = ico ? ico.textContent : '';
     if (ico) ico.textContent = '✓';
-    setTimeout(() => { el.classList.remove('copied'); if (ico) ico.textContent = prev; }, 1200);
+    if (sr) sr.textContent = 'Copied to clipboard';
+    setTimeout(() => { el.classList.remove('copied'); if (ico) ico.textContent = prev; if (sr) sr.textContent = ''; }, 1200);
   };
   try {
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -1275,5 +1301,5 @@ async function boot() {
 }
 if (typeof document !== 'undefined') boot();
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { columnOf, matchesFilter, relTime, epicRollup, epicHealth, isLive, lifecyclePhase, wtSummary, renderMarkdown, isActivationKey, needsButtonSemantics, State, gateBucket, isCustomized, gateCommand, roleCommand, stageRailModel, shortId };
+  module.exports = { columnOf, matchesFilter, relTime, epicRollup, epicHealth, isLive, lifecyclePhase, wtSummary, renderMarkdown, isActivationKey, needsButtonSemantics, State, gateBucket, isCustomized, gateCommand, roleCommand, stageRailModel, shortId, isDefaultBinding, renderingHarnesses };
 }

--- a/web/dashboard/app.test.js
+++ b/web/dashboard/app.test.js
@@ -247,6 +247,35 @@ test('cockpit: roleCommand yields the exact role→skill binding command', () =>
   expect(app.roleCommand({ role: 'plan', skill: 'my-plan' })).toBe('forge role plan --use my-plan');
 });
 
+test('cockpit: isDefaultBinding flags the self-noop default, not customized bindings', () => {
+  // dev→dev with no override → default self-binding (copy would be a no-op)
+  expect(app.isDefaultBinding({ role: 'dev', skill: 'dev', configSource: 'package-defaults' })).toBe(true);
+  // a different skill → meaningful, not default
+  expect(app.isDefaultBinding({ role: 'dev', skill: 'my-skill', configSource: 'package-defaults' })).toBe(false);
+  // same name but overridden in config → still show the (re-applying) command
+  expect(app.isDefaultBinding({ role: 'dev', skill: 'dev', configSource: '.forge/config.yaml' })).toBe(false);
+});
+
+test('cockpit: rail state tracks real config — a disabled unlocked rail offers ENABLE, not disable', () => {
+  // enabled + unlocked (default kernel_tracking) → disable command
+  expect(app.gateCommand({ id: 'rail.kernel_tracking', enabled: true, locked: false })).toBe('forge gate disable rail.kernel_tracking');
+  // AFTER `forge gate disable rail.kernel_tracking` → re-bake shows enabled:false;
+  // the cockpit must now offer ENABLE (never a stale "disable")
+  expect(app.gateCommand({ id: 'rail.kernel_tracking', enabled: false, locked: false })).toBe('forge gate enable rail.kernel_tracking');
+  // a disabled rail is customized → cfgBadge must reflect the override (isCustomized)
+  expect(app.isCustomized('.forge/config.yaml')).toBe(true);
+  // locked rails never emit a command
+  expect(app.gateCommand({ id: 'rail.secret_scan', enabled: true, locked: true })).toBe(null);
+});
+
+test('cockpit: renderingHarnesses derives SessionStart support from the matrix (no hardcoding)', () => {
+  const wf = { harnessMatrix: { claude: { rendered: true }, cursor: { rendered: false }, codex: { rendered: false } } };
+  expect(app.renderingHarnesses(wf)).toEqual(['claude']);
+  // if the matrix changes, the derivation changes with it
+  const wf2 = { harnessMatrix: { claude: { rendered: true }, cursor: { rendered: true } } };
+  expect(app.renderingHarnesses(wf2)).toEqual(['claude', 'cursor']);
+});
+
 test('cockpit: shortId strips the primitive prefix', () => {
   expect(app.shortId('gate.plan-exit')).toBe('plan-exit');
   expect(app.shortId('evidence.tdd-tests')).toBe('tdd-tests');

--- a/web/dashboard/app.test.js
+++ b/web/dashboard/app.test.js
@@ -215,3 +215,89 @@ test('baked snapshot, when generated, is well-formed', () => {
   const cancelled = snap.issues.filter((i) => i.status === 'cancelled').length;
   expect(placed + cancelled).toBe(snap.issues.length);
 });
+
+/* ---------- Workflow cockpit (84970f9d) ---------- */
+test('cockpit: gateBucket classifies stage / human / write-verify gates', () => {
+  expect(app.gateBucket({ id: 'gate.plan-exit' })).toBe('stage');
+  expect(app.gateBucket({ id: 'gate.ship-entry' })).toBe('stage');
+  expect(app.gateBucket({ id: 'gate.intent' })).toBe('human');
+  expect(app.gateBucket({ id: 'gate.plan-approval' })).toBe('human');
+  expect(app.gateBucket({ id: 'gate.merge' })).toBe('human');
+  expect(app.gateBucket({ id: 'gate.issue_verify' })).toBe('verify');
+});
+
+test('cockpit: isCustomized flags overrides, not package defaults', () => {
+  expect(app.isCustomized('package-defaults')).toBe(false);
+  expect(app.isCustomized('package-default')).toBe(false);
+  expect(app.isCustomized(undefined)).toBe(false);
+  expect(app.isCustomized('project-config')).toBe(true);
+});
+
+test('cockpit: gateCommand yields the exact toggle command, null when locked', () => {
+  // enabled + unlocked → disable command
+  expect(app.gateCommand({ id: 'gate.plan-exit', enabled: true, locked: false })).toBe('forge gate disable gate.plan-exit');
+  // disabled → enable command
+  expect(app.gateCommand({ id: 'gate.plan-exit', enabled: false, locked: false })).toBe('forge gate enable gate.plan-exit');
+  // locked → no command (fixed, never toggleable)
+  expect(app.gateCommand({ id: 'gate.plan-exit', enabled: true, locked: true })).toBe(null);
+});
+
+test('cockpit: roleCommand yields the exact role→skill binding command', () => {
+  expect(app.roleCommand({ role: 'dev', skill: 'dev' })).toBe('forge role dev --use dev');
+  expect(app.roleCommand({ role: 'plan', skill: 'my-plan' })).toBe('forge role plan --use my-plan');
+});
+
+test('cockpit: shortId strips the primitive prefix', () => {
+  expect(app.shortId('gate.plan-exit')).toBe('plan-exit');
+  expect(app.shortId('evidence.tdd-tests')).toBe('tdd-tests');
+  expect(app.shortId('artifact.design-doc')).toBe('design-doc');
+  expect(app.shortId(null)).toBe('');
+});
+
+test('cockpit: stageRailModel joins the 6 role stages with the 4 phase records', () => {
+  const wf = {
+    stageOrder: ['plan', 'dev', 'validate', 'ship', 'review', 'verify'],
+    roles: ['plan', 'dev', 'validate', 'ship', 'review', 'verify'].map((r) => ({ role: r, skill: r })),
+    phases: [{ id: 'plan' }, { id: 'dev' }, { id: 'validate' }, { id: 'ship' }],
+  };
+  const rail = app.stageRailModel(wf);
+  expect(rail.map((n) => n.id)).toEqual(['plan', 'dev', 'validate', 'ship', 'review', 'verify']);
+  // every stage has a role binding
+  expect(rail.every((n) => n.role)).toBe(true);
+  // only the first four have a phase record — review/verify are role-only (honest SEAM)
+  expect(rail.filter((n) => n.phase).map((n) => n.id)).toEqual(['plan', 'dev', 'validate', 'ship']);
+  expect(rail.find((n) => n.id === 'review').phase).toBe(null);
+  expect(rail.find((n) => n.id === 'verify').phase).toBe(null);
+});
+
+test('baked snapshot: workflow cockpit surface is well-formed when generated', () => {
+  const path = join(here, 'data.json');
+  if (!existsSync(path)) return; // generated artifact; absent on a fresh clone / CI
+  const wf = JSON.parse(readFileSync(path, 'utf8')).workflow;
+  if (!wf) return; // bake degraded to null (lib unavailable) — nothing to assert
+  // the closed 6-stage role order
+  expect(wf.stageOrder).toEqual(['plan', 'dev', 'validate', 'ship', 'review', 'verify']);
+  expect(wf.roleIds).toEqual(wf.stageOrder);
+  // core baked collections present
+  ['phases', 'roles', 'gates', 'rails', 'evidence', 'artifacts', 'planSubSkills', 'skills', 'skillDirs'].forEach((k) => {
+    expect(Array.isArray(wf[k])).toBe(true);
+  });
+  // 6 roles, one per stage
+  expect(wf.roles.length).toBe(6);
+  // the 8 gates split 4 stage / 3 human / 1 write-verify
+  const buckets = { stage: 0, human: 0, verify: 0 };
+  wf.gates.forEach((g) => { buckets[app.gateBucket(g)]++; });
+  expect(buckets).toEqual({ stage: 4, human: 3, verify: 1 });
+  // exactly one rail is unlocked (rail.kernel_tracking); the rest are fixed L1
+  const unlocked = wf.rails.filter((r) => !r.locked);
+  expect(unlocked.length).toBe(1);
+  expect(unlocked[0].id).toBe('rail.kernel_tracking');
+  // 5 /plan sub-skills
+  expect(wf.planSubSkills.length).toBe(5);
+  // honest per-harness render matrix — only Claude injects at SessionStart
+  expect(wf.harnessMatrix.claude.rendered).toBe(true);
+  expect(wf.harnessMatrix.cursor.rendered).toBe(false);
+  // profiles baked (read-only SEAM) + lint result present
+  expect(Object.keys(wf.profiles).length).toBeGreaterThan(0);
+  expect(typeof wf.lint.ok).toBe('boolean');
+});

--- a/web/dashboard/generate-snapshot.mjs
+++ b/web/dashboard/generate-snapshot.mjs
@@ -13,10 +13,12 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 function findRepoRoot(start) {
   let dir = start;
@@ -336,6 +338,87 @@ console.log(`  ops: ${worktrees.length} worktrees, ${prs.length} open PRs, ${mer
 console.log(`  stage_runs: ${stagePopulated}/${claimedOpen.length} claimed issues have a real current_stage · stale leases: ${staleLeaseCount}`);
 console.log(`  needs-attention: ${needsAttention.length}`);
 
+// ---- workflow cockpit surface (84970f9d) ----------------------------------
+// Point-in-time bake of the CONFIGURABLE workflow architecture: the resolved
+// runtime graph (stages/gates/rails/roles/evidence/artifacts/plan sub-skills),
+// the raw .forge/config.yaml (absent = all-defaults), the workflow PROFILES, a
+// skills catalog (precedence + lock + per-harness render status), and lint
+// warnings. Read-only + copy-as-command in Tier-1; the config-intent WRITE path
+// is Tier-2 (9f2f0320) and drops into the same DataSource seam later.
+const skillDirLabel = (dir) => {
+  const s = String(dir).replace(/\\/g, '/');
+  const rootS = String(ROOT).replace(/\\/g, '/');
+  if (/\/\.skills$/.test(s)) return 'user';
+  if (s.startsWith(rootS)) return 'project';
+  return 'packaged';
+};
+
+function buildSkillsCatalog() {
+  const { skillSearchDirs } = require(join(ROOT, 'lib', 'config-writer.js'));
+  const dirs = skillSearchDirs(ROOT); // ordered: .skills > skills > packaged
+  let lock = {};
+  try { lock = JSON.parse(readFileSync(join(ROOT, 'skills-lock.json'), 'utf8')).skills || {}; }
+  catch { lock = {}; }
+  const byName = new Map();
+  dirs.forEach((dir) => {
+    if (!existsSync(dir)) return;
+    const label = skillDirLabel(dir);
+    for (const name of readdirSync(dir)) {
+      if (!existsSync(join(dir, name, 'SKILL.md'))) continue;
+      const existing = byName.get(name);
+      if (existing) { if (!existing.sources.includes(label)) existing.sources.push(label); continue; }
+      const l = lock[name] || null;
+      byName.set(name, {
+        name, winner: label, sources: [label],
+        lock: l ? { source: l.source, sourceType: l.sourceType, hash: String(l.computedHash || '').slice(0, 12) } : null,
+      });
+    }
+  });
+  const skills = [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  const skillDirs = dirs.map((d) => ({ path: String(d).replace(/\\/g, '/'), label: skillDirLabel(d), exists: existsSync(d) }));
+  return { skills, skillDirs };
+}
+
+const workflow = tryRun(() => {
+  const { getResolvedRuntimeGraph, lintRuntimeGraphConfig, ROLE_IDS } = require(join(ROOT, 'lib', 'core', 'runtime-graph.js'));
+  const { loadRawConfig } = require(join(ROOT, 'lib', 'config-writer.js'));
+  const { PROFILES } = require(join(ROOT, 'lib', 'workflow-profiles.js'));
+  const { SESSION_START_SUPPORT } = require(join(ROOT, 'lib', 'hook-renderer.js'));
+  const graph = getResolvedRuntimeGraph({ projectRoot: ROOT });
+  const lint = lintRuntimeGraphConfig({ projectRoot: ROOT });
+  const rawConfig = loadRawConfig(ROOT);
+  const configPresent = !!rawConfig && Object.keys(rawConfig).length > 0;
+  const { skills, skillDirs } = buildSkillsCatalog();
+  return {
+    stageOrder: [...ROLE_IDS], roleIds: [...ROLE_IDS],
+    phases: graph.phases, roles: graph.roles, gates: graph.gates, rails: graph.rails,
+    evidence: graph.evidence, artifacts: graph.artifacts, adapters: graph.adapters,
+    actions: graph.actions, edges: graph.edges,
+    planSubSkills: graph.planning?.subSkills ?? [],
+    planTemplate: graph.planning?.template ?? null,
+    config: graph.config, rawConfig: configPresent ? rawConfig : null, configPresent,
+    profiles: PROFILES,
+    lint: { ok: lint.ok, errors: lint.errors ?? [], warnings: lint.warnings ?? [] },
+    skills, skillDirs, harnessMatrix: SESSION_START_SUPPORT,
+    seams: {
+      reviewVerifyPhases: 'review/verify are ROLES (role.review, role.verify) — the runtime graph exposes phase records only for plan/dev/validate/ship; their gates/evidence are role-only until phase records land',
+      profilesEdit: '8e7e5ad6 · workflow PROFILES editing surface (read-only in cockpit)',
+      writePath: '9f2f0320 · Tier-2 forge serve config-intent write path (Tier-1 = copy-as-command)',
+      commentBack: 'e244f12d · Tier-1 comment-back (forge inbox verb)',
+      // North-star control plane covers EVERY extensibility surface. These three
+      // surfaces get reserved placeholder sections in the cockpit (follow-up bake).
+      hooksSurface: 'follow-up · hooks surface (enforcement + SessionStart per harness) not baked yet',
+      mcpSurface: 'follow-up · MCP servers surface (configured servers × harness) not baked yet',
+      rulesSurface: 'follow-up · rules surface (rules/*.md → per-harness ports) not baked yet',
+      // Target control-state model is TRI-STATE, richer than today's on/off.
+      tristate: 'target control state is tri-state: mandatory / optional / permission-based (today the graph exposes enabled/disabled only — rendered honestly)',
+    },
+  };
+}, null, 'workflow cockpit bake');
+if (workflow) {
+  console.log(`  workflow: ${workflow.phases.length} phases, ${workflow.gates.length} gates, ${workflow.rails.length} rails, ${workflow.skills.length} skills, config ${workflow.configPresent ? 'present' : 'all-defaults'}`);
+}
+
 // ---- assemble + write -----------------------------------------------------
 const snapshot = {
   generated_at: new Date().toISOString(),
@@ -374,6 +457,7 @@ const snapshot = {
   },
   needsAttention,
   backlog: null, // SEAM: kernel backlog state (b2f856b1) not yet landed
+  workflow, // cockpit surface (84970f9d) — configurable workflow architecture
   status: statusRes,
   memory,
   issues,

--- a/web/dashboard/styles.css
+++ b/web/dashboard/styles.css
@@ -633,3 +633,91 @@ tr.child .rowname .tt { color: var(--muted); font-size: 12px; }
 .detail__panel:focus-visible,
 a:focus-visible,
 button:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+
+/* ============================================================================
+ * Workflow cockpit (84970f9d) — same mono/brutalist skin, vars only (theme-safe).
+ * ========================================================================== */
+.wcockpit .wmute { color: var(--faint); font-family: var(--mono); font-size: 10.5px; }
+.wcockpit .wk { font-family: var(--mono); font-size: 9.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--faint); margin-right: 8px; }
+.wnote { font-family: var(--mono); font-size: 11px; padding: 8px 11px; border: 1px solid var(--line); margin-bottom: 14px; color: var(--muted); }
+.wnote--warn { border-color: var(--text); color: var(--text); }
+.wnote--warn ul { margin: 6px 0 0; padding-left: 18px; }
+
+/* honesty badges + tags */
+.wbadge { font-family: var(--mono); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; padding: 1px 6px; border: 1px solid var(--line-2); color: var(--muted); white-space: nowrap; }
+.wbadge--custom { background: var(--text); color: var(--bg); border-color: var(--text); }
+.wbadge--default { color: var(--faint); border-style: dashed; }
+.wbadge--fixed { color: var(--muted); border-style: dotted; }
+.wbadge--locked { color: var(--faint); border-style: dashed; opacity: .8; }
+.wbadge--on { color: var(--text); }
+.wbadge--off { color: var(--faint); border-style: dashed; }
+.wbadge--win { background: var(--surface-2); color: var(--text); }
+.wtag { font-family: var(--mono); font-size: 10px; padding: 1px 6px; border: 1px solid var(--line); color: var(--muted); margin-right: 5px; display: inline-block; margin-bottom: 4px; }
+.wtag--ev { border-style: dashed; }
+.wtag--art { color: var(--faint); }
+.wtag--kw { color: var(--faint); }
+.wtag--muted, .wtag--muted { color: var(--faint); border-style: dashed; opacity: .7; }
+
+/* copy-as-command chip */
+.cmdchip { display: inline-flex; align-items: center; gap: 8px; background: var(--surface-2); border: 1px solid var(--line-2); padding: 4px 9px; cursor: pointer; font-family: var(--mono); max-width: 100%; overflow: hidden; }
+.cmdchip:hover { border-color: var(--text); background: var(--hover); }
+.cmdchip code { font-family: var(--mono); font-size: 11.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cmdchip__ico { color: var(--faint); font-size: 12px; }
+.cmdchip.copied { border-color: var(--text); }
+.cmdchip.copied .cmdchip__ico { color: var(--text); }
+
+/* stage rail */
+.stagerail { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 10px; margin: 12px 0 8px; }
+.stage { border: 1px solid var(--line); background: var(--surface); padding: 12px 13px; display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+.stage--roleonly { border-style: dashed; }
+.stage__hd { display: flex; align-items: baseline; gap: 8px; }
+.stage__n { font-family: var(--mono); font-size: 10px; color: var(--faint); border: 1px solid var(--line-2); width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center; }
+.stage__id { font-family: var(--mono); font-size: 14px; font-weight: 700; color: var(--text); }
+.stage__role { font-size: 12px; color: var(--muted); line-height: 1.5; }
+.stage__role b { color: var(--text); font-weight: 600; }
+.stage__cmd { margin: 2px 0; }
+.stage__row { font-size: 11px; line-height: 1.6; }
+.wsubs { margin: 4px 0 0; padding-left: 20px; font-family: var(--mono); font-size: 10.5px; color: var(--muted); }
+.wseam { font-family: var(--mono); font-size: 9.5px; color: var(--faint); border-top: 1px dashed var(--line); padding-top: 6px; line-height: 1.55; }
+
+/* panels grid (gates + rails side by side, stack on narrow) */
+.wgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 14px 0; }
+@media (max-width: 820px) { .wgrid { grid-template-columns: 1fr; } }
+.wpanel { border: 1px solid var(--line); background: var(--surface); padding: 13px 15px; margin-bottom: 14px; }
+.wpanel--seam { border-style: dashed; }
+.wpanel__hd { font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; color: var(--text); margin-bottom: 10px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.wpanel__sub { font-size: 11px; color: var(--muted); margin-bottom: 10px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+
+/* gate / rail rows */
+.gategrp { margin-bottom: 12px; }
+.gategrp__t { font-family: var(--mono); font-size: 9.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--faint); margin-bottom: 6px; }
+.grow { border: 1px solid var(--line); padding: 8px 10px; margin-bottom: 7px; display: grid; grid-template-columns: 1fr auto; gap: 6px 10px; align-items: center; }
+.grow--locked { opacity: .72; border-style: dashed; }
+.grow__main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.grow__meta { display: flex; align-items: center; gap: 6px; justify-self: end; flex-wrap: wrap; }
+.grow__cmd { grid-column: 1 / -1; }
+.gid { font-family: var(--mono); font-size: 11.5px; color: var(--text); }
+.glabel { font-size: 11px; color: var(--muted); }
+
+/* skills catalog */
+.sklist { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 6px; }
+.skrow { display: flex; align-items: center; gap: 7px; border: 1px solid var(--line); padding: 6px 9px; flex-wrap: wrap; }
+.skname { font-family: var(--mono); font-size: 11.5px; color: var(--text); }
+.hchip { font-family: var(--mono); font-size: 10px; padding: 1px 7px; border: 1px solid var(--line-2); }
+.hchip--on { color: var(--text); }
+.hchip--off { color: var(--faint); border-style: dashed; }
+
+/* profiles */
+.profrow { border-top: 1px solid var(--line); padding: 9px 0; }
+.profrow:first-of-type { border-top: none; }
+.profrow__hd { font-size: 12.5px; color: var(--text); margin-bottom: 4px; }
+.profrow__stages { font-family: var(--mono); font-size: 11px; color: var(--muted); margin-bottom: 5px; }
+.profrow__kw { line-height: 1.7; }
+
+/* tri-state control note + reserved follow-up surfaces */
+.wnote--tri { border-style: dashed; color: var(--muted); }
+.wbadge--tri { color: var(--faint); border-style: dotted; }
+.wbadge--soon { color: var(--faint); border-style: dashed; }
+.wgrid--3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 820px) { .wgrid--3 { grid-template-columns: 1fr; } }
+.wpanel--future { border-style: dashed; opacity: .82; }

--- a/web/dashboard/styles.css
+++ b/web/dashboard/styles.css
@@ -642,6 +642,7 @@ button:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
 .wnote { font-family: var(--mono); font-size: 11px; padding: 8px 11px; border: 1px solid var(--line); margin-bottom: 14px; color: var(--muted); }
 .wnote--warn { border-color: var(--text); color: var(--text); }
 .wnote--warn ul { margin: 6px 0 0; padding-left: 18px; }
+.wnote--ok { color: var(--muted); border-style: dashed; }
 
 /* honesty badges + tags */
 .wbadge { font-family: var(--mono); font-size: 9px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; padding: 1px 6px; border: 1px solid var(--line-2); color: var(--muted); white-space: nowrap; }
@@ -656,7 +657,7 @@ button:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
 .wtag--ev { border-style: dashed; }
 .wtag--art { color: var(--faint); }
 .wtag--kw { color: var(--faint); }
-.wtag--muted, .wtag--muted { color: var(--faint); border-style: dashed; opacity: .7; }
+.wtag--muted { color: var(--faint); border-style: dashed; opacity: .7; }
 
 /* copy-as-command chip */
 .cmdchip { display: inline-flex; align-items: center; gap: 8px; background: var(--surface-2); border: 1px solid var(--line-2); padding: 4px 9px; cursor: pointer; font-family: var(--mono); max-width: 100%; overflow: hidden; }
@@ -665,6 +666,7 @@ button:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
 .cmdchip__ico { color: var(--faint); font-size: 12px; }
 .cmdchip.copied { border-color: var(--text); }
 .cmdchip.copied .cmdchip__ico { color: var(--text); }
+.cmdchip__sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 
 /* stage rail */
 .stagerail { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 10px; margin: 12px 0 8px; }


### PR DESCRIPTION
## What

Turns the read-only Forge dashboard into a **control plane over the configurable workflow architecture** (Tier-1). The dashboard is a static `file://` SPA (no server), so "customize" = **copy-as-command**.

## Cockpit renders (one section per surface)

- **Chain** — 6-stage rail `plan → dev → validate → ship → review → verify` from `ROLE_IDS`; each card shows its `role → skill` binding, gates/evidence/artifacts (where a phase record exists), and `/plan`'s 5 sub-skills.
- **Gates + rails** — 4 stage gates + 3 human gates + `gate.issue_verify`, each enabled/**LOCKED** (locked greyed + why, mirroring `gate.js`); rails shown separately (all locked except `rail.kernel_tracking`). A tri-state control-state note (mandatory/optional/permission) reserves the richer target model.
- **Skills** — precedence winner (`.skills` > `skills` > packaged), `skills-lock` hash/source, per-harness SessionStart matrix (only Claude injects — honest).
- **Profiles × stage** + classification keywords, marked read-only/SEAM.
- **More surfaces** — reserved follow-up placeholders for **Hooks / MCP / Rules** so the north-star control plane slots in without a redesign.
- Honesty badges throughout (`customized` vs `default`, `fixed`, `locked`).

## Copy-as-command (Tier-1 write path)

Every configurable item renders its exact command with a copy button: `forge gate disable/enable <id>`, `forge role <stage> --use <skill>`. Flows through the existing `DataSource` seam so the Tier-2 server (#9f2f0320) drops in without render changes.

## Snapshot bake (`generate-snapshot.mjs`)

New point-in-time `snapshot.workflow`: resolved runtime graph, raw `.forge/config.yaml` (absent = all-defaults), PROFILES, skills catalog + lock + harness matrix, and `lintRuntimeGraphConfig` warnings.

## Honest SEAM

`review`/`verify` are **roles only** — the runtime graph exposes phase records for `plan/dev/validate/ship` only; their gates/evidence are not faked. HOOKS/MCP/RULES data is a follow-up (structure reserved).

## Verify

- Regenerated snapshot; asserted `workflow` fields in `data.json`. `node --check` clean.
- `bun test web/dashboard/app.test.js` — 21 pass (new pure-helper + snapshot-integrity tests).
- `eslint --max-warnings 0` clean; all new functions sonarjs cognitive-complexity < 15.
- Rendered over HTTP + Playwright: 6 stages, 8 gates + 6 rails, 15 copy-commands, 20 skills, 6 profiles, Hooks/MCP/Rules placeholders, tri-state badges.

Issue: `84970f9d-878c-4577-9000-adbceefc0128`
Epic: `363954dd-f6e1-4463-870c-c020c06db2aa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
