### PR TITLE
feat(shepherd): arm the PR watcher on any open PR (forge push + watch --adopt)

### DIFF
--- a/lib/commands/push.js
+++ b/lib/commands/push.js
@@ -4,6 +4,8 @@ const { execFileSync, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const forgeToken = require('../../scripts/check-forge-token');
+const { startPrWatcherDetached } = require('../pr-monitor/watch-lifecycle');
+const { autoShepherdRailEnabled } = require('./ship');
 
 const isWindows = process.platform === 'win32';
 
@@ -108,6 +110,57 @@ async function autoFileBackingIssueForPush(projectRoot, execFn, deps = {}) {
   } catch (_err) { /* non-blocking: tracking must never break a push */ // NOSONAR S2486
     return null;
   }
+}
+
+/**
+ * Resolve the OPEN PR number for the current branch via `gh pr view`. Returns
+ * null when there is no PR, gh is unavailable, or anything errors (fail-open).
+ * NEVER throws.
+ *
+ * @param {function} execFn - execFileSync or mock
+ * @returns {number|null}
+ */
+function resolveOpenPrNumber(execFn) {
+	try {
+		const out = execFn('gh', ['pr', 'view', '--json', 'number', '-q', '.number'], {
+			encoding: 'utf8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		const n = Number.parseInt(String(out).trim(), 10);
+		return Number.isInteger(n) && n > 0 ? n : null;
+	} catch (_err) { /* intentional: no open PR / gh missing → arm nothing */ // NOSONAR S2486
+		return null;
+	}
+}
+
+/**
+ * Best-effort, NON-BLOCKING arm of the constant PR watcher after a successful
+ * push, when an OPEN PR exists for the current branch. This closes the gap where
+ * PRs not born from `forge ship` (gh pr create, the GitHub UI, an earlier push)
+ * never got a watcher. Gated by the default-ON `rail.auto_shepherd`, idempotent
+ * via the watch loop's own PID/journal lock, and reusing the same
+ * `startPrWatcherDetached` as ship. MUST NEVER throw into or fail the push: a
+ * disabled rail, no PR, a gh error, or a spawn error all degrade to
+ * `{ armed: false }`.
+ *
+ * @param {object} params
+ * @returns {{ armed: boolean, reason?: string, prNumber?: number }}
+ */
+function maybeArmWatcherAfterPush({
+	projectRoot,
+	execFn,
+	startWatcher = startPrWatcherDetached,
+	railEnabled = autoShepherdRailEnabled,
+	prLookup = resolveOpenPrNumber,
+}) {
+	try {
+		if (!railEnabled(projectRoot)) return { armed: false, reason: 'rail.auto_shepherd disabled' };
+		const prNumber = prLookup(execFn);
+		if (!prNumber) return { armed: false, reason: 'no-open-pr' };
+		const res = startWatcher({ prNumber, cwd: projectRoot });
+		return { armed: !!(res && res.started), reason: res && res.reason, prNumber };
+	} catch (err) {
+		return { armed: false, reason: err.message };
+	}
 }
 
 /**
@@ -247,6 +300,17 @@ module.exports = {
 			};
 		}
 
+		// Arm the constant PR watcher for this branch's open PR (best-effort,
+		// gated by rail.auto_shepherd, never fails the push). Covers PRs not born
+		// from `forge ship`.
+		maybeArmWatcherAfterPush({
+			projectRoot,
+			execFn,
+			startWatcher: deps?.startWatcher,
+			railEnabled: deps?.railEnabled,
+			prLookup: deps?.prLookup,
+		});
+
 		return {
 			success: true,
 			quickMode,
@@ -259,5 +323,7 @@ module.exports = {
 	// Exposed for unit tests; not part of the CLI surface.
 	_internal: {
 		autoFileBackingIssueForPush,
+		maybeArmWatcherAfterPush,
+		resolveOpenPrNumber,
 	},
 };

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -36,6 +36,7 @@ const { validatePrStateAdapter } = require('../pr-state-validator');
 const { gatherMonitorSnapshot } = require('../pr-monitor/gather');
 const { pollEvents } = require('../pr-monitor/monitor');
 const { watchLoop } = require('../pr-monitor/watch');
+const { startPrWatcherDetached } = require('../pr-monitor/watch-lifecycle');
 const monitorJournal = require('../pr-monitor/journal');
 const { EVENT_TYPES: T } = require('../pr-monitor/events');
 
@@ -270,11 +271,66 @@ function wireSignals() {
  * @param {object} [deps]
  * @returns {Promise<object>}
  */
+/**
+ * List every OPEN PR number via `gh pr list`. Fail-open: any error yields an
+ * empty list (adopt then arms nothing) rather than throwing.
+ *
+ * @param {Function} [exec] - gh runner (test injection).
+ * @returns {number[]}
+ */
+function defaultListOpenPrs(exec = execFileSync) {
+  try {
+    const out = exec('gh', ['pr', 'list', '--state', 'open', '--json', 'number', '-q', '.[].number'], {
+      encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return String(out)
+      .split(/\r?\n/)
+      .map((s) => Number.parseInt(s.trim(), 10))
+      .filter((n) => Number.isInteger(n) && n > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * `forge shepherd watch --adopt` — arm a detached watcher for EVERY currently-open
+ * PR (covers PRs created via gh/UI, or before this rail existed). Idempotent: the
+ * watch loop's PID/journal lock means an already-watched PR is not double-started.
+ * Fail-open per PR and overall — never throws.
+ *
+ * @param {string} projectRoot
+ * @param {object} [deps]
+ * @returns {{ success: true, adopted: number[], total: number }}
+ */
+function handleAdopt(projectRoot, deps = {}) {
+  const listOpenPrs = deps.listOpenPrs || defaultListOpenPrs;
+  const startWatcher = deps.startWatcher || startPrWatcherDetached;
+  let prs;
+  try {
+    prs = listOpenPrs();
+  } catch {
+    prs = [];
+  }
+  if (!Array.isArray(prs)) prs = [];
+  const adopted = [];
+  for (const pr of prs) {
+    try {
+      const res = startWatcher({ prNumber: pr, cwd: projectRoot });
+      if (res && res.started) adopted.push(pr);
+    } catch { /* fail-open per PR: one bad arm never blocks the rest */ }
+  }
+  return { success: true, adopted, total: prs.length };
+}
+
 async function handleWatch(args, projectRoot, deps = {}) {
   const rawArgs = args || [];
+  // `--adopt` (no PR arg): arm a detached watcher for every open PR.
+  if (rawArgs.includes('--adopt')) {
+    return handleAdopt(projectRoot, deps);
+  }
   const pr = rawArgs.find((a) => !String(a).startsWith('--') && a !== 'watch');
   if (!pr) {
-    return { success: false, error: 'Usage: forge shepherd watch <pr>' };
+    return { success: false, error: 'Usage: forge shepherd watch <pr> | forge shepherd watch --adopt' };
   }
 
   const built = await buildMonitorContext(pr, projectRoot, deps);
@@ -424,7 +480,7 @@ async function handler(args, _flags, projectRoot, deps = {}) {
 module.exports = {
   name: 'shepherd',
   description: 'Run one bounded monitor pass over a PR (rerun flaky checks, escalate, hand off — never merges)',
-  usage: 'Usage: forge shepherd <pr> [--auto-rebase] [--bundle --json] [--pull --json] | forge shepherd events <pr> --since <seq> [--json] | forge shepherd watch <pr>',
+  usage: 'Usage: forge shepherd <pr> [--auto-rebase] [--bundle --json] [--pull --json] | forge shepherd events <pr> --since <seq> [--json] | forge shepherd watch <pr> | forge shepherd watch --adopt',
   handler,
   handleEvents,
   handleWatch,

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -39,6 +39,7 @@ const { watchLoop } = require('../pr-monitor/watch');
 const { startPrWatcherDetached } = require('../pr-monitor/watch-lifecycle');
 const monitorJournal = require('../pr-monitor/journal');
 const { EVENT_TYPES: T } = require('../pr-monitor/events');
+const { autoShepherdRailEnabled } = require('./ship');
 
 const DEFAULT_RERUN_BUDGET = 3;
 
@@ -296,13 +297,21 @@ function defaultListOpenPrs(exec = execFileSync) {
  * `forge shepherd watch --adopt` — arm a detached watcher for EVERY currently-open
  * PR (covers PRs created via gh/UI, or before this rail existed). Idempotent: the
  * watch loop's PID/journal lock means an already-watched PR is not double-started.
- * Fail-open per PR and overall — never throws.
+ * Fail-open per PR and overall — never throws. Honors the default-ON
+ * `rail.auto_shepherd` rail: when a maintainer has disabled it, adoption is a
+ * no-op — no PR listing, no watcher spawn — matching `forge push`/`forge ship`.
  *
  * @param {string} projectRoot
  * @param {object} [deps]
- * @returns {{ success: true, adopted: number[], total: number }}
+ * @returns {{ success: true, adopted: number[], total: number, reason?: string }}
  */
 function handleAdopt(projectRoot, deps = {}) {
+  const railEnabled = deps.railEnabled || autoShepherdRailEnabled;
+  // Gate BEFORE listing PRs / spawning watchers: a disabled rail must not spawn
+  // detached watchers. No-op result mirrors the fail-open (empty) adoption shape.
+  if (!railEnabled(projectRoot)) {
+    return { success: true, adopted: [], total: 0, reason: 'rail.auto_shepherd disabled' };
+  }
   const listOpenPrs = deps.listOpenPrs || defaultListOpenPrs;
   const startWatcher = deps.startWatcher || startPrWatcherDetached;
   let prs;
@@ -316,7 +325,7 @@ function handleAdopt(projectRoot, deps = {}) {
   for (const pr of prs) {
     try {
       const res = startWatcher({ prNumber: pr, cwd: projectRoot });
-      if (res && res.started) adopted.push(pr);
+      if (res?.started) adopted.push(pr);
     } catch { /* fail-open per PR: one bad arm never blocks the rest */ }
   }
   return { success: true, adopted, total: prs.length };

--- a/test/pr-monitor/arm-on-push.test.js
+++ b/test/pr-monitor/arm-on-push.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const push = require('../../lib/commands/push');
+const shepherd = require('../../lib/commands/shepherd');
+
+const { maybeArmWatcherAfterPush } = push._internal;
+
+// Gap 1 (epic c2d398e5, refs cf8361bc): arm the constant PR watcher on ANY open
+// PR, not just `forge ship`. `forge push` arms the current branch's open PR;
+// `forge shepherd watch --adopt` arms every open PR. Both reuse the existing
+// startPrWatcherDetached, are gated by rail.auto_shepherd, and NEVER throw into
+// the push/adopt path.
+
+describe('maybeArmWatcherAfterPush (forge push wiring)', () => {
+  test('arms the watcher when the rail is on and an open PR exists', () => {
+    const calls = [];
+    const r = maybeArmWatcherAfterPush({
+      projectRoot: '/r', execFn: () => '',
+      startWatcher: (opts) => { calls.push(opts); return { started: true, pid: 1 }; },
+      railEnabled: () => true,
+      prLookup: () => 42,
+    });
+    expect(r.armed).toBe(true);
+    expect(r.prNumber).toBe(42);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].prNumber).toBe(42);
+    expect(calls[0].cwd).toBe('/r');
+  });
+
+  test('skips when there is no open PR for the branch', () => {
+    let called = false;
+    const r = maybeArmWatcherAfterPush({
+      projectRoot: '/r', execFn: () => '',
+      startWatcher: () => { called = true; return { started: true }; },
+      railEnabled: () => true,
+      prLookup: () => null,
+    });
+    expect(called).toBe(false);
+    expect(r.armed).toBe(false);
+    expect(r.reason).toBe('no-open-pr');
+  });
+
+  test('skips when rail.auto_shepherd is disabled', () => {
+    let called = false;
+    const r = maybeArmWatcherAfterPush({
+      projectRoot: '/r', execFn: () => '',
+      startWatcher: () => { called = true; return { started: true }; },
+      railEnabled: () => false,
+      prLookup: () => 42,
+    });
+    expect(called).toBe(false);
+    expect(r.armed).toBe(false);
+    expect(r.reason).toMatch(/rail\.auto_shepherd/);
+  });
+
+  test('never throws when the PR lookup throws — push must survive', () => {
+    const r = maybeArmWatcherAfterPush({
+      projectRoot: '/r', execFn: () => '',
+      startWatcher: () => ({ started: true }),
+      railEnabled: () => true,
+      prLookup: () => { throw new Error('gh boom'); },
+    });
+    expect(r.armed).toBe(false);
+    expect(r.reason).toMatch(/gh boom/);
+  });
+
+  test('never throws when the watcher spawn throws', () => {
+    const r = maybeArmWatcherAfterPush({
+      projectRoot: '/r', execFn: () => '',
+      startWatcher: () => { throw new Error('spawn boom'); },
+      railEnabled: () => true,
+      prLookup: () => 7,
+    });
+    expect(r.armed).toBe(false);
+    expect(r.reason).toMatch(/spawn boom/);
+  });
+});
+
+describe('forge shepherd watch --adopt', () => {
+  test('arms a detached watcher for every open PR', async () => {
+    const calls = [];
+    const res = await shepherd.handler(['watch', '--adopt'], {}, '/r', {
+      listOpenPrs: () => [10, 11, 12],
+      startWatcher: (opts) => { calls.push(opts.prNumber); return { started: true }; },
+    });
+    expect(res.success).toBe(true);
+    expect(calls.sort((a, b) => a - b)).toEqual([10, 11, 12]);
+    expect(res.adopted.sort((a, b) => a - b)).toEqual([10, 11, 12]);
+    expect(res.total).toBe(3);
+  });
+
+  test('does NOT double-arm an already-running watcher (idempotent)', async () => {
+    const res = await shepherd.handler(['watch', '--adopt'], {}, '/r', {
+      listOpenPrs: () => [5, 6],
+      // PR 6 already has a running watcher → startWatcher reports not started.
+      startWatcher: (opts) => ({ started: opts.prNumber === 5 }),
+    });
+    expect(res.adopted).toEqual([5]);
+    expect(res.total).toBe(2);
+  });
+
+  test('is fail-open when listing open PRs throws', async () => {
+    const res = await shepherd.handler(['watch', '--adopt'], {}, '/r', {
+      listOpenPrs: () => { throw new Error('gh down'); },
+      startWatcher: () => ({ started: true }),
+    });
+    expect(res.success).toBe(true);
+    expect(res.adopted).toEqual([]);
+  });
+
+  test('one bad arm never blocks the rest', async () => {
+    const res = await shepherd.handler(['watch', '--adopt'], {}, '/r', {
+      listOpenPrs: () => [1, 2, 3],
+      startWatcher: (opts) => {
+        if (opts.prNumber === 2) throw new Error('arm 2 failed');
+        return { started: true };
+      },
+    });
+    expect(res.adopted.sort((a, b) => a - b)).toEqual([1, 3]);
+  });
+});

--- a/test/pr-monitor/arm-on-push.test.js
+++ b/test/pr-monitor/arm-on-push.test.js
@@ -120,4 +120,20 @@ describe('forge shepherd watch --adopt', () => {
     });
     expect(res.adopted.sort((a, b) => a - b)).toEqual([1, 3]);
   });
+
+  test('is a no-op when rail.auto_shepherd is disabled — no listing, no spawn', async () => {
+    let listed = false;
+    let spawned = false;
+    const res = await shepherd.handler(['watch', '--adopt'], {}, '/r', {
+      railEnabled: () => false,
+      listOpenPrs: () => { listed = true; return [1, 2, 3]; },
+      startWatcher: () => { spawned = true; return { started: true }; },
+    });
+    expect(listed).toBe(false);
+    expect(spawned).toBe(false);
+    expect(res.success).toBe(true);
+    expect(res.adopted).toEqual([]);
+    expect(res.total).toBe(0);
+    expect(res.reason).toMatch(/rail\.auto_shepherd/);
+  });
 });


### PR DESCRIPTION
## What

Closes Gap 1 (epic c2d398e5, refs cf8361bc): the constant PR-shepherd watcher only auto-started from `forge ship`, so PRs made via `gh pr create`, the GitHub UI, or an earlier push got **no** watcher. This arms the watcher on **any open PR**.

Two arming paths — both reuse the existing `startPrWatcherDetached` (detached, unref'd, idempotent via the watch loop's PID/journal lock), both gated by the default-ON `rail.auto_shepherd`, both fail-open:

1. **`forge push`** — after a successful push, resolves the current branch's OPEN PR (`gh pr view --json number`) and arms its watcher. A disabled rail, no PR, a gh error, or a spawn error all degrade to not-armed and **never fail the push**.
2. **`forge shepherd watch --adopt`** — arms a detached watcher for **every** open PR (`gh pr list`), idempotent (already-running PRs are not double-started), fail-open per PR and overall.

Reuses ship's `autoShepherdRailEnabled` for the rail gate (no new rail logic). Core (watch loop / journal / watch-lifecycle) untouched.

## Tests

`test/pr-monitor/arm-on-push.test.js` (9): push arms on rail-on + open-PR; skips on no-PR / rail-off; never throws when the gh lookup or spawn throws; `--adopt` arms all open PRs, is idempotent, is fail-open when listing throws, and one bad arm never blocks the rest. ESLint clean; `forge release check` PASS.

## Note

**Stacked on PR #407** (needs the `rail.auto_shepherd` rail added there) — its diff includes #407's commit until #407 merges; rebases cleanly onto master afterward.

Refs cf8361bc, epic c2d398e5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically starts PR monitoring after a successful push when enabled and an open PR is found.
  * Added `forge shepherd watch --adopt` to start monitoring all currently open PRs.
  * Adoption continues for other PRs if one watcher fails.

* **Bug Fixes**
  * Monitoring setup failures no longer interrupt push or adoption workflows.
  * Re-running adoption avoids starting duplicate watchers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->