### PR TITLE
feat(pr-monitor): Tier-2 safe auto-actions (update-branch + rerun-flaky)

### DIFF
--- a/.github/workflows/pr-monitor.yml
+++ b/.github/workflows/pr-monitor.yml
@@ -4,9 +4,15 @@ name: PR Monitor
 # check state, keeps a SINGLE sticky comment up to date so async review-bot
 # (CodeRabbit / Greptile / Qodo) or human feedback in a window nobody is watching
 # never rots, AND lands ONE actionable `pr-verdict:*` label (the cheap agent read).
-# It LABELS state (check-failed / threads-open / mergeable / …) but takes no MERGE
-# action: it NEVER merges, NEVER resolves review threads, NEVER blocks, and is
-# fail-closed (`unknown` on unreadable signals).
+# It LABELS state (check-failed / threads-open / mergeable / …) and, in Tier-2
+# (issue addf5297), takes at most ONE of two SAFE, fail-closed ACTIONS off the same
+# verdict: update-branch on an otherwise-clean-behind PR, or re-run a genuinely
+# infrastructural (cancelled/timed-out/stale) required check once per head SHA. It
+# still NEVER merges the PR, NEVER resolves review threads, NEVER force-pushes,
+# NEVER touches code, NEVER blocks, and is fail-closed (`unknown` on unreadable
+# signals). The decision core is lib/pr-monitor/auto-actions.js (unit-tested);
+# per-head-SHA idempotency markers (`forge/auto-update`, `forge/auto-rerun`) keep
+# it loop-safe.
 #
 # Signal source: Forge's own agnostic gather, `forge shepherd <pr> --bundle
 # --json` (lib/pr-bundle.js) for the sticky's threads/checks. Unresolved threads
@@ -37,10 +43,18 @@ on:
   check_suite:
     types: [completed]
 
+# Tier-1 (surface/label) needs only read + PR/checks write. Tier-2 auto-actions
+# add two scoped writes: `contents: write` for the update-branch merge (merge base
+# INTO an otherwise-clean-behind PR — never a PR merge), and `actions: write` to
+# re-run a genuinely-flaky required check. For fork PRs (`pull_request` from a
+# fork) GitHub hands this workflow a READ-ONLY token regardless of this block, so
+# these elevated scopes only ever apply to same-repo PRs — forks are also skipped
+# explicitly by the decision core (auto-actions isFork guard).
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   checks: write
+  actions: write
 
 # DELIBERATELY NO `concurrency:` group. A per-PR group does NOT help here: GitHub's
 # queue replacement cancels the previously-PENDING run in a group UNCONDITIONALLY
@@ -291,3 +305,104 @@ jobs:
             -f 'output[title]=PR monitor surfaced review + check state' \
             -f 'output[summary]=See the Forge PR Monitor sticky comment + the pr-verdict:* label. Surface-only: labels state, never merges, never resolves threads.' \
             > /dev/null && echo "Published neutral check for $SHA" || echo "::warning::Neutral check publish failed (non-fatal)."
