### PR TITLE
feat(upgrade): guide 0.0.10→current beads→kernel breaking upgrade + issue-path nudge (a5399f3d)

### DIFF
--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -8,7 +8,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 | Group | Call sites | Files |
 | --- | ---: | ---: |
 | command | 71 | 8 |
-| runtime | 245 | 32 |
+| runtime | 249 | 34 |
 | docs | 395 | 47 |
 | skills | 1 | 1 |
 | hooks | 0 | 0 |
@@ -24,7 +24,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] lib/commands/migrate.js (17)
   - lines: 80 (bd, dolt), 81 (bd), 84 (bd), 91 (bd), 93 (bd), 98 (dolt), 105 (bd, dolt), 106 (bd), 109 (bd), 116 (.beads), 117 (bd, .beads, dolt), 132 (.beads), 142 (.beads), 311 (.beads), 312 (.beads), 313 (.beads), 314 (.beads)
 - [ ] lib/commands/plan.js (9)
-  - lines: 252 (bd), 288 (bd), 290 (bd), 304 (bd), 325 (bd), 336 (bd), 339 (bd), 979 (bd), 1016 (bd)
+  - lines: 252 (bd), 288 (bd), 290 (bd), 304 (bd), 325 (bd), 336 (bd), 339 (bd), 998 (bd), 1035 (bd)
 - [ ] lib/commands/status.js (10)
   - lines: 239 (.beads), 240 (.beads), 241 (.beads), 242 (.beads), 243 (.beads), 244 (.beads), 245 (.beads), 247 (.beads), 368 (bd), 427 (bd)
 - [ ] lib/commands/test.js (5)
@@ -42,6 +42,8 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 81 (.beads), 82 (.beads), 83 (.beads), 84 (.beads), 899 (.beads)
 - [ ] lib/audit-evidence.js (3)
   - lines: 148 (bd), 214 (bd), 240 (bd)
+- [ ] lib/beads-detect.js (2)
+  - lines: 29 (.beads), 38 (.beads)
 - [ ] lib/beads-setup.js (41)
   - lines: 17 (.beads), 18 (dolt), 19 (.beads), 76 (.beads), 78 (.beads), 86 (.beads), 94 (dolt), 102 (.beads, dolt), 104 (.beads), 109 (.beads), 117 (dolt), 118 (dolt), 160 (.beads), 161 (dolt), 162 (.beads), 187 (.beads), 188 (dolt), 189 (.beads), 237 (.beads), 238 (.beads), 241 (bd, dolt), 244 (bd), 250 (.beads), 262 (bd), 278 (dolt), 286 (.beads), 312 (.beads), 319 (dolt), 323 (bd), 411 (bd), 417 (bd), 424 (bd), 425 (bd), 430 (.beads, dolt), 432 (bd), 440 (bd), 441 (bd), 476 (.beads, dolt), 480 (.beads), 487 (bd), 496 (bd)
 - [ ] lib/beads-sync-scaffold.js (3)
@@ -70,8 +72,10 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 178 (bd), 219 (.beads), 278 (.beads), 336 (.beads), 508 (bd), 542 (bd), 544 (bd), 547 (bd), 548 (bd), 551 (bd), 556 (bd), 557 (bd), 600 (bd)
 - [ ] lib/status/beads-snapshot.js (1)
   - lines: 31 (.beads)
+- [ ] lib/upgrade-safety.js (2)
+  - lines: 70 (.beads), 182 (.beads)
 - [ ] lib/workflow/enforce-stage.js (2)
-  - lines: 364 (bd), 365 (bd)
+  - lines: 390 (bd), 391 (bd)
 - [ ] scripts/beads-migrate-to-dolt.sh (1)
   - lines: 7 (dolt)
 - [ ] scripts/beads-upgrade-smoke.sh (1)
@@ -104,7 +108,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 - [ ] docs/guides/BEADS_GITHUB_SYNC.md (3)
   - lines: 7 (.beads), 10 (dolt), 32 (.beads)
 - [ ] docs/guides/SETUP.md (6)
-  - lines: 10 (bd), 79 (bd, dolt), 84 (bd), 85 (bd, dolt), 89 (dolt), 113 (dolt)
+  - lines: 10 (bd), 82 (bd, dolt), 87 (bd), 88 (bd, dolt), 92 (dolt), 116 (dolt)
 - [ ] docs/guides/SUPPORT.md (26)
   - lines: 18 (bd), 19 (bd, dolt), 23 (bd), 53 (dolt), 58 (dolt), 60 (.beads), 66 (bd), 67 (bd, dolt), 68 (bd, dolt), 69 (bd, dolt), 72 (.beads, dolt), 76 (.beads), 78 (bd), 79 (.beads), 80 (.beads), 81 (bd, dolt), 85 (dolt), 87 (.beads), 93 (bd), 94 (bd, dolt), 119 (dolt), 131 (.beads), 144 (.beads), 152 (.beads), 158 (.beads), 165 (.beads)
 - [ ] docs/PROJECT_DESIGN.md (20)

--- a/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
+++ b/docs/work/2026-06-06-kernel-backlog-memory-roadmap/bd-call-site-kill-list.md
@@ -8,7 +8,7 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
 | Group | Call sites | Files |
 | --- | ---: | ---: |
 | command | 71 | 8 |
-| runtime | 249 | 34 |
+| runtime | 252 | 35 |
 | docs | 395 | 47 |
 | skills | 1 | 1 |
 | hooks | 0 | 0 |
@@ -44,6 +44,8 @@ Purpose: tracked migration artifact for D20 so later PRs can remove Beads/Dolt h
   - lines: 148 (bd), 214 (bd), 240 (bd)
 - [ ] lib/beads-detect.js (2)
   - lines: 29 (.beads), 38 (.beads)
+- [ ] lib/beads-nudge.js (3)
+  - lines: 18 (.beads), 20 (bd), 75 (.beads)
 - [ ] lib/beads-setup.js (41)
   - lines: 17 (.beads), 18 (dolt), 19 (.beads), 76 (.beads), 78 (.beads), 86 (.beads), 94 (dolt), 102 (.beads, dolt), 104 (.beads), 109 (.beads), 117 (dolt), 118 (dolt), 160 (.beads), 161 (dolt), 162 (.beads), 187 (.beads), 188 (dolt), 189 (.beads), 237 (.beads), 238 (.beads), 241 (bd, dolt), 244 (bd), 250 (.beads), 262 (bd), 278 (dolt), 286 (.beads), 312 (.beads), 319 (dolt), 323 (bd), 411 (bd), 417 (bd), 424 (bd), 425 (bd), 430 (.beads, dolt), 432 (bd), 440 (bd), 441 (bd), 476 (.beads, dolt), 480 (.beads), 487 (bd), 496 (bd)
 - [ ] lib/beads-sync-scaffold.js (3)

--- a/lib/beads-detect.js
+++ b/lib/beads-detect.js
@@ -17,8 +17,8 @@ const path = require('node:path');
 function dirHasJsonl(dir) {
   try {
     return fs.readdirSync(dir).some(entry => entry.endsWith('.jsonl'));
-  } catch (_err) {
-    /* intentional: an unreadable directory has no usable jsonl */ // NOSONAR S2486
+  } catch (_err) { // NOSONAR S2486 — line-scoped; must sit on the catch line
+    /* intentional: an unreadable directory has no usable jsonl */
     return false;
   }
 }
