### PR TITLE
feat(ship): gate auto-start PR shepherd watch on default-ON rail.auto_shepherd

### DIFF
--- a/docs/reference/shepherd.md
+++ b/docs/reference/shepherd.md
@@ -128,5 +128,8 @@ surface as every other rail.
 
 ## State
 
-Progress is durable in GitHub PR comments and labels plus `git`. There is no
-separate local state store.
+Progress is durable in GitHub PR comments and labels plus `git`. The one local
+store is the constant monitor's per-PR journal under
+`.forge/pr-monitor/<repo>-<pr>/` (the append-only `events.ndjson` + snapshot and
+consumer cursors) — the delivery/replay surface for `forge shepherd watch` and
+`events --since`. The bounded shepherd pass itself keeps no separate local state.

--- a/docs/reference/shepherd.md
+++ b/docs/reference/shepherd.md
@@ -67,6 +67,23 @@ up from there.
 a `/loop`) that re-invokes the bounded pass with a debounce of at least 60
 seconds and cancel-in-progress. The shepherd itself never waits in-process.
 
+## Auto-start on ship (`rail.auto_shepherd`)
+
+`forge shepherd watch <pr>` is the constant, self-stopping local monitor loop
+(≈60 s jittered cadence; appends events to the per-PR NDJSON journal under
+`.forge/pr-monitor/<repo>-<pr>/`; self-stops on `PR_MERGED`/`PR_CLOSED`). On a
+successful `forge ship`, the new PR's watcher is **auto-started detached** so a
+shipped PR is tended without a manual trigger. The spawn is best-effort and
+**never fails ship** (a spawn or config-read error degrades to "not started"),
+and it is idempotent — the watch-lifecycle PID/journal lock prevents a second
+watcher for the same PR.
+
+This auto-start is governed by the default-ON, unlocked **`rail.auto_shepherd`**
+rail. Opt out with `forge gate disable rail.auto_shepherd` (re-enable with
+`forge gate enable rail.auto_shepherd`); when disabled, `forge ship` skips the
+auto-start. This keeps the behavior honestly toggleable through the same config
+surface as every other rail.
+
 ## Terminal states
 
 | State         | Meaning |

