### PR TITLE
fix(ship): degrade stage gate to warn + kernel-seed when no authoritative state (B1)

### DIFF
--- a/lib/workflow/enforce-stage.js
+++ b/lib/workflow/enforce-stage.js
@@ -428,6 +428,14 @@ async function enforceStageEntry({
     return enforceWithFileState(currentState, stageId, flags, args, finish);
   }
 
+  // B1 — strict mode is the explicit opt-in to the legacy fail-closed behavior:
+  // require prior stages / authoritative state. The default (unset) degrades to a
+  // loud warning and seeds the kernel so future gating gets real data. A recorded
+  // history that CONTRADICTS (e.g. validate started-but-not-done) still throws in
+  // both modes — that rework protection lives in enforceWithKernelState below and
+  // is never weakened by this flag.
+  const strict = process.env.FORGE_STAGE_GATE === 'strict';
+
   // No inline/file state: the kernel is authoritative. Gate on recorded stage
   // completions (tolerant read) so `ship` is reachable from a pure-CLI
   // plan->dev->validate progression with no .forge-state.json.
@@ -436,15 +444,37 @@ async function enforceStageEntry({
     if (decided) {
       return decided;
     }
+    // enforceWithKernelState returned null → the kernel has an issue linked but
+    // NO recorded predecessor (a contradiction would have thrown above). Degrade
+    // to warn + seed unless strict: allow the stage and let finish() record it so
+    // future gating has real history.
+    if (!strict) {
+      warn(
+        `[forge] no recorded workflow history for issue ${issueId} — allowing '${stageId}' ` +
+        `and recording it in the kernel. Set FORGE_STAGE_GATE=strict to require prior stages.`
+      );
+      return finish({ allowed: true, stage: stageId, workflowState: null, degradedGate: 'kernel-empty' });
+    }
   }
 
   if (STATELESS_ENTRY_STAGES.has(stageId)) {
     return finish({ allowed: true, stage: stageId, workflowState: null });
   }
 
+  // No workflow state AND no kernel-linked issue for this branch. Degrade to warn
+  // unless strict so incremental adoption (fresh setup, in-flight branch, manual
+  // commit) is not blocked.
+  if (!strict) {
+    warn(
+      `[forge] no workflow state and no kernel-linked issue for this branch — stage gate skipped for '${stageId}'. ` +
+      `Link an issue with 'forge worktree create <slug>' to enable stage tracking.`
+    );
+    return finish({ allowed: true, stage: stageId, workflowState: null, degradedGate: 'no-kernel-context' });
+  }
+
   throw new Error(
     `Stage ${stageId} requires authoritative workflow state. ` +
-    `Provide --workflow-state or restore ${WORKFLOW_STATE_FILENAME} before continuing.`
+    `Provide --workflow-state or restore ${WORKFLOW_STATE_FILENAME} before continuing (or unset FORGE_STAGE_GATE).`
   );
 }
 

--- a/test/workflow/enforce-stage-kernel.test.js
+++ b/test/workflow/enforce-stage-kernel.test.js
@@ -206,15 +206,82 @@ describe('B1: enforceStageEntry uses the kernel as stage-state authority', () =>
     expect(driver.getCurrentStage({ issue_id: issueId }, {}).stage).toBe('dev');
   }, TIMEOUT);
 
