### PR TITLE
fix(grounding): close kernel driver after context-event I/O (Windows EBUSY)

### DIFF
--- a/lib/grounding/context-events.js
+++ b/lib/grounding/context-events.js
@@ -39,10 +39,22 @@ const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
  */
 async function resolveGroundingKernel(projectRoot, deps = {}) {
   if (deps.kernelBroker && deps.kernelDriver) {
-    return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config };
+    // Injected (shared) kernel — the caller owns its lifecycle; never close it.
+    return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config, ownsKernel: false };
   }
   const built = await buildMigratedKernelIssueDeps({ projectRoot });
-  return { broker: built.kernelBroker, driver: built.kernelDriver, config: built.kernelBroker.config };
+  // We built this connection just for a grounding read/append, so WE must close
+  // it — otherwise the SQLite handle leaks and, on Windows, locks the DB's
+  // directory (EBUSY on rmSync). Read commands (recap/show/claim) hold no other
+  // kernel handle, so leaving it open is a pure leak.
+  return { broker: built.kernelBroker, driver: built.kernelDriver, config: built.kernelBroker.config, ownsKernel: true };
+}
+
+/** Close a kernel driver only when this module built it (never an injected one). */
+function closeIfOwned(kernel) {
+  if (kernel && kernel.ownsKernel && kernel.driver && typeof kernel.driver.close === 'function') {
+    try { kernel.driver.close(); } catch { /* best-effort: closing is cleanup, never fatal */ }
+  }
 }
 
 /** Coarse window bucket for a timestamp — the roll-over that makes re-reads fresh. */