--- a/lib/commands/ship.js
+++ b/lib/commands/ship.js
@@ -13,6 +13,32 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { startPrWatcherDetached } = require('../pr-monitor/watch-lifecycle');
+const { getResolvedRuntimeGraph } = require('../core/runtime-graph');
+
+const AUTO_SHEPHERD_RAIL = 'rail.auto_shepherd';
+
+/**
+ * Whether the default-ON `rail.auto_shepherd` rail permits auto-starting the PR
+ * watcher. Reads the SAME resolved runtime graph the `forge gate enable|disable`
+ * surface writes (`workflow.gates.rail.auto_shepherd.enabled`), so the toggle is
+ * config-honest. FAIL-OPEN: only an explicit `enabled === false` disables it — a
+ * missing rail or any resolution error falls back to enabled (the default), and
+ * this NEVER throws (ship must not fail on a config read).
+ *
+ * @param {string} [projectRoot]
+ * @param {Function} [resolveGraph] - injectable graph resolver (tests).
+ * @returns {boolean}
+ */
+function autoShepherdRailEnabled(projectRoot = process.cwd(), resolveGraph = getResolvedRuntimeGraph) {
+	try {
+		const graph = resolveGraph({ projectRoot });
+		const rail = [...(graph.rails || []), ...(graph.gates || [])]
+			.find(entry => entry.id === AUTO_SHEPHERD_RAIL);
+		return !(rail && rail.enabled === false);
+	} catch {
+		return true;
+	}
+}
 
 function getExecOptions() {
 	return { encoding: 'utf8', cwd: process.cwd(), timeout: 120000 };
@@ -490,12 +516,21 @@ async function createPR(options) { // NOSONAR S3776
  * ship: `startWatcher` (startPrWatcherDetached) already never throws, and this
  * guard keeps even a surprise error from surfacing to the ship caller.
  *
- * @param {{ dryRun: boolean, prNumber?: string|number, startWatcher: Function }} params
+ * Gated by the default-ON `rail.auto_shepherd` rail: when a maintainer has
+ * disabled it (`forge gate disable rail.auto_shepherd`), the watcher is skipped
+ * so the auto-start is honestly toggleable. The rail check is fail-open and
+ * wrapped in the same try/catch, so neither a disabled rail nor a config-read
+ * error ever fails ship.
+ *
+ * @param {{ dryRun: boolean, prNumber?: string|number, startWatcher: Function, railEnabled?: Function }} params
  * @returns {{ started: boolean, reason?: string }}
  */
-function maybeStartPrWatcher({ dryRun, prNumber, startWatcher }) {
+function maybeStartPrWatcher({ dryRun, prNumber, startWatcher, railEnabled = autoShepherdRailEnabled }) {
 	if (dryRun || !prNumber) return { started: false, reason: 'skipped' };
 	try {
+		if (!railEnabled(process.cwd())) {
+			return { started: false, reason: 'rail.auto_shepherd disabled' };
+		}
 		return startWatcher({ prNumber, cwd: process.cwd() });
 	} catch (err) {
 		return { started: false, reason: err.message };
@@ -503,7 +538,7 @@ function maybeStartPrWatcher({ dryRun, prNumber, startWatcher }) {
 }
 
 async function executeShip(options) {
-	const { featureSlug, title, dryRun = false, startWatcher = startPrWatcherDetached } = options || {};
+	const { featureSlug, title, dryRun = false, startWatcher = startPrWatcherDetached, railEnabled = autoShepherdRailEnabled } = options || {};
 
 	// Validate feature slug
 	if (!featureSlug || typeof featureSlug !== 'string' || featureSlug.trim() === '') {
@@ -555,7 +590,7 @@ async function executeShip(options) {
 		});
 		const result = await createPR({ title, body: prBody, dryRun });
 		if (!result.success) return result;
-		maybeStartPrWatcher({ dryRun, prNumber: result.prNumber, startWatcher });
+		maybeStartPrWatcher({ dryRun, prNumber: result.prNumber, startWatcher, railEnabled });
 		return {
 			success: true,
 			prUrl: result.prUrl,
@@ -589,6 +624,7 @@ module.exports = {
 		};
 	},
 	maybeStartPrWatcher,
+	autoShepherdRailEnabled,
 	extractKeyDecisions,
 	extractTestScenarios,
 	getTestCoverage,

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -452,6 +452,7 @@ const RESOLVED_RUNTIME_GRAPH = {
     { key: 'signed_commits', label: 'Signed commits', description: 'Preserve commit provenance requirements where configured.' },
     { key: 'schema_integrity', label: 'Schema integrity', description: 'Keep runtime graph and config schemas internally consistent.' },
     { key: 'kernel_tracking', label: 'Kernel issue tracking', description: 'Every issue, idea, bug, and decision discussed is filed to the Forge Kernel.', locked: false },
+    { key: 'auto_shepherd', label: 'Auto-start PR shepherd watch', description: 'On `forge ship` success, auto-start the detached, self-stopping `forge shepherd watch <pr>` monitor so a shipped PR is tended without a manual trigger. Default-ON, UNLOCKED — opt out with `forge gate disable rail.auto_shepherd`.', locked: false },
   ].map(def => Rail({ id: `rail.${def.key}`, ...def })),
   adapters: [
     Adapter({

--- a/test/pr-monitor/ship-auto-shepherd-rail.test.js
+++ b/test/pr-monitor/ship-auto-shepherd-rail.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const { maybeStartPrWatcher, autoShepherdRailEnabled } = require('../../lib/commands/ship');
+const { getDefaultRuntimeGraph } = require('../../lib/core/runtime-graph');
+
+// rail.auto_shepherd (issue cf8361bc / epic c2d398e5): the default-ON, UNLOCKED
+// rail that governs whether `forge ship` auto-starts the detached
+// `forge shepherd watch <pr>` monitor. Toggle via `forge gate disable
+// rail.auto_shepherd`. These tests pin: (1) the rail is registered default-ON +
+// unlocked; (2) the resolver-backed check is fail-OPEN (default-ON on any error);
+// (3) maybeStartPrWatcher honors the rail while never failing ship.
+
+describe('rail.auto_shepherd registration', () => {
+  test('is a default-ON, unlocked rail in the runtime graph', () => {
+    const graph = getDefaultRuntimeGraph();
+    const rail = graph.rails.find((r) => r.id === 'rail.auto_shepherd');
+    expect(rail).toBeDefined();
+    expect(rail.key).toBe('auto_shepherd');
+    expect(rail.enabled).toBe(true);
+    expect(rail.locked).toBe(false);
+  });
+});
+
+describe('autoShepherdRailEnabled — fail-open resolver check', () => {
+  const railEntry = (enabled) => ({ rails: [{ id: 'rail.auto_shepherd', enabled }], gates: [] });
+
+  test('true when the resolved rail is enabled', () => {
+    expect(autoShepherdRailEnabled('/root', () => railEntry(true))).toBe(true);
+  });
+
+  test('false ONLY when the resolved rail is explicitly disabled', () => {
+    expect(autoShepherdRailEnabled('/root', () => railEntry(false))).toBe(false);
+  });
+
+  test('true (default-ON) when the rail is absent from the resolved graph', () => {
+    expect(autoShepherdRailEnabled('/root', () => ({ rails: [], gates: [] }))).toBe(true);
+  });
+
+  test('true (fail-open) when resolving the graph throws — never blocks ship', () => {
+    expect(autoShepherdRailEnabled('/root', () => { throw new Error('config unreadable'); })).toBe(true);
+  });
+});
+
+describe('maybeStartPrWatcher — rail gating', () => {
+  test('starts the watcher when the rail is enabled and a PR exists', () => {
+    const calls = [];
+    const res = maybeStartPrWatcher({
+      dryRun: false, prNumber: 42,
+      startWatcher: (opts) => { calls.push(opts); return { started: true, pid: 7 }; },
+      railEnabled: () => true,
+    });
+    expect(res.started).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].prNumber).toBe(42);
+  });
+
+  test('does NOT start when the rail is disabled', () => {
+    let called = false;
+    const res = maybeStartPrWatcher({
+      dryRun: false, prNumber: 42,
+      startWatcher: () => { called = true; return { started: true }; },
+      railEnabled: () => false,
+    });
+    expect(called).toBe(false);
+    expect(res.started).toBe(false);
+    expect(res.reason).toMatch(/rail\.auto_shepherd/);
+  });
+
+  test('rail is not even consulted on a dry run / missing PR (skip wins first)', () => {
+    let railChecked = false;
+    const res = maybeStartPrWatcher({
+      dryRun: true, prNumber: 5,
+      startWatcher: () => ({ started: true }),
+      railEnabled: () => { railChecked = true; return true; },
+    });
+    expect(res.started).toBe(false);
+    expect(railChecked).toBe(false);
+  });
+
+  test('never fails ship even if the rail check throws', () => {
+    const res = maybeStartPrWatcher({
+      dryRun: false, prNumber: 9,
+      startWatcher: () => ({ started: true }),
+      railEnabled: () => { throw new Error('boom'); },
+    });
+    expect(res.started).toBe(false);
+    expect(res.reason).toMatch(/boom/);
+  });
+});


### PR DESCRIPTION
## What

Makes the local `forge shepherd watch <pr>` auto-start-on-ship **honestly toggleable** — the one gap from epic c2d398e5 Tier-1. Everything else was already built and wired on master: `watch.js` (constant ~60s self-stopping loop), `journal.js` (per-PR NDJSON under `.forge/pr-monitor/`), `forge shepherd events --since`, `startPrWatcherDetached` (detached/unref'd/never-throws), and `ship.js` already calls `maybeStartPrWatcher` after `createPR` success. The missing piece was a toggle.

## Change

- **New rail** `rail.auto_shepherd` (default-ON, UNLOCKED) in `lib/core/runtime-graph.js`. Toggle via the existing surface: `forge gate disable|enable rail.auto_shepherd`.
- **`lib/commands/ship.js`**: `maybeStartPrWatcher` now consults `autoShepherdRailEnabled()` before spawning the watcher. Disabled rail → skip (`reason: 'rail.auto_shepherd disabled'`); default-ON → unchanged. The check reads the SAME resolved runtime graph the gate writes (`workflow.gates.rail.auto_shepherd.enabled`), so it is config-honest (#399).
- **Fail-open + never fails ship**: the rail check is wrapped in the same try/catch and returns enabled on any config-read error or missing rail; a disabled rail or a spawn error only ever yields `{ started: false }`. Invariants preserved — never merges, never resolves threads.
- **Docs**: `docs/reference/shepherd.md` gains an "Auto-start on ship (`rail.auto_shepherd`)" section.

## Tests (TDD)

`test/pr-monitor/ship-auto-shepherd-rail.test.js` (9 tests): rail registered default-ON/unlocked; `autoShepherdRailEnabled` fail-open (missing rail / throw → enabled, explicit `false` → disabled); `maybeStartPrWatcher` starts on rail-on+PR, skips on rail-off, does not consult the rail on dryRun/no-PR, never throws into ship. Existing `watch-lifecycle.test.js`, `runtime-graph.test.js`, `ship.test.js`, `gate.test.js`, `control-plane.test.js`, `adoption-profiles.test.js`, `docs-shepherd.test.js` all still green. ESLint clean; `forge release check` PASS; CLI toggle verified end-to-end.

Refs cf8361bc, epic c2d398e5, 33e1bbd3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `forge ship` can auto-start a detached PR monitoring watcher when the `rail.auto_shepherd` rail is enabled.
  - Auto-start is best-effort and fail-open (watcher won’t block `ship` if the rail check can’t be resolved).
  - Watcher startup is idempotent to prevent duplicate monitors per PR, and dry-runs won’t start watchers.

- **Documentation**
  - Documented the `rail.auto_shepherd` auto-start behavior and how monitoring state/persistence works locally.

- **Tests**
  - Added coverage for rail registration, enablement logic, and watcher-start behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->