-  test('still hard-blocks ship when the kernel has NO recorded stage (fail-closed)', async () => {
-    // No stage recorded, no .forge-state.json, no inline state → nothing durable
-    // says we progressed, so ship must not silently pass.
+  test('B1: ship with a linked issue and empty stage history is allowed, warns, and records ship start', async () => {
+    // Fresh setup / in-flight branch: an issue IS linked but no plan->validate
+    // history was ever walked. Degrade-to-warn (default) so incremental adoption
+    // is not blocked, and seed the kernel so future gating gets real data.
+    const warnings = [];
+    const result = await enforceStageEntry({
+      commandName: 'ship',
+      projectRoot,
+      kernelDriver: driver,
+      activeIssueId: issueId,
+      health: HEALTHY,
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.stage).toBe('ship');
+    expect(result.degradedGate).toBe('kernel-empty');
+    // The warning must name the issue so the operator can see what was allowed.
+    expect(warnings.some(w => w.includes(issueId))).toBe(true);
+    // Entering ship was recorded into the kernel (history is now seeded).
+    expect(driver.getCurrentStage({ issue_id: issueId }, {}).stage).toBe('ship');
+  }, TIMEOUT);
+
+  test('B1: ship stays blocked when validate is started but not done (rework protection preserved)', async () => {
+    // A recorded-but-contradicting history must still fail-closed regardless of
+    // the degrade-to-warn default — this is the dev<->validate rework guard.
+    driver.recordStageRun({ issue_id: issueId, stage: 'validate', action: 'start' }, {});
+
     await expect(enforceStageEntry({
       commandName: 'ship',
       projectRoot,
       kernelDriver: driver,
       activeIssueId: issueId,
       health: HEALTHY,
-    })).rejects.toThrow(/authoritative workflow state/i);
+    })).rejects.toThrow(/validate to be completed/i);
+  }, TIMEOUT);
+
+  test('B1: review after a degraded ship is allowed once ship is recorded done', async () => {
+    // Degraded ship (empty history) seeds a ship start; the command runner then
+    // records completion on handler success. review must now pass the real gate.
+    const ship = await enforceStageEntry({
+      commandName: 'ship',
+      projectRoot,
+      kernelDriver: driver,
+      activeIssueId: issueId,
+      health: HEALTHY,
+      warn: () => {},
+    });
+    expect(ship.allowed).toBe(true);
+    ship.recordCompletion();
+
+    const review = await enforceStageEntry({
+      commandName: 'review',
+      projectRoot,
+      kernelDriver: driver,
+      activeIssueId: issueId,
+      health: HEALTHY,
+    });
+    expect(review.allowed).toBe(true);
+    expect(review.stage).toBe('review');
+  }, TIMEOUT);
+
+  test('B1: FORGE_STAGE_GATE=strict restores the hard authoritative-state block', async () => {
+    const prev = process.env.FORGE_STAGE_GATE;
+    process.env.FORGE_STAGE_GATE = 'strict';
+    try {
+      await expect(enforceStageEntry({
+        commandName: 'ship',
+        projectRoot,
+        kernelDriver: driver,
+        activeIssueId: issueId,
+        health: HEALTHY,
+      })).rejects.toThrow(/authoritative workflow state/i);
+    } finally {
+      if (prev === undefined) delete process.env.FORGE_STAGE_GATE;
+      else process.env.FORGE_STAGE_GATE = prev;
+    }
   }, TIMEOUT);
 });

--- a/test/workflow/enforce-stage.test.js
+++ b/test/workflow/enforce-stage.test.js
@@ -180,8 +180,31 @@ describe('workflow enforce-stage', () => {
     }));
   });
 