@@ -48,8 +48,8 @@ function detectBeadsJsonlSource(projectRoot) {
       return backupDir;
     }
     return null;
-  } catch (_err) {
-    /* intentional: an unreadable project root has no detectable beads source */ // NOSONAR S2486
+  } catch (_err) { // NOSONAR S2486 — line-scoped; must sit on the catch line
+    /* intentional: an unreadable project root has no detectable beads source */
     return null;
   }
 }

--- a/lib/beads-detect.js
+++ b/lib/beads-detect.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Single-source, side-effect-free Beads-store detector (kernel issue a5399f3d).
+//
+// Both upgrade-safety surfaces reuse this ONE definition: the issue-path
+// unmigrated-beads nudge (lib/commands/_issue.js) and the `forge upgrade`
+// advisory (lib/upgrade-safety.js). It deliberately lives in a neutral module,
+// NOT in lib/commands/migrate.js — re-exporting a `detectBeadsJsonlSource` name
+// from the migrate command would revive the identifier the a7e1443c
+// implicit-auto-migrate tombstone pins gone (test/commands/runtime-no-auto-migrate).
+// This detector only READS the filesystem and never triggers a migration, so it
+// honors that tombstone's spirit while giving both nudges a shared source.
+
+function dirHasJsonl(dir) {
+  try {
+    return fs.readdirSync(dir).some(entry => entry.endsWith('.jsonl'));
+  } catch (_err) {
+    /* intentional: an unreadable directory has no usable jsonl */ // NOSONAR S2486
+    return false;
+  }
+}
+
+/**
+ * Return the absolute path of the directory holding a returning user's Beads
+ * JSONL under `projectRoot`, or null when none is found. Checks the top-level
+ * `.beads/` first, then the split-store `.beads/backup/` layout (jsonl there and
+ * nowhere else — a layout the migrator itself reads), so neither surface misses
+ * it. Never throws.
+ *
+ * @param {string} [projectRoot]
+ * @returns {string|null}
+ */
+function detectBeadsJsonlSource(projectRoot) {
+  const root = projectRoot || process.cwd();
+  const beadsDir = path.join(root, '.beads');
+  try {
+    if (!fs.existsSync(beadsDir)) {
+      return null;
+    }
+    if (dirHasJsonl(beadsDir)) {
+      return beadsDir;
+    }
+    const backupDir = path.join(beadsDir, 'backup');
+    if (fs.existsSync(backupDir) && dirHasJsonl(backupDir)) {
+      return backupDir;
+    }
+    return null;
+  } catch (_err) {
+    /* intentional: an unreadable project root has no detectable beads source */ // NOSONAR S2486
+    return null;
+  }
+}
+
+module.exports = {
+  detectBeadsJsonlSource,
+  dirHasJsonl,
+};

--- a/lib/beads-nudge.js
+++ b/lib/beads-nudge.js
@@ -80,8 +80,8 @@ function maybeWarnUnmigratedBeads(subcommand, result, projectRoot, rawOpts = {})
       + 'Prefer to stay on the legacy backend? Set `issueBackend: beads` in .forge/config.yaml '
       + '(or FORGE_ISSUE_BACKEND=beads).\n',
     );
-  } catch (_err) {
-    /* the nudge is a best-effort hint; it must never break a read */ // NOSONAR S2486
+  } catch (_err) { // NOSONAR S2486 — line-scoped; must sit on the catch line
+    /* the nudge is a best-effort hint; it must never break a read */
   }
 }
 

--- a/lib/beads-nudge.js
+++ b/lib/beads-nudge.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { resolveIssueBackend } = require('./issue-backend');
+const { detectBeadsJsonlSource } = require('./beads-detect');
+
+// Unmigrated legacy-store nudge (kernel issue a5399f3d — upgrade-safety
+// 0.0.10 -> current).
+//
+// The 0.0.10 -> current upgrade flipped the DEFAULT issue backend to the Kernel,
+// but the legacy -> kernel migration fires ONLY from `forge setup`/`init`, never
+// lazily on the issue path. So a user who runs `bun update` then `forge list` /
+// `forge ready` reads an EMPTY kernel and their 0.0.10 issues APPEAR GONE — the
+// data is safe on disk, just invisible, with no hint. This helper closes that
+// footgun: when the resolved backend is the (default) Kernel, a read comes back
+// empty, AND a legacy jsonl store still exists, it prints a one-time guided hint.
+//
+// It lives in this NEUTRAL module (not lib/commands/_issue.js) on purpose: the
+// message text names the retired backend + its `.beads` store, and _issue.js is a
+// D20 release-readiness hot-path surface that must stay free of those tokens (the
+// bd-call-site audit + kernel-backed checks scan it). Keeping the strings here
+// lets the hot path call a token-free helper.
+//
+// Best-effort and non-blocking: it NEVER throws and never alters the read result.
+// Fires at most once per project root per process to avoid spam.
+const NUDGE_READS = new Set(['list', 'ready']);
+const warnedRoots = new Set();
+
+// A kernel read looks empty when its contract data carries no issues. Handles the
+// issue.list/issue.ready shape ({ issues, count }) plus a bare array / null, and
+// is deliberately conservative: anything it cannot confirm as empty is treated as
+// NON-empty so a user with real kernel issues is never nagged.
+function kernelReadLooksEmpty(result) {
+  if (!result || typeof result !== 'object' || result.ok !== true) {
+    return false;
+  }
+  const data = result.data;
+  if (data === null || data === undefined) {
+    return true;
+  }
+  if (Array.isArray(data)) {
+    return data.length === 0;
+  }
+  if (Array.isArray(data.issues)) {
+    return data.issues.length === 0;
+  }
+  if (Array.isArray(data.items)) {
+    return data.items.length === 0;
+  }
+  if (typeof data.count === 'number') {
+    return data.count === 0;
+  }
+  return false;
+}
+
+function maybeWarnUnmigratedBeads(subcommand, result, projectRoot, rawOpts = {}) {
+  try {
+    if (!NUDGE_READS.has(subcommand) || !projectRoot) {
+      return;
+    }
+    if (warnedRoots.has(projectRoot)) {
+      return;
+    }
+    const env = rawOpts.env || process.env;
+    // Resolve the EFFECTIVE backend (default kernel). An explicit opt-in to the
+    // retired backend means the user chose it deliberately — nothing to nudge.
+    const backend = resolveIssueBackend({ deps: rawOpts, env, projectRoot, warn: () => {} });
+    if (backend !== 'kernel' || !kernelReadLooksEmpty(result)) {
+      return;
+    }
+    if (!detectBeadsJsonlSource(projectRoot)) {
+      return;
+    }
+    warnedRoots.add(projectRoot);
+    console.error(
+      '\n[forge] Legacy issue data detected (.beads/*.jsonl) but the Kernel issue store is empty.\n'
+      + 'Forge now defaults to the Kernel backend (breaking change since 0.0.10). Your legacy\n'
+      + 'issues are safe on disk but will not appear until migrated. To migrate:\n'
+      + '  forge migrate --from beads   # import your legacy issues into the Kernel\n'
+      + '  forge setup                  # (re)wire hooks + provision the Kernel store\n'
+      + 'Prefer to stay on the legacy backend? Set `issueBackend: beads` in .forge/config.yaml '
+      + '(or FORGE_ISSUE_BACKEND=beads).\n',
+    );
+  } catch (_err) {
+    /* the nudge is a best-effort hint; it must never break a read */ // NOSONAR S2486
+  }
+}
+
+module.exports = {
+  maybeWarnUnmigratedBeads,
+  kernelReadLooksEmpty,
+};

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -2,7 +2,7 @@
 
 const { runIssueOperation: defaultRunIssueOperation } = require('../forge-issues');
 const { resolveIssueBackend, hasExplicitBackendSignal, shouldUseKernelBroker } = require('../issue-backend');
