### PR TITLE
chore(release): OIDC Trusted Publishing + bump to 0.1.0-beta.2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,8 +60,16 @@ jobs:
       # Verify package contents before publishing (no build needed - pure JS package)
       - name: Verify package contents
         run: npm pack --dry-run
-      # Publish. A prerelease version (contains a hyphen, e.g. 0.1.0-beta.1) goes under the
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.x,
+      # so upgrade before publishing. This is what lets the workflow auth via OIDC
+      # instead of a long-lived NPM_TOKEN (which expires — see the beta.1 publish failure).
+      - name: Ensure OIDC-capable npm
+        run: npm install -g npm@latest && npm --version
+      # Publish. A prerelease version (contains a hyphen, e.g. 0.1.0-beta.2) goes under the
       # `beta` dist-tag so `npm install forge-workflow` keeps resolving the latest STABLE.
+      # Auth is npm Trusted Publishing (OIDC) via the `id-token: write` permission above —
+      # NO NODE_AUTH_TOKEN needed; the trusted-publisher config on npmjs.com authorizes this
+      # exact repo + workflow file.
       - name: Publish to npm
         run: |
           VERSION=$(node -p "require('./package.json').version")
@@ -71,5 +79,3 @@ jobs:
           else
             npm publish --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-beta.2] - 2026-07-15
+
+The **beta-blocker hardening wave** — Forge's advertised loop now composes end to end, its quality gates fail closed, its control surfaces describe themselves honestly, and the runtime is Beads-free. Every change below was adversarially reviewed before merge. (v0.1.0-beta.1 was tagged but never reached npm — its publish token had expired; this release switches to OIDC Trusted Publishing and is the first npm beta.)
+
+### Fixed
+
+- **`forge ship` is reachable from the pure CLI.** `plan`/`dev`/`validate`/`ship` persist and read workflow stage state in the Kernel (completion-gated at the enforcement chokepoint), so **any** agent driving the bare CLI reaches ship — previously the stage state was written only by a Claude-specific slash layer, so a non-Claude agent ran every stage green then dead-ended. `plan --issue <id>` links an existing issue instead of forking a duplicate; `--issue` with no value errors instead of creating one. (#380)
+- **Quality gates fail closed.** `forge validate` reports `SKIPPED` (never a silent `PASS`) on 0 tests; `forge preflight` fails on an unresolvable base instead of vacuously passing, and no longer runs Forge's own internal test files inside a consumer repo. Further preflight fail-open residuals closed. (#381, #386)
+- **`forge setup` installs real TDD enforcement — on the live path.** Native `.git/hooks` fallback when lefthook's binary is absent, honors `core.hooksPath`, writes real hook jobs (never the stock example), verifies hooks are active with a loud non-zero exit when they aren't, never resolves/writes hooks into an ancestor repo, and never clobbers a user's existing hook without a backup. (#382, #388)
+- npm publishing now authenticates via **Trusted Publishing (OIDC)** instead of a long-lived `NPM_TOKEN` (which had expired and silently failed the beta.1 publish).
+
+### Added
+
+- **`forge serve` shared-machine hardening.** Single-instance `serve.lock` (dead-PID reclaim), server state files created with restrictive permissions + a startup audit, and a hash-chained mutation journal verified at every startup. (#383)
+- **`forge control` — an honest tri-state control plane.** Set gates/rails `mandatory`/`optional`/`permission` over the **real resolver-enforced** config field (no parallel un-enforced key); refuses to "control" surfaces it can't enforce. Ships a state × enforcement-locus **guarantee matrix** and locus badges that state honestly what is run-time-enforced vs declared vs advisory. (#385)
+- **Surface-only, author-agnostic PR auto-monitor.** A GitHub Actions workflow that posts a single sticky summary of unresolved review threads (grouped by author — any review bot or human) + failing/pending checks; fail-closed on both halves, never merges and never posts a verdict. (#384)
+- Single-binary distribution (`bun build --compile`, checksum-verified install script) + an interactive local `forge serve` dashboard with a comment-back inbox. (#378, #379)
+
+### Changed
+
+- **Beads is retired from the runtime.** The default kernel-primary path touches no Beads — the unconditional bootstrap/health probes (and their "Beads-not-initialized" stderr noise) are gone. An opt-in `forge migrate` import/export is the only remaining Beads surface. (#387)
+
+### Known limitation (honest by design)
+
+- The *configurable* gate/rail registry is not yet consumed by a runtime deny — real quality enforcement today lives in the lefthook TDD pre-commit hook, fail-closed `validate`/`preflight`, and kernel stage-order/completion (all independent of the configurable flags). The `forge control` guarantee matrix documents exactly what each control does today; wiring the registry to those enforcement points is tracked for a later release.
+
 ## [0.1.0-beta.1] - 2026-07-09
 
 First public release (beta). Published under the npm `beta` dist-tag. The default issue backend changed from Beads to the built-in Kernel store, the Kernel's git-tracked JSONL portability loop now works end to end, and a pre-beta audit hardened the CLI surface, docs, and npm packaging.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-workflow",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "Local runtime control plane for AI-assisted engineering workflows, gates, evidence, and all AI agents",
   "bin": {
     "forge": "bin/forge.js",


### PR DESCRIPTION
## Problem
v0.1.0-beta.1 was tagged and GitHub-released, but the npm publish **failed with E404** — the `NPM_TOKEN` secret had expired (last successful publish was v0.0.10, ~3 months ago), and npm's package settings now require 2FA. So `forge-workflow@0.1.0-beta.1` never reached npm.

## Fix
Switch `.github/workflows/npm-publish.yml` to **npm Trusted Publishing (OIDC)** — no long-lived token to expire:
- Add `npm install -g npm@latest` (Trusted Publishing needs npm ≥ 11.5.1; Node 22 ships 10.x).
- Remove `NODE_AUTH_TOKEN`; auth now comes from the existing `id-token: write` OIDC exchange + the trusted-publisher config on npmjs.com (repo `harshanandak/forge`, workflow `npm-publish.yml`).

## Release
- Bump `package.json` 0.1.0-beta.1 → **0.1.0-beta.2** (the tag-matches-version guard requires this).
- Add the `[0.1.0-beta.2]` CHANGELOG: the beta-blocker hardening wave (B1–B6), Beads-runtime-free, the PR auto-monitor, and hook-safety.

## After merge
1. Configure the trusted publisher on npmjs.com (org `harshanandak`, repo `forge`, workflow `npm-publish.yml`, allow `npm publish`).
2. Cut `v0.1.0-beta.2` → OIDC publishes `forge-workflow@0.1.0-beta.2` under the `beta` dist-tag.

Workflow edit used the sanctioned `FORGE_PROTECTED_STATE_ALLOWED_SURFACES=workflows` affordance (gate ran + audited; no `--no-verify`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `forge setup`, hook hardening, serve/control monitoring, and pull request monitoring capabilities.
  - Added opt-in migration support and Trusted Publishing improvements.

- **Bug Fixes**
  - Improved CLI stage wiring and fail-closed quality checks.
  - Updated command output and clarified known limitations.

- **Release**
  - Published version `0.1.0-beta.2` with updated release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->