### PR TITLE
feat(shepherd): surface PR-monitor events into each turn (hooks shepherd-events)

### DIFF
--- a/docs/reference/shepherd.md
+++ b/docs/reference/shepherd.md
@@ -86,10 +86,11 @@ surface as every other rail.
 
 ## Surfacing events back to the agent (`forge hooks shepherd-events`)
 
-The constant watch loop and `forge shepherd events <pr> --since <seq>` write
-per-PR NDJSON journals under `.forge/pr-monitor/<repo>-<pr>/`, but a journal only
-helps if something reads it. `forge hooks shepherd-events` is the thin, agent-
-agnostic CONSUMER: it reads the NEW budget events across all open-PR journals
+The constant watch loop is the PRODUCER: it writes per-PR NDJSON journals under
+`.forge/pr-monitor/<repo>-<pr>/`, while the `forge shepherd events <pr> --since
+<seq>` pull surface reads existing records back from them. But a journal only
+helps if the working agent sees it. `forge hooks shepherd-events` is the thin,
+agent-agnostic CONSUMER: it reads the NEW budget events across all open-PR journals
 since a persisted per-PR **consumer cursor** (kept in `consumer.cursor`, distinct
 from the watcher's snapshot), renders a **compact, capped** summary of the
 actionable transitions only — verdict changes, failed checks, new review threads,

--- a/docs/reference/shepherd.md
+++ b/docs/reference/shepherd.md
@@ -67,6 +67,25 @@ up from there.
 a `/loop`) that re-invokes the bounded pass with a debounce of at least 60
 seconds and cancel-in-progress. The shepherd itself never waits in-process.
 