@@ -102,50 +114,55 @@ function isIdempotencyRace(error) {
 async function recordContextLoaded(projectRoot, params = {}) {
   const { issueId, cmd, session, budget, env, deps, now, windowMs } = params;
   const actor = resolveIssueActor(env || process.env) || 'forge';
-  const { driver, config } = await resolveGroundingKernel(projectRoot, deps);
-
-  const entity = await driver.loadKernelEntity(ISSUE_ENTITY_TYPE, issueId, {}, config);
-  if (!entity) {
-    return { ok: false, issueMissing: true, actor };
-  }
-
-  const nowIso = now || new Date().toISOString();
-  const win = Number.isFinite(windowMs) ? windowMs : DEFAULT_WINDOW_MS;
-  const bucket = windowBucket(Date.parse(nowIso), win);
-  const scope = session || actor;
-  const idempotencyKey = contextLoadedIdempotencyKey(issueId, scope, bucket);
-
-  const existing = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
-  if (existing) {
-    return { ok: true, duplicate: true, event: parseContextEvent(existing), actor };
-  }
-
-  const payload = { actor };
-  if (typeof session === 'string' && session.length > 0) payload.session = session;
-  if (typeof cmd === 'string' && cmd.length > 0) payload.cmd = cmd;
-  if (budget !== undefined) payload.budget = budget;
-
-  const event = {
-    entity_type: ISSUE_ENTITY_TYPE,
-    entity_id: issueId,
-    event_type: CONTEXT_LOADED_EVENT,
-    idempotency_key: idempotencyKey,
-    expected_revision: 0,
-    actor,
-    origin: CONTEXT_EVENT_ORIGIN,
-    payload,
-    created_at: nowIso,
-  };
+  const kernel = await resolveGroundingKernel(projectRoot, deps);
+  const { driver, config } = kernel;
 
   try {
-    const inserted = await driver.insertKernelEvent(event, {}, config);
-    return { ok: true, duplicate: false, event: parseContextEvent(inserted), actor };
-  } catch (error) {
-    if (isIdempotencyRace(error)) {
-      const winner = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
-      return { ok: true, duplicate: true, event: winner ? parseContextEvent(winner) : parseContextEvent(event), actor };
+    const entity = await driver.loadKernelEntity(ISSUE_ENTITY_TYPE, issueId, {}, config);
+    if (!entity) {
+      return { ok: false, issueMissing: true, actor };
     }
-    throw error;
+
+    const nowIso = now || new Date().toISOString();
+    const win = Number.isFinite(windowMs) ? windowMs : DEFAULT_WINDOW_MS;
+    const bucket = windowBucket(Date.parse(nowIso), win);
+    const scope = session || actor;
+    const idempotencyKey = contextLoadedIdempotencyKey(issueId, scope, bucket);
+
+    const existing = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
+    if (existing) {
+      return { ok: true, duplicate: true, event: parseContextEvent(existing), actor };
+    }
+
+    const payload = { actor };
+    if (typeof session === 'string' && session.length > 0) payload.session = session;
+    if (typeof cmd === 'string' && cmd.length > 0) payload.cmd = cmd;
+    if (budget !== undefined) payload.budget = budget;
+
+    const event = {
+      entity_type: ISSUE_ENTITY_TYPE,
+      entity_id: issueId,
+      event_type: CONTEXT_LOADED_EVENT,
+      idempotency_key: idempotencyKey,
+      expected_revision: 0,
+      actor,
+      origin: CONTEXT_EVENT_ORIGIN,
+      payload,
+      created_at: nowIso,
+    };
+
+    try {
+      const inserted = await driver.insertKernelEvent(event, {}, config);
+      return { ok: true, duplicate: false, event: parseContextEvent(inserted), actor };
+    } catch (error) {
+      if (isIdempotencyRace(error)) {
+        const winner = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
+        return { ok: true, duplicate: true, event: winner ? parseContextEvent(winner) : parseContextEvent(event), actor };
+      }
+      throw error;
+    }
+  } finally {
+    closeIfOwned(kernel);
   }
 }
 
@@ -155,11 +172,15 @@ async function recordContextLoaded(projectRoot, params = {}) {
  * @returns {Promise<Array<{ event_type: string, actor: string, created_at: string, session?: string, cmd?: string }>>}
  */
 async function listContextLoadedEvents(projectRoot, issueId, options = {}) {
-  const { driver, config } = await resolveGroundingKernel(projectRoot, options.deps);
-  const rows = await driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, config);
-  return (rows || [])
-    .filter(row => row.event_type === CONTEXT_LOADED_EVENT)
-    .map(parseContextEvent);
+  const kernel = await resolveGroundingKernel(projectRoot, options.deps);
+  try {
+    const rows = await kernel.driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, kernel.config);
+    return (rows || [])
+      .filter(row => row.event_type === CONTEXT_LOADED_EVENT)
+      .map(parseContextEvent);
+  } finally {
+    closeIfOwned(kernel);
+  }
 }
 
 /**
@@ -206,12 +227,17 @@ function eventsSatisfyFreshness(events, { session, windowMs, now } = {}) {
  */
 async function readFirstVerdict(projectRoot, issueId, options = {}) {
   const { session, windowMs, now, deps } = options;
-  const { driver, config } = await resolveGroundingKernel(projectRoot, deps);
-  const entity = await driver.loadKernelEntity(ISSUE_ENTITY_TYPE, issueId, {}, config);
-  if (!entity) return 'missing';
-  const rows = await driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, config);
-  const events = (rows || []).filter(row => row.event_type === CONTEXT_LOADED_EVENT).map(parseContextEvent);
-  return eventsSatisfyFreshness(events, { session, windowMs, now }) ? 'loaded' : 'unread';
+  const kernel = await resolveGroundingKernel(projectRoot, deps);
+  const { driver, config } = kernel;
+  try {
+    const entity = await driver.loadKernelEntity(ISSUE_ENTITY_TYPE, issueId, {}, config);
+    if (!entity) return 'missing';
+    const rows = await driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, config);
+    const events = (rows || []).filter(row => row.event_type === CONTEXT_LOADED_EVENT).map(parseContextEvent);
+    return eventsSatisfyFreshness(events, { session, windowMs, now }) ? 'loaded' : 'unread';
+  } finally {
+    closeIfOwned(kernel);
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
## Hotfix for master (regression from #410)

PR #410 (P1 grounding, gate.read_first) merged with a Windows-only regression: **master's Full Matrix (windows) is now failing** at `test/orientation.test.js:106` with `EBUSY: resource busy or locked` on the afterEach `rmSync`.

## Root cause

`lib/grounding/context-events.js` (recordContextLoaded / listContextLoadedEvents / readFirstVerdict) builds a fresh kernel via `buildMigratedKernelIssueDeps` on every `forge recap` / `show` / `claim` but never closed the SQLite driver. The leaked handle locks the DB directory on Windows, so `orientation.test.js`'s recap-command test (which emits a `context.loaded` event into its temp project) leaves the temp dir locked → `rmSync` EBUSY at cleanup. The recap assertions themselves pass — it is purely a leaked handle. gate-events uses the same build-per-call pattern but only runs on explicit `forge gate` commands, so it never hit a read-command test.

## Fix

`resolveGroundingKernel` now tags whether it **built** the connection; each consumer closes the driver in a `finally` block, but only when we own it (never an injected/shared kernel the caller manages). Read commands hold no other kernel handle, so this was a pure leak.

## Verification

- `test/orientation.test.js` green locally on Windows (was EBUSY before the fix).
- Grounding + claim/issue suites (48 tests in the fast set; 92 in the broader sweep) green; ESLint clean.

Refs e037a559, epic 6ef96e92. Follow-up to #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)