+
+      # ---------------------------------------------------------------------------
+      # TIER-2 auto-actions (issue addf5297). Everything ABOVE surfaces state and
+      # NEVER changes the PR; everything BELOW may take ONE of two SAFE, fail-closed
+      # actions keyed off the SAME `--pull` verdict payload (pull.json). All steps
+      # are best-effort (continue-on-error) so an action can NEVER red-X the monitor
+      # or block merge. The honest line is preserved: it may update-branch and
+      # rerun-flaky, but it NEVER merges, NEVER resolves threads, NEVER force-pushes,
+      # NEVER touches code.
+      # ---------------------------------------------------------------------------
+      - name: Decide auto-actions (surface-safe)
+        if: steps.resolve.outputs.should_run == 'true'
+        id: autoact
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -uo pipefail
+          # pull.json is the SAME `--pull --json` payload the verdict step read; the
+          # decision core (lib/pr-monitor/auto-actions, unit-tested) turns it into
+          # update_branch / rerun flags. Fork PRs skip the branch update (a base-repo
+          # token cannot push a fork). A failed fork read falls closed to isFork=true.
+          IS_FORK=$(gh pr view "$PR" --repo "$GH_REPO" --json isCrossRepository --jq '.isCrossRepository' 2>/dev/null || echo true)
+          node scripts/pr-auto-actions.js pull.json "$IS_FORK"
+
+      - name: 'Auto-action: update otherwise-clean-behind branch'
+        if: steps.resolve.outputs.should_run == 'true' && steps.autoact.outputs.update_branch == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -uo pipefail
+          # Merge base INTO the PR branch — the "last mile" for a clean-but-behind PR.
+          # This is NOT a PR merge and touches no code; it only clears BEHIND churn.
+          SHA=$(gh pr view "$PR" --repo "$GH_REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+          if [ -z "$SHA" ]; then echo "No head sha; skip auto-update."; exit 0; fi
+          # Idempotency + anti-loop: a per-head-SHA marker check-run. Skip if we
+          # already acted on THIS sha. A SUCCESSFUL update changes the head sha, so
+          # the CI run it triggers is a NEW sha that is no longer BEHIND and will not
+          # re-fire — the marker only suppresses redundant fires within the burst of
+          # events on the same sha (check_suite alone fires ~10x/push; see the #394
+          # history on why we must not churn the same sha).
+          EXISTING=$(gh api "repos/$GH_REPO/commits/$SHA/check-runs" --jq '[.check_runs[]|select(.name=="forge/auto-update")]|length' 2>/dev/null || echo 0)
+          if [ "$EXISTING" != "0" ]; then echo "Already auto-updated $SHA; skip."; exit 0; fi
+          # expected_head_sha makes GitHub reject the update if the head moved since
+          # we read it (guards against acting on a stale sha).
+          if gh api -X PUT "repos/$GH_REPO/pulls/$PR/update-branch" -f expected_head_sha="$SHA" > update.out 2>&1; then
+            echo "update-branch requested for PR #$PR @ $SHA"
+          else
+            echo "::warning::update-branch failed (non-fatal):"; cat update.out || true
+          fi
+          # Stamp the marker regardless of the update's outcome so a transient failure
+          # does not re-loop on this same sha (the next push mints a new sha to retry).
+          gh api -X POST "repos/$GH_REPO/check-runs" \
+            -f name='forge/auto-update' \
+            -f head_sha="$SHA" \
+            -f status='completed' \
+            -f conclusion='neutral' \
+            -f 'output[title]=Forge auto-update-branch (otherwise-clean-behind)' \
+            -f 'output[summary]=Merged base into an otherwise-clean-behind PR. Surface-safe: never merges the PR, never resolves threads, never touches code.' \
+            > /dev/null 2>&1 || true
+
+      - name: 'Auto-action: rerun genuinely-flaky required check (once)'
+        if: steps.resolve.outputs.should_run == 'true' && steps.autoact.outputs.rerun == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+          RERUN_RUN_IDS: ${{ steps.autoact.outputs.rerun_run_ids }}
+        run: |
+          set -uo pipefail
+          # Re-run ONLY the failed jobs of runs whose required check failed with an
+          # INFRASTRUCTURAL conclusion (cancelled/timed-out/stale/startup-failure) —
+          # never a real FAILURE (the decision core fails the whole rerun closed if
+          # ANY failing required check is a genuine failure). Once per head sha.
+          SHA=$(gh pr view "$PR" --repo "$GH_REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+          if [ -z "$SHA" ]; then echo "No head sha; skip rerun."; exit 0; fi
+          EXISTING=$(gh api "repos/$GH_REPO/commits/$SHA/check-runs" --jq '[.check_runs[]|select(.name=="forge/auto-rerun")]|length' 2>/dev/null || echo 0)
+          if [ "$EXISTING" != "0" ]; then echo "Already reran for $SHA; skip."; exit 0; fi
+          IFS=',' read -ra IDS <<< "${RERUN_RUN_IDS:-}"
+          for RID in "${IDS[@]}"; do
+            [ -z "$RID" ] && continue
+            if gh run rerun "$RID" --failed > /dev/null 2>&1; then
+              echo "Re-ran failed jobs of run $RID"
+            else
+              echo "::warning::rerun of run $RID failed (non-fatal)."
+            fi
+          done
+          gh api -X POST "repos/$GH_REPO/check-runs" \
+            -f name='forge/auto-rerun' \
+            -f head_sha="$SHA" \
+            -f status='completed' \
+            -f conclusion='neutral' \
+            -f 'output[title]=Forge auto-rerun flaky required check' \
+            -f 'output[summary]=Re-ran the failed jobs of an infrastructural (cancelled/timed-out/stale) required check once. Surface-safe: never merges, never resolves threads.' \
+            > /dev/null 2>&1 || true

--- a/lib/pr-monitor/auto-actions.js
+++ b/lib/pr-monitor/auto-actions.js
@@ -1,0 +1,175 @@
+'use strict';
+
+/**
+ * PR-monitor Tier-2 auto-actions — the SAFE, fail-closed *action* half of the
+ * shepherd (issue addf5297, epic c2d398e5). Tier-1 (lib/pr-pull.js computeVerdict
+ * + the pr-monitor workflow) LABELS a PR's state but takes no action, so PRs that
+ * only need "master merged in" sit untended until a human/agent nudges them.
+ *
+ * This module decides — PURELY, from the SAME `forge shepherd <pr> --pull --json`
+ * payload the monitor already computes — whether the monitor may take one of two
+ * surface-safe actions:
+ *   1. `updateBranch` — merge base into an OTHERWISE-CLEAN-but-BEHIND PR (the
+ *      "last mile" case). This is the highest-value, safest action: it clears the
+ *      BEHIND churn without ever touching a PR that has a real blocker.
+ *   2. `rerunFlaky`   — re-run a required check whose failure is INFRASTRUCTURAL
+ *      (cancelled / timed-out / stale / startup-failure), never a real test
+ *      FAILURE/ERROR.
+ *
+ * It NEVER merges, NEVER resolves review threads, NEVER force-pushes, NEVER edits
+ * code. It only decides; the workflow executes the `gh` calls (and owns
+ * per-head-SHA idempotency markers). Every gate below is fail-CLOSED: any missing
+ * field, degraded read, real failure, fork, draft, or unclassifiable signal
+ * yields `should:false`.
+ *
+ * @module pr-monitor/auto-actions
+ */
+
+/**
+ * Check conclusions that are INFRASTRUCTURAL flakes — a re-run may legitimately
+ * turn them green. Mirrors lib/pr-shepherd.js `isFailed`'s not-green terminal
+ * conclusions MINUS the genuinely-broken ones (FAILURE/ERROR/ACTION_REQUIRED).
+ */
+const INFRA_CONCLUSIONS = new Set(['CANCELLED', 'TIMED_OUT', 'STALE', 'STARTUP_FAILURE']);
+
+/** Conclusions that mean the code is genuinely broken — NEVER auto-rerun these. */
+const REAL_FAILURE_CONCLUSIONS = new Set(['FAILURE', 'ERROR', 'ACTION_REQUIRED']);
+
+/**
+ * Pull the numeric Actions run id from a job/run "details" URL
+ * (`.../actions/runs/<run>/job/<job>` or `.../actions/runs/<run>`). Returns null
+ * when absent — a null run id fails the rerun decision closed.
+ *
+ * @param {string} url
+ * @returns {string | null}
+ */
+function runIdFromUrl(url) {
+  const m = String(url || '').match(/\/runs\/(\d+)/);
+  return m ? m[1] : null;
+}
+
+/**
+ * A payload is DEGRADED (some verdict-relevant read failed or the head moved
+ * mid-gather) when its evidence lists unreadable sources or a torn read. Acting
+ * on a degraded gather could act on stale/false state, so both actions fail
+ * closed on it — even though `verdict==='BEHIND'` already implies a clean read,
+ * this stays an explicit, independent guard.
+ *
+ * @param {object} payload
+ * @returns {boolean}
+ */
+function isDegraded(payload) {
+  const ev = (payload && payload.evidence) || {};
+  const unreadable = Array.isArray(ev.unreadable) ? ev.unreadable : [];
+  return unreadable.length > 0 || ev.tornRead === true;
+}
+
+/**
+ * Decide whether to auto-update (merge base into) an otherwise-clean-but-BEHIND
+ * PR. Fires ONLY for the "last mile" case:
+ *   - verdict is exactly `BEHIND` (which itself guarantees rank-1 UNKNOWN and
+ *     rank-2 BLOCKED-CONFLICT did NOT fire — i.e. the read was clean and there is
+ *     no conflict);
+ *   - the PR is NOT a draft and NOT a fork (a base-repo token cannot push a fork
+ *     branch, and forks are out of scope);
+ *   - the read is not degraded;
+ *   - and the ONLY blocker is the behind-base one — every other blocker type
+ *     (failing/missing/skipped/pending required checks, bot-status gates,
+ *     unresolved threads, changes-requested / review-required, conflict) is
+ *     absent. `blockers[]` is computed independently of the verdict precedence,
+ *     so it still lists lower-precedence blockers that `BEHIND` masks — which is
+ *     exactly why we key on it rather than on the single verdict string.
+ *
+ * @param {object} payload - the `--pull --json` payload.
+ * @param {{ isFork?: boolean }} [opts]
+ * @returns {{ should: boolean, reason: string }}
+ */
+function decideUpdateBranch(payload, opts = {}) {
+  const skip = (reason) => ({ should: false, reason });
+  if (!payload || typeof payload !== 'object') return skip('no payload — fail closed');
+  if (opts.isFork) return skip('fork PR — a base-repo token cannot update a fork branch');
+  if (isDegraded(payload)) return skip('degraded/torn read — fail closed');
+  if (payload.verdict !== 'BEHIND') return skip(`verdict ${payload.verdict || 'UNKNOWN'} is not BEHIND`);
+  if (payload.draft === true) return skip('draft PR — not ready to advance');
+  if (!Array.isArray(payload.blockers)) return skip('blockers[] unavailable — fail closed');
+  const others = payload.blockers.filter((b) => b && b.type !== 'behind');
+  if (others.length > 0) {
+    return skip(`other blocker(s) present: ${others.map((b) => b.type).join(', ')}`);
+  }
+  return { should: true, reason: 'otherwise-clean-behind — only blocker is behind-base; merge base in' };
+}
+
+/**
+ * Decide whether to re-run flaky REQUIRED checks. Fires ONLY when EVERY failing
+ * required check is infrastructural (cancelled/timed-out/stale/startup-failure)
+ * with a derivable run id, and NONE is a real FAILURE/ERROR/ACTION_REQUIRED. A
+ * single real failure, an unclassifiable conclusion, a required-failing check
+ * with no matching `failures[]` entry, or a missing run id fails the WHOLE
+ * decision closed (never rerun a genuinely-broken PR, never loop on a real bug).
+ *
+ * @param {object} payload - the `--pull --json` payload.
+ * @returns {{ should: boolean, checks: Array<{name:string,conclusion:string,runId:string|null}>, runIds: string[], reason: string }}
+ */
+function decideRerun(payload) {
+  const empty = (reason) => ({ should: false, checks: [], runIds: [], reason });
+  if (!payload || typeof payload !== 'object') return empty('no payload — fail closed');
+  if (isDegraded(payload)) return empty('degraded/torn read — fail closed');
+
+  const rc = payload.requiredChecks || {};
+  const failingNames = Array.isArray(rc.failing) ? rc.failing : [];
+  if (failingNames.length === 0) return empty('no failing required checks');
+
+  const failures = Array.isArray(payload.failures) ? payload.failures : [];
+  const conclByName = new Map();
+  const urlByName = new Map();
+  for (const f of failures) {
+    if (!f || !f.name) continue;
+    if (!conclByName.has(f.name)) {
+      conclByName.set(f.name, String(f.conclusion || '').toUpperCase());
+      urlByName.set(f.name, f.jobUrl || f.detailsUrl || null);
+    }
+  }
+
+  const picked = [];
+  for (const name of failingNames) {
+    const concl = conclByName.get(name);
+    if (!concl) return empty(`required check "${name}" has no known conclusion — cannot confirm flaky, fail closed`);
+    if (REAL_FAILURE_CONCLUSIONS.has(concl)) return empty(`required check "${name}" is a real failure (${concl}) — never rerun`);
+    if (!INFRA_CONCLUSIONS.has(concl)) return empty(`required check "${name}" conclusion ${concl} is not classified infrastructural — fail closed`);
+    picked.push({ name, conclusion: concl, runId: runIdFromUrl(urlByName.get(name)) });
+  }
+
+  const runIds = [...new Set(picked.map((p) => p.runId).filter(Boolean))];
+  if (runIds.length === 0) return empty('no run id derivable from failure jobUrl — fail closed');
+  return {
+    should: true,
+    checks: picked,
+    runIds,
+    reason: `all ${picked.length} failing required check(s) are infrastructural (${picked.map((p) => p.conclusion).join(', ')})`,
+  };
+}
+
+/**
+ * Compute the full auto-action decision from a `--pull --json` payload. Pure and
+ * independently testable — no I/O, no `gh`, no side effects.
+ *
+ * @param {object} payload
+ * @param {{ isFork?: boolean }} [opts]
+ * @returns {{ updateBranch: object, rerunFlaky: object }}
+ */
+function decideAutoActions(payload, opts = {}) {
+  return {
+    updateBranch: decideUpdateBranch(payload, opts),
+    rerunFlaky: decideRerun(payload),
+  };
+}
+
+module.exports = {
+  decideAutoActions,
+  decideUpdateBranch,
+  decideRerun,
+  runIdFromUrl,
+  isDegraded,
+  INFRA_CONCLUSIONS,
+  REAL_FAILURE_CONCLUSIONS,
+};

--- a/scripts/pr-auto-actions.js
+++ b/scripts/pr-auto-actions.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * pr-auto-actions — the pr-monitor workflow's bridge from the `--pull --json`
+ * verdict payload to Tier-2 auto-action DECISIONS. Reads the payload file the
+ * monitor already wrote (default `pull.json`), asks lib/pr-monitor/auto-actions
+ * (the single, unit-tested decision core) what is safe to do, and emits the
+ * flags to `$GITHUB_OUTPUT` (or stdout locally) for the workflow's action steps.
+ *
+ * This script performs NO GitHub writes and takes NO action — it only decides.
+ * The workflow owns the visible `gh` calls and the per-head-SHA idempotency
+ * markers. Fails CLOSED: an unreadable/malformed payload or any thrown error
+ * yields `update_branch=false` / `rerun=false`.
+ *
+ * Usage: node scripts/pr-auto-actions.js [pull.json] [isFork]
+ *   isFork: "true" when the PR head is a cross-repository fork (skips update).
+ *
+ * @module scripts/pr-auto-actions
+ */
+
+const fs = require('node:fs');
+
+const { decideAutoActions } = require('../lib/pr-monitor/auto-actions');
+
+/**
+ * Append `key=value` lines to `$GITHUB_OUTPUT` when set, else print them. Values
+ * are single-line (booleans / csv / short reasons) so no multiline escaping is
+ * needed; newlines are stripped defensively.
+ *
+ * @param {Record<string,string>} outputs
+ */
+function emitOutputs(outputs) {
+  const target = process.env.GITHUB_OUTPUT;
+  const text = Object.entries(outputs)
+    .map(([k, val]) => `${k}=${String(val).replace(/[\r\n]+/g, ' ')}`)
+    .join('\n') + '\n';
+  if (target) fs.appendFileSync(target, text);
+  else process.stdout.write(text);
+}
+
+/** Read + parse the payload file, returning null (fail-closed) on any error. */
+function readPayload(path) {
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function main(argv) {
+  const path = argv[2] || 'pull.json';
+  const isFork = String(argv[3] || '').toLowerCase() === 'true';
+
+  const payload = readPayload(path);
+  if (!payload) {
+    // Fail closed: no readable verdict payload → take no action.
+    emitOutputs({
+      update_branch: 'false', update_reason: `no readable payload at ${path}`,
+      rerun: 'false', rerun_run_ids: '', rerun_reason: `no readable payload at ${path}`,
+    });
+    console.log(`auto-actions: no readable payload at ${path} — no action (fail closed)`);
+    return 0;
+  }
+
+  const { updateBranch, rerunFlaky } = decideAutoActions(payload, { isFork });
+  emitOutputs({
+    update_branch: updateBranch.should ? 'true' : 'false',
+    update_reason: updateBranch.reason,
+    rerun: rerunFlaky.should ? 'true' : 'false',
+    rerun_run_ids: (rerunFlaky.runIds || []).join(','),
+    rerun_reason: rerunFlaky.reason,
+  });
+  console.log(`auto-actions: update_branch=${updateBranch.should} (${updateBranch.reason})`);
+  console.log(`auto-actions: rerun=${rerunFlaky.should} (${rerunFlaky.reason})`);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exit(main(process.argv));
+  } catch (err) {
+    // Absolute fail-closed backstop: never let this script red-X the monitor.
+    emitOutputs({
+      update_branch: 'false', update_reason: `error: ${(err && err.message) || err}`,
+      rerun: 'false', rerun_run_ids: '', rerun_reason: `error: ${(err && err.message) || err}`,
+    });
+    console.log(`auto-actions: error — no action (fail closed): ${(err && err.message) || err}`);
+    process.exit(0);
+  }
+}
+
+module.exports = { emitOutputs, readPayload, main };

--- a/test/pr-monitor/auto-actions.test.js
+++ b/test/pr-monitor/auto-actions.test.js
@@ -1,0 +1,223 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const {
+  decideAutoActions,
+  decideUpdateBranch,
+  decideRerun,
+  runIdFromUrl,
+} = require('../../lib/pr-monitor/auto-actions');
+
+/** An otherwise-clean-behind payload; override any field per test. */
+function behindPayload(over = {}) {
+  return {
+    pr: '1',
+    verdict: 'BEHIND',
+    evidence: { unreadable: [], tornRead: false, behind: 2 },
+    draft: false,
+    behind: 2,
+    blockers: [{ type: 'behind', detail: 'Branch is 2 commit(s) behind base — update/rebase.' }],
+    requiredChecks: {},
+    failures: [],
+    ...over,
+  };
+}
+
+describe('decideUpdateBranch — the otherwise-clean-behind gate', () => {
+  test('BEHIND + clean → update', () => {
+    const d = decideUpdateBranch(behindPayload());
+    expect(d.should).toBe(true);
+  });
+
+  test('BEHIND + failing required check → NO update', () => {
+    const d = decideUpdateBranch(behindPayload({
+      blockers: [
+        { type: 'behind', detail: 'behind' },
+        { type: 'check-failing', detail: 'Required check(s) failing: test' },
+      ],
+      requiredChecks: { failing: ['test'] },
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('check-failing');
+  });
+
+  test('BEHIND + unresolved threads → NO update', () => {
+    const d = decideUpdateBranch(behindPayload({
+      blockers: [
+        { type: 'behind', detail: 'behind' },
+        { type: 'unresolved-threads', detail: '1 unresolved review thread(s)' },
+      ],
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('unresolved-threads');
+  });
+
+  test('BEHIND + changes-requested → NO update', () => {
+    const d = decideUpdateBranch(behindPayload({
+      blockers: [
+        { type: 'behind', detail: 'behind' },
+        { type: 'changes-requested', detail: 'A reviewer requested changes' },
+      ],
+    }));
+    expect(d.should).toBe(false);
+  });
+
+  test('conflict verdict → NO update', () => {
+    const d = decideUpdateBranch(behindPayload({
+      verdict: 'BLOCKED-CONFLICT',
+      blockers: [{ type: 'conflict', detail: 'Merge conflict' }],
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('not BEHIND');
+  });
+
+  test('draft → NO update', () => {
+    const d = decideUpdateBranch(behindPayload({
+      draft: true,
+      blockers: [
+        { type: 'draft', detail: 'PR is a draft' },
+        { type: 'behind', detail: 'behind' },
+      ],
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('draft');
+  });
+
+  test('fork → NO update', () => {
+    const d = decideUpdateBranch(behindPayload(), { isFork: true });
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('fork');
+  });
+
+  test('degraded read (unreadable) → NO update even if verdict says BEHIND', () => {
+    const d = decideUpdateBranch(behindPayload({
+      evidence: { unreadable: ['threads'], tornRead: false },
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('degraded');
+  });
+
+  test('torn read → NO update', () => {
+    const d = decideUpdateBranch(behindPayload({
+      evidence: { unreadable: [], tornRead: true },
+    }));
+    expect(d.should).toBe(false);
+  });
+
+  test('non-BEHIND verdict (CLEAN) → NO update', () => {
+    const d = decideUpdateBranch(behindPayload({ verdict: 'CLEAN-MERGEABLE', blockers: [] }));
+    expect(d.should).toBe(false);
+  });
+
+  test('missing blockers[] → NO update (fail closed)', () => {
+    const d = decideUpdateBranch(behindPayload({ blockers: undefined }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('blockers');
+  });
+
+  test('null payload → NO update (fail closed)', () => {
+    expect(decideUpdateBranch(null).should).toBe(false);
+  });
+
+  test('mergeStateStatus=BEHIND with behind count 0 (no behind blocker listed) → still update', () => {
+    // GitHub reports BEHIND but the commit count was unavailable, so computeBlockers
+    // omitted the behind entry — the blockers list is empty, which is still clean.
+    const d = decideUpdateBranch(behindPayload({ behind: 0, blockers: [] }));
+    expect(d.should).toBe(true);
+  });
+});
+
+describe('decideRerun — flaky required-check rerun gate', () => {
+  test('single cancelled required check → rerun once', () => {
+    const d = decideRerun(behindPayload({
+      verdict: 'BLOCKED-CHECKS',
+      requiredChecks: { failing: ['test'] },
+      failures: [{ name: 'test', conclusion: 'CANCELLED', jobUrl: 'https://github.com/o/r/actions/runs/555/job/9' }],
+    }));
+    expect(d.should).toBe(true);
+    expect(d.runIds).toEqual(['555']);
+  });
+
+  test('timed_out / stale / startup_failure are all infrastructural → rerun', () => {
+    for (const c of ['TIMED_OUT', 'STALE', 'STARTUP_FAILURE']) {
+      const d = decideRerun(behindPayload({
+        requiredChecks: { failing: ['x'] },
+        failures: [{ name: 'x', conclusion: c, jobUrl: 'https://github.com/o/r/actions/runs/1/job/2' }],
+      }));
+      expect(d.should).toBe(true);
+    }
+  });
+
+  test('real FAILURE → NO rerun', () => {
+    const d = decideRerun(behindPayload({
+      requiredChecks: { failing: ['test'] },
+      failures: [{ name: 'test', conclusion: 'FAILURE', jobUrl: 'https://github.com/o/r/actions/runs/1/job/2' }],
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('real failure');
+  });
+
+  test('mixed infra + real failure → NO rerun (whole decision fails closed)', () => {
+    const d = decideRerun(behindPayload({
+      requiredChecks: { failing: ['flaky', 'broken'] },
+      failures: [
+        { name: 'flaky', conclusion: 'CANCELLED', jobUrl: 'https://github.com/o/r/actions/runs/1/job/2' },
+        { name: 'broken', conclusion: 'FAILURE', jobUrl: 'https://github.com/o/r/actions/runs/2/job/3' },
+      ],
+    }));
+    expect(d.should).toBe(false);
+  });
+
+  test('required-failing check with no matching failures[] entry → NO rerun', () => {
+    const d = decideRerun(behindPayload({
+      requiredChecks: { failing: ['ghost'] },
+      failures: [],
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('no known conclusion');
+  });
+
+  test('infra conclusion but no derivable run id → NO rerun', () => {
+    const d = decideRerun(behindPayload({
+      requiredChecks: { failing: ['test'] },
+      failures: [{ name: 'test', conclusion: 'CANCELLED', jobUrl: 'not-a-url' }],
+    }));
+    expect(d.should).toBe(false);
+    expect(d.reason).toContain('run id');
+  });
+
+  test('no failing required checks → NO rerun', () => {
+    expect(decideRerun(behindPayload()).should).toBe(false);
+  });
+
+  test('degraded read → NO rerun', () => {
+    const d = decideRerun(behindPayload({
+      evidence: { unreadable: ['requiredChecks'], tornRead: false },
+      requiredChecks: { failing: ['test'] },
+      failures: [{ name: 'test', conclusion: 'CANCELLED', jobUrl: 'https://github.com/o/r/actions/runs/1/job/2' }],
+    }));
+    expect(d.should).toBe(false);
+  });
+});
+
+describe('runIdFromUrl', () => {
+  test('extracts run id from a job details URL', () => {
+    expect(runIdFromUrl('https://github.com/o/r/actions/runs/12345/job/678')).toBe('12345');
+  });
+  test('extracts run id from a bare run URL', () => {
+    expect(runIdFromUrl('https://github.com/o/r/actions/runs/999')).toBe('999');
+  });
+  test('returns null when absent', () => {
+    expect(runIdFromUrl('nope')).toBeNull();
+    expect(runIdFromUrl(null)).toBeNull();
+  });
+});
+
+describe('decideAutoActions — combined', () => {
+  test('bundles both decisions', () => {
+    const d = decideAutoActions(behindPayload());
+    expect(d.updateBranch.should).toBe(true);
+    expect(d.rerunFlaky.should).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Makes the constant, agent-agnostic PR shepherd **ACT**, not just LABEL. Tier-1 (PR #403/#404) surfaces a `pr-verdict:*` label but takes no action, so PRs that only need "master merged in" sit untended. Tier-2 adds two SAFE, fail-closed auto-actions in the pr-monitor workflow, keyed off the SAME `forge shepherd <pr> --pull` verdict payload the monitor already computes.

## Actions (both surface-safe, best-effort)

1. **Auto-update-branch on an otherwise-clean-but-BEHIND PR** — the highest-value, safest case ("last mile, just needs base merged in"). Fires ONLY when verdict is exactly `BEHIND`, not a draft, not a fork, read not degraded, AND the only blocker is behind-base (`blockers[]` minus the `behind` entry is empty — so any failing/missing/skipped/pending required check, unresolved thread, changes-requested, or conflict vetoes it). Uses `blockers[]` rather than the single verdict string because `BEHIND` masks lower-precedence blockers in the precedence ladder.
2. **Rerun a genuinely-flaky REQUIRED check, once per head SHA** — ONLY when EVERY failing required check is infrastructural (`CANCELLED`/`TIMED_OUT`/`STALE`/`STARTUP_FAILURE`). A single real `FAILURE`/`ERROR`/`ACTION_REQUIRED`, an unclassifiable conclusion, or a missing run id fails the WHOLE decision closed. Never reruns a real failure, never loops.

## Guards / honest line

- **Never** merges the PR, resolves review threads, force-pushes, or touches code.
- **Anti-loop + idempotency**: per-head-SHA marker check-runs (`forge/auto-update`, `forge/auto-rerun`). A successful update mints a new, no-longer-`BEHIND` SHA, so it cannot re-fire; the marker only suppresses redundant fires within the burst of events on the same SHA. No `concurrency:` group reintroduced (preserves the #394 fix — no CANCELLED red-X trail).
- All action steps are `continue-on-error` — an action can never red-X the monitor or block merge.
- Fork PRs get a read-only token from GitHub regardless, and are also skipped explicitly by the decision core.
- Decision logic is a **pure, unit-tested core** (`lib/pr-monitor/auto-actions.js`, 25 tests) — not inline YAML.

## Permissions

Adds scoped `contents: write` (update-branch merge) + `actions: write` (rerun) to the workflow. These only take effect for same-repo PRs (fork `pull_request` runs are read-only regardless).

## Testing

- `bun test test/pr-monitor/auto-actions.test.js` → 25 pass (BEHIND+clean→update; BEHIND+failing/threads/changes-requested→no update; conflict/draft/fork/degraded→no update; flaky-cancelled→rerun; real-failure/mixed/missing-conclusion/no-run-id→no rerun).
- `bun test test/pr-monitor/ test/pr-monitor-snapshot.test.js test/commands-shepherd-pull.test.js` → 133 pass.
- ESLint clean; workflow YAML parses; `forge release check` → PASS.

Refs addf5297, epic c2d398e5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
