### PR TITLE
fix(plan): create feature branch without switching shared checkout HEAD (aa14966c)

### DIFF
--- a/lib/commands/plan.js
+++ b/lib/commands/plan.js
@@ -659,7 +659,10 @@ async function createKernelIssue(featureName, researchPath, scope, options = {})
 
 /**
  * Create feature branch
- * Creates and checks out a new git branch following feat/<slug> convention
+ * Creates a new git branch following feat/<slug> convention WITHOUT switching
+ * the shared checkout's HEAD (uses `git branch`, not `git checkout -b`).
+ * Switching HEAD in the shared working tree corrupts concurrent agents
+ * (kernel issue aa14966c); isolated work happens in a dedicated worktree.
  *
  * Security: Uses execFileSync with array args to prevent command injection
  *
@@ -695,8 +698,13 @@ function createFeatureBranch(featureSlug) {
 			// Branch doesn't exist, continue (expected case)
 		}
 
-		// Create and checkout branch
-		execFileSync('git', ['checkout', '-b', branchName], getExecOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
+		// Create the branch WITHOUT switching the shared checkout's HEAD.
+		// Historically this used `git checkout -b`, which flipped the shared
+		// working tree onto the new branch and corrupted concurrent agents
+		// (kernel issue aa14966c). `git branch` creates the ref at the current
+		// HEAD without touching the working tree; isolated work happens in a
+		// dedicated worktree (`forge worktree create`), never the shared tree.
+		execFileSync('git', ['branch', branchName], getExecOptions());  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
 
 		return {
 			success: true,

--- a/lib/commands/plan.js
+++ b/lib/commands/plan.js
@@ -692,7 +692,7 @@ function createFeatureBranch(featureSlug) {
 			execFileSync('git', ['rev-parse', '--verify', branchName], { ...getExecOptions(), stdio: 'pipe' });  // NOSONAR S4036 - hardcoded CLI command, no user input, developer tool context
 			return {
 				success: false,
-				error: `Branch ${branchName} already exists\n\nSwitch to it with: git checkout ${branchName}`,
+				error: `Branch ${branchName} already exists\n\nWork on it in an isolated checkout: forge worktree create ${featureSlug}\n(or, working solo: git switch ${branchName})`,
 			};
 		} catch {
 			// Branch doesn't exist, continue (expected case)
@@ -1085,6 +1085,12 @@ async function executePlan(featureName, options = {}) { // NOSONAR S3776
 			beadsIssueId: issue.issueId,
 			branchName: branch.branchName,
 			linked: Boolean(explicitIssueId),
+			// A FRESH branch was created (HEAD did NOT move — aa14966c). Stage
+			// commands resolve the CHECKED-OUT branch, so the user must enter an
+			// isolated checkout on this branch before /dev, or stage state resolves
+			// against the default branch (no linkage → ship dead-ends). When the
+			// branch was reused, HEAD is already on it and /dev works directly.
+			branchCreated: !branch.reused,
 			summary: explicitIssueId
 				? `Plan linked to existing issue ${issue.issueId} (${scope.type} scope)`
 				: `Plan created for ${featureName} (${scope.type} scope)`,
@@ -1123,7 +1129,20 @@ module.exports = {
 		const lines = [`${header}: ${result.summary || result.branchName || featureName}`];
 		if (result.issueId) lines.push(`${issueBackendLabel(result.issueBackend)}: ${result.issueId}`);
 		if (result.branchName) lines.push(`Branch: ${result.branchName}`);
-		if (result.nextCommand) lines.push(`Next: ${result.nextCommand}`);
+		if (result.branchCreated) {
+			// A fresh branch was created but HEAD was NOT switched (aa14966c). Stage
+			// commands (/dev, /validate, /ship) resolve the CHECKED-OUT branch — from
+			// the shared tree that is still the default branch, which has no
+			// branch->issue linkage, so ship would dead-end. Direct the user into an
+			// isolated checkout on the new branch first.
+			const slug = String(result.branchName).replace(/^feat\//, '');
+			lines.push('Next: work on this branch in an isolated checkout (HEAD stays put in the shared tree):');
+			lines.push(`  forge worktree create ${slug}    # concurrent-safe; checks out the existing ${result.branchName}`);
+			lines.push(`  # or, working solo:  git switch ${result.branchName}`);
+			lines.push(`Then run ${result.nextCommand || '/dev'} from that checkout.`);
+		} else if (result.nextCommand) {
+			lines.push(`Next: ${result.nextCommand}`);
+		}
 
 		return {
 			...result,

--- a/test/commands/plan-branch-isolation.test.js
+++ b/test/commands/plan-branch-isolation.test.js
@@ -1,0 +1,61 @@
+// Regression test for kernel issue aa14966c:
+// A Forge process must NEVER switch the shared checkout's HEAD branch.
+// `/plan` (executePlan -> createFeatureBranch) previously ran `git checkout -b`,
+// which flipped the shared working tree onto feat/<slug>, corrupting concurrent
+// agents. createFeatureBranch must create the branch WITHOUT switching HEAD.
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { createFeatureBranch } = require('../../lib/commands/plan.js');
+
+const nodeFs = require('node:fs');
+const nodeOs = require('node:os');
+const nodePath = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+function git(cwd, args) {
+	return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+}
+
+function currentBranch(cwd) {
+	return git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+}
+
+describe('createFeatureBranch — shared-checkout HEAD isolation (aa14966c)', () => {
+	let repoDir;
+	let originalCwd;
+
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		repoDir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'forge-headbug-'));
+		git(repoDir, ['init', '-b', 'master']);
+		git(repoDir, ['config', 'user.email', 'test@example.com']);
+		git(repoDir, ['config', 'user.name', 'Test']);
+		nodeFs.writeFileSync(nodePath.join(repoDir, 'README.md'), '# test\n');
+		git(repoDir, ['add', '.']);
+		git(repoDir, ['commit', '-m', 'initial']);
+		// createFeatureBranch resolves cwd via process.cwd()
+		process.chdir(repoDir);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		nodeFs.rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	test('creates the branch but leaves the shared checkout HEAD on master', () => {
+		const before = currentBranch(repoDir);
+		expect(before).toBe('master');
+
+		const result = createFeatureBranch('head-isolation-demo');
+
+		expect(result.success).toBe(true);
+		expect(result.branchName).toBe('feat/head-isolation-demo');
+
+		// The branch must now exist...
+		const branches = git(repoDir, ['branch', '--list', 'feat/head-isolation-demo']);
+		expect(branches).toContain('feat/head-isolation-demo');
+
+		// ...but the shared working tree must STILL be on master (no HEAD flip).
+		expect(currentBranch(repoDir)).toBe('master');
+	});
+});

--- a/test/commands/plan-branch-isolation.test.js
+++ b/test/commands/plan-branch-isolation.test.js
@@ -1,23 +1,69 @@
-// Regression test for kernel issue aa14966c:
-// A Forge process must NEVER switch the shared checkout's HEAD branch.
-// `/plan` (executePlan -> createFeatureBranch) previously ran `git checkout -b`,
-// which flipped the shared working tree onto feat/<slug>, corrupting concurrent
-// agents. createFeatureBranch must create the branch WITHOUT switching HEAD.
+// Regression tests for kernel issue aa14966c + the composed plan-first flow.
+//
+// 1. HEAD isolation: a Forge process must NEVER switch the shared checkout's
+//    HEAD. `/plan` (executePlan -> createFeatureBranch) previously ran
+//    `git checkout -b`, which flipped the shared working tree onto feat/<slug>,
+//    corrupting concurrent agents. createFeatureBranch must create the branch
+//    WITHOUT switching HEAD.
+//
+// 2. Reachability: because HEAD does NOT move, the branch->issue linkage plan
+//    registers for feat/<slug> is only reachable from a checkout whose HEAD is
+//    ON feat/<slug> (an isolated worktree, or a solo `git switch`). This test
+//    derives the branch from HEAD the way the CLI does (detectWorktree, which
+//    detectBranchName wraps) and drives the REAL enforce-stage reader
+//    (resolveActiveIssueId) — it does NOT inject `branch:` explicitly. From the
+//    shared tree (HEAD on master) resolution is null (the ship dead-end); from a
+//    worktree on feat/<slug> it resolves the issue (ship reachable).
+//
+// 3. Guidance: when plan creates a fresh branch it must tell the user to enter
+//    an isolated checkout before stage commands — never a bare "Next: /dev" that
+//    would run /dev from master.
 
 const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
-const { createFeatureBranch } = require('../../lib/commands/plan.js');
+const {
+	createFeatureBranch,
+	registerBranchIssueLinkage,
+	handler,
+} = require('../../lib/commands/plan.js');
+const { resolveActiveIssueId } = require('../../lib/workflow/enforce-stage.js');
+const { detectWorktree } = require('../../lib/detect-worktree.js');
 
 const nodeFs = require('node:fs');
 const nodeOs = require('node:os');
 const nodePath = require('node:path');
 const { execFileSync } = require('node:child_process');
 
+const GIT_ENV = {
+	...process.env,
+	GIT_AUTHOR_NAME: 'test',
+	GIT_AUTHOR_EMAIL: 'test@example.com',
+	GIT_COMMITTER_NAME: 'test',
+	GIT_COMMITTER_EMAIL: 'test@example.com',
+};
+
 function git(cwd, args) {
-	return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+	return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe', env: GIT_ENV }).trim();
 }
 
-function currentBranch(cwd) {
-	return git(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+function initRepo() {
+	const dir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'forge-headbug-'));
+	git(dir, ['init', '-b', 'master']);
+	git(dir, ['config', 'user.email', 'test@example.com']);
+	git(dir, ['config', 'user.name', 'Test']);
+	nodeFs.writeFileSync(nodePath.join(dir, 'README.md'), '# test\n');
+	git(dir, ['add', '.']);
+	git(dir, ['commit', '-m', 'initial']);
+	return dir;
+}
+
+// In-memory stand-in for the kernel worktree registry: the same shape plan
+// writes (registerWorktree) and enforce-stage reads (listWorktrees, newest first).
+function makeRegistryDriver() {
+	const rows = [];
+	return {
+		registerWorktree(row) { rows.unshift(row); },
+		listWorktrees() { return rows; },
+	};
 }
 
 describe('createFeatureBranch — shared-checkout HEAD isolation (aa14966c)', () => {
@@ -26,15 +72,8 @@ describe('createFeatureBranch — shared-checkout HEAD isolation (aa14966c)', ()
 
 	beforeEach(() => {
 		originalCwd = process.cwd();
-		repoDir = nodeFs.mkdtempSync(nodePath.join(nodeOs.tmpdir(), 'forge-headbug-'));
-		git(repoDir, ['init', '-b', 'master']);
-		git(repoDir, ['config', 'user.email', 'test@example.com']);
-		git(repoDir, ['config', 'user.name', 'Test']);
-		nodeFs.writeFileSync(nodePath.join(repoDir, 'README.md'), '# test\n');
-		git(repoDir, ['add', '.']);
-		git(repoDir, ['commit', '-m', 'initial']);
-		// createFeatureBranch resolves cwd via process.cwd()
-		process.chdir(repoDir);
+		repoDir = initRepo();
+		process.chdir(repoDir); // createFeatureBranch resolves cwd via process.cwd()
 	});
 
 	afterEach(() => {
@@ -43,8 +82,7 @@ describe('createFeatureBranch — shared-checkout HEAD isolation (aa14966c)', ()
 	});
 
 	test('creates the branch but leaves the shared checkout HEAD on master', () => {
-		const before = currentBranch(repoDir);
-		expect(before).toBe('master');
+		expect(git(repoDir, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe('master');
 
 		const result = createFeatureBranch('head-isolation-demo');
 
@@ -52,10 +90,97 @@ describe('createFeatureBranch — shared-checkout HEAD isolation (aa14966c)', ()
 		expect(result.branchName).toBe('feat/head-isolation-demo');
 
 		// The branch must now exist...
-		const branches = git(repoDir, ['branch', '--list', 'feat/head-isolation-demo']);
-		expect(branches).toContain('feat/head-isolation-demo');
+		expect(git(repoDir, ['branch', '--list', 'feat/head-isolation-demo']))
+			.toContain('feat/head-isolation-demo');
 
 		// ...but the shared working tree must STILL be on master (no HEAD flip).
-		expect(currentBranch(repoDir)).toBe('master');
+		expect(git(repoDir, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe('master');
+	});
+});
+
+describe('plan-first reachability — branch derived from HEAD (aa14966c composition)', () => {
+	let repoDir;
+	let wtDir;
+	let originalCwd;
+
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		repoDir = initRepo();
+		process.chdir(repoDir);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		if (wtDir) nodeFs.rmSync(wtDir, { recursive: true, force: true });
+		nodeFs.rmSync(repoDir, { recursive: true, force: true });
+		wtDir = undefined;
+	});
+
+	test('linkage is unreachable from master (dead-end) but reachable from a worktree on feat/<slug>', async () => {
+		const driver = makeRegistryDriver();
+		const ISSUE_ID = 'kernel-reach-1';
+
+		// Simulate `/plan`: create the branch (HEAD stays on master) and register
+		// the branch->issue linkage exactly as executePlan does.
+		const branch = createFeatureBranch('head-reach-demo');
+		expect(branch.success).toBe(true);
+		await registerBranchIssueLinkage({ projectRoot: repoDir, driver }, branch.branchName, ISSUE_ID);
+
+		// The CLI derives the branch from HEAD (detectWorktree == detectBranchName's
+		// source). From the shared tree HEAD is master → NO linkage row → null.
+		// This is the exact ship dead-end the honest next-step guidance prevents.
+		const branchFromSharedTree = detectWorktree(repoDir).branch;
+		expect(branchFromSharedTree).toBe('master');
+		expect(await resolveActiveIssueId(driver, branchFromSharedTree)).toBeNull();
+
+		// Follow the honest next step: enter an isolated worktree ON feat/<slug>.
+		wtDir = nodePath.join(nodePath.dirname(repoDir), `${nodePath.basename(repoDir)}-wt`);
+		git(repoDir, ['worktree', 'add', wtDir, branch.branchName]);
+
+		// Now the CLI-derived branch is feat/<slug> and resolution reaches the issue
+		// → /dev, /validate, /ship resolve authoritative state (no null dead-end).
+		const branchFromWorktree = detectWorktree(wtDir).branch;
+		expect(branchFromWorktree).toBe('feat/head-reach-demo');
+		expect(await resolveActiveIssueId(driver, branchFromWorktree)).toBe(ISSUE_ID);
+	});
+});
+
+describe('plan guidance — fresh branch must direct into an isolated checkout', () => {
+	let originalCwd;
+	let repoDir;
+	let prevBackend;
+
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		repoDir = initRepo();
+		nodeFs.mkdirSync(nodePath.join(repoDir, 'docs', 'research'), { recursive: true });
+		nodeFs.writeFileSync(
+			nodePath.join(repoDir, 'docs', 'research', 'head-guidance-demo.md'),
+			'# Head Guidance Demo\n\n**Timeline**: 2 hours\n**Strategic/Tactical**: Tactical\n',
+		);
+		prevBackend = process.env.FORGE_ISSUE_BACKEND;
+		delete process.env.FORGE_ISSUE_BACKEND; // default resolver → kernel
+		process.chdir(repoDir);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		if (prevBackend === undefined) delete process.env.FORGE_ISSUE_BACKEND;
+		else process.env.FORGE_ISSUE_BACKEND = prevBackend;
+		nodeFs.rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	test('output points into a worktree / git switch, not a bare "Next: /dev" from master', async () => {
+		const fakeRun = async () => ({ ok: true, command: 'issue.create', data: { id: 'kernel-guid-1' }, next_commands: [] });
+
+		const result = await handler(['head guidance demo'], {}, repoDir, { runIssueOperation: fakeRun });
+
+		expect(result.success).toBe(true);
+		expect(result.branchCreated).toBe(true);
+		// Honest next step: enter isolation on the created branch before stage cmds.
+		expect(result.output).toContain('forge worktree create head-guidance-demo');
+		expect(result.output).toContain('git switch feat/head-guidance-demo');
+		// It must NOT tell the user to just run /dev from the current (master) tree.
+		expect(result.output).not.toContain('Next: /dev');
 	});
 });


### PR DESCRIPTION
## Summary
`createFeatureBranch` used `git checkout -b`, which flipped the **shared** working tree onto `feat/<slug>`. With concurrent agents in the main checkout this switched HEAD mid-task, so commits landed on the wrong branch (kernel issue `aa14966c`). Now uses `git branch` to create the ref at current HEAD **without touching the working tree**; isolated work happens in a dedicated worktree.

## Test
Adds a regression test asserting the shared checkout HEAD stays put. Full pre-push suite green (tests 134s).

Refs: aa14966c-6fcb-42e5-bd54-44ea851db703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a feature branch no longer switches the current working tree’s branch, preventing disruption to ongoing work in shared environments.
  * Branches are now created safely while preserving the existing checkout state.

* **Tests**
  * Added regression coverage to verify branch creation and ensure the current branch remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->