### PR TITLE
test(grounding): assert kernel-driver close/ownership invariant

### DIFF
--- a/lib/gate-events.js
+++ b/lib/gate-events.js
@@ -48,10 +48,25 @@ const GATE_EVENT_ORIGIN = 'cli';
  */
 async function resolveGateKernel(projectRoot, deps = {}) {
   if (deps.kernelBroker && deps.kernelDriver) {
-    return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config };
+    // Injected (shared) kernel — the caller owns its lifecycle; never close it.
+    return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config, ownsKernel: false };
   }
-  const built = await buildMigratedKernelIssueDeps({ projectRoot });
-  return { broker: built.kernelBroker, driver: built.kernelDriver, config: built.kernelBroker.config };
+  // We built this connection for a single gate read/append, so WE must close it —
+  // an unclosed SQLite handle leaks and, on Windows, locks the DB directory
+  // (EBUSY on rmSync). Same class as the grounding context.loaded fix (kernel
+  // issue e62e4bde); safe here today because gate events only fire on explicit
+  // `forge gate` commands, but the leak is identical so we close proactively.
+  // `deps.kernelBuilder` is a test seam over buildMigratedKernelIssueDeps.
+  const build = deps.kernelBuilder || buildMigratedKernelIssueDeps;
+  const built = await build({ projectRoot });
+  return { broker: built.kernelBroker, driver: built.kernelDriver, config: built.kernelBroker.config, ownsKernel: true };
+}
+
+/** Close a kernel driver only when this module built it (never an injected one). */
+function closeIfOwned(kernel) {
+  if (kernel && kernel.ownsKernel && kernel.driver && typeof kernel.driver.close === 'function') {
+    try { kernel.driver.close(); } catch { /* best-effort: closing is cleanup, never fatal */ }
+  }
 }
 
 /**
@@ -110,44 +125,49 @@ async function recordGateEvent(projectRoot, params = {}) {
   }
 
   const actor = resolveIssueActor(env || process.env) || 'forge';
-  const { driver, config } = await resolveGateKernel(projectRoot, deps);
-
-  const entity = await driver.loadKernelEntity(ISSUE_ENTITY_TYPE, issueId, {}, config);
-  if (!entity) {
-    return { ok: false, issueMissing: true, actor };
-  }
-
-  const idempotencyKey = gateIdempotencyKey(eventType, issueId, gateId, actor);
-
-  const existing = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
-  if (existing) {
-    return { ok: true, duplicate: true, event: parseGateEvent(existing), actor };
-  }
-
-  const payload = { gate: gateId, actor };
-  if (typeof reason === 'string' && reason.length > 0) payload.reason = reason;
-
-  const event = {
-    entity_type: ISSUE_ENTITY_TYPE,
-    entity_id: issueId,
-    event_type: eventType,
-    idempotency_key: idempotencyKey,
-    expected_revision: 0,
-    actor,
-    origin: GATE_EVENT_ORIGIN,
-    payload,
-    created_at: now || new Date().toISOString(),
-  };
+  const kernel = await resolveGateKernel(projectRoot, deps);
+  const { driver, config } = kernel;
 
   try {
-    const inserted = await driver.insertKernelEvent(event, {}, config);
-    return { ok: true, duplicate: false, event: parseGateEvent(inserted), actor };
-  } catch (error) {
-    if (isIdempotencyRace(error)) {
-      const winner = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
-      return { ok: true, duplicate: true, event: winner ? parseGateEvent(winner) : parseGateEvent(event), actor };
+    const entity = await driver.loadKernelEntity(ISSUE_ENTITY_TYPE, issueId, {}, config);
+    if (!entity) {
+      return { ok: false, issueMissing: true, actor };
     }
-    throw error;
+
+    const idempotencyKey = gateIdempotencyKey(eventType, issueId, gateId, actor);
+
+    const existing = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
+    if (existing) {
+      return { ok: true, duplicate: true, event: parseGateEvent(existing), actor };
+    }
+
+    const payload = { gate: gateId, actor };
+    if (typeof reason === 'string' && reason.length > 0) payload.reason = reason;
+
+    const event = {
+      entity_type: ISSUE_ENTITY_TYPE,
+      entity_id: issueId,
+      event_type: eventType,
+      idempotency_key: idempotencyKey,
+      expected_revision: 0,
+      actor,
+      origin: GATE_EVENT_ORIGIN,
+      payload,
+      created_at: now || new Date().toISOString(),
+    };
+
+    try {
+      const inserted = await driver.insertKernelEvent(event, {}, config);
+      return { ok: true, duplicate: false, event: parseGateEvent(inserted), actor };
+    } catch (error) {
+      if (isIdempotencyRace(error)) {
+        const winner = await driver.loadKernelEventByIdempotencyKey(idempotencyKey, {}, config);
+        return { ok: true, duplicate: true, event: winner ? parseGateEvent(winner) : parseGateEvent(event), actor };
+      }
+      throw error;
+    }
+  } finally {
+    closeIfOwned(kernel);
   }
 }
 
@@ -160,11 +180,15 @@ async function recordGateEvent(projectRoot, params = {}) {
  * @returns {Promise<Array<{ event_type: string, gate: string, actor: string, created_at: string, reason?: string }>>}
  */
 async function listGateEvents(projectRoot, issueId, options = {}) {
-  const { driver, config } = await resolveGateKernel(projectRoot, options.deps);
-  const rows = await driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, config);
-  return (rows || [])
-    .filter(row => typeof row.event_type === 'string' && row.event_type.startsWith('gate.'))
-    .map(parseGateEvent);
+  const kernel = await resolveGateKernel(projectRoot, options.deps);
+  try {
+    const rows = await kernel.driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, kernel.config);
+    return (rows || [])
+      .filter(row => typeof row.event_type === 'string' && row.event_type.startsWith('gate.'))
+      .map(parseGateEvent);
+  } finally {
+    closeIfOwned(kernel);
+  }
 }
 
 /**

--- a/lib/gate-events.js
+++ b/lib/gate-events.js
@@ -23,7 +23,7 @@
  * runtime graph + `.forge/config.yaml`; this module only records/reads the events.
  */
 
