### PR TITLE
feat(cli): memory noun shortcuts + passthrough fix (P1, febf7690)

### DIFF
--- a/bin/forge.js
+++ b/bin/forge.js
@@ -61,11 +61,14 @@ const {
 const { resetSoft, resetHard, reinstall } = require('../lib/reset');
 const { loadCommands, executeCommand } = require('../lib/commands/_registry');
 const {
-  aliasNames,
   isAlias,
   isHiddenAlias,
+  isVisibleAlias,
+  resolveAlias,
   resolveDispatch,
   maybeWarnDeprecation,
+  passthroughAliasNames,
+  visibleAliasNames,
 } = require('../lib/commands/_aliases');
 const { resolveCommandOpts } = require('../lib/commands/_resolve-command-opts');
 const { getPackageRoot } = require('../lib/package-root');
@@ -2352,8 +2355,11 @@ function parseFlags() {
 
   // Issue passthrough commands delegate all flags to bd.
   // Skip global parsing so flags like --type, -p, --help reach the handler intact.
-  // Canonical `issue` plus the hidden back-compat aliases (single source of truth).
-  const issuePassthroughCommands = [...aliasNames(), 'issue'];
+  // Canonical `issue` plus the ISSUE-canonical back-compat aliases only. Non-issue
+  // aliases (e.g. the memory shortcuts remember/recall/insights) are excluded so
+  // their global flags still parse exactly as their standalone commands' did —
+  // keeping bare `recall -p <dir>` / `recall --help` byte-identical.
+  const issuePassthroughCommands = [...passthroughAliasNames(), 'issue'];
   if (issuePassthroughCommands.includes(args[0])) {
     return flags;
   }
@@ -2613,15 +2619,30 @@ function showHelp() {
   console.log('  Run `forge init --help` for all profile/classification/harness flags.');
   console.log('');
 
+  // Shortcuts block: VISIBLE back-compat aliases for a canonical `<noun> <sub>`
+  // form (e.g. `remember` -> `forge memory add`). The bare verb keeps working and
+  // is documented here; the noun form is canonical. Rendered as its own block ABOVE
+  // "Additional commands" (and trimmed from that enumeration below) so the noun
+  // surface reads clean.
+  const shortcutNames = visibleAliasNames();
+  if (shortcutNames.length > 0) {
+    console.log('Shortcuts (bare aliases for canonical noun subcommands):');
+    const shortcutWidth = Math.max(...shortcutNames.map(name => name.length));
+    for (const name of shortcutNames) {
+      console.log(`  ${name.padEnd(shortcutWidth)}  -> forge ${resolveAlias(name).canonical}`);
+    }
+    console.log('');
+  }
+
   // Append auto-discovered registry commands. Hidden issue aliases (the bare
   // passthroughs + plural `issues`, plus any command self-declaring `hidden: true`)
-  // still route and execute, but are trimmed from this enumeration so `forge issue`
-  // reads as the single canonical issue surface. This registry instance is loaded
-  // solely to render help, so deleting from its Map only affects the printed list —
-  // command dispatch (main) uses a separate registry and is unaffected.
+  // AND the visible noun shortcuts rendered above are trimmed from this enumeration
+  // so the canonical noun surface reads clean; both remain routable. This registry
+  // instance is loaded solely to render help, so deleting from its Map only affects
+  // the printed list — command dispatch (main) uses a separate registry.
   const helpRegistry = loadCommands(path.join(__dirname, '..', 'lib', 'commands'));
   for (const [name, cmd] of [...helpRegistry.commands]) {
-    if (isHiddenAlias(name) || cmd.hidden === true) {
+    if (isHiddenAlias(name) || isVisibleAlias(name) || cmd.hidden === true) {
       helpRegistry.commands.delete(name);
     }
   }

--- a/lib/commands/_aliases.js
+++ b/lib/commands/_aliases.js
@@ -52,6 +52,20 @@ const ALIASES = {
   claims: { canonical: 'issue claims', visible: false },
   // `issues` is the plural convenience form of `issue list`.
   issues: { canonical: 'issue list', visible: false },
+
+  // P1 (kernel issue febf7690) — memory noun shortcuts. The `memory` noun
+  // (add/recall/search/insights) shipped in PR #392 (issue 25362344); P1 wires the
+  // bare verbs as VISIBLE back-compat shortcuts of the canonical `memory <sub>`
+  // form. The canonical WRITE verb is `memory add` (there is NO `save`). These stay
+  // registered command files (remember.js/recall.js/insights.js), so resolveDispatch
+  // is a strict no-op for them and bare-verb dispatch stays byte-identical; the
+  // entries exist to document the mapping and drive the `forge --help` Shortcuts
+  // block. They are deliberately NOT bd flag-passthrough aliases (see
+  // passthroughAliasNames) so global flags (`-p`, `--help`, `--all`) still parse
+  // exactly as they did for the standalone commands.
+  remember: { canonical: 'memory add', visible: true },
+  recall: { canonical: 'memory recall', visible: true },
+  insights: { canonical: 'memory insights', visible: true },
 };
 
 /**
@@ -78,6 +92,29 @@ function isAlias(name) {
  */
 function aliasNames() {
   return Object.keys(ALIASES);
+}
+
+/**
+ * The subset of aliases that delegate ALL flag parsing to the issue backend (bd)
+ * and therefore must SKIP global flag parsing in bin/forge.js so flags like
+ * `--type` / `-p` / `--help` reach the handler intact. This is issue-specific:
+ * only issue-canonical aliases passthrough. Non-issue aliases (e.g. the P1 memory
+ * shortcuts) parse global flags normally — exactly as their standalone command
+ * files did — so their behaviour stays byte-identical after becoming aliases.
+ * @returns {string[]}
+ */
+function passthroughAliasNames() {
+  return Object.keys(ALIASES).filter(name => ALIASES[name].canonical.startsWith('issue '));
+}
+
+/**
+ * Names of aliases shown in the `forge --help` Shortcuts block — visible
+ * back-compat shortcuts for a canonical `<noun> <sub>` form. Hidden (back-compat
+ * only) aliases are excluded.
+ * @returns {string[]}
+ */
+function visibleAliasNames() {
+  return Object.keys(ALIASES).filter(name => ALIASES[name].visible === true);
 }
 
 /**
@@ -182,6 +219,8 @@ module.exports = {
   resolveAlias,
   isAlias,
   aliasNames,
+  passthroughAliasNames,
+  visibleAliasNames,
   isHidden,
   isHiddenAlias,
   isVisibleAlias,

--- a/lib/commands/_aliases.js
+++ b/lib/commands/_aliases.js
@@ -60,7 +60,7 @@ const ALIASES = {
   // registered command files (remember.js/recall.js/insights.js), so resolveDispatch
   // is a strict no-op for them and bare-verb dispatch stays byte-identical; the
   // entries exist to document the mapping and drive the `forge --help` Shortcuts
-  // block. They are deliberately NOT bd flag-passthrough aliases (see
+  // block. They are deliberately NOT issue-backend flag-passthrough aliases (see
   // passthroughAliasNames) so global flags (`-p`, `--help`, `--all`) still parse
   // exactly as they did for the standalone commands.
   remember: { canonical: 'memory add', visible: true },
@@ -95,7 +95,7 @@ function aliasNames() {
 }
 
 /**
- * The subset of aliases that delegate ALL flag parsing to the issue backend (bd)
+ * The subset of aliases that delegate ALL flag parsing to the issue backend
  * and therefore must SKIP global flag parsing in bin/forge.js so flags like
  * `--type` / `-p` / `--help` reach the handler intact. This is issue-specific:
  * only issue-canonical aliases passthrough. Non-issue aliases (e.g. the P1 memory

--- a/test/commands/_aliases.test.js
+++ b/test/commands/_aliases.test.js
@@ -18,8 +18,17 @@ const LEGACY_ISSUE_ALIASES = [
 ];
 
 describe('command aliases — declarative map', () => {
-  test('aliasNames() equals the migrated ISSUE_ALIAS_COMMANDS set (back-compat)', () => {
-    expect([...aliases.aliasNames()].sort()).toEqual([...LEGACY_ISSUE_ALIASES].sort());
+  test('passthroughAliasNames() equals the migrated ISSUE_ALIAS_COMMANDS set (bd flag-passthrough back-compat)', () => {
+    // The bd flag-passthrough set — the aliases bin/forge.js skips global flag
+    // parsing for — is exactly the issue-canonical aliases, unchanged by P1.
+    expect([...aliases.passthroughAliasNames()].sort()).toEqual([...LEGACY_ISSUE_ALIASES].sort());
+  });
+
+  test('aliasNames() is a superset of the legacy issue aliases (map also holds P1 memory shortcuts)', () => {
+    const all = new Set(aliases.aliasNames());
+    for (const name of LEGACY_ISSUE_ALIASES) {
+      expect(all.has(name)).toBe(true);
+    }
   });
 
   test('every seed alias resolves to a canonical "issue <sub>" form', () => {
@@ -38,6 +47,59 @@ describe('command aliases — declarative map', () => {
   test('isAlias reflects membership', () => {
     expect(aliases.isAlias('create')).toBe(true);
     expect(aliases.isAlias('status')).toBe(false);
+  });
+});
+
+describe('command aliases — memory noun shortcuts (P1, febf7690)', () => {
+  // The memory noun (add/recall/search/insights) shipped in PR #392 (issue
+  // 25362344). P1 wires remember/recall/insights as VISIBLE back-compat shortcuts
+  // of the canonical `memory <sub>` form. The canonical WRITE verb is `memory add`
+  // (there is no `save`).
+  const MEMORY_SHORTCUTS = {
+    remember: 'memory add',
+    recall: 'memory recall',
+    insights: 'memory insights',
+  };
+
+  test('remember/recall/insights are VISIBLE, non-deprecated aliases of a memory subcommand', () => {
+    for (const [name, canonical] of Object.entries(MEMORY_SHORTCUTS)) {
+      const descriptor = aliases.resolveAlias(name);
+      expect(descriptor).toBeDefined();
+      expect(descriptor.canonical).toBe(canonical);
+      expect(descriptor.visible).toBe(true);
+      expect(descriptor.deprecated).toBeUndefined();
+      expect(aliases.isVisibleAlias(name)).toBe(true);
+      expect(aliases.isHiddenAlias(name)).toBe(false);
+    }
+  });
+
+  test('visibleAliasNames() lists exactly the memory shortcuts', () => {
+    expect([...aliases.visibleAliasNames()].sort()).toEqual(Object.keys(MEMORY_SHORTCUTS).sort());
+  });
+
+  test('memory shortcuts are NOT in the bd flag-passthrough set (keeps -p / --help byte-identical)', () => {
+    const passthrough = new Set(aliases.passthroughAliasNames());
+    for (const name of Object.keys(MEMORY_SHORTCUTS)) {
+      expect(passthrough.has(name)).toBe(false);
+    }
+  });
+
+  test('a registered memory shortcut is never rewritten (byte-identical dispatch)', () => {
+    // remember/recall/insights keep their own command files, so resolveDispatch
+    // is a strict no-op — dispatch is identical to before P1.
+    for (const name of Object.keys(MEMORY_SHORTCUTS)) {
+      const out = aliases.resolveDispatch(name, [name, 'foo', '--json'], () => true);
+      expect(out.redirected).toBe(false);
+      expect(out.command).toBe(name);
+      expect(out.args).toEqual([name, 'foo', '--json']);
+    }
+  });
+
+  test('an unregistered memory shortcut would route to its memory subcommand', () => {
+    const out = aliases.resolveDispatch('recall', ['recall', 'bun', '--limit', '3'], () => false);
+    expect(out.redirected).toBe(true);
+    expect(out.command).toBe('memory');
+    expect(out.args).toEqual(['memory', 'recall', 'bun', '--limit', '3']);
   });
 });
 

--- a/test/forge-cli-registry.test.js
+++ b/test/forge-cli-registry.test.js
@@ -208,6 +208,52 @@ describe('CLI Registry Integration', () => {
     });
   });
 
+  describe('memory noun + visible shortcuts (P1, febf7690)', () => {
+    test('forge --help lists the memory noun in Additional commands', () => {
+      const { stdout } = runForge(['--help']);
+      const names = parseAdditionalCommands(stdout);
+      expect(names).toContain('memory');
+    });
+
+    test('forge --help moves remember/recall/insights into a Shortcuts block, not Additional commands', () => {
+      const { stdout } = runForge(['--help']);
+      const names = parseAdditionalCommands(stdout);
+      // The bare verbs are no longer enumerated as top-level commands...
+      for (const alias of ['remember', 'recall', 'insights']) {
+        expect(names).not.toContain(alias);
+      }
+      // ...they surface in a Shortcuts block mapping to their canonical memory sub.
+      expect(stdout).toContain('Shortcuts');
+      expect(stdout).toMatch(/remember\s+-> forge memory add/);
+      expect(stdout).toMatch(/recall\s+-> forge memory recall/);
+      expect(stdout).toMatch(/insights\s+-> forge memory insights/);
+    });
+
+    test('bare forge recall --help still prints recall usage (passthrough fix keeps --help parsed)', () => {
+      // Regression guard: if the memory shortcuts leaked into the bd flag-passthrough
+      // set, --help would reach the recall handler as a query instead of short-circuiting.
+      const { stdout, stderr, status } = runForge(['recall', '--help']);
+      const combined = stdout + stderr;
+      expect(status).toBe(0);
+      expect(combined).toContain('forge recall');
+      expect(combined).not.toContain('FORGE_SETUP_REQUIRED');
+    });
+
+    test('bare forge remember --help still prints remember usage', () => {
+      const { stdout, stderr, status } = runForge(['remember', '--help']);
+      const combined = stdout + stderr;
+      expect(status).toBe(0);
+      expect(combined).toContain('forge remember');
+    });
+
+    test('forge memory --help prints the memory noun surface', () => {
+      const { stdout, stderr, status } = runForge(['memory', '--help']);
+      const combined = stdout + stderr;
+      expect(status).toBe(0);
+      expect(combined).toContain('memory');
+    });
+  });
+
   describe('hidden issue aliases stay executable (back-compat)', () => {
     test('hidden aliases remain routable in the registry', () => {
       const { commands } = loadCommands(path.join(__dirname, '..', 'lib', 'commands'));


### PR DESCRIPTION
## Summary

P1 of command-surface unification (kernel issue `febf7690`, epic `eea186fa`).

**Key reconciliation:** the `memory` noun was **already shipped** by PR #392 (issue `25362344`) with subcommands `add / recall / search / insights` + typed notes — the P1 design doc's premise ("no memory.js today") was stale. Per owner ruling (Option A), this PR keeps #392's shipped taxonomy (canonical write verb is **`memory add`**, no `save`) and delivers only the genuinely-missing piece: wiring the bare verbs as visible back-compat aliases + the passthrough fix.

## What changed

- **`lib/commands/_aliases.js`** — `remember → memory add`, `recall → memory recall`, `insights → memory insights`, all `visible: true`, none deprecated. Added `passthroughAliasNames()` (issue-canonical only) and `visibleAliasNames()`.
- **`bin/forge.js`** — passthrough list now uses `passthroughAliasNames()` instead of `aliasNames()`, so the memory shortcuts stay **out** of the bd flag-passthrough set. Added a `--help` **Shortcuts** block (remember/recall/insights render there, trimmed from "Additional commands"; `memory` shows as a noun).

## Backward-compat (HARD invariant) — confirmed byte-identical

- `remember`/`recall`/`insights` remain **registered command files**, so `resolveDispatch` never rewrites them — bare-verb dispatch is unchanged.
- The passthrough fix is what keeps `recall -p <dir>` and `recall --help` byte-identical (had the memory verbs leaked into the passthrough set, global flags would have stopped parsing). Guarded by an integration test.
- Smoke-verified: bare `remember` write → `memory recall` read → bare `recall <query>` all round-trip through the same store; `-p` honored.

## Tests (TDD)

- `test/commands/_aliases.test.js` — visible/canonical/non-deprecated mapping, `visibleAliasNames`, memory verbs excluded from `passthroughAliasNames`, resolveDispatch no-op when registered + routes when unregistered. Updated the P0 `aliasNames` test to assert the passthrough set (the real bd invariant) is unchanged.
- `test/forge-cli-registry.test.js` — memory in Additional commands, remember/recall/insights in the Shortcuts block (not Additional), `recall --help`/`remember --help`/`memory --help` all work.
- 85/85 pass across the 6 memory/alias/registry/handler test files; ESLint clean.

## Note

The design doc (`docs/work/2026-07-16-command-surface-unification/design.md`) lives on the **unmerged `cmd-surface` branch**, not master, so its "note #392 pre-shipped the noun" update isn't in this PR — the reconciliation is documented in `_aliases.js` code comments here instead.

Refs `febf7690`, epic `eea186fa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)