### PR TITLE
fix(setup): honor disabled gates in hook enforcement verdict + exit code (eda6d866)

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -2738,21 +2738,96 @@ function installForgeHookScripts() {
 // enforce (issue eda6d866). The hook scripts are installed unconditionally but are
 // INERT when their gate/rail is disabled in .forge/config.yaml, so setup must not
 // claim "enforcement active" when the resolved config says otherwise.
-function describeHookEnforcement(root = projectRoot) {
+// Resolve — from the SAME .forge/config.yaml the hooks read at run time — whether the TDD
+// gate is active and how many protected paths are guarded. The reporting/exit layer gates
+// its verdict on this so setup never claims (or fails over) a state the user deliberately
+// disabled (issue eda6d866). On resolver THROW (missing/corrupt config), fail TOWARD
+// enforcement (tddActive:true, resolved:false) so a broken config can never silently
+// downgrade the human-facing verdict.
+function resolveHookEnforcementState(root = projectRoot) {
   try {
     const { getResolvedRuntimeGraph } = require('../core/runtime-graph');
     const graph = getResolvedRuntimeGraph({ projectRoot: root });
     const tddRail = (graph.rails || []).find(rail => rail.id === 'rail.tdd_intent');
     const tddActive = !tddRail || tddRail.enabled !== false;
     const protectedCount = Array.isArray(graph.protectedPaths) ? graph.protectedPaths.length : 0;
-    const tdd = tddActive ? 'active' : 'disabled in config (hook inert)';
-    const pp = protectedCount > 0
-      ? `active (${protectedCount} path${protectedCount === 1 ? '' : 's'})`
-      : 'disabled in config (hook inert)';
-    return `TDD gate: ${tdd}; protected-path: ${pp}`;
+    return { tddActive, protectedCount, resolved: true };
   } catch {
-    return null; // never let an honest-status line block setup
+    return { tddActive: true, protectedCount: 0, resolved: false };
   }
+}
+
+function describeHookEnforcement(root = projectRoot) {
+  const state = resolveHookEnforcementState(root);
+  if (!state.resolved) {
+    return null; // never let an honest-status line block setup (resolver threw)
+  }
+  const tdd = state.tddActive ? 'active' : 'disabled in config (hook inert)';
+  const pp = state.protectedCount > 0
+    ? `active (${state.protectedCount} path${state.protectedCount === 1 ? '' : 's'})`
+    : 'disabled in config (hook inert)';
+  return `TDD gate: ${tdd}; protected-path: ${pp}`;
+}
+
+// Pure reporting/exit-layer verdict (issue eda6d866): fold the file-presence hook check
+// (verifyHooksActive) and the resolved config state (resolveHookEnforcementState) into the
+// message/level and whether setup should exit non-zero. Kept pure + exported so the four
+// honesty cases are unit-testable without spawning setup. The caller folds "are we in a git
+// repo" into `loud`, so a non-git dir (nothing to hook into) only ever warns.
+function buildHookVerdict(verdict, state, options = {}) {
+  const loud = options.loud === true;
+  const tddActive = !state || state.tddActive !== false;
+  if (verdict.active) {
+    if (tddActive) {
+      return {
+        message: `  ✓ Git hook enforcement active (${verdict.method}).`,
+        level: 'log',
+        exitFailure: false,
+      };
+    }
+    // Hooks installed but the TDD gate is OFF in config → the scripts are inert by the
+    // user's own choice. Say so honestly instead of over-claiming "enforcement active".
+    return {
+      message: `  ✓ Git hooks installed (${verdict.method}) — TDD gate disabled in .forge/config.yaml, hooks are inert. Re-enable: forge gate enable rail.tdd_intent`,
+      level: 'log',
+      exitFailure: false,
+    };
+  }
+  if (!tddActive) {
+    // Hooks not active AND the user disabled enforcement — this is the CHOSEN state (e.g.
+    // `init --profile minimal`), so never banner or exit non-zero for it, even under loud.
+    return {
+      message: '  ℹ Git hooks not active — enforcement is disabled in .forge/config.yaml anyway.',
+      level: 'info',
+      exitFailure: false,
+    };
+  }
+  // TDD is ON but hooks are inert — the silent-inert bug B3. Loud setup in a git repo fails
+  // LOUDLY + non-zero; otherwise (init/repair path, or non-git dir folded into !loud) warn.
+  if (loud) {
+    const addCmd = PKG_MANAGER === 'bun'
+      ? 'bun add -d'
+      : PKG_MANAGER === 'npm'
+        ? 'npm install --save-dev'
+        : `${PKG_MANAGER} add -D`;
+    const message = [
+      '',
+      '  ============================================================',
+      '  ⚠ TDD ENFORCEMENT IS NOT ACTIVE',
+      `     ${verdict.reason || 'no pre-commit hook is installed'}.`,
+      '     `forge ship` will block until hooks are active. To fix:',
+      `       ${addCmd} lefthook  &&  npx lefthook install`,
+      '     (or re-run `forge setup` in the repo root).',
+      '  ============================================================',
+      '',
+    ].join('\n');
+    return { message, level: 'error', exitFailure: true };
+  }
+  return {
+    message: `  ⚠ TDD enforcement is NOT active: ${verdict.reason || 'no pre-commit hook installed'}.`,
+    level: 'warn',
+    exitFailure: false,
+  };
 }
 
 function installGitHooks(options = {}) { // NOSONAR — Extracted as-is from bin/forge.js; complexity reduction deferred
@@ -2763,7 +2838,13 @@ function installGitHooks(options = {}) { // NOSONAR — Extracted as-is from bin
   // init deliberately degrades to a warning rather than failing, and repair runs inside
   // another command's flow.
   const loud = options.loud === true;
-  console.log('Installing git hooks (TDD enforcement)...');
+  // Honest header: when the TDD gate is disabled in config the hooks install but are inert,
+  // so don't announce "(TDD enforcement)" for a state the user turned off (issue eda6d866).
+  console.log(
+    resolveHookEnforcementState(projectRoot).tddActive
+      ? 'Installing git hooks (TDD enforcement)...'
+      : 'Installing git hooks (TDD gate disabled in config — hooks will be inert)...'
+  );
 
   // Install the Forge hook SCRIPTS first, unconditionally: they back BOTH the lefthook
   // pre-commit gate AND the native harness hooks that forge setup renders regardless of
@@ -2855,29 +2936,24 @@ function installGitHooks(options = {}) { // NOSONAR — Extracted as-is from bin
   }
 
   const verdict = verifyHooksActive(projectRoot);
-  if (verdict.active) {
-    console.log(`  ✓ Git hook enforcement active (${verdict.method}).`);
-  } else if (loud && resolveGitHooksDir(projectRoot)) {
-    // In a git repo but enforcement is inert — the exact silent-inert bug B3 kills.
-    // Fail LOUDLY and non-zero so `forge setup` never ends green with hooks off.
-    // (A non-git dir has nothing to hook into, so it only warns — see the else.)
-    const addCmd = PKG_MANAGER === 'bun'
-      ? 'bun add -d'
-      : PKG_MANAGER === 'npm'
-        ? 'npm install --save-dev'
-        : `${PKG_MANAGER} add -D`;
-    console.error('');
-    console.error('  ============================================================');
-    console.error('  ⚠ TDD ENFORCEMENT IS NOT ACTIVE');
-    console.error(`     ${verdict.reason || 'no pre-commit hook is installed'}.`);
-    console.error('     `forge ship` will block until hooks are active. To fix:');
-    console.error(`       ${addCmd} lefthook  &&  npx lefthook install`);
-    console.error('     (or re-run `forge setup` in the repo root).');
-    console.error('  ============================================================');
-    console.error('');
-    process.exitCode = 1;
+  const state = resolveHookEnforcementState(projectRoot);
+  // A non-git dir has nothing to hook into, so it must only ever WARN (never banner/exit).
+  // Fold that into `loud` before building the verdict so buildHookVerdict stays pure. When
+  // the TDD gate is disabled in config, the verdict is info-level with no failure exit even
+  // under loud setup — enforcement honestly follows the resolved config (issue eda6d866).
+  const inGitRepo = Boolean(resolveGitHooksDir(projectRoot));
+  const built = buildHookVerdict(verdict, state, { loud: loud && inGitRepo });
+  if (built.level === 'error') {
+    console.error(built.message);
+  } else if (built.level === 'warn') {
+    console.warn(built.message);
+  } else if (built.level === 'info') {
+    console.info(built.message);
   } else {
-    console.warn(`  ⚠ TDD enforcement is NOT active: ${verdict.reason || 'no pre-commit hook installed'}.`);
+    console.log(built.message);
+  }
+  if (built.exitFailure) {
+    process.exitCode = 1;
   }
 }
 
@@ -4305,6 +4381,8 @@ module.exports = {
 
   // Expose internals for testing and cross-command use
   describeHookEnforcement,
+  resolveHookEnforcementState,
+  buildHookVerdict,
   checkPrerequisites,
   setupCoreDocs,
   displaySetupSummary,

--- a/test/setup-enforcement-honesty.test.js
+++ b/test/setup-enforcement-honesty.test.js
@@ -9,6 +9,7 @@ const path = require('node:path');
 // the resolved .forge/config.yaml — the hook scripts install unconditionally but are
 // inert when their gate/rail is disabled, so setup must not over-claim (issue eda6d866).
 const setup = require('../lib/commands/setup');
+const { renderAdoptionConfigYaml } = require('../lib/adoption-profiles');
 
 let root;
 
@@ -41,5 +42,54 @@ describe('describeHookEnforcement (honest resolved-state summary)', () => {
     writeConfig('protectedPaths:\n  - .forge/config.yaml\n  - AGENTS.md\n');
     const desc = setup.describeHookEnforcement(root);
     expect(desc).toMatch(/protected-path: active \(2 paths\)/);
+  });
+
+  test('minimal profile → describe reports the TDD gate disabled', () => {
+    writeConfig(renderAdoptionConfigYaml('minimal'));
+    const desc = setup.describeHookEnforcement(root);
+    expect(desc).toMatch(/TDD gate: disabled/);
+  });
+});
+
+describe('resolveHookEnforcementState (config-resolved hook state)', () => {
+  test('minimal profile disables the TDD rail → tddActive false, resolved true', () => {
+    writeConfig(renderAdoptionConfigYaml('minimal'));
+    const state = setup.resolveHookEnforcementState(root);
+    expect(state.tddActive).toBe(false);
+    expect(state.resolved).toBe(true);
+  });
+
+  test('gate-disable shape (workflow.gates[rail.tdd_intent].enabled:false) → tddActive false', () => {
+    writeConfig('workflow:\n  gates:\n    rail.tdd_intent:\n      enabled: false\n');
+    const state = setup.resolveHookEnforcementState(root);
+    expect(state.tddActive).toBe(false);
+    expect(state.resolved).toBe(true);
+  });
+
+  test('full-profile shape (rails.tdd_intent.enabled:false) → tddActive false', () => {
+    writeConfig('rails:\n  rail.tdd_intent:\n    enabled: false\n');
+    const state = setup.resolveHookEnforcementState(root);
+    expect(state.tddActive).toBe(false);
+    expect(state.resolved).toBe(true);
+  });
+
+  test('no config → default enforcement on (tddActive true)', () => {
+    const state = setup.resolveHookEnforcementState(root);
+    expect(state.tddActive).toBe(true);
+    expect(state.resolved).toBe(true);
+  });
+
+  test('corrupt YAML → fail TOWARD enforcement (tddActive true, resolved false)', () => {
+    writeConfig('workflow:\n  gates:\n   : : : broken\n  - not valid yaml\n');
+    const state = setup.resolveHookEnforcementState(root);
+    expect(state.tddActive).toBe(true);
+    expect(state.resolved).toBe(false);
+  });
+
+  test('flipping config true→false re-resolves without any reinstall', () => {
+    writeConfig('rails:\n  rail.tdd_intent:\n    enabled: true\n');
+    expect(setup.resolveHookEnforcementState(root).tddActive).toBe(true);
+    writeConfig('rails:\n  rail.tdd_intent:\n    enabled: false\n');
+    expect(setup.resolveHookEnforcementState(root).tddActive).toBe(false);
   });
 });

--- a/test/setup-hook-verdict.test.js
+++ b/test/setup-hook-verdict.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+
+// buildHookVerdict is the PURE reporting/exit layer for git-hook enforcement (issue
+// eda6d866). It maps the file-presence hook check (verifyHooksActive) PLUS the resolved
+// config state (resolveHookEnforcementState) onto a human-facing { message, level,
+// exitFailure } verdict. The bug it fixes: setup used to print "enforcement active" (or
+// even fail loudly + exit 1) for a state the user DELIBERATELY chose by disabling the TDD
+// gate. These cases pin the four honesty outcomes without spawning setup.
+const setup = require('../lib/commands/setup');
+
+const ACTIVE = { active: true, method: 'native' };
+const INERT = { active: false, method: 'none', reason: 'no pre-commit hook installed' };
+const ENABLED = { tddActive: true };
+const DISABLED = { tddActive: false };
+
+describe('buildHookVerdict (honest reporting/exit layer)', () => {
+  test('hooks active + TDD enabled → "enforcement active", no failure exit', () => {
+    const v = setup.buildHookVerdict(ACTIVE, ENABLED, { loud: true });
+    expect(v.message).toContain('Git hook enforcement active');
+    expect(v.message).toContain('(native)');
+    expect(v.exitFailure).toBe(false);
+  });
+
+  test('hooks active + TDD disabled → inert message, no failure exit (the reported bug)', () => {
+    const v = setup.buildHookVerdict(ACTIVE, DISABLED, { loud: true });
+    expect(v.message).toContain('TDD gate disabled in .forge/config.yaml');
+    expect(v.message).toContain('inert');
+    expect(v.message).not.toContain('enforcement active');
+    expect(v.exitFailure).toBe(false);
+  });
+
+  test('no hooks + TDD disabled + loud → info message, exitFailure FALSE (minimal setup must not exit 1)', () => {
+    const v = setup.buildHookVerdict(INERT, DISABLED, { loud: true });
+    expect(v.level).toBe('info');
+    expect(v.message).toContain('disabled in .forge/config.yaml anyway');
+    expect(v.message).not.toContain('TDD ENFORCEMENT IS NOT ACTIVE');
+    expect(v.exitFailure).toBe(false);
+  });
+
+  test('no hooks + TDD enabled + loud → failure banner text, exitFailure TRUE (preserved behavior)', () => {
+    const v = setup.buildHookVerdict(INERT, ENABLED, { loud: true });
+    expect(v.level).toBe('error');
+    expect(v.message).toContain('TDD ENFORCEMENT IS NOT ACTIVE');
+    expect(v.exitFailure).toBe(true);
+  });
+
+  test('no hooks + TDD enabled + quiet → warn, exitFailure false', () => {
+    const v = setup.buildHookVerdict(INERT, ENABLED, { loud: false });
+    expect(v.level).toBe('warn');
+    expect(v.message).toContain('NOT active');
+    expect(v.exitFailure).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the remaining half of **eda6d866**. `forge setup` / `forge init --profile minimal` (all gates disabled) still printed `✓ Git hook enforcement active` and could even exit 1 with a `TDD ENFORCEMENT IS NOT ACTIVE` banner for a state the user **deliberately chose**. The config toggles didn't govern the human-facing verdict/exit.

## Context — the run-time half already shipped

The hook scripts already honor config at run time: `.forge/hooks/check-tdd.js` and `.forge/hooks/forge-native-hook.js` read `.forge/config.yaml`, honor both config shapes (`workflow.gates['rail.tdd_intent']` and `rails.tdd_intent`), and fail toward enforcement on malformed YAML. The `minimal` profile genuinely disables everything. This PR fixes only the **reporting/exit layer** in `lib/commands/setup.js` that over-claimed.

## What changed

- **`resolveHookEnforcementState(root)`** → `{ tddActive, protectedCount, resolved }`, extracted from `describeHookEnforcement`'s resolver body. On resolver throw → `{ tddActive: true, resolved: false }` (fail toward enforcement). `describeHookEnforcement` now formats over it; its exported string API + `catch→null` behavior are unchanged.
- **Pure `buildHookVerdict(verdict, state, { loud })`** → `{ message, level, exitFailure }`, four cases:
  1. active + enabled → unchanged `✓ Git hook enforcement active (method).`, no exit failure
  2. active + disabled → `✓ Git hooks installed … TDD gate disabled …, hooks are inert. Re-enable: forge gate enable rail.tdd_intent`, no exit failure
  3. inactive + disabled → info `ℹ Git hooks not active — enforcement is disabled in .forge/config.yaml anyway.`, **no exit 1 even when loud** (the bug)
  4. inactive + enabled → existing loud banner + `exitFailure:true` preserved byte-for-byte
- **Verdict block** now resolves state once, builds the verdict, prints at its level, and sets `process.exitCode = 1` only when `exitFailure`. Non-git dirs are folded into `!loud` so they only ever warn.
- Honest install header when the TDD gate is disabled in config.

## Untouched (by design)

- `verifyHooksActive` semantics (file-presence-based, config-blind) — feeds stage `HOOKS_NOT_ACTIVE` gating.
- The hook script bodies.
- The dead `bin/forge.js` legacy banner copy.

## Tests

- `test/setup-hook-verdict.test.js` (new): the four honesty cases, incl. `inactive + disabled + loud → info, exitFailure false` (the reported bug) and `inactive + enabled + loud → banner, exitFailure true` (preserved).
- `test/setup-enforcement-honesty.test.js` (extended): minimal profile, `workflow.gates` shape, `rails` shape, corrupt YAML (fail toward enforcement), and true→false re-resolve without reinstall.

`bun test test/setup*.test.js` → 184 pass, 0 fail. ESLint clean. Pre-push green.

Kernel issue: eda6d866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Setup now accurately reports whether TDD hook enforcement is enabled based on the resolved configuration.
  - Clearer messages distinguish active hooks, inactive hooks, and intentionally disabled TDD gates.
  - Configuration errors or missing settings are handled conservatively instead of being reported as silently successful.
  - Non-Git directories now produce warnings without failing setup, while Git repositories correctly report enforcement failures when applicable.
- **Tests**
  - Added coverage for configuration changes, disabled enforcement profiles, invalid YAML, and setup verdict behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->