-  test('enforceStageEntry requires workflow state for non-plan stages', async () => {
+  test('enforceStageEntry allows ship with no state and no kernel context, with a warning', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-missing-state-'));
+    try {
+      const warnings = [];
+      const result = await enforceStageEntry({
+        commandName: 'ship',
+        flags: {},
+        projectRoot: tmpDir,
+        health: { healthy: true, hardStop: false, diagnostics: [] },
+        warn: (m) => warnings.push(m)
+      });
+
+      expect(result.allowed).toBe(true);
+      expect(result.stage).toBe('ship');
+      expect(result.degradedGate).toBe('no-kernel-context');
+      expect(warnings.some(w => /stage gate skipped/i.test(w))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('enforceStageEntry with FORGE_STAGE_GATE=strict restores the authoritative-state error for ship', async () => {
+    const prev = process.env.FORGE_STAGE_GATE;
+    process.env.FORGE_STAGE_GATE = 'strict';
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-strict-ship-'));
     try {
       await expect(enforceStageEntry({
         commandName: 'ship',
@@ -190,6 +213,8 @@ describe('workflow enforce-stage', () => {
         health: { healthy: true, hardStop: false, diagnostics: [] }
       })).rejects.toThrow(/requires authoritative workflow state/i);
     } finally {
+      if (prev === undefined) delete process.env.FORGE_STAGE_GATE;
+      else process.env.FORGE_STAGE_GATE = prev;
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
@@ -234,8 +259,31 @@ describe('workflow enforce-stage', () => {
     }
   });
 
-  test('enforceStageEntry requires workflow state for review so ship-to-review transitions stay guarded', async () => {
+  test('enforceStageEntry allows review with no state and no kernel context, with a warning', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-review-missing-state-'));
+    try {
+      const warnings = [];
+      const result = await enforceStageEntry({
+        commandName: 'review',
+        flags: {},
+        projectRoot: tmpDir,
+        health: { healthy: true, hardStop: false, diagnostics: [] },
+        warn: (m) => warnings.push(m)
+      });
+
+      expect(result.allowed).toBe(true);
+      expect(result.stage).toBe('review');
+      expect(result.degradedGate).toBe('no-kernel-context');
+      expect(warnings.some(w => /stage gate skipped/i.test(w))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('enforceStageEntry with FORGE_STAGE_GATE=strict restores the authoritative-state error for review', async () => {
+    const prev = process.env.FORGE_STAGE_GATE;
+    process.env.FORGE_STAGE_GATE = 'strict';
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-strict-review-'));
     try {
       await expect(enforceStageEntry({
         commandName: 'review',
@@ -244,6 +292,8 @@ describe('workflow enforce-stage', () => {
         health: { healthy: true, hardStop: false, diagnostics: [] }
       })).rejects.toThrow(/requires authoritative workflow state/i);
     } finally {
+      if (prev === undefined) delete process.env.FORGE_STAGE_GATE;
+      else process.env.FORGE_STAGE_GATE = prev;
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Problem (B1 — P0)

After `forge setup`, `forge ship` (and `review`) threw:

> Stage ship requires authoritative workflow state. Provide --workflow-state or restore .forge-state.json.

whenever no `/plan → /dev → /validate → /ship` history had been walked — i.e. **fresh setup, an in-flight branch, or a manual commit**. This hard-blocked incremental adoption.

## Root cause

`lib/commands/ship.js` never reads workflow state; the gate lives in stage-entry enforcement (`lib/workflow/enforce-stage.js`). `ship` only needs the gate to PASS — it consumes zero state fields. So the fix is a **gate-decision change**, not synthesizing any JSON.

## Design — degrade-to-warn + kernel seeding (default), strict opt-in

When no authoritative state exists anywhere, **allow** the stage with a loud stderr warning and let the existing kernel recording seed history (so future gating gets real data):

- **linked issue + empty stage history** → warn (naming the issue id), allow, record the stage start → `degradedGate: 'kernel-empty'`
- **no state + no kernel-linked issue** → warn, allow → `degradedGate: 'no-kernel-context'`

Preserved fail-closed behavior:

- A recorded history that **contradicts** (e.g. `validate` started-but-not-done — the dev↔validate rework guard) still **throws**, regardless of mode.
- Inline `--workflow-state` and `.forge-state.json` file-state paths are **unchanged** (backward compat).

## Strict-mode escape hatch

`FORGE_STAGE_GATE=strict` restores the legacy hard error (require prior stages / authoritative state). The error text now appends "(or unset FORGE_STAGE_GATE)".

## Tests (TDD — RED → GREEN)

- `test/workflow/enforce-stage-kernel.test.js`: ship with linked issue + empty history is allowed/warns/records start; ship stays blocked when validate started-but-not-done (regression); review allowed after a degraded ship records ship done; strict restores the block.
- `test/workflow/enforce-stage.test.js`: ship & review with no state + no kernel context allowed with warning; `FORGE_STAGE_GATE=strict` restores the authoritative-state error for both; inline `--workflow-state` tests stay green.

Full `test/workflow/` dir: 105 pass / 0 fail. ESLint clean. Pre-push: 266 tests pass, lint green.

Consumers of the enforcement return object grepped (`_registry.js`, `bin/forge.js`, `status.js`) — the added `degradedGate` field is additive and breaks none.

Closes the B1 fix tracked in kernel issue a3bcb34a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stage checks now support a permissive degraded mode when workflow history or kernel context is unavailable.
  * Allowed stages display a warning and record available stage history when possible.
  * Set `FORGE_STAGE_GATE=strict` to require authoritative workflow state and restore hard-blocking behavior.

* **Bug Fixes**
  * Preserved rework protection when a prior stage has started but not completed.
  * Improved stage progression after completing a degraded workflow stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->