### PR TITLE
fix(preflight): close 3 residual fail-open holes in preflight gates (FU-B2)

### DIFF
--- a/lib/commands/preflight.js
+++ b/lib/commands/preflight.js
@@ -48,12 +48,29 @@ function gitVerifyRef(exec, ref) {
   }
 }
 
+/**
+ * True when `ref` resolves to the SAME commit as HEAD. Diffing HEAD against such
+ * a ref yields zero files, so it is never a usable integration base.
+ */
+function refEqualsHead(exec, ref) {
+  const refSha = gitTryOut(exec, ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`]);
+  if (!refSha) return false;
+  const headSha = gitTryOut(exec, ['rev-parse', '--verify', '--quiet', 'HEAD^{commit}']);
+  return !!headSha && refSha === headSha;
+}
+
 function resolveBaseRef(exec) {
   const originHead = gitTryOut(exec, ['rev-parse', '--abbrev-ref', 'origin/HEAD']);
   if (originHead && originHead !== 'origin/HEAD') return originHead;
 
+  // `@{upstream}` is the CURRENT branch's OWN remote-tracking ref. On a fully
+  // pushed feature branch it points AT HEAD, so diffing against it produces 0
+  // changed files and every gate passes vacuously (fail-OPEN). Accept it as a
+  // base only when it is a real integration point ahead of us — never when it
+  // resolves to our own HEAD. Fall through to a real base (origin/main, …) or
+  // FAIL if none exists, rather than manufacture a wrong-but-'resolved' base.
   const upstream = gitTryOut(exec, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}']);
-  if (upstream) return upstream;
+  if (upstream && !refEqualsHead(exec, upstream)) return upstream;
 
   for (const ref of ['origin/main', 'origin/master', 'main', 'master']) {
     if (gitVerifyRef(exec, ref)) return ref;

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -127,7 +127,17 @@ function getChangedFiles(execFileSync, options = {}) {
 			encoding: 'utf8',
 			timeout: 5000,
 		}).trim();
-	} catch (_e) { // NOSONAR S2486
+	} catch (err) { // NOSONAR S2486
+		// A git-diff FAILURE is NOT the same as "no files changed": we could not
+		// determine the change set at all. Callers that must fail closed (preflight)
+		// pass { strict: true } so the error surfaces instead of masquerading as an
+		// empty list. The default path keeps the historical empty-list fallback that
+		// `forge test --affected` and the pre-push mapping rely on to run the full
+		// suite, so their semantics are unchanged.
+		if (options.strict) {
+			const reason = err && err.message ? err.message : String(err);
+			throw new Error(`git diff failed while computing changed files: ${reason}`);
+		}
 		/* intentional: git diff failed, no affected files to report */
 		return [];
 	}

--- a/lib/preflight/gates.js
+++ b/lib/preflight/gates.js
@@ -158,7 +158,10 @@ function runAffectedTests({
 } = {}) {
   const resolver = typeof resolveTests === 'function'
     ? resolveTests
-    : () => getAffectedTestFiles(projectRoot, execFileSync, nodeFs);
+    // strict:true so a failed `git diff` THROWS here instead of returning [] —
+    // otherwise a git error would masquerade as "no affected tests" (fast-lane
+    // green), a fail-OPEN. The catch below turns that throw into a closed gate.
+    : () => getAffectedTestFiles(projectRoot, execFileSync, nodeFs, { strict: true });
   let targets;
   try {
     targets = resolver() || [];

--- a/lib/preflight/runner.js
+++ b/lib/preflight/runner.js
@@ -49,11 +49,20 @@ async function executeGate(gate) {
   }
   const durationMs = Date.now() - started;
   const skipped = !!outcome?.skipped;
+  // A skipped gate is a pass-through: it is neither a pass nor a failure, so it
+  // must never short-circuit later gates (see runGates fast-fail). BUT a skip
+  // must never MASK an explicit failure — a gate that reports {ok:false} has
+  // failed regardless of a skipped flag, so it stays failed and short-circuits.
+  const explicitOk = !!outcome?.ok;
+  const ok = skipped ? outcome?.ok !== false : explicitOk;
+  // Contract: an explicit ok:false can never normalize to a pass. Guards against
+  // a future edit reintroducing the skip-masks-failure bug (4b73b6bf).
+  if (outcome && outcome.ok === false && ok === true) {
+    throw new Error('executeGate contract violation: skipped must not override an explicit ok:false');
+  }
   return {
     name: gate.name,
-    // A skipped gate is a pass-through: it is neither a pass nor a failure, so
-    // it must never short-circuit later gates (see runGates fast-fail).
-    ok: skipped ? true : !!outcome?.ok,
+    ok,
     skipped,
     summary: outcome?.summary || '',
     durationMs,

--- a/test/commands/preflight.test.js
+++ b/test/commands/preflight.test.js
@@ -132,3 +132,47 @@ describe('resolveChangeSet — strict base detection (B2)', () => {
     expect(calls.some((c) => c.startsWith('diff --name-only abc123...HEAD'))).toBe(true);
   });
 });
+
+// 45a63715: a fully-pushed feature branch's own @{upstream} points AT HEAD, so
+// diffing against it yields 0 changed files and every gate passes vacuously.
+// resolveBaseRef must reject an upstream equal to our own HEAD and demand a real
+// integration base (origin/main, etc.) — or FAIL when none exists.
+describe('resolveBaseRef — reject own-upstream-at-HEAD (45a63715)', () => {
+  const { resolveBaseRef } = require('../../lib/commands/preflight');
+
+  // No origin/HEAD; @{upstream} = origin/feature which resolves to the SAME sha
+  // as HEAD (branch fully pushed). A real base (origin/main) exists.
+  function makeExec({ mainExists = true, headSha = 'deadbeef', upstreamSha = 'deadbeef' } = {}) {
+    return (_cmd, args) => {
+      const a = args.join(' ');
+      if (a.includes('origin/HEAD')) throw new Error('origin/HEAD not set');
+      if (a.includes('@{upstream}')) return 'origin/feature\n';
+      if (a.includes('origin/feature') && a.includes('rev-parse')) return `${upstreamSha}\n`;
+      if (a.startsWith('rev-parse') && a.includes('HEAD')) return `${headSha}\n`;
+      // rev-parse --verify --quiet <ref> for the fallback candidate list
+      if (a.includes('--verify') && a.includes('origin/main')) {
+        if (mainExists) return 'main-sha\n';
+        throw new Error('bad ref');
+      }
+      if (a.includes('--verify')) throw new Error('bad ref');
+      return '';
+    };
+  }
+
+  test('own upstream at HEAD is skipped in favor of a real integration base', () => {
+    const base = resolveBaseRef(makeExec({ mainExists: true }));
+    expect(base).not.toBe('origin/feature');
+    expect(base).toBe('origin/main');
+  });
+
+  test('own upstream at HEAD with NO real base resolves to null (fail-closed)', () => {
+    const base = resolveBaseRef(makeExec({ mainExists: false }));
+    expect(base).toBeNull();
+  });
+
+  test('an upstream AHEAD of HEAD (unpushed commits) is still a usable base', () => {
+    // upstream sha differs from HEAD → diffing it yields a real change set.
+    const base = resolveBaseRef(makeExec({ headSha: 'aaa', upstreamSha: 'bbb' }));
+    expect(base).toBe('origin/feature');
+  });
+});

--- a/test/commands/test.test.js
+++ b/test/commands/test.test.js
@@ -538,3 +538,60 @@ describe('forge test command', () => {
 		});
 	});
 });
+
+// bfaa6e2a: getChangedFiles/getAffectedTestFiles caught a failed `git diff` and
+// returned [] — indistinguishable from a legitimate "no files changed". On
+// preflight's DEFAULT resolver path that surfaced as a green fast-lane pass: a
+// real fail-OPEN. Under opt-in strict mode a git-diff FAILURE must throw so the
+// caller can fail closed. The default (no-strict) path MUST stay unchanged so
+// `forge test --affected` and the pre-push mapping keep falling back to the
+// full suite on an empty/failed diff.
+describe('getChangedFiles/getAffectedTestFiles — strict distinguishes ERROR from EMPTY (bfaa6e2a)', () => {
+	// exec that succeeds for ref resolution but THROWS on the actual `git diff`.
+	const gitDiffThrows = (cmd, args) => {
+		if (cmd === 'git' && args && args[0] === 'diff') {
+			throw new Error('fatal: bad revision');
+		}
+		return '';
+	};
+
+	test('DEFAULT: git diff failure returns [] (preserves forge test / pre-push semantics)', () => {
+		expect(testCommand.getChangedFiles(gitDiffThrows)).toEqual([]);
+		expect(
+			testCommand.getAffectedTestFiles('/fake/root', gitDiffThrows, makeFsStub()),
+		).toEqual([]);
+	});
+
+	test('STRICT: git diff failure THROWS (fail-closed) instead of masquerading as empty', () => {
+		expect(() => testCommand.getChangedFiles(gitDiffThrows, { strict: true })).toThrow();
+		expect(() => testCommand.getAffectedTestFiles(
+			'/fake/root', gitDiffThrows, makeFsStub(), { strict: true },
+		)).toThrow();
+	});
+
+	test('STRICT: a genuinely EMPTY diff (git succeeded, no changes) is NOT an error', () => {
+		const emptyDiff = makeExecFileSync({ gitDiffOutput: '' });
+		expect(testCommand.getChangedFiles(emptyDiff, { strict: true })).toEqual([]);
+		expect(testCommand.getAffectedTestFiles(
+			'/fake/root', emptyDiff, makeFsStub(), { strict: true },
+		)).toEqual([]);
+	});
+});
+
+// bfaa6e2a wiring: `forge test --affected` must NOT adopt strict mode — a git
+// failure there falls back to the full suite (safe), never crashes the command.
+describe('forge test --affected — resilient to git failure (bfaa6e2a semantics guard)', () => {
+	test('git diff failure falls back to the full suite, does not throw', async () => {
+		const spawnSpy = makeSpawnSync();
+		const result = await testCommand.handler([], { affected: true }, '/fake/root', {
+			fs: makeFsStub(),
+			execFileSync: (cmd, args) => {
+				if (cmd === 'git' && args && args[0] === 'diff') throw new Error('fatal: bad revision');
+				return '';
+			},
+			spawnSync: spawnSpy,
+		});
+		expect(result.success).toBe(true);
+		expect(spawnSpy.calls[0].args).toEqual(['run', 'test']);
+	});
+});

--- a/test/preflight/runner.test.js
+++ b/test/preflight/runner.test.js
@@ -75,3 +75,40 @@ describe('runGates — skipped outcome honored (B2)', () => {
     expect(line.startsWith('PASS')).toBe(false);
   });
 });
+
+// 4b73b6bf: `ok: skipped ? true : ...` coerced {ok:false, skipped:true} to a pass,
+// so a gate that reported BOTH skipped AND failed was silently treated green.
+// A skip must never mask an explicit failure.
+describe('runGates — skip must not mask an explicit ok:false (4b73b6bf)', () => {
+  test('{ok:false, skipped:true} stays a FAILURE (not coerced to pass)', async () => {
+    const gates = [
+      { name: 'x', run: async () => ({ ok: false, skipped: true, summary: 'boom' }) },
+    ];
+    const { ok, results } = await runGates(gates);
+    expect(ok).toBe(false);
+    expect(results[0].ok).toBe(false);
+  });
+
+  test('a failed-but-skipped gate still short-circuits later gates', async () => {
+    const ran = [];
+    const gates = [
+      { name: 'a', run: async () => ({ ok: false, skipped: true, summary: 'masked fail' }) },
+      { name: 'b', run: async () => { ran.push('b'); return { ok: true }; } },
+    ];
+    const { ok, results } = await runGates(gates);
+    expect(ok).toBe(false);
+    expect(ran).not.toContain('b');
+    expect(results[1].skipped).toBe(true);
+  });
+
+  test('a genuine skip (ok undefined) still passes through and does not short-circuit', async () => {
+    const ran = [];
+    const gates = [
+      { name: 'a', run: async () => ({ skipped: true, summary: 'n/a' }) },
+      { name: 'b', run: async () => { ran.push('b'); return { ok: true }; } },
+    ];
+    const { ok } = await runGates(gates);
+    expect(ok).toBe(true);
+    expect(ran).toContain('b');
+  });
+});


### PR DESCRIPTION
## Summary

Clears three fail-closed correctness residuals deferred by the B2 fail-closed work (#381), all in the preflight/gates area. Bundled per FU-B2. Kernel issues: **45a63715**, **4b73b6bf**, **bfaa6e2a** (children of beta epic 068374e5).

## The three fixes

### 1. bfaa6e2a (MED) — git-error masqueraded as "no affected tests" (fail-OPEN)
`getChangedFiles`/`getAffectedTestFiles` (`lib/commands/test.js`) caught a failed `git diff` and returned `[]` — indistinguishable from a legitimate "no files changed". On preflight's **default** affected-test resolver path this surfaced as a green fast-lane PASS. #381 added a fail-closed `try/catch` in `runAffectedTests`, but it was dead code because the error was swallowed downstream and never thrown.

**Fix:** opt-in `{ strict }` on `getChangedFiles` — a `git diff` **failure** throws; a genuinely empty diff still returns `[]`. Wired `strict: true` into the preflight resolver (`lib/preflight/gates.js`) so #381's catch is finally live and fails closed. `forge test --affected` and the pre-push mapping (`scripts/test.js`) call **without** strict, so they keep falling back to the full suite on an empty/failed diff — **semantics unchanged**.

### 2. 45a63715 (LOW) — own-upstream resolved as base → vacuous pass
`resolveBaseRef` (`lib/commands/preflight.js`) accepted `@{upstream}` even when it pointed **at HEAD** (a fully-pushed feature branch), giving 0 changed files and vacuously-passing gates.

**Fix:** reject an upstream whose commit equals HEAD; fall through to a real integration base (`origin/main`, …) or return `null` → FAIL. An upstream **ahead** of HEAD (unpushed commits) remains a usable base.

### 3. 4b73b6bf (LOW) — skip masked a failure
`executeGate` (`lib/preflight/runner.js`) `ok: skipped ? true : ...` coerced `{ok:false, skipped:true}` to `ok:true`.

**Fix:** a skip is a pass-through **only** when the gate did not also report `ok:false`; added a contract assert guarding against regression.

## Testing (TDD)
- Wrote failing tests first (5 RED), then implemented to green.
- Change-scoped suites fully green: `test/preflight/{runner,gates}.test.js`, `test/commands/{preflight,test}.test.js` — **70 pass, 0 fail**; plus related suites (scripts test-runner, push, validate, preflight variants) **97 pass, 0 fail**.
- `eslint --max-warnings 0` and the sonar-parity config both clean on all four changed files.
- Full `bun test` surfaces only **pre-existing environmental flakes** in unrelated files (`forge-cli-registry`, `forge-skills-pack`, `migrate-dry-run`, `setup-lefthook-repair`) — all infra failures (`not a git repository`, `ENOTCONN`, `EBUSY`, `/root`, 30s+ git-fixture timeouts), none touching the changed code. CI runs the full suite on Linux.

## `forge test` semantics
Confirmed unchanged — strict mode is opt-in; only preflight adopts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)