+## Surfacing events back to the agent (`forge hooks shepherd-events`)
+
+The constant watch loop and `forge shepherd events <pr> --since <seq>` write
+per-PR NDJSON journals under `.forge/pr-monitor/<repo>-<pr>/`, but a journal only
+helps if something reads it. `forge hooks shepherd-events` is the thin, agent-
+agnostic CONSUMER: it reads the NEW budget events across all open-PR journals
+since a persisted per-PR **consumer cursor** (kept in `consumer.cursor`, distinct
+from the watcher's snapshot), renders a **compact, capped** summary of the
+actionable transitions only — verdict changes, failed checks, new review threads,
+merged/closed — then advances the cursor so nothing re-surfaces.
+
+For Claude Code this is wired as a **UserPromptSubmit** context hook (the honest
+capability matrix: only Claude exposes that additionalContext surface; Cursor /
+Codex / Hermes carry an explicit skip reason). It is **additive and FAIL-OPEN** —
+a missing/empty digest, a corrupt journal, or no `.forge/pr-monitor` at all never
+blocks a prompt — and it reads the user's own local journal only: it never
+injects into stdin and never drives the agent. Any other harness can call the
+same verb (or `forge shepherd events`) on its own cadence.
+
 ## Terminal states
 
 | State         | Meaning |

--- a/lib/commands/hooks.js
+++ b/lib/commands/hooks.js
@@ -190,7 +190,11 @@ async function handleInboxPickup(rest, projectRoot, opts = {}) {
 function handleShepherdEvents(rest, projectRoot, opts = {}) {
   try {
     const harness = parseHarness(rest);
-    if (!userPromptSubmitCapability(harness).rendered) return { success: true, output: '' };
+    const capability = userPromptSubmitCapability(harness);
+    // Honest capability matrix: a non-Claude harness gets an explicit skip
+    // reason as surface-only result metadata (for callers/telemetry) but NEVER
+    // any injected output — `reason` must not drive the agent.
+    if (!capability.rendered) return { success: true, output: '', reason: capability.reason };
     const collect = opts.collectDigest || collectDigest;
     const { text } = collect({ root: projectRoot });
     if (!text) return { success: true, output: '' };

--- a/lib/commands/hooks.js
+++ b/lib/commands/hooks.js
@@ -30,11 +30,13 @@ const {
 const { sessionStartCapability, userPromptSubmitCapability, sessionEndCapability } = require('../hook-renderer');
 const { collectDigestData, buildMemoryDigest, defaultFetchIssues, defaultFetchNotes } = require('../memory-digest');
 const { collectInbox, buildInboxNudge } = require('../inbox');
+const { collectDigest } = require('../pr-monitor/digest');
 
 function usage() {
   return 'Usage: forge hooks install --global [--harness codex|hermes|all] [--dry-run]\n'
     + '       forge hooks session-start --harness <claude> (machine-facing; emits SessionStart context)\n'
     + '       forge hooks inbox-pickup --harness <claude> (machine-facing; emits UserPromptSubmit context)\n'
+    + '       forge hooks shepherd-events --harness <claude> (machine-facing; emits UserPromptSubmit PR-monitor deltas)\n'
     + '       forge hooks capture --harness <claude> --trigger <precompact|stop> (machine-facing; captures a session summary on exit)';
 }
 
@@ -163,6 +165,36 @@ async function handleInboxPickup(rest, projectRoot, opts = {}) {
     const nudge = buildInboxNudge(pending);
     if (nudge.empty) return { success: true, output: '' };
     return { success: true, output: formatUserPromptSubmit(harness, nudge.text) };
+  } catch {
+    // Fail-open: a context hook must never break a prompt.
+    return { success: true, output: '' };
+  }
+}
+
+/**
+ * `forge hooks shepherd-events --harness <h>` — the PR-shepherd CONTEXT hook. On each
+ * prompt it emits harness-native UserPromptSubmit JSON carrying a COMPACT, capped digest
+ * of NEW PR-monitor events (verdict changes, failed checks, new threads, merged/closed)
+ * since the last read across all open-PR journals, then advances the per-PR consumer
+ * cursor so nothing re-surfaces. This is the CONSUMER side of the constant watcher: the
+ * watch loop writes the journal, this pushes the deltas to the working agent. It reads the
+ * user's OWN local journal via a supported hook — it NEVER injects into stdin and NEVER
+ * drives the agent (Anthropic Usage Policy). FAIL-OPEN: any failure, an unsupported
+ * harness, or no new events yields '' (the harness injects nothing). NEVER throws.
+ *
+ * @param {string[]} rest - args after the `shepherd-events` action.
+ * @param {string} projectRoot
+ * @param {object} [opts] - injectable digest collector ({ collectDigest }).
+ * @returns {{ success: boolean, output: string }}
+ */
+function handleShepherdEvents(rest, projectRoot, opts = {}) {
+  try {
+    const harness = parseHarness(rest);
+    if (!userPromptSubmitCapability(harness).rendered) return { success: true, output: '' };
+    const collect = opts.collectDigest || collectDigest;
+    const { text } = collect({ root: projectRoot });
+    if (!text) return { success: true, output: '' };
+    return { success: true, output: formatUserPromptSubmit(harness, text) };
   } catch {
     // Fail-open: a context hook must never break a prompt.
     return { success: true, output: '' };
@@ -319,11 +351,12 @@ async function handler(args, flags = {}, projectRoot, opts = {}) {
   const action = args[0];
   if (action === 'session-start') return handleSessionStart(args.slice(1), projectRoot, opts);
   if (action === 'inbox-pickup') return handleInboxPickup(args.slice(1), projectRoot, opts);
+  if (action === 'shepherd-events') return handleShepherdEvents(args.slice(1), projectRoot, opts);
   if (action === 'capture') return handleCapture(args.slice(1), projectRoot, opts);
   if (action === 'install') return handleInstall(args, flags, opts);
   return {
     success: false,
-    error: `forge hooks supports: install, session-start, inbox-pickup, capture.\n${usage()}`,
+    error: `forge hooks supports: install, session-start, inbox-pickup, shepherd-events, capture.\n${usage()}`,
   };
 }
 

--- a/lib/hook-renderer.js
+++ b/lib/hook-renderer.js
@@ -75,6 +75,11 @@ const FORGE_CONTEXT_MARKER = 'hooks session-start';
 // re-merge recognizes + replaces the Forge-owned UserPromptSubmit entry in place, exactly
 // as FORGE_CONTEXT_MARKER does for the SessionStart entry.
 const FORGE_INBOX_CONTEXT_MARKER = 'hooks inbox-pickup';
+// The PR-shepherd events context hook (a SECOND UserPromptSubmit-tier hook). Its own
+// marker so a re-merge recognizes + replaces the Forge-owned entry in place. The whole
+// Forge UserPromptSubmit group is already recognized via the inbox marker, but this keeps
+// the shepherd-events command independently identifiable (symmetry with the other tiers).
+const FORGE_SHEPHERD_EVENTS_MARKER = 'hooks shepherd-events';
 // The capture-on-exit context hook (PreCompact + Stop tier). A THIRD context marker so a
 // re-merge recognizes + replaces the Forge-owned PreCompact/Stop entries in place. Both
 // events share this one marker (they differ only by a --trigger suffix on the command).
@@ -173,6 +178,20 @@ const FORGE_HOOK_CONTRACT = Object.freeze({
       enforces: 'Comment-back pickup: surface a compact count+pointer nudge for pending targeted dashboard instruction comments on each UserPromptSubmit (compact to avoid additionalContext accumulation; full fenced digest is at SessionStart + `forge inbox`). Additive and FAIL-OPEN — a missing nudge never blocks a prompt.',
       lifecycle: 'user-prompt-submit',
       command: `${FORGE_CLI} hooks inbox-pickup`,
+    }),
+    Object.freeze({
+      id: 'shepherd-events',
+      kind: 'context',
+      cliAction: 'shepherd-events',
+      // PR-SHEPHERD DELTAS: surfaces a compact, capped digest of NEW PR-monitor events
+      // (verdict changes, failed checks, new threads, merged/closed) since the last read,
+      // then advances the per-PR consumer cursor. This is the CONSUMER side of the constant
+      // watcher — the watch loop writes the journal, this pushes the deltas each turn. Reads
+      // the user's OWN local journal via a supported hook — NEVER stdin injection, never
+      // drives the agent (Anthropic Usage Policy).
+      enforces: 'PR shepherd events: on each UserPromptSubmit, surface a compact, capped digest of NEW PR-monitor events (verdict changes, failed checks, new threads, merged/closed) since the last read across open-PR journals, then advance the cursor. Compact to avoid additionalContext accumulation. Additive and FAIL-OPEN — a missing digest never blocks a prompt.',
+      lifecycle: 'user-prompt-submit',
+      command: `${FORGE_CLI} hooks shepherd-events`,
     }),
     Object.freeze({
       id: 'memory-capture',
@@ -276,8 +295,17 @@ function renderClaudeHooks(contract) {
     // Surfaces pending targeted dashboard instruction comments (fenced kernel DATA) on each
     // prompt; the command emits { hookSpecificOutput.additionalContext }. Reads the user's
     // own kernel data via a supported hook — NEVER stdin injection (Anthropic Usage Policy).
+    // Both UserPromptSubmit context hooks share ONE Forge-owned group (inbox-pickup +
+    // PR-shepherd deltas). Claude runs every hook in the group and appends each hook's
+    // additionalContext; keeping them in one group means a re-merge replaces the pair
+    // atomically (the group is Forge-owned via either marker). Both are compact + fail-open.
     UserPromptSubmit: [
-      { hooks: [{ type: 'command', command: harnessCommand(contract, 'inbox-pickup', 'claude') }] },
+      {
+        hooks: [
+          { type: 'command', command: harnessCommand(contract, 'inbox-pickup', 'claude') },
+          { type: 'command', command: harnessCommand(contract, 'shepherd-events', 'claude') },
+        ],
+      },
     ],
     // Capture-on-exit (memory capture). PreCompact fires before context is compacted; Stop
     // fires when the agent finishes. Both call the same capture command; the event stamps the
@@ -369,6 +397,7 @@ function isForgeCommand(command) {
     && (command.includes(FORGE_HOOK_MARKER)
       || command.includes(FORGE_CONTEXT_MARKER)
       || command.includes(FORGE_INBOX_CONTEXT_MARKER)
+      || command.includes(FORGE_SHEPHERD_EVENTS_MARKER)
       || command.includes(FORGE_CAPTURE_CONTEXT_MARKER));
 }
 

--- a/lib/pr-monitor/digest.js
+++ b/lib/pr-monitor/digest.js
@@ -2,12 +2,13 @@
 
 /**
  * PR-shepherd digest — the thin CONSUMER half of the constant monitor (epic
- * c2d398e5, 33e1bbd3). The watch loop / `forge shepherd events` write per-PR
- * NDJSON journals under `.forge/pr-monitor/<repo>-<pr>/`, but nothing surfaced
- * those events back to a working agent. This module reads the NEW budget events
- * across all PR journals since a persisted per-PR CONSUMER cursor, renders a
- * COMPACT capped summary, and advances the cursor — the exact payload a harness
- * hook (Claude UserPromptSubmit) injects each turn.
+ * c2d398e5, 33e1bbd3). The constant watch loop is the PRODUCER: it writes the
+ * per-PR NDJSON journals under `.forge/pr-monitor/<repo>-<pr>/` (the `forge
+ * shepherd events` pull surface reads those same records back). Nothing, though,
+ * surfaced those events to a working agent. This module is a pure READER: it
+ * reads the NEW budget events across all PR journals since a persisted per-PR
+ * CONSUMER cursor, renders a COMPACT capped summary, and advances the cursor —
+ * the exact payload a harness hook (Claude UserPromptSubmit) injects each turn.
  *
  * The CORE (events/journal/watch/monitor) is untouched: this only READS the
  * journal via `journal.readEventsSince` and keeps its OWN `consumer.cursor`

--- a/lib/pr-monitor/digest.js
+++ b/lib/pr-monitor/digest.js
@@ -1,0 +1,205 @@
+'use strict';
+
+/**
+ * PR-shepherd digest — the thin CONSUMER half of the constant monitor (epic
+ * c2d398e5, 33e1bbd3). The watch loop / `forge shepherd events` write per-PR
+ * NDJSON journals under `.forge/pr-monitor/<repo>-<pr>/`, but nothing surfaced
+ * those events back to a working agent. This module reads the NEW budget events
+ * across all PR journals since a persisted per-PR CONSUMER cursor, renders a
+ * COMPACT capped summary, and advances the cursor — the exact payload a harness
+ * hook (Claude UserPromptSubmit) injects each turn.
+ *
+ * The CORE (events/journal/watch/monitor) is untouched: this only READS the
+ * journal via `journal.readEventsSince` and keeps its OWN `consumer.cursor`
+ * (distinct from the watcher's snapshot), so consumption never disturbs
+ * production. Every function is fail-open — a bad journal degrades to skipped,
+ * never throws — because it feeds a hook that must never block a prompt.
+ *
+ * @module pr-monitor/digest
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const journalMod = require('./journal');
+
+/**
+ * The event types worth surfacing on each turn — the ACTIONABLE transitions
+ * (verdict flip, a failed check, a new review thread, terminal merge/close).
+ * Everything else (head pushes, green checks, degraded notices) stays in the
+ * journal for `forge shepherd events` but is NOT pushed, to keep the injected
+ * context tiny.
+ */
+const BUDGET_TYPES = Object.freeze(new Set([
+  'verdict.changed', 'check.failed', 'thread.opened', 'pr.merged', 'pr.closed',
+]));
+
+const DEFAULT_CAP = 8;
+const CONSUMER_CURSOR_FILE = 'consumer.cursor';
+
+/** Absolute `.forge/pr-monitor` root for a project. */
+function monitorRoot(root) {
+  return path.join(root, '.forge', 'pr-monitor');
+}
+
+/** The per-PR consumer cursor path (distinct from the watcher's snapshot/pid). */
+function cursorPath(dir) {
+  return path.join(dir, CONSUMER_CURSOR_FILE);
+}
+
+/**
+ * List absolute PR journal dirs (those containing an events.ndjson). Fail-open:
+ * a missing monitor root or unreadable dir yields []. Injectable fs for tests.
+ *
+ * @param {string} root
+ * @param {{ readdirSync?: Function, existsSync?: Function }} [deps]
+ * @returns {string[]}
+ */
+function discoverPrDirs(root, deps = {}) {
+  const readdir = deps.readdirSync || fs.readdirSync;
+  const exists = deps.existsSync || fs.existsSync;
+  try {
+    return readdir(monitorRoot(root), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => path.join(monitorRoot(root), e.name))
+      .filter((dir) => exists(path.join(dir, 'events.ndjson')));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read a PR's consumer cursor (the last consumed seq). Fail-open → 0 (no cursor,
+ * unreadable, or malformed all mean "start from the beginning").
+ *
+ * @param {string} dir
+ * @param {{ readFileSync?: Function }} [deps]
+ * @returns {number}
+ */
+function readConsumerCursor(dir, deps = {}) {
+  const readFile = deps.readFileSync || fs.readFileSync;
+  try {
+    const obj = JSON.parse(readFile(cursorPath(dir), 'utf8'));
+    const seq = Number(obj && obj.seq);
+    return Number.isFinite(seq) && seq >= 0 ? seq : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Persist a PR's consumer cursor. Fail-open: an unwritable cursor returns false
+ * (next turn re-reads the same events — a duplicate nudge, never a crash).
+ *
+ * @param {string} dir
+ * @param {number} seq
+ * @param {{ writeFileSync?: Function }} [deps]
+ * @returns {boolean}
+ */
+function writeConsumerCursor(dir, seq, deps = {}) {
+  const writeFile = deps.writeFileSync || fs.writeFileSync;
+  try {
+    writeFile(cursorPath(dir), `${JSON.stringify({ seq: Number(seq) || 0 })}\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A compact one-line label for a budget event. PURE. Bounded so injected context
+ * stays tiny; the full record is always available via `forge shepherd events`.
+ *
+ * @param {object} e - a journal event.
+ * @returns {string}
+ */
+function renderEventLine(e) {
+  const pr = e.pr != null ? `#${e.pr}` : '#?';
+  const d = e.data || {};
+  let detail;
+  switch (e.type) {
+    case 'verdict.changed': detail = (e.verdict && (e.verdict.verdict || e.verdict.state)) || d.verdict || d.to || ''; break;
+    case 'check.failed': detail = d.name || d.check || ''; break;
+    case 'thread.opened': detail = d.author ? `by ${d.author}` : (d.path || ''); break;
+    case 'pr.merged': detail = 'merged'; break;
+    case 'pr.closed': detail = 'closed'; break;
+    default: detail = '';
+  }
+  const suffix = detail ? `: ${String(detail).slice(0, 60)}` : '';
+  return `- PR ${pr} ${e.type}${suffix}`;
+}
+
+/**
+ * PURE: filter events to the budget types, cap the count, and render lines.
+ *
+ * @param {object[]} events
+ * @param {{ cap?: number }} [opts]
+ * @returns {{ lines: string[], total: number }}
+ */
+function renderDigestLines(events, { cap = DEFAULT_CAP } = {}) {
+  const budget = (Array.isArray(events) ? events : []).filter((e) => e && BUDGET_TYPES.has(e.type));
+  const lines = budget.map(renderEventLine);
+  return { lines: lines.slice(0, cap), total: lines.length };
+}
+
+/**
+ * Format the compact injected block (a header + capped lines + an overflow
+ * pointer), or '' when there is nothing to surface. PURE.
+ */
+function formatBlock(lines, total, cap, prs) {
+  if (lines.length === 0) return '';
+  const on = prs.length ? ` on PR(s) ${prs.join(', ')}` : '';
+  const more = total > cap ? `\n(+${total - cap} more — see \`forge shepherd events <pr> --since <seq>\`)` : '';
+  return `[forge PR shepherd] ${total} new event(s)${on}:\n${lines.join('\n')}${more}`;
+}
+
+/**
+ * Collect a compact digest of NEW budget events across every PR journal since the
+ * per-PR consumer cursor, advancing each cursor past EVERYTHING read (budget and
+ * non-budget alike, so skipped types never re-surface). Fail-open throughout.
+ *
+ * @param {object} args
+ * @param {string} args.root - project root.
+ * @param {object} [args.journal] - journal module (test injection).
+ * @param {number} [args.cap] - max lines in the block.
+ * @param {object} [args.fsDeps] - injectable fs for discovery + cursor I/O.
+ * @returns {{ text: string, total: number, prs: string[] }}
+ */
+function collectDigest({ root, journal = journalMod, cap = DEFAULT_CAP, fsDeps = {} } = {}) {
+  const dirs = discoverPrDirs(root, fsDeps);
+  const allLines = [];
+  const prs = new Set();
+  for (const dir of dirs) {
+    const cursor = readConsumerCursor(dir, fsDeps);
+    let evs;
+    try {
+      evs = journal.readEventsSince(dir, cursor);
+    } catch {
+      evs = [];
+    }
+    if (!Array.isArray(evs) || evs.length === 0) continue;
+    const maxSeq = evs.reduce((m, e) => Math.max(m, Number(e.seq) || 0), cursor);
+    for (const e of evs) {
+      if (!e || !BUDGET_TYPES.has(e.type)) continue;
+      allLines.push(renderEventLine(e));
+      if (e.pr != null) prs.add(String(e.pr));
+    }
+    writeConsumerCursor(dir, maxSeq, fsDeps);
+  }
+  const capped = allLines.slice(0, cap);
+  return { text: formatBlock(capped, allLines.length, cap, [...prs]), total: allLines.length, prs: [...prs] };
+}
+
+module.exports = {
+  BUDGET_TYPES,
+  DEFAULT_CAP,
+  monitorRoot,
+  cursorPath,
+  discoverPrDirs,
+  readConsumerCursor,
+  writeConsumerCursor,
+  renderEventLine,
+  renderDigestLines,
+  formatBlock,
+  collectDigest,
+};

--- a/test/hook-renderer.test.js
+++ b/test/hook-renderer.test.js
@@ -36,11 +36,12 @@ describe('Forge hook contract', () => {
   test('declares enforcement (protected-path, tdd-gate) + context (memory-inject, inbox-pickup, memory-capture) intents', () => {
     expect(FORGE_HOOK_CONTRACT.kind).toBe('forge.hookContract');
     const ids = FORGE_HOOK_CONTRACT.intents.map(i => i.id);
-    expect(ids).toEqual(['protected-path', 'tdd-gate', 'memory-inject', 'inbox-pickup', 'memory-capture']);
+    expect(ids).toEqual(['protected-path', 'tdd-gate', 'memory-inject', 'inbox-pickup', 'shepherd-events', 'memory-capture']);
     // Each context intent routes to the `forge` CLI via a `hooks <cliAction>` marker.
     const CONTEXT_MARKERS = {
       'memory-inject': FORGE_CONTEXT_MARKER,
       'inbox-pickup': 'hooks inbox-pickup',
+      'shepherd-events': 'hooks shepherd-events',
       'memory-capture': 'hooks capture',
     };
     for (const intent of FORGE_HOOK_CONTRACT.intents) {

--- a/test/pr-monitor/digest.test.js
+++ b/test/pr-monitor/digest.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+const {
+  BUDGET_TYPES,
+  renderDigestLines,
+  collectDigest,
+  readConsumerCursor,
+  writeConsumerCursor,
+} = require('../../lib/pr-monitor/digest');
+const hooks = require('../../lib/commands/hooks');
+
+// Gap 2 (epic c2d398e5, 33e1bbd3): the thin CONSUMER that surfaces NEW PR-monitor
+// journal events into each turn. Pure digest core + a fail-open UserPromptSubmit
+// hook. The CORE (events/journal/watch) is untouched.
+
+const ev = (type, over = {}) => ({ type, pr: '12', seq: 1, data: {}, ...over });
+
+describe('renderDigestLines — budget filter + cap (pure)', () => {
+  test('keeps only budget event types', () => {
+    const events = [
+      ev('verdict.changed', { verdict: { verdict: 'BEHIND' } }),
+      ev('head.pushed'),
+      ev('checks.green'),
+      ev('check.failed', { data: { name: 'eslint' } }),
+      ev('thread.opened', { data: { author: 'coderabbitai' } }),
+      ev('pr.merged'),
+      ev('monitor.degraded'),
+    ];
+    const { lines, total } = renderDigestLines(events, { cap: 10 });
+    expect(total).toBe(4); // verdict.changed, check.failed, thread.opened, pr.merged
+    expect(lines.join('\n')).toContain('verdict.changed');
+    expect(lines.join('\n')).toContain('BEHIND');
+    expect(lines.join('\n')).toContain('eslint');
+    expect(lines.join('\n')).not.toContain('head.pushed');
+    expect(lines.join('\n')).not.toContain('checks.green');
+  });
+
+  test('caps the number of rendered lines', () => {
+    const events = Array.from({ length: 20 }, (_, i) => ev('check.failed', { data: { name: `c${i}` } }));
+    const { lines, total } = renderDigestLines(events, { cap: 5 });
+    expect(lines).toHaveLength(5);
+    expect(total).toBe(20);
+  });
+
+  test('BUDGET_TYPES is exactly the five actionable transitions', () => {
+    expect([...BUDGET_TYPES].sort()).toEqual(
+      ['check.failed', 'pr.closed', 'pr.merged', 'thread.opened', 'verdict.changed'],
+    );
+  });
+});
+
+describe('collectDigest — reads since cursor, advances cursor, fail-open', () => {
+  // A fake journal + in-memory fs so no real .forge/pr-monitor is touched.
+  function harness(events) {
+    const cursors = {}; // dir -> seq
+    const fsDeps = {
+      readdirSync: () => [{ name: 'repo-12', isDirectory: () => true }],
+      existsSync: () => true,
+      readFileSync: (p) => {
+        const dir = p.replace(/[/\\]consumer\.cursor$/, '');
+        if (!(dir in cursors)) throw new Error('no cursor');
+        return JSON.stringify({ seq: cursors[dir] });
+      },
+      writeFileSync: (p, body) => {
+        const dir = p.replace(/[/\\]consumer\.cursor$/, '');
+        cursors[dir] = JSON.parse(body).seq;
+      },
+    };
+    const journal = { readEventsSince: (_dir, since) => events.filter((e) => e.seq > since) };
+    return { fsDeps, journal, cursors };
+  }
+
+  test('surfaces new budget events and advances the cursor past everything read', () => {
+    const events = [
+      { type: 'head.pushed', pr: '12', seq: 1, data: {} },
+      { type: 'check.failed', pr: '12', seq: 2, data: { name: 'eslint' } },
+      { type: 'verdict.changed', pr: '12', seq: 3, verdict: { verdict: 'BLOCKED-CHECKS' }, data: {} },
+    ];
+    const { fsDeps, journal, cursors } = harness(events);
+    const first = collectDigest({ root: '/r', journal, fsDeps });
+    expect(first.total).toBe(2); // check.failed + verdict.changed (head.pushed skipped)
+    expect(first.text).toContain('eslint');
+    expect(first.text).toContain('BLOCKED-CHECKS');
+    expect(first.prs).toEqual(['12']);
+    // cursor advanced to the max seq READ (3), including the skipped head.pushed
+    expect(Object.values(cursors)[0]).toBe(3);
+
+    // Second call with no new events → empty, idempotent.
+    const second = collectDigest({ root: '/r', journal, fsDeps });
+    expect(second.total).toBe(0);
+    expect(second.text).toBe('');
+  });
+
+  test('is fail-open when a journal read throws', () => {
+    const fsDeps = {
+      readdirSync: () => [{ name: 'repo-9', isDirectory: () => true }],
+      existsSync: () => true,
+      readFileSync: () => { throw new Error('no cursor'); },
+      writeFileSync: () => {},
+    };
+    const journal = { readEventsSince: () => { throw new Error('corrupt journal'); } };
+    const out = collectDigest({ root: '/r', journal, fsDeps });
+    expect(out.total).toBe(0);
+    expect(out.text).toBe('');
+  });
+
+  test('is fail-open when there is no .forge/pr-monitor at all', () => {
+    const fsDeps = { readdirSync: () => { throw new Error('ENOENT'); } };
+    const out = collectDigest({ root: '/nowhere', fsDeps });
+    expect(out).toEqual({ text: '', total: 0, prs: [] });
+  });
+
+  test('cursor read defaults to 0 and write round-trips (injected fs)', () => {
+    const store = {};
+    const fsDeps = {
+      readFileSync: (p) => { if (!(p in store)) throw new Error('missing'); return store[p]; },
+      writeFileSync: (p, body) => { store[p] = body; },
+    };
+    expect(readConsumerCursor('/d', fsDeps)).toBe(0);
+    writeConsumerCursor('/d', 7, fsDeps);
+    expect(readConsumerCursor('/d', fsDeps)).toBe(7);
+  });
+});
+
+describe('forge hooks shepherd-events — the UserPromptSubmit consumer hook', () => {
+  test('claude: wraps a non-empty digest as UserPromptSubmit additionalContext', async () => {
+    const res = await hooks.handler(['shepherd-events', '--harness', 'claude'], {}, '/r', {
+      collectDigest: () => ({ text: '[forge PR shepherd] 1 new event(s) on PR(s) 12:\n- PR #12 pr.merged: merged', total: 1, prs: ['12'] }),
+    });
+    expect(res.success).toBe(true);
+    const parsed = JSON.parse(res.output);
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('UserPromptSubmit');
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('pr.merged');
+  });
+
+  test('claude: empty digest → emits nothing (no injection)', async () => {
+    const res = await hooks.handler(['shepherd-events', '--harness', 'claude'], {}, '/r', {
+      collectDigest: () => ({ text: '', total: 0, prs: [] }),
+    });
+    expect(res).toEqual({ success: true, output: '' });
+  });
+
+  test('non-claude harness → emits nothing (honest capability matrix)', async () => {
+    const res = await hooks.handler(['shepherd-events', '--harness', 'cursor'], {}, '/r', {
+      collectDigest: () => ({ text: 'should not be used', total: 1, prs: ['12'] }),
+    });
+    expect(res.output).toBe('');
+  });
+
+  test('fail-open: a throwing collector never breaks the prompt', async () => {
+    const res = await hooks.handler(['shepherd-events', '--harness', 'claude'], {}, '/r', {
+      collectDigest: () => { throw new Error('boom'); },
+    });
+    expect(res).toEqual({ success: true, output: '' });
+  });
+});

--- a/test/pr-monitor/digest.test.js
+++ b/test/pr-monitor/digest.test.js
@@ -147,6 +147,8 @@ describe('forge hooks shepherd-events — the UserPromptSubmit consumer hook', (
       collectDigest: () => ({ text: 'should not be used', total: 1, prs: ['12'] }),
     });
     expect(res.output).toBe('');
+    // Skip reason preserved as surface-only metadata (never injected).
+    expect(res.reason).toBe('no-user-prompt-surface');
   });
 
   test('fail-open: a throwing collector never breaks the prompt', async () => {


### PR DESCRIPTION
## What

Closes Gap 2 (epic c2d398e5, 33e1bbd3): the watch loop writes per-PR NDJSON journals under `.forge/pr-monitor/<repo>-<pr>/`, but **nothing consumed them**, so shepherd activity never reached the working agent — the biggest reason the shepherd "felt absent". This adds the thin CONSUMER half. The CORE (events/journal/watch/monitor) is **untouched**.

## How

- **`lib/pr-monitor/digest.js`** (new, pure + fail-open): discover open-PR journals, read NEW events since a persisted per-PR **consumer cursor** (`consumer.cursor`, distinct from the watcher's snapshot), filter to the actionable **budget types** (`verdict.changed`, `check.failed`, `thread.opened`, `pr.merged`, `pr.closed`), cap, render a compact block, and advance the cursor past everything read (skipped types never re-surface).
- **`forge hooks shepherd-events`**: the agent-agnostic pull the hook calls. Emits Claude `UserPromptSubmit` `additionalContext`; **only Claude renders** (honest capability matrix — Cursor/Codex/Hermes carry an explicit skip reason); **FAIL-OPEN** — empty/corrupt/missing journal never blocks a prompt; reads the user's **own local journal only** (no stdin injection, never drives the agent, per Anthropic Usage Policy).
- **Hook contract**: new default `shepherd-events` context intent (`user-prompt-submit`), rendered as a **second hook in the one Forge-owned Claude UserPromptSubmit group** (so a re-merge replaces the pair atomically), with its own idempotency marker.

## Tests (TDD)

`test/pr-monitor/digest.test.js`: budget filter + cap; read-since-cursor + advance + idempotent empty second read; fail-open on corrupt/missing journal / no `.forge/pr-monitor`; cursor round-trip; the hook wraps a non-empty digest, emits nothing on empty / non-claude, and never throws. Existing `hook-renderer`, `hook-renderer-inbox`, `harness-capability-matrix`, `hooks` command tests updated/green. ESLint clean; `forge release check` PASS.

Independent of #407/#408 (branches off master; reads the journal only).

Refs c2d398e5, 33e1bbd3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added PR shepherd event updates through the Claude Code context hook.
  - Surfaces actionable changes such as verdict updates, failed checks, review threads, and merged or closed PRs.
  - Prevents repeated notifications by tracking previously delivered events.
  - Limits displayed updates and indicates when additional events are available.
  - Other harnesses can invoke the same event command independently.

- **Documentation**
  - Added guidance for configuring and using shepherd event updates, including fail-open behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->