-const { buildMigratedKernelIssueDeps } = require('./kernel/cli-broker-factory');
+const { resolveOwnedKernel, closeIfOwned } = require('./kernel/owned-kernel');
 const { resolveIssueActor } = require('./forge-issues');
 
 const GATE_APPROVED_EVENT = 'gate.approved';
@@ -37,37 +37,12 @@ const GATE_EVENT_TYPES = {
 const ISSUE_ENTITY_TYPE = 'issue';
 const GATE_EVENT_ORIGIN = 'cli';
 
-/**
- * Resolve the kernel broker + driver + config. Tests (and the orchestrator) inject
- * a shared, already-migrated kernel via `deps`; the CLI path builds a fresh one for
- * the (short-lived) process.
- *
- * @param {string} projectRoot
- * @param {{ kernelBroker?: Object, kernelDriver?: Object }} [deps]
- * @returns {Promise<{ broker: Object, driver: Object, config: Object }>}
- */
-async function resolveGateKernel(projectRoot, deps = {}) {
-  if (deps.kernelBroker && deps.kernelDriver) {
-    // Injected (shared) kernel — the caller owns its lifecycle; never close it.
-    return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config, ownsKernel: false };
-  }
-  // We built this connection for a single gate read/append, so WE must close it —
-  // an unclosed SQLite handle leaks and, on Windows, locks the DB directory
-  // (EBUSY on rmSync). Same class as the grounding context.loaded fix (kernel
-  // issue e62e4bde); safe here today because gate events only fire on explicit
-  // `forge gate` commands, but the leak is identical so we close proactively.
-  // `deps.kernelBuilder` is a test seam over buildMigratedKernelIssueDeps.
-  const build = deps.kernelBuilder || buildMigratedKernelIssueDeps;
-  const built = await build({ projectRoot });
-  return { broker: built.kernelBroker, driver: built.kernelDriver, config: built.kernelBroker.config, ownsKernel: true };
-}
-
-/** Close a kernel driver only when this module built it (never an injected one). */
-function closeIfOwned(kernel) {
-  if (kernel && kernel.ownsKernel && kernel.driver && typeof kernel.driver.close === 'function') {
-    try { kernel.driver.close(); } catch { /* best-effort: closing is cleanup, never fatal */ }
-  }
-}
+// Kernel lifecycle (resolve + close-what-you-built) is shared with
+// grounding/context-events via lib/kernel/owned-kernel. A gate read/append that
+// builds its own kernel must close it — an unclosed SQLite handle leaks and, on
+// Windows, locks the DB directory (EBUSY on rmSync, kernel issue e62e4bde). Safe
+// here today because gate events only fire on explicit `forge gate` commands,
+// but the leak is identical so we close proactively via closeIfOwned.
 
 /**
  * Idempotency key for a gate event. Scoped to issue + gate + actor + decision so a
@@ -125,7 +100,7 @@ async function recordGateEvent(projectRoot, params = {}) {
   }
 
   const actor = resolveIssueActor(env || process.env) || 'forge';
-  const kernel = await resolveGateKernel(projectRoot, deps);
+  const kernel = await resolveOwnedKernel(projectRoot, deps);
   const { driver, config } = kernel;
 
   try {
@@ -180,7 +155,7 @@ async function recordGateEvent(projectRoot, params = {}) {
  * @returns {Promise<Array<{ event_type: string, gate: string, actor: string, created_at: string, reason?: string }>>}
  */
 async function listGateEvents(projectRoot, issueId, options = {}) {
-  const kernel = await resolveGateKernel(projectRoot, options.deps);
+  const kernel = await resolveOwnedKernel(projectRoot, options.deps);
   try {
     const rows = await kernel.driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, kernel.config);
     return (rows || [])

--- a/lib/grounding/context-events.js
+++ b/lib/grounding/context-events.js
@@ -42,7 +42,10 @@ async function resolveGroundingKernel(projectRoot, deps = {}) {
     // Injected (shared) kernel — the caller owns its lifecycle; never close it.
     return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config, ownsKernel: false };
   }
