### PR TITLE
fix(ci): remove invalid pull_request_review_thread trigger from pr-monitor

### DIFF
--- a/.github/workflows/pr-monitor.yml
+++ b/.github/workflows/pr-monitor.yml
@@ -23,12 +23,15 @@ on:
     types: [submitted, dismissed]
   pull_request_review_comment:
     types: [created]
-  # Resolving/unresolving a review thread is what clears (or re-raises) the
-  # threads-open signal — without this trigger, closing the LAST unresolved thread
-  # would leave a stale `pr-verdict:blocked-threads` label + sticky until some
-  # unrelated event happened to re-run the monitor (CodeRabbit PR #403).
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  # NOTE: there is deliberately NO `pull_request_review_thread` trigger here.
+  # GitHub Actions does NOT support it as a workflow `on:` event (it's a webhook
+  # event only — actionlint flags it, and it silently never fires), so resolving
+  # the LAST unresolved thread has no dedicated re-run trigger. That threads-open
+  # signal instead clears on the NEXT event that DOES re-run the monitor —
+  # pull_request_review (submitted/dismissed), pull_request_review_comment,
+  # issue_comment, or check_suite — which in practice accompanies almost every
+  # thread-resolving action. The label may briefly lag a pure "click resolve, no
+  # comment" until then; that's the accepted fail-closed tradeoff (CodeRabbit PR #403).
   issue_comment:
     types: [created]
   check_suite:
@@ -74,7 +77,7 @@ jobs:
           # jq errors are swallowed (|| true): a monitor must never red-X itself on an
           # unrelated or malformed event — no PR context means a clean no-op, not a fail.
           case "$EVENT_NAME" in
-            pull_request|pull_request_review|pull_request_review_comment|pull_request_review_thread)
+            pull_request|pull_request_review|pull_request_review_comment)
               PR=$(jq -r '.pull_request.number // empty' "$EVENT_PATH" 2>/dev/null || true) ;;
             issue_comment)
               # Only PR comments carry .issue.pull_request; plain issue comments are skipped.


### PR DESCRIPTION
## What

Removes the `pull_request_review_thread` trigger from `.github/workflows/pr-monitor.yml` — it is **not** a valid GitHub Actions `on:` event.

## Why

`pull_request_review_thread` exists only as a **webhook** event, not a workflow trigger. Verified from source:
- Absent from GitHub's official [events-that-trigger-workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) page (live fetch: 0 occurrences; sibling anchors `pull_request_review` / `pull_request_review_comment` present).
- Flagged by actionlint 1.7.12: `unknown Webhook event "pull_request_review_thread"`.

As written it silently never fired **and** is an actionlint error. It reached master via #403 because the CodeRabbit thread flagging it was resolved as a false positive before the corrected read; this is the clean fixup off `master`.

## Change

- Remove the `pull_request_review_thread:` trigger block.
- Remove its now-dead branch in the PR-number resolver `case`.
- Keep an honest inline note: the threads-open signal clears on the next event that DOES re-run the monitor (`pull_request_review` / `pull_request_review_comment` / `issue_comment` / `check_suite`), which accompanies almost every thread-resolving action. A pure "click resolve, no comment" briefly lags until then — accepted fail-closed tradeoff for a surface-only monitor.

## Verification

- YAML parses (5 valid triggers).
- `forge release check` = PASS (D20 clean).
- 148 targeted tests green: `pr-monitor-snapshot` + `ci-workflow` + `docs-consistency` + `pr-monitor/`.

Kernel: 2785e26e-0555-426c-84bb-03ddb967e6f4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request monitoring workflow event handling.
  * Removed unsupported review-thread event triggers and adjusted supported event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->