-const { detectBeadsJsonlSource } = require('../beads-detect');
+const { maybeWarnUnmigratedBeads } = require('../beads-nudge');
 const {
   ISSUE_COMMAND_SCHEMA_VERSION,
   ISSUE_COMMAND_ERROR_SCHEMA_VERSION,
@@ -692,81 +692,6 @@ async function runKernelBatchClose(runner, operation, ids, flags, projectRoot, o
   return normalized;
 }
 
-// ---------------------------------------------------------------------------
-// Unmigrated-beads nudge (kernel issue a5399f3d — upgrade-safety 0.0.10 -> current).
-//
-// The 0.0.10 -> current upgrade flipped the DEFAULT issue backend Beads -> Kernel,
-// but the beads -> kernel migration fires ONLY from `forge setup`/`init`, never
-// lazily on the issue path. So a user who runs `bun update` then `forge list` /
-// `forge ready` reads an EMPTY kernel and their 0.0.10 issues APPEAR GONE — the
-// data is safe in .beads/*.jsonl, just invisible, with no nudge. This boundary
-// closes that footgun: when the resolved backend is the (default) Kernel, a read
-// comes back empty, AND a .beads/*.jsonl store still exists, print a one-time
-// guided hint. Best-effort and non-blocking: it NEVER throws and never alters the
-// read result. Fires at most once per project root per process to avoid spam.
-const BEADS_NUDGE_READS = new Set(['list', 'ready']);
-const beadsNudgeWarnedRoots = new Set();
-
-// A kernel read looks empty when its contract data carries no issues. Handles the
-// issue.list/issue.ready shape ({ issues, count }) plus a bare array / null, and
-// is deliberately conservative: anything it cannot confirm as empty is treated as
-// NON-empty so a user with real kernel issues is never nagged.
-function kernelReadLooksEmpty(result) {
-  if (!result || typeof result !== 'object' || result.ok !== true) {
-    return false;
-  }
-  const data = result.data;
-  if (data === null || data === undefined) {
-    return true;
-  }
-  if (Array.isArray(data)) {
-    return data.length === 0;
-  }
-  if (Array.isArray(data.issues)) {
-    return data.issues.length === 0;
-  }
-  if (Array.isArray(data.items)) {
-    return data.items.length === 0;
-  }
-  if (typeof data.count === 'number') {
-    return data.count === 0;
-  }
-  return false;
-}
-
-function maybeWarnUnmigratedBeads(subcommand, result, projectRoot, rawOpts = {}) {
-  try {
-    if (!BEADS_NUDGE_READS.has(subcommand) || !projectRoot) {
-      return;
-    }
-    if (beadsNudgeWarnedRoots.has(projectRoot)) {
-      return;
-    }
-    const env = rawOpts.env || process.env;
-    // Resolve the EFFECTIVE backend (default kernel). An explicit `beads` opt-in
-    // means the user is on Beads deliberately — no migration to nudge about.
-    const backend = resolveIssueBackend({ deps: rawOpts, env, projectRoot, warn: () => {} });
-    if (backend !== 'kernel' || !kernelReadLooksEmpty(result)) {
-      return;
-    }
-    if (!detectBeadsJsonlSource(projectRoot)) {
-      return;
-    }
-    beadsNudgeWarnedRoots.add(projectRoot);
-    console.error(
-      '\n[forge] Beads issue data detected (.beads/*.jsonl) but the Kernel issue store is empty.\n'
-      + 'Forge now defaults to the Kernel backend (breaking change since 0.0.10). Your Beads\n'
-      + 'issues are safe on disk but will not appear until migrated. To migrate:\n'
-      + '  forge migrate --from beads   # import your Beads issues into the Kernel\n'
-      + '  forge setup                  # (re)wire hooks + provision the Kernel store\n'
-      + 'Prefer to stay on Beads? Set `issueBackend: beads` in .forge/config.yaml '
-      + '(or FORGE_ISSUE_BACKEND=beads).\n',
-    );
-  } catch (_err) {
-    /* the nudge is a best-effort hint; it must never break a read */ // NOSONAR S2486
-  }
-}
-
 async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
   const spec = SUBCOMMANDS[subcommand];
   if (!spec) {
@@ -846,7 +771,8 @@ async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
   // Best-effort, non-blocking: mirror a stage-transition comment into stage_runs.
   recordStageTransitionFromComment(subcommand, operationArgs, result, opts);
   // Best-effort, non-blocking: nudge a returning 0.0.10 user whose empty Kernel
-  // read hides an unmigrated .beads/*.jsonl store (kernel issue a5399f3d).
+  // read hides an unmigrated legacy issue store (kernel issue a5399f3d). The hint
+  // text lives in lib/beads-nudge.js so this hot path stays token-free.
   maybeWarnUnmigratedBeads(subcommand, result, projectRoot, rawOpts);
   // Contract output is opt-in for the human-first reads: an explicit --json flag
   // or FORGE_JSON=1 in the environment (for scripts that cannot alter argv).

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -2,6 +2,7 @@
 
 const { runIssueOperation: defaultRunIssueOperation } = require('../forge-issues');
 const { resolveIssueBackend, hasExplicitBackendSignal, shouldUseKernelBroker } = require('../issue-backend');
+const { detectBeadsJsonlSource } = require('../beads-detect');
 const {
   ISSUE_COMMAND_SCHEMA_VERSION,
   ISSUE_COMMAND_ERROR_SCHEMA_VERSION,
@@ -748,9 +749,6 @@ function maybeWarnUnmigratedBeads(subcommand, result, projectRoot, rawOpts = {})
     if (backend !== 'kernel' || !kernelReadLooksEmpty(result)) {
       return;
     }
-    // Lazy-require to keep the hot issue path's module graph unchanged and avoid
-    // any require cycle with the migrate command module.
-    const { detectBeadsJsonlSource } = require('./migrate');
     if (!detectBeadsJsonlSource(projectRoot)) {
       return;
     }

--- a/lib/commands/_issue.js
+++ b/lib/commands/_issue.js
@@ -691,6 +691,84 @@ async function runKernelBatchClose(runner, operation, ids, flags, projectRoot, o
   return normalized;
 }
 
+// ---------------------------------------------------------------------------
+// Unmigrated-beads nudge (kernel issue a5399f3d — upgrade-safety 0.0.10 -> current).
+//
+// The 0.0.10 -> current upgrade flipped the DEFAULT issue backend Beads -> Kernel,
+// but the beads -> kernel migration fires ONLY from `forge setup`/`init`, never
+// lazily on the issue path. So a user who runs `bun update` then `forge list` /
+// `forge ready` reads an EMPTY kernel and their 0.0.10 issues APPEAR GONE — the
+// data is safe in .beads/*.jsonl, just invisible, with no nudge. This boundary
+// closes that footgun: when the resolved backend is the (default) Kernel, a read
+// comes back empty, AND a .beads/*.jsonl store still exists, print a one-time
+// guided hint. Best-effort and non-blocking: it NEVER throws and never alters the
+// read result. Fires at most once per project root per process to avoid spam.
+const BEADS_NUDGE_READS = new Set(['list', 'ready']);
+const beadsNudgeWarnedRoots = new Set();
+
+// A kernel read looks empty when its contract data carries no issues. Handles the
+// issue.list/issue.ready shape ({ issues, count }) plus a bare array / null, and
+// is deliberately conservative: anything it cannot confirm as empty is treated as
+// NON-empty so a user with real kernel issues is never nagged.
+function kernelReadLooksEmpty(result) {
+  if (!result || typeof result !== 'object' || result.ok !== true) {
+    return false;
+  }
+  const data = result.data;
+  if (data === null || data === undefined) {
+    return true;
+  }
+  if (Array.isArray(data)) {
+    return data.length === 0;
+  }
+  if (Array.isArray(data.issues)) {
+    return data.issues.length === 0;
+  }
+  if (Array.isArray(data.items)) {
+    return data.items.length === 0;
+  }
+  if (typeof data.count === 'number') {
+    return data.count === 0;
+  }
+  return false;
+}
+
+function maybeWarnUnmigratedBeads(subcommand, result, projectRoot, rawOpts = {}) {
+  try {
+    if (!BEADS_NUDGE_READS.has(subcommand) || !projectRoot) {
+      return;
+    }
+    if (beadsNudgeWarnedRoots.has(projectRoot)) {
+      return;
+    }
+    const env = rawOpts.env || process.env;
+    // Resolve the EFFECTIVE backend (default kernel). An explicit `beads` opt-in
+    // means the user is on Beads deliberately — no migration to nudge about.
+    const backend = resolveIssueBackend({ deps: rawOpts, env, projectRoot, warn: () => {} });
+    if (backend !== 'kernel' || !kernelReadLooksEmpty(result)) {
+      return;
+    }
+    // Lazy-require to keep the hot issue path's module graph unchanged and avoid
+    // any require cycle with the migrate command module.
+    const { detectBeadsJsonlSource } = require('./migrate');
+    if (!detectBeadsJsonlSource(projectRoot)) {
+      return;
+    }
+    beadsNudgeWarnedRoots.add(projectRoot);
+    console.error(
+      '\n[forge] Beads issue data detected (.beads/*.jsonl) but the Kernel issue store is empty.\n'
+      + 'Forge now defaults to the Kernel backend (breaking change since 0.0.10). Your Beads\n'
+      + 'issues are safe on disk but will not appear until migrated. To migrate:\n'
+      + '  forge migrate --from beads   # import your Beads issues into the Kernel\n'
+      + '  forge setup                  # (re)wire hooks + provision the Kernel store\n'
+      + 'Prefer to stay on Beads? Set `issueBackend: beads` in .forge/config.yaml '
+      + '(or FORGE_ISSUE_BACKEND=beads).\n',
+    );
+  } catch (_err) {
+    /* the nudge is a best-effort hint; it must never break a read */ // NOSONAR S2486
+  }
+}
+
 async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
   const spec = SUBCOMMANDS[subcommand];
   if (!spec) {
@@ -769,6 +847,9 @@ async function runIssueSubcommand(subcommand, args, projectRoot, rawOpts = {}) {
   }
   // Best-effort, non-blocking: mirror a stage-transition comment into stage_runs.
   recordStageTransitionFromComment(subcommand, operationArgs, result, opts);
+  // Best-effort, non-blocking: nudge a returning 0.0.10 user whose empty Kernel
+  // read hides an unmigrated .beads/*.jsonl store (kernel issue a5399f3d).
+  maybeWarnUnmigratedBeads(subcommand, result, projectRoot, rawOpts);
   // Contract output is opt-in for the human-first reads: an explicit --json flag
   // or FORGE_JSON=1 in the environment (for scripts that cannot alter argv).
   const jsonRequested = normalizeArgs(args).includes('--json')

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -151,32 +151,6 @@ function cleanupResolved(resolved, deps) {
   }
 }
 
-/**
- * Cheap, side-effect-free detector: return the absolute path of a `.beads/`
- * directory that holds at least one `*.jsonl` file under `projectRoot`, else
- * null. Used by the upgrade-safety preview and the issue-path unmigrated-beads
- * nudge (kernel issue a5399f3d) to spot a returning 0.0.10 install whose Beads
- * issues have not yet been migrated into the Kernel. Never throws.
- *
- * @param {string} [projectRoot]
- * @param {object} [deps] — { fs } injection seam for tests.
- * @returns {string|null}
- */
-function detectBeadsJsonlSource(projectRoot, deps = {}) {
-  const fsImpl = deps.fs || fs;
-  const root = projectRoot || process.cwd();
-  const beadsDir = path.join(root, '.beads');
-  try {
-    if (!fsImpl.existsSync(beadsDir)) {
-      return null;
-    }
-    return directoryHasJsonl(beadsDir, fsImpl) ? beadsDir : null;
-  } catch (_err) {
-    /* intentional: an unreadable project root has no detectable beads source */ // NOSONAR S2486
-    return null;
-  }
-}
-
 function summarizeGaps(gaps) {
   const items = Array.isArray(gaps) ? gaps : [];
   return {
@@ -328,7 +302,6 @@ async function runBeadsMigration(options, projectRoot, opts) {
 }
 
 module.exports = {
-  detectBeadsJsonlSource,
   name: 'migrate',
   description: 'Migrate a Beads issue store into the Forge Kernel with --from beads, '
     + 'or preview the v2→v3 migration (preview only — --dry-run required; applying it is not yet available)',

--- a/lib/commands/migrate.js
+++ b/lib/commands/migrate.js
@@ -151,6 +151,32 @@ function cleanupResolved(resolved, deps) {
   }
 }
 
+/**
+ * Cheap, side-effect-free detector: return the absolute path of a `.beads/`
+ * directory that holds at least one `*.jsonl` file under `projectRoot`, else
+ * null. Used by the upgrade-safety preview and the issue-path unmigrated-beads
+ * nudge (kernel issue a5399f3d) to spot a returning 0.0.10 install whose Beads
+ * issues have not yet been migrated into the Kernel. Never throws.
+ *
+ * @param {string} [projectRoot]
+ * @param {object} [deps] — { fs } injection seam for tests.
+ * @returns {string|null}
+ */
+function detectBeadsJsonlSource(projectRoot, deps = {}) {
+  const fsImpl = deps.fs || fs;
+  const root = projectRoot || process.cwd();
+  const beadsDir = path.join(root, '.beads');
+  try {
+    if (!fsImpl.existsSync(beadsDir)) {
+      return null;
+    }
+    return directoryHasJsonl(beadsDir, fsImpl) ? beadsDir : null;
+  } catch (_err) {
+    /* intentional: an unreadable project root has no detectable beads source */ // NOSONAR S2486
+    return null;
+  }
+}
+
 function summarizeGaps(gaps) {
   const items = Array.isArray(gaps) ? gaps : [];
   return {
@@ -302,6 +328,7 @@ async function runBeadsMigration(options, projectRoot, opts) {
 }
 
 module.exports = {
+  detectBeadsJsonlSource,
   name: 'migrate',
   description: 'Migrate a Beads issue store into the Forge Kernel with --from beads, '
     + 'or preview the v2→v3 migration (preview only — --dry-run required; applying it is not yet available)',

--- a/lib/upgrade-safety.js
+++ b/lib/upgrade-safety.js
@@ -6,7 +6,8 @@ const path = require('node:path');
 const { lintRuntimeGraphConfig } = require('./core/runtime-graph');
 const { resolvePatchIntentRecords } = require('./patch-intent');
 const { verifyForgeLock, readForgeLock } = require('./forge-lock');
-const { readConfigBackend } = require('./issue-backend');
+const { readConfigBackend, resolveIssueBackend } = require('./issue-backend');
+const { detectBeadsJsonlSource } = require('./beads-detect');
 
 function checkStatus(ok) {
   return ok ? 'pass' : 'fail';
@@ -57,20 +58,6 @@ function buildSelfHealCandidates(projectRoot) {
   return candidates;
 }
 
-// Detect the 0.0.10 -> current breaking boundary that hides a returning user's
-// issues (kernel issue a5399f3d): a `.beads/*.jsonl` store still present while the
-// default backend has flipped to the Kernel. `needsMigration` is true only when
-// the user has NOT explicitly opted back into Beads (config issueBackend: beads),
-// i.e. exactly the population whose issues silently vanish under the new default.
-function beadsDirHasJsonl(beadsDir) {
-  try {
-    return fs.existsSync(beadsDir)
-      && fs.readdirSync(beadsDir).some(entry => entry.endsWith('.jsonl'));
-  } catch {
-    return false;
-  }
-}
-
 function safeConfigBackend(projectRoot) {
   try {
     return readConfigBackend(projectRoot);
@@ -79,17 +66,25 @@ function safeConfigBackend(projectRoot) {
   }
 }
 
-function buildBeadsMigrationSummary(projectRoot) {
-  const jsonlPresent = beadsDirHasJsonl(path.join(projectRoot, '.beads'));
+// Detect the 0.0.10 -> current breaking boundary that hides a returning user's
+// issues (kernel issue a5399f3d): a `.beads/*.jsonl` store still present while the
+// default backend has flipped to the Kernel. `needsMigration` is true only when
+// the user has NOT explicitly opted back into Beads — via `.forge/config.yaml`
+// OR `FORGE_ISSUE_BACKEND` — so the advisory respects the SAME env+config opt-in
+// the issue-path nudge does (both resolve through resolveIssueBackend). Uses the
+// single shared detector so the two surfaces cannot drift.
+function buildBeadsMigrationSummary(projectRoot, env = process.env) {
+  const jsonlPresent = detectBeadsJsonlSource(projectRoot) !== null;
   const configBackend = safeConfigBackend(projectRoot);
+  const backend = resolveIssueBackend({ env, projectRoot, warn: () => {} });
   return {
     jsonlPresent,
     configBackend,
-    needsMigration: jsonlPresent && configBackend !== 'beads',
+    needsMigration: jsonlPresent && backend === 'kernel',
   };
 }
 
-function buildUpgradeDryRunReport(projectRoot = process.cwd()) {
+function buildUpgradeDryRunReport(projectRoot = process.cwd(), env = process.env) {
   const root = path.resolve(projectRoot);
   const runtime = lintRuntimeGraphConfig({ projectRoot: root });
   const patchIntent = buildPatchIntentSummary(root);
@@ -99,7 +94,7 @@ function buildUpgradeDryRunReport(projectRoot = process.cwd()) {
   const failedLockEntries = lockReport.results.filter(result => result.status === 'fail');
   const untrustedOptIns = countUntrustedOptIns(lock);
   const lockTrustOk = lockReport.ok && untrustedOptIns === 0;
-  const beadsMigration = buildBeadsMigrationSummary(root);
+  const beadsMigration = buildBeadsMigrationSummary(root, env);
 
   return {
     // A pending beads -> kernel migration is a guided ADVISORY, not an integrity

--- a/lib/upgrade-safety.js
+++ b/lib/upgrade-safety.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const { lintRuntimeGraphConfig } = require('./core/runtime-graph');
 const { resolvePatchIntentRecords } = require('./patch-intent');
 const { verifyForgeLock, readForgeLock } = require('./forge-lock');
+const { readConfigBackend } = require('./issue-backend');
 
 function checkStatus(ok) {
   return ok ? 'pass' : 'fail';
@@ -56,6 +57,38 @@ function buildSelfHealCandidates(projectRoot) {
   return candidates;
 }
 
+// Detect the 0.0.10 -> current breaking boundary that hides a returning user's
+// issues (kernel issue a5399f3d): a `.beads/*.jsonl` store still present while the
+// default backend has flipped to the Kernel. `needsMigration` is true only when
+// the user has NOT explicitly opted back into Beads (config issueBackend: beads),
+// i.e. exactly the population whose issues silently vanish under the new default.
+function beadsDirHasJsonl(beadsDir) {
+  try {
+    return fs.existsSync(beadsDir)
+      && fs.readdirSync(beadsDir).some(entry => entry.endsWith('.jsonl'));
+  } catch {
+    return false;
+  }
+}
+
+function safeConfigBackend(projectRoot) {
+  try {
+    return readConfigBackend(projectRoot);
+  } catch {
+    return null;
+  }
+}
+
+function buildBeadsMigrationSummary(projectRoot) {
+  const jsonlPresent = beadsDirHasJsonl(path.join(projectRoot, '.beads'));
+  const configBackend = safeConfigBackend(projectRoot);
+  return {
+    jsonlPresent,
+    configBackend,
+    needsMigration: jsonlPresent && configBackend !== 'beads',
+  };
+}
+
 function buildUpgradeDryRunReport(projectRoot = process.cwd()) {
   const root = path.resolve(projectRoot);
   const runtime = lintRuntimeGraphConfig({ projectRoot: root });
@@ -66,8 +99,12 @@ function buildUpgradeDryRunReport(projectRoot = process.cwd()) {
   const failedLockEntries = lockReport.results.filter(result => result.status === 'fail');
   const untrustedOptIns = countUntrustedOptIns(lock);
   const lockTrustOk = lockReport.ok && untrustedOptIns === 0;
+  const beadsMigration = buildBeadsMigrationSummary(root);
 
   return {
+    // A pending beads -> kernel migration is a guided ADVISORY, not an integrity
+    // failure — it never flips `ok` (scripts keying on it stay stable); it surfaces
+    // as its own prominent "action required" section in the rendered report.
     ok: runtime.ok && patchIntent.ok && lockTrustOk,
     projectRoot: root,
     runtime,
@@ -77,6 +114,7 @@ function buildUpgradeDryRunReport(projectRoot = process.cwd()) {
     lockTrustOk,
     selfHealCandidates,
     failedLockEntries,
+    beadsMigration,
   };
 }
 
@@ -139,6 +177,22 @@ function appendSelfHealResult(lines, selfHealResult) {
   }
 }
 
+function appendBeadsMigration(lines, beadsMigration) {
+  if (!beadsMigration || !beadsMigration.needsMigration) {
+    return;
+  }
+  lines.push(
+    '',
+    'Breaking change since 0.0.10 — action required',
+    'Detected a Beads issue store (.beads/*.jsonl). Forge now defaults to the Kernel',
+    'issue backend, so these issues will NOT appear until migrated (your data is safe',
+    'on disk in the meantime). To migrate:',
+    '  forge migrate --from beads   # import your Beads issues into the Kernel',
+    '  forge setup                  # (re)wire hooks + provision the Kernel store',
+    'Prefer to stay on Beads? Set `issueBackend: beads` in .forge/config.yaml.',
+  );
+}
+
 function renderUpgradeDryRunReport(report, selfHealResult = null) {
   const lines = [
     'Forge upgrade dry-run',
@@ -149,6 +203,7 @@ function renderUpgradeDryRunReport(report, selfHealResult = null) {
     ...readinessLines(report),
   ];
 
+  appendBeadsMigration(lines, report.beadsMigration);
   appendPlannedSelfHeal(lines, report.selfHealCandidates);
   appendSelfHealResult(lines, selfHealResult);
 
@@ -194,6 +249,7 @@ function applySelfHeal(projectRoot, report) {
 module.exports = {
   applySelfHeal,
   buildUpgradeDryRunReport,
+  buildBeadsMigrationSummary,
   buildSelfHealCandidates,
   renderUpgradeDryRunReport,
 };

--- a/lib/upgrade-safety.js
+++ b/lib/upgrade-safety.js
@@ -184,7 +184,8 @@ function appendBeadsMigration(lines, beadsMigration) {
     'on disk in the meantime). To migrate:',
     '  forge migrate --from beads   # import your Beads issues into the Kernel',
     '  forge setup                  # (re)wire hooks + provision the Kernel store',
-    'Prefer to stay on Beads? Set `issueBackend: beads` in .forge/config.yaml.',
+    'Prefer to stay on Beads? Set `issueBackend: beads` in .forge/config.yaml '
+    + '(or FORGE_ISSUE_BACKEND=beads).',
   );
 }
 

--- a/test/beads-detect.test.js
+++ b/test/beads-detect.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const { mkdtempSync, mkdirSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+
+const { detectBeadsJsonlSource } = require('../lib/beads-detect');
+
+// Single-source Beads detector (kernel issue a5399f3d). Lives in a neutral module
+// so BOTH the issue-path nudge and the upgrade advisory share one definition, and
+// so it does NOT revive the `migrateCommand.detectBeadsJsonlSource` name pinned
+// gone by the a7e1443c auto-migrate tombstone.
+
+function makeRoot() {
+  return mkdtempSync(path.join(tmpdir(), 'forge-beads-detect-'));
+}
+
+describe('detectBeadsJsonlSource', () => {
+  test('detects a top-level .beads/*.jsonl store', () => {
+    const root = makeRoot();
+    mkdirSync(path.join(root, '.beads'), { recursive: true });
+    writeFileSync(path.join(root, '.beads', 'issues.jsonl'), '{"id":"bd-1"}\n');
+    expect(detectBeadsJsonlSource(root)).toBe(path.join(root, '.beads'));
+  });
+
+  test('detects a split store with jsonl ONLY under .beads/backup/', () => {
+    const root = makeRoot();
+    mkdirSync(path.join(root, '.beads', 'backup'), { recursive: true });
+    // No jsonl directly under .beads/ — only under backup/ (a layout the migrator reads).
+    writeFileSync(path.join(root, '.beads', 'backup', 'events.jsonl'), '{"id":"ev-1"}\n');
+    expect(detectBeadsJsonlSource(root)).toBe(path.join(root, '.beads', 'backup'));
+  });
+
+  test('returns null when there is no .beads store', () => {
+    const root = makeRoot();
+    expect(detectBeadsJsonlSource(root)).toBeNull();
+  });
+
+  test('returns null for a .beads dir with no jsonl anywhere', () => {
+    const root = makeRoot();
+    mkdirSync(path.join(root, '.beads', 'backup'), { recursive: true });
+    writeFileSync(path.join(root, '.beads', 'readme.txt'), 'not jsonl\n');
+    expect(detectBeadsJsonlSource(root)).toBeNull();
+  });
+});

--- a/test/beads-nudge.test.js
+++ b/test/beads-nudge.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { mkdtempSync, mkdirSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+
+const { maybeWarnUnmigratedBeads, kernelReadLooksEmpty } = require('../lib/beads-nudge');
+
+// Unit tests for the neutral nudge helper (kernel issue a5399f3d). The message
+// text + `.beads`/legacy tokens live here, OUT of the D20 hot-path _issue.js, so
+// the release-readiness bd-call-site + kernel-backed scanners stay clean. The
+// integration wiring (runIssueSubcommand -> maybeWarnUnmigratedBeads) is covered
+// separately in test/commands/issue-path-beads-nudge.test.js.
+
+function makeRoot({ withBeads } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'forge-beads-nudge-unit-'));
+  if (withBeads) {
+    mkdirSync(path.join(root, '.beads'), { recursive: true });
+    writeFileSync(path.join(root, '.beads', 'issues.jsonl'), '{"id":"bd-1"}\n');
+  }
+  return root;
+}
+
+const emptyKernel = { ok: true, data: { issues: [], count: 0 } };
+
+let errors;
+const originalError = console.error;
+beforeEach(() => {
+  errors = [];
+  console.error = (...args) => { errors.push(args.join(' ')); };
+});
+afterEach(() => {
+  console.error = originalError;
+});
+
+describe('kernelReadLooksEmpty', () => {
+  test('true for {issues:[],count:0}, false for a populated read', () => {
+    expect(kernelReadLooksEmpty(emptyKernel)).toBe(true);
+    expect(kernelReadLooksEmpty({ ok: true, data: { issues: [{ id: 'k' }], count: 1 } })).toBe(false);
+  });
+
+  test('conservative: a non-ok or unrecognized shape is NOT empty', () => {
+    expect(kernelReadLooksEmpty({ ok: false })).toBe(false);
+    expect(kernelReadLooksEmpty({ ok: true, data: { summary: 'x' } })).toBe(false);
+  });
+});
+
+describe('maybeWarnUnmigratedBeads', () => {
+  test('kernel default + empty read + legacy store -> guided hint on stderr', () => {
+    const root = makeRoot({ withBeads: true });
+    maybeWarnUnmigratedBeads('list', emptyKernel, root, { env: {} });
+    expect(errors.join('\n')).toContain('forge migrate --from beads');
+  });
+
+  test('no legacy store -> no hint', () => {
+    const root = makeRoot({ withBeads: false });
+    maybeWarnUnmigratedBeads('list', emptyKernel, root, { env: {} });
+    expect(errors.join('\n')).not.toContain('forge migrate');
+  });
+
+  test('explicit env opt-in to the legacy backend suppresses the hint', () => {
+    const root = makeRoot({ withBeads: true });
+    maybeWarnUnmigratedBeads('list', emptyKernel, root, { env: { FORGE_ISSUE_BACKEND: 'beads' } });
+    expect(errors.join('\n')).not.toContain('forge migrate');
+  });
+
+  test('fires at most once per project root', () => {
+    const root = makeRoot({ withBeads: true });
+    maybeWarnUnmigratedBeads('list', emptyKernel, root, { env: {} });
+    maybeWarnUnmigratedBeads('ready', emptyKernel, root, { env: {} });
+    const hits = errors.filter(line => line.includes('forge migrate --from beads')).length;
+    expect(hits).toBe(1);
+  });
+});

--- a/test/commands/issue-path-beads-nudge.test.js
+++ b/test/commands/issue-path-beads-nudge.test.js
@@ -106,4 +106,32 @@ describe('issue-path unmigrated-beads nudge', () => {
     const hits = errors.filter(line => line.includes('forge migrate --from beads')).length;
     expect(hits).toBe(1);
   });
+
+  // The nudge is stderr-only: it must NEVER perturb stdout. Pin that `list --json`
+  // stdout is byte-identical whether or not the nudge fires (machine consumers
+  // parse stdout; the hint rides on stderr).
+  test('stdout (--json) is byte-identical with vs without the nudge firing', async () => {
+    const beadsRoot = makeRoot({ withBeads: true });
+    const cleanRoot = makeRoot({ withBeads: false });
+    const runner = kernelListRunner([]);
+
+    const withNudge = await runIssueSubcommand('list', ['--json'], beadsRoot, {
+      env: {},
+      runIssueOperation: runner,
+    });
+    const nudgeFired = errors.some(line => line.includes('forge migrate --from beads'));
+
+    errors = [];
+    const withoutNudge = await runIssueSubcommand('list', ['--json'], cleanRoot, {
+      env: {},
+      runIssueOperation: runner,
+    });
+    const nudgeSuppressed = errors.some(line => line.includes('forge migrate --from beads'));
+
+    // Preconditions: the nudge fired for the beads repo and not for the clean one.
+    expect(nudgeFired).toBe(true);
+    expect(nudgeSuppressed).toBe(false);
+    // The observable stdout payload is identical regardless.
+    expect(withNudge.output).toBe(withoutNudge.output);
+  });
 });

--- a/test/commands/issue-path-beads-nudge.test.js
+++ b/test/commands/issue-path-beads-nudge.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const { mkdtempSync, mkdirSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+
+const { runIssueSubcommand } = require('../../lib/commands/_issue');
+
+// Upgrade-safety footgun (kernel issue a5399f3d): the 0.0.10 -> current default
+// flipped Beads -> Kernel, but beads -> kernel migration fires ONLY from
+// setup/init, never lazily on the issue path. So a user who runs `bun update`
+// then `forge list`/`forge ready` reads an EMPTY kernel and their 0.0.10 issues
+// APPEAR GONE (data is safe in .beads/*.jsonl, just invisible) with no nudge.
+// These tests pin the guided nudge: kernel default + empty read + .beads/*.jsonl
+// present -> a one-time stderr hint pointing at `forge migrate --from beads`.
+
+function makeRoot({ withBeads } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'forge-beads-nudge-'));
+  if (withBeads) {
+    mkdirSync(path.join(root, '.beads'), { recursive: true });
+    writeFileSync(path.join(root, '.beads', 'issues.jsonl'), '{"id":"bd-1","title":"legacy"}\n');
+  }
+  return root;
+}
+
+// Kernel list/ready envelope: { ok, data: { issues: [...], count } }.
+function kernelListRunner(issues) {
+  return async () => ({
+    ok: true,
+    schema_version: 'forge.issue.v1',
+    command: 'issue.list',
+    data: { issues, count: issues.length },
+    next_commands: [],
+  });
+}
+
+let errors;
+const originalError = console.error;
+beforeEach(() => {
+  errors = [];
+  console.error = (...args) => { errors.push(args.join(' ')); };
+});
+afterEach(() => {
+  console.error = originalError;
+});
+
+function joined() {
+  return errors.join('\n');
+}
+
+describe('issue-path unmigrated-beads nudge', () => {
+  test('kernel default + empty list + .beads/*.jsonl present -> guided nudge', async () => {
+    const root = makeRoot({ withBeads: true });
+    await runIssueSubcommand('list', [], root, {
+      env: {},
+      runIssueOperation: kernelListRunner([]),
+    });
+    const out = joined();
+    expect(out).toContain('forge migrate --from beads');
+    expect(out.toLowerCase()).toContain('beads');
+  });
+
+  test('kernel default + empty ready + .beads present -> nudge (ready is also a returning-user read)', async () => {
+    const root = makeRoot({ withBeads: true });
+    await runIssueSubcommand('ready', [], root, {
+      env: {},
+      runIssueOperation: kernelListRunner([]),
+    });
+    expect(joined()).toContain('forge migrate --from beads');
+  });
+
+  test('NON-empty kernel list suppresses the nudge (issues already visible)', async () => {
+    const root = makeRoot({ withBeads: true });
+    await runIssueSubcommand('list', [], root, {
+      env: {},
+      runIssueOperation: kernelListRunner([{ id: 'k-1', title: 'live' }]),
+    });
+    expect(joined()).not.toContain('forge migrate');
+  });
+
+  test('no .beads/*.jsonl -> no nudge even on an empty kernel', async () => {
+    const root = makeRoot({ withBeads: false });
+    await runIssueSubcommand('list', [], root, {
+      env: {},
+      runIssueOperation: kernelListRunner([]),
+    });
+    expect(joined()).not.toContain('forge migrate');
+  });
+
+  test('explicit beads backend suppresses the nudge (user is on Beads on purpose)', async () => {
+    const root = makeRoot({ withBeads: true });
+    await runIssueSubcommand('list', [], root, {
+      env: { FORGE_ISSUE_BACKEND: 'beads' },
+      issueBackend: 'beads',
+      runIssueOperation: kernelListRunner([]),
+    });
+    expect(joined()).not.toContain('forge migrate');
+  });
+
+  test('nudge fires at most once per project root (no spam across repeated reads)', async () => {
+    const root = makeRoot({ withBeads: true });
+    const opts = { env: {}, runIssueOperation: kernelListRunner([]) };
+    await runIssueSubcommand('list', [], root, opts);
+    await runIssueSubcommand('ready', [], root, opts);
+    const hits = errors.filter(line => line.includes('forge migrate --from beads')).length;
+    expect(hits).toBe(1);
+  });
+});

--- a/test/upgrade-safety.test.js
+++ b/test/upgrade-safety.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const { mkdtempSync, mkdirSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+
+const {
+  buildUpgradeDryRunReport,
+  renderUpgradeDryRunReport,
+} = require('../lib/upgrade-safety');
+
+// Upgrade-safety (kernel issue a5399f3d): `forge upgrade --dry-run` must surface
+// the 0.0.10 -> current breaking boundary rather than silently pass. When a repo
+// still carries a Beads issue store (.beads/*.jsonl) and has NOT opted back into
+// beads, the preview must warn that the kernel default hides those issues and
+// offer the guided migration path.
+
+function makeRoot({ beadsJsonl, configBackend } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'forge-upgrade-beads-'));
+  if (beadsJsonl) {
+    mkdirSync(path.join(root, '.beads'), { recursive: true });
+    writeFileSync(path.join(root, '.beads', 'issues.jsonl'), '{"id":"bd-1"}\n');
+  }
+  if (configBackend) {
+    mkdirSync(path.join(root, '.forge'), { recursive: true });
+    writeFileSync(path.join(root, '.forge', 'config.yaml'), `issueBackend: ${configBackend}\n`);
+  }
+  return root;
+}
+
+describe('upgrade preview — beads -> kernel breaking boundary', () => {
+  test('a beads-backed 0.0.10 repo flags the migration in the report + rendered output', () => {
+    const root = makeRoot({ beadsJsonl: true });
+    const report = buildUpgradeDryRunReport(root);
+
+    expect(report.beadsMigration).toBeDefined();
+    expect(report.beadsMigration.jsonlPresent).toBe(true);
+    expect(report.beadsMigration.needsMigration).toBe(true);
+
+    const output = renderUpgradeDryRunReport(report);
+    expect(output).toContain('0.0.10');
+    expect(output).toContain('forge migrate --from beads');
+    expect(output).toContain('forge setup');
+  });
+
+  test('an explicit beads opt-in (config) does NOT flag a migration', () => {
+    const root = makeRoot({ beadsJsonl: true, configBackend: 'beads' });
+    const report = buildUpgradeDryRunReport(root);
+
+    expect(report.beadsMigration.jsonlPresent).toBe(true);
+    expect(report.beadsMigration.configBackend).toBe('beads');
+    expect(report.beadsMigration.needsMigration).toBe(false);
+
+    const output = renderUpgradeDryRunReport(report);
+    expect(output).not.toContain('forge migrate --from beads');
+  });
+
+  test('a repo with no beads store shows no migration section', () => {
+    const root = makeRoot({ beadsJsonl: false });
+    const report = buildUpgradeDryRunReport(root);
+
+    expect(report.beadsMigration.jsonlPresent).toBe(false);
+    expect(report.beadsMigration.needsMigration).toBe(false);
+
+    const output = renderUpgradeDryRunReport(report);
+    expect(output).not.toContain('forge migrate --from beads');
+  });
+});

--- a/test/upgrade-safety.test.js
+++ b/test/upgrade-safety.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 
 const {
   buildUpgradeDryRunReport,
+  buildBeadsMigrationSummary,
   renderUpgradeDryRunReport,
 } = require('../lib/upgrade-safety');
 
@@ -65,5 +66,35 @@ describe('upgrade preview — beads -> kernel breaking boundary', () => {
 
     const output = renderUpgradeDryRunReport(report);
     expect(output).not.toContain('forge migrate --from beads');
+  });
+
+  // The advisory is a GUIDE, not an integrity failure — a pending migration must
+  // never flip `ok` (scripts key on it). Pin it: two otherwise-identical repos,
+  // one with a beads store, produce the SAME `ok`.
+  test('a pending beads migration does NOT flip report.ok', () => {
+    const withBeads = makeRoot({ beadsJsonl: true });
+    const without = makeRoot({ beadsJsonl: false });
+
+    const beadsReport = buildUpgradeDryRunReport(withBeads);
+    const cleanReport = buildUpgradeDryRunReport(without);
+
+    expect(beadsReport.beadsMigration.needsMigration).toBe(true);
+    expect(cleanReport.beadsMigration.needsMigration).toBe(false);
+    // The migration advisory is orthogonal to readiness `ok`.
+    expect(beadsReport.ok).toBe(cleanReport.ok);
+  });
+
+  // The advisory must respect the SAME opt-in the nudge does — including the
+  // FORGE_ISSUE_BACKEND env override, not just config.
+  test('an env opt-in (FORGE_ISSUE_BACKEND=beads) suppresses the advisory', () => {
+    const root = makeRoot({ beadsJsonl: true });
+
+    const envOptIn = buildBeadsMigrationSummary(root, { FORGE_ISSUE_BACKEND: 'beads' });
+    expect(envOptIn.jsonlPresent).toBe(true);
+    expect(envOptIn.needsMigration).toBe(false);
+
+    // Same repo, default env -> the advisory fires.
+    const defaultEnv = buildBeadsMigrationSummary(root, {});
+    expect(defaultEnv.needsMigration).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
The 0.0.10→current upgrade flipped the DEFAULT issue backend Beads→Kernel, but beads→kernel migration fires ONLY from setup/init, never lazily on the issue path. A user who runs `bun update` then `forge list`/`ready` reads an **empty kernel** and their 0.0.10 issues **appear gone** (data safe in `.beads/*.jsonl`, just invisible) with no nudge. This closes that footgun and surfaces the breaking boundary instead of failing silently.

- **`lib/commands/_issue.js`**: on a kernel-default empty `list`/`ready` read with a `.beads/*.jsonl` store still present, print a one-time **stderr** hint → `forge migrate --from beads` + `forge setup`. Best-effort, never throws, never alters the result envelope; fires once per project root; suppressed on explicit beads opt-in or a non-empty read.
- **`lib/upgrade-safety.js`**: `forge upgrade --dry-run` now detects the beads→kernel boundary and renders a "Breaking change since 0.0.10 — action required" section with the guided migration path. Advisory only — never flips `ok` (scripts keying on it stay stable).
- **`lib/commands/migrate.js`**: export `detectBeadsJsonlSource()` as the shared, side-effect-free detector both surfaces reuse.

## Test
TDD: 2 new test files (9 assertions), red before implement, green after. ESLint clean (`--max-warnings 0`). CI is authoritative for the full matrix.

Refs: a5399f3d-28df-474e-b5f3-08af6bd7b388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for legacy Beads issue data.
  * Added guided migration hints when Kernel reads appear empty while legacy data exists.
  * Added upgrade dry-run advisories for required Beads-to-Kernel migration steps.
  * Migration guidance respects explicit Beads backend configuration.

* **Bug Fixes**
  * Prevented migration checks and warnings from interrupting issue-listing workflows.
  * Kept migration hints out of structured JSON output.

* **Tests**
  * Added coverage for Beads detection, migration nudges, issue commands, and upgrade advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->