-  const built = await buildMigratedKernelIssueDeps({ projectRoot });
+  // `deps.kernelBuilder` is a test seam over buildMigratedKernelIssueDeps; the CLI
+  // path uses the real builder. Either way WE built it, so ownsKernel is true.
+  const build = deps.kernelBuilder || buildMigratedKernelIssueDeps;
+  const built = await build({ projectRoot });
   // We built this connection just for a grounding read/append, so WE must close
   // it — otherwise the SQLite handle leaks and, on Windows, locks the DB's
   // directory (EBUSY on rmSync). Read commands (recap/show/claim) hold no other

--- a/lib/grounding/context-events.js
+++ b/lib/grounding/context-events.js
@@ -21,7 +21,7 @@
  * `.forge/config.yaml`; this module only records/reads the events.
  */
 
-const { buildMigratedKernelIssueDeps } = require('../kernel/cli-broker-factory');
+const { resolveOwnedKernel, closeIfOwned } = require('../kernel/owned-kernel');
 const { resolveIssueActor } = require('../forge-issues');
 
 const CONTEXT_LOADED_EVENT = 'context.loaded';
@@ -32,33 +32,8 @@ const CONTEXT_EVENT_ORIGIN = 'cli';
 // `workflow.gates.gate.read_first.window` at the call site (P2).
 const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
 
-/**
- * Resolve the kernel driver + config. Tests inject a shared, already-migrated
- * kernel via `deps`; the CLI path builds a fresh one for the short-lived process
- * (same shape as gate-events' resolveGateKernel).
- */
-async function resolveGroundingKernel(projectRoot, deps = {}) {
-  if (deps.kernelBroker && deps.kernelDriver) {
-    // Injected (shared) kernel — the caller owns its lifecycle; never close it.
-    return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config, ownsKernel: false };
-  }
-  // `deps.kernelBuilder` is a test seam over buildMigratedKernelIssueDeps; the CLI
-  // path uses the real builder. Either way WE built it, so ownsKernel is true.
-  const build = deps.kernelBuilder || buildMigratedKernelIssueDeps;
-  const built = await build({ projectRoot });
-  // We built this connection just for a grounding read/append, so WE must close
-  // it — otherwise the SQLite handle leaks and, on Windows, locks the DB's
-  // directory (EBUSY on rmSync). Read commands (recap/show/claim) hold no other
-  // kernel handle, so leaving it open is a pure leak.
-  return { broker: built.kernelBroker, driver: built.kernelDriver, config: built.kernelBroker.config, ownsKernel: true };
-}
-
-/** Close a kernel driver only when this module built it (never an injected one). */
-function closeIfOwned(kernel) {
-  if (kernel && kernel.ownsKernel && kernel.driver && typeof kernel.driver.close === 'function') {
-    try { kernel.driver.close(); } catch { /* best-effort: closing is cleanup, never fatal */ }
-  }
-}
+// Kernel lifecycle (resolve + close-what-you-built) is shared with gate-events
+// via lib/kernel/owned-kernel; `resolveOwnedKernel`/`closeIfOwned` are imported.
 
 /** Coarse window bucket for a timestamp — the roll-over that makes re-reads fresh. */
 function windowBucket(nowMs, windowMs) {
@@ -117,7 +92,7 @@ function isIdempotencyRace(error) {
 async function recordContextLoaded(projectRoot, params = {}) {
   const { issueId, cmd, session, budget, env, deps, now, windowMs } = params;
   const actor = resolveIssueActor(env || process.env) || 'forge';
-  const kernel = await resolveGroundingKernel(projectRoot, deps);
+  const kernel = await resolveOwnedKernel(projectRoot, deps);
   const { driver, config } = kernel;
 
   try {
@@ -175,7 +150,7 @@ async function recordContextLoaded(projectRoot, params = {}) {
  * @returns {Promise<Array<{ event_type: string, actor: string, created_at: string, session?: string, cmd?: string }>>}
  */
 async function listContextLoadedEvents(projectRoot, issueId, options = {}) {
-  const kernel = await resolveGroundingKernel(projectRoot, options.deps);
+  const kernel = await resolveOwnedKernel(projectRoot, options.deps);
   try {
     const rows = await kernel.driver.listKernelEvents(ISSUE_ENTITY_TYPE, issueId, {}, kernel.config);
     return (rows || [])
@@ -230,7 +205,7 @@ function eventsSatisfyFreshness(events, { session, windowMs, now } = {}) {
  */
 async function readFirstVerdict(projectRoot, issueId, options = {}) {
   const { session, windowMs, now, deps } = options;
-  const kernel = await resolveGroundingKernel(projectRoot, deps);
+  const kernel = await resolveOwnedKernel(projectRoot, deps);
   const { driver, config } = kernel;
   try {
     const entity = await driver.loadKernelEntity(ISSUE_ENTITY_TYPE, issueId, {}, config);

--- a/lib/kernel/owned-kernel.js
+++ b/lib/kernel/owned-kernel.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * @module kernel/owned-kernel
+ *
+ * Shared kernel-lifecycle helper for the pure-append event modules
+ * (grounding/context-events, gate-events). Both resolve a kernel driver the same
+ * way and carry the same close-what-you-built invariant, so it lives here once
+ * instead of being copied per module.
+ *
+ * The invariant: an INJECTED (shared) kernel is caller-owned and must NEVER be
+ * closed here — closing it would break the next operation that reuses it. A
+ * kernel this module BUILDS for a single short-lived read/append it MUST close —
+ * an unclosed SQLite handle leaks and, on Windows, locks the DB directory
+ * (`EBUSY` on `rmSync`, kernel issue e62e4bde).
+ */
+
+const { buildMigratedKernelIssueDeps } = require('./cli-broker-factory');
+
+/**
+ * Resolve the kernel driver + config. An injected (shared) kernel is returned
+ * untouched with `ownsKernel:false` — the caller owns its lifecycle. Otherwise a
+ * fresh one is built (via `deps.kernelBuilder`, a test seam over
+ * `buildMigratedKernelIssueDeps`, or the real builder) and tagged
+ * `ownsKernel:true` so {@link closeIfOwned} closes it.
+ */
+async function resolveOwnedKernel(projectRoot, deps = {}) {
+  if (deps.kernelBroker && deps.kernelDriver) {
+    return { broker: deps.kernelBroker, driver: deps.kernelDriver, config: deps.kernelBroker.config, ownsKernel: false };
+  }
+  const build = deps.kernelBuilder || buildMigratedKernelIssueDeps;
+  const built = await build({ projectRoot });
+  return { broker: built.kernelBroker, driver: built.kernelDriver, config: built.kernelBroker.config, ownsKernel: true };
+}
+
+/** Close a kernel driver only when this module built it (never an injected one). */
+function closeIfOwned(kernel) {
+  if (kernel && kernel.ownsKernel && kernel.driver && typeof kernel.driver.close === 'function') {
+    try { kernel.driver.close(); } catch { /* best-effort: closing is cleanup, never fatal */ }
+  }
+}
+
+module.exports = { resolveOwnedKernel, closeIfOwned };

--- a/test/gate-events.test.js
+++ b/test/gate-events.test.js
@@ -155,3 +155,62 @@ describe('gate-events module', () => {
     expect(await isGateApproved(UNUSED_ROOT, issue, 'gate.merge', { deps: deps(kernel) })).toBe(false);
   });
 });
+
+// Driver-lifecycle invariant (same class as the grounding fix, kernel issue
+// e62e4bde): a kernel gate-events BUILDS itself must be closed (an unclosed
+// SQLite handle locks the DB dir on Windows -> rmSync EBUSY); an INJECTED/shared
+// kernel must NEVER be closed (the caller owns it). Cross-platform: counts close().
+describe('gate-events kernel-driver lifecycle', () => {
+  // Wrap a driver so its methods still hit the real :memory: kernel, but close()
+  // is counted instead of actually closing (so the shared db stays usable).
+  function withCloseCounter(driver) {
+    const counter = { count: 0 };
+    const wrapped = {};
+    for (const key of Object.keys(driver)) {
+      wrapped[key] = typeof driver[key] === 'function' ? driver[key].bind(driver) : driver[key];
+    }
+    wrapped.close = () => { counter.count += 1; };
+    return { driver: wrapped, counter };
+  }
+
+  test('an INJECTED/shared kernel is NEVER closed', async () => {
+    const kernel = await freshKernel();
+    const issue = await seedIssue(kernel, 'gate-life-injected');
+    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
+    const injected = { kernelBroker: kernel.kernelBroker, kernelDriver: driver };
+
+    await recordGateEvent(UNUSED_ROOT, {
+      issueId: issue, gateId: 'gate.merge', decision: 'approved', env: { FORGE_ACTOR: 'a' }, deps: injected,
+    });
+    await listGateEvents(UNUSED_ROOT, issue, { deps: injected });
+
+    expect(counter.count).toBe(0);
+  });
+
+  test('a kernel the module BUILT itself is closed after record and list', async () => {
+    const kernel = await freshKernel();
+    const issue = await seedIssue(kernel, 'gate-life-owned');
+    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
+    const built = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
+
+    await recordGateEvent(UNUSED_ROOT, {
+      issueId: issue, gateId: 'gate.merge', decision: 'approved', env: { FORGE_ACTOR: 'a' }, deps: built,
+    });
+    expect(counter.count).toBe(1);
+
+    await listGateEvents(UNUSED_ROOT, issue, { deps: built });
+    expect(counter.count).toBe(2);
+  });
+
+  test('the built kernel is closed even when the issue is missing', async () => {
+    const kernel = await freshKernel();
+    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
+    const built = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
+
+    const result = await recordGateEvent(UNUSED_ROOT, {
+      issueId: 'ghost', gateId: 'gate.merge', decision: 'approved', env: { FORGE_ACTOR: 'a' }, deps: built,
+    });
+    expect(result.issueMissing).toBe(true);
+    expect(counter.count).toBe(1); // finally still closes on the early return
+  });
+});

--- a/test/grounding/kernel-lifecycle.test.js
+++ b/test/grounding/kernel-lifecycle.test.js
@@ -44,47 +44,61 @@ function withCloseCounter(driver) {
     wrapped[key] = typeof driver[key] === 'function' ? driver[key].bind(driver) : driver[key];
   }
   wrapped.close = () => { counter.count += 1; };
-  return { driver: wrapped, counter };
+  // dispose closes the REAL driver so the underlying SQLite handle is released
+  // during teardown (unclosed handles lock the DB dir on Windows -> rmSync EBUSY).
+  return { driver: wrapped, counter, dispose: () => driver.close() };
 }
 
 describe('grounding kernel-driver lifecycle', () => {
   test('an INJECTED/shared kernel is NEVER closed (caller owns it)', async () => {
     const kernel = await freshKernel();
-    const issue = await seedIssue(kernel, 'life-injected');
-    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
-    const deps = { kernelBroker: kernel.kernelBroker, kernelDriver: driver };
+    const { driver, counter, dispose } = withCloseCounter(kernel.kernelDriver);
+    try {
+      const issue = await seedIssue(kernel, 'life-injected');
+      const deps = { kernelBroker: kernel.kernelBroker, kernelDriver: driver };
 
-    await recordContextLoaded(ROOT, { issueId: issue, cmd: 'recap', env: { FORGE_ACTOR: 'a' }, deps });
-    await readFirstVerdict(ROOT, issue, { deps });
+      await recordContextLoaded(ROOT, { issueId: issue, cmd: 'recap', env: { FORGE_ACTOR: 'a' }, deps });
+      await readFirstVerdict(ROOT, issue, { deps });
 
-    expect(counter.count).toBe(0);
-    // The shared kernel is still usable afterwards (would throw if we'd closed it).
-    const events = await listContextLoadedEvents(ROOT, issue, { deps });
-    expect(events.length).toBeGreaterThan(0);
+      expect(counter.count).toBe(0);
+      // The shared kernel is still usable afterwards (would throw if we'd closed it).
+      const events = await listContextLoadedEvents(ROOT, issue, { deps });
+      expect(events.length).toBeGreaterThan(0);
+    } finally {
+      dispose(); // always close the REAL driver so teardown can rmSync the DB dir
+    }
   });
 
   test('a kernel the module BUILT itself is closed after each read/append', async () => {
     const kernel = await freshKernel();
-    const issue = await seedIssue(kernel, 'life-owned');
-    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
-    // kernelBuilder is the test seam over buildMigratedKernelIssueDeps — supplying
-    // it (without kernelBroker/kernelDriver) drives the OWNED path.
-    const deps = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
+    const { driver, counter, dispose } = withCloseCounter(kernel.kernelDriver);
+    try {
+      const issue = await seedIssue(kernel, 'life-owned');
+      // kernelBuilder is the test seam over buildMigratedKernelIssueDeps — supplying
+      // it (without kernelBroker/kernelDriver) drives the OWNED path.
+      const deps = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
 
-    await recordContextLoaded(ROOT, { issueId: issue, cmd: 'recap', env: { FORGE_ACTOR: 'a' }, deps });
-    expect(counter.count).toBe(1);
+      await recordContextLoaded(ROOT, { issueId: issue, cmd: 'recap', env: { FORGE_ACTOR: 'a' }, deps });
+      expect(counter.count).toBe(1);
 
-    await readFirstVerdict(ROOT, issue, { deps });
-    expect(counter.count).toBe(2);
+      await readFirstVerdict(ROOT, issue, { deps });
+      expect(counter.count).toBe(2);
+    } finally {
+      dispose(); // always close the REAL driver so teardown can rmSync the DB dir
+    }
   });
 
   test('the built kernel is closed even when the issue is missing', async () => {
     const kernel = await freshKernel();
-    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
-    const deps = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
+    const { driver, counter, dispose } = withCloseCounter(kernel.kernelDriver);
+    try {
+      const deps = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
 
-    const result = await recordContextLoaded(ROOT, { issueId: 'ghost', env: { FORGE_ACTOR: 'a' }, deps });
-    expect(result.issueMissing).toBe(true);
-    expect(counter.count).toBe(1); // finally still closes on the early return
+      const result = await recordContextLoaded(ROOT, { issueId: 'ghost', env: { FORGE_ACTOR: 'a' }, deps });
+      expect(result.issueMissing).toBe(true);
+      expect(counter.count).toBe(1); // finally still closes on the early return
+    } finally {
+      dispose(); // always close the REAL driver so teardown can rmSync the DB dir
+    }
   });
 });

--- a/test/grounding/kernel-lifecycle.test.js
+++ b/test/grounding/kernel-lifecycle.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Regression coverage for the driver-lifecycle invariant behind the Windows
+// EBUSY bug (follow-up to #410): the grounding event store builds a fresh kernel
+// on every `forge recap`/`show`/`claim` when no kernel is injected, and MUST
+// close that SQLite driver — an unclosed handle locks the DB directory on
+// Windows so a later `fs.rmSync` throws `EBUSY: resource busy or locked`
+// (observed at test/orientation.test.js:106). Equally important: an INJECTED
+// (shared) kernel must NEVER be closed — the caller/orchestrator owns it, and
+// closing it would break the next operation that reuses it.
+//
+// These assertions are cross-platform (they count close() calls) and complement
+// the end-to-end Windows guard in test/orientation.test.js.
+
+const { describe, expect, test } = require('bun:test');
+
+const {
+  recordContextLoaded,
+  readFirstVerdict,
+  listContextLoadedEvents,
+} = require('../../lib/grounding/context-events');
+const { buildMigratedKernelIssueDeps } = require('../../lib/kernel/cli-broker-factory');
+
+const ROOT = '/unused-because-deps-are-injected';
+
+async function freshKernel() {
+  return buildMigratedKernelIssueDeps({ databasePath: ':memory:' });
+}
+async function seedIssue(kernel, id) {
+  const res = await kernel.kernelBroker.runIssueOperation(
+    'create', ['--id', id, '--title', 'unit', '--type', 'task'], { actor: 'seed', origin: 'test' },
+  );
+  expect(res.ok).toBe(true);
+  return res.data.id;
+}
+
+// Wrap a driver so its methods still hit the real :memory: kernel, but close()
+// is counted instead of actually closing (so the shared db stays usable across
+// assertions).
+function withCloseCounter(driver) {
+  const counter = { count: 0 };
+  const wrapped = {};
+  for (const key of Object.keys(driver)) {
+    wrapped[key] = typeof driver[key] === 'function' ? driver[key].bind(driver) : driver[key];
+  }
+  wrapped.close = () => { counter.count += 1; };
+  return { driver: wrapped, counter };
+}
+
+describe('grounding kernel-driver lifecycle', () => {
+  test('an INJECTED/shared kernel is NEVER closed (caller owns it)', async () => {
+    const kernel = await freshKernel();
+    const issue = await seedIssue(kernel, 'life-injected');
+    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
+    const deps = { kernelBroker: kernel.kernelBroker, kernelDriver: driver };
+
+    await recordContextLoaded(ROOT, { issueId: issue, cmd: 'recap', env: { FORGE_ACTOR: 'a' }, deps });
+    await readFirstVerdict(ROOT, issue, { deps });
+
+    expect(counter.count).toBe(0);
+    // The shared kernel is still usable afterwards (would throw if we'd closed it).
+    const events = await listContextLoadedEvents(ROOT, issue, { deps });
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  test('a kernel the module BUILT itself is closed after each read/append', async () => {
+    const kernel = await freshKernel();
+    const issue = await seedIssue(kernel, 'life-owned');
+    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
+    // kernelBuilder is the test seam over buildMigratedKernelIssueDeps — supplying
+    // it (without kernelBroker/kernelDriver) drives the OWNED path.
+    const deps = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
+
+    await recordContextLoaded(ROOT, { issueId: issue, cmd: 'recap', env: { FORGE_ACTOR: 'a' }, deps });
+    expect(counter.count).toBe(1);
+
+    await readFirstVerdict(ROOT, issue, { deps });
+    expect(counter.count).toBe(2);
+  });
+
+  test('the built kernel is closed even when the issue is missing', async () => {
+    const kernel = await freshKernel();
+    const { driver, counter } = withCloseCounter(kernel.kernelDriver);
+    const deps = { kernelBuilder: async () => ({ kernelBroker: kernel.kernelBroker, kernelDriver: driver }) };
+
+    const result = await recordContextLoaded(ROOT, { issueId: 'ghost', env: { FORGE_ACTOR: 'a' }, deps });
+    expect(result.issueMissing).toBe(true);
+    expect(counter.count).toBe(1); // finally still closes on the early return
+  });
+});

--- a/test/kernel/owned-kernel.test.js
+++ b/test/kernel/owned-kernel.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+// Unit coverage for the shared kernel-lifecycle helper extracted from
+// gate-events + grounding/context-events. The invariant under test: an INJECTED
+// kernel is caller-owned (ownsKernel:false, never closed here); a BUILT kernel is
+// module-owned (ownsKernel:true, closed by closeIfOwned). These use fakes — no
+// real SQLite — so they only assert the ownership/close wiring; the end-to-end
+// close behaviour is covered by test/grounding/kernel-lifecycle.test.js.
+
+const { describe, expect, test } = require('bun:test');
+
+const { resolveOwnedKernel, closeIfOwned } = require('../../lib/kernel/owned-kernel');
+
+describe('owned-kernel resolveOwnedKernel', () => {
+  test('an injected broker+driver is returned untouched with ownsKernel:false', async () => {
+    const config = { db: 'shared' };
+    const kernelBroker = { config };
+    const kernelDriver = { close: () => { throw new Error('must never be built/closed'); } };
+
+    const resolved = await resolveOwnedKernel('/root', { kernelBroker, kernelDriver });
+
+    expect(resolved.ownsKernel).toBe(false);
+    expect(resolved.driver).toBe(kernelDriver);
+    expect(resolved.broker).toBe(kernelBroker);
+    expect(resolved.config).toBe(config);
+  });
+
+  test('the kernelBuilder seam drives the built path with ownsKernel:true', async () => {
+    const config = { db: 'built' };
+    const kernelDriver = { close: () => {} };
+    let seenArgs;
+    const kernelBuilder = async (args) => {
+      seenArgs = args;
+      return { kernelBroker: { config }, kernelDriver };
+    };
+
+    const resolved = await resolveOwnedKernel('/root', { kernelBuilder });
+
+    expect(resolved.ownsKernel).toBe(true);
+    expect(resolved.driver).toBe(kernelDriver);
+    expect(resolved.config).toBe(config);
+    expect(seenArgs).toEqual({ projectRoot: '/root' });
+  });
+});
+
+describe('owned-kernel closeIfOwned', () => {
+  test('closes the driver only when the module owns it', () => {
+    let count = 0;
+    const kernel = { ownsKernel: true, driver: { close: () => { count += 1; } } };
+    closeIfOwned(kernel);
+    expect(count).toBe(1);
+  });
+
+  test('never closes an injected (unowned) driver', () => {
+    let count = 0;
+    const kernel = { ownsKernel: false, driver: { close: () => { count += 1; } } };
+    closeIfOwned(kernel);
+    expect(count).toBe(0);
+  });
+
+  test('is a no-op when the kernel or its close() is missing', () => {
+    expect(() => closeIfOwned(null)).not.toThrow();
+    expect(() => closeIfOwned({ ownsKernel: true })).not.toThrow();
+    expect(() => closeIfOwned({ ownsKernel: true, driver: {} })).not.toThrow();
+  });
+
+  test('swallows a driver.close() error (cleanup is best-effort)', () => {
+    const kernel = { ownsKernel: true, driver: { close: () => { throw new Error('boom'); } } };
+    expect(() => closeIfOwned(kernel)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Follow-up hardening for the #411 driver-leak fix

#411 fixed the Windows EBUSY leak (grounding builds a kernel per `recap`/`show`/`claim` and must close its own SQLite driver) and merged fast to un-break master. This adds the **explicit regression coverage** that the fix PR didn't carry.

## What

- `test/grounding/kernel-lifecycle.test.js` — cross-platform assertions on the driver-lifecycle invariant, both directions:
  - a kernel the module **builds itself** is closed after every read/append (recap/show/claim), including the issue-missing early return;
  - an **injected/shared** kernel is **never** closed (the caller/orchestrator owns it — closing it would break the next reuse).
  
  This complements the end-to-end Windows guard already in `test/orientation.test.js` (which is what originally caught the leak), with a fast, platform-independent check that counts `driver.close()` calls.
- A tiny `deps.kernelBuilder` test seam over `buildMigratedKernelIssueDeps` in `context-events.js` so the owned-close path is directly assertable without a real on-disk kernel. CLI path unchanged.

## Follow-up flagged (not fixed here)

`lib/gate-events.js` uses the same build-per-call kernel pattern and does not close its driver. It's **safe today** because it only runs on explicit `forge gate` commands (never a read-command temp-dir cleanup), so it's tracked as a separate follow-up (kernel issue `e62e4bde`) rather than fixed in this PR.

Refs e037a559, epic 6ef96e92. Follow-up to #410 / #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel-driver lifecycle management to prevent resource leaks and Windows database locking errors.
  * Injected/shared kernels are no longer closed by these event modules; they remain usable after operations.
  * Internally created kernels are reliably closed after record/list workflows, including early exits and error paths.
* **New Features**
  * Added a shared “owned kernel” helper to consistently manage kernel ownership and cleanup across event modules.
* **Tests**
  * Added regression and unit tests covering kernel ownership/close behavior across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->