### PR TITLE
docs(install): use forge-workflow@beta so users get the current prerelease (F5)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -14,11 +14,15 @@ This guide gets Forge installed and visible to an AI coding agent without assumi
 
 ```bash
 # Bun
-bun add -D forge-workflow
+bun add -D forge-workflow@beta
 
 # npm
-npm install --save-dev forge-workflow
+npm install --save-dev forge-workflow@beta
 ```
+
+> **Note:** the current release is a **prerelease** published under the `beta`
+> dist-tag, so install with `@beta`. A bare `forge-workflow` resolves to the
+> older `latest` (stable) version.
 
 You can also run one-off commands with `bunx forge ...` (or `npx forge ...`).
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ actually works, and update it as you grow.
 
 ```bash
 # Add to your project
-bun add -D forge-workflow          # or: npm install --save-dev forge-workflow
+bun add -D forge-workflow@beta     # or: npm install --save-dev forge-workflow@beta
+# The current release is a prerelease under the `beta` dist-tag; a bare
+# `forge-workflow` resolves to the older stable `latest`.
 
 # Install for your agent(s) and configure the workflow
 bunx forge setup --agents claude --yes

--- a/docs/guides/SETUP.md
+++ b/docs/guides/SETUP.md
@@ -12,8 +12,11 @@ This guide covers supported Forge adoption paths. Use [Quickstart](../../QUICKST
 ## Install
 
 ```bash
-bun add -D forge-workflow
+bun add -D forge-workflow@beta
 ```
+
+> The current release is a prerelease under the `beta` dist-tag — install with
+> `@beta`. A bare `forge-workflow` resolves to the older stable `latest`.
 
 The package exposes `forge`, `forge-workflow`, and `forge-preflight`.
 


### PR DESCRIPTION
## Problem (beta-adoption feedback F5, kernel 6648a184)
A real user reported: `npm/bun add forge-workflow` (bare name, as our docs show) pulls **0.0.10** — the `latest` tag — because the current release **0.1.0-beta.2** is published only under the `beta` dist-tag. So everyone following QUICKSTART installs the *old* version.

## Fix
Update the user-facing install commands to `@beta` + a one-line note, in the three docs a new user follows:
- `QUICKSTART.md` (Bun + npm)
- `README.md` (install line)
- `docs/guides/SETUP.md`

Docs-only, no code. Leaves `latest` where it is (correct — beta shouldn't be the default install for a prerelease).