### PR TITLE
fix(worktree): base new worktree on default branch + add --base + print base (B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`forge worktree create` bases the new branch on the default branch, not the current checkout.** A worktree created while on a WIP branch previously forked from the current HEAD and silently inherited unrelated commits. New worktrees now fork from the repository default branch (`origin/<default>` when the remote ref exists, else the local default); a new `--base <ref>` flag overrides it (invalid refs error and create nothing), and `create` prints the base it used so the fork point is never silent. (B2)
+
 ## [0.1.0-beta.2] - 2026-07-15
 
 The **beta-blocker hardening wave** — Forge's advertised loop now composes end to end, its quality gates fail closed, its control surfaces describe themselves honestly, and the runtime is Beads-free. Every change below was adversarially reviewed before merge. (v0.1.0-beta.1 was tagged but never reached npm — its publish token had expired; this release switches to OIDC Trusted Publishing and is the first npm beta.)

--- a/docs/guides/SUPPORT.md
+++ b/docs/guides/SUPPORT.md
@@ -108,6 +108,11 @@ Create isolated work:
 forge worktree create <slug> --branch <branch-name>
 ```
 
+The new branch is forked from the repository's default branch (`origin/<default>`
+when present, else the local default), not the current checkout — so a worktree
+made from a WIP branch does not inherit unrelated commits. Override with
+`--base <ref>` to fork from a specific ref; `create` prints the base it used.
+
 Remove it:
 
 ```bash

--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -105,11 +105,20 @@ forge sync
 
 ```bash
 forge worktree create <slug> --branch <branch-name>
+forge worktree create <slug> --base <ref>
 forge worktree remove <slug>
 forge clean --dry-run
 ```
 
 Slugs must not contain `..`, `/`, or `\`.
+
+A new worktree's branch is forked from the repository's **default branch**
+(`origin/<default>` when the remote ref exists, else the local default) — **not**
+the checkout's current branch/HEAD — so a worktree created from a WIP branch never
+silently inherits unrelated commits. Pass `--base <ref>` to fork from a specific
+ref instead; an invalid `--base` errors and creates nothing. `create` prints the
+base it used (e.g. `Created worktree <path> on <branch> (based on origin/main).`)
+so the fork point is never silent.
 
 ## Adapters
 

--- a/lib/commands/worktree.js
+++ b/lib/commands/worktree.js
@@ -3,6 +3,7 @@
 const { execFileSync, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { detectDefaultBranch } = require('../beads-sync-scaffold');
 
 /**
  * Forge Worktree Command
@@ -51,6 +52,40 @@ function branchExists(branchName, runFile) {
   } catch (_err) { /* intentional: branch doesn't exist */ // NOSONAR S2486
     return false;
   }
+}
+
+/**
+ * True when a git ref resolves to a commit (branch, tag, remote-tracking ref, or SHA).
+ * @param {string} ref - The ref to check
+ * @param {string} projectRoot - Repo root to run git in
+ * @param {Function} runFile - execFileSync function (for DI)
+ * @returns {boolean}
+ */
+function refExists(ref, projectRoot, runFile) {
+  try {
+    runFile('git', ['-C', projectRoot, 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`], { stdio: ['pipe', 'pipe', 'pipe'] });
+    return true;
+  } catch (_err) { /* intentional: ref does not resolve */ // NOSONAR S2486
+    return false;
+  }
+}
+
+/**
+ * Resolve the base ref a NEW worktree branch should fork from. Defaults to the
+ * repo's DEFAULT branch (NOT the checkout's current HEAD) so a worktree created
+ * off a WIP branch never silently inherits unrelated commits. Prefers the remote
+ * default (`origin/<default>`) when present, else the local default branch, and
+ * falls back to the detected name so git surfaces a clear error if neither exists.
+ * @param {string} projectRoot - Repo root
+ * @param {Function} runFile - execFileSync function (for DI)
+ * @returns {string} The base ref to pass to `git worktree add ... <base>`
+ */
+function resolveDefaultBase(projectRoot, runFile) {
+  const def = detectDefaultBranch(projectRoot, { _exec: runFile });
+  const originRef = `origin/${def}`;
+  if (refExists(originRef, projectRoot, runFile)) return originRef;
+  if (refExists(def, projectRoot, runFile)) return def;
+  return def;
 }
 
 /**
@@ -278,6 +313,14 @@ async function handleCreate(slug, flags, projectRoot, opts) {
 
   const worktreePath = path.resolve(worktreesDir, slug);
 
+  // Validate an explicit --base up front so a bad ref errors BEFORE anything is
+  // created (no branch, no worktree dir). Base only applies when creating a NEW
+  // branch; an existing branch is checked out as-is.
+  const explicitBase = flags['--base'] || null;
+  if (explicitBase && !refExists(explicitBase, projectRoot, runFile)) {
+    return { success: false, error: `Invalid --base: ref '${explicitBase}' not found. Verify it exists (git rev-parse --verify ${explicitBase}).` };
+  }
+
   // Step 0: Check if worktree already exists
   if (fsApi.existsSync(worktreePath)) {
     // A pre-existing worktree may be checked out on a different branch than the
@@ -303,12 +346,17 @@ async function handleCreate(slug, flags, projectRoot, opts) {
   // Step 1: Ensure .worktrees/ dir exists
   fsApi.mkdirSync(worktreesDir, { recursive: true });
 
-  // Step 2: Create git worktree
+  // Step 2: Create git worktree. For a NEW branch, fork from an explicit --base or
+  // the repo's DEFAULT branch — NOT the checkout's current HEAD — so the worktree
+  // never silently inherits unrelated WIP commits (B2). An existing branch is
+  // checked out as-is (no base applies).
   const hasBranch = branchExists(branchName, runFile);
+  let base = null;
   if (hasBranch) {
     runFile('git', ['worktree', 'add', worktreePath, branchName], { stdio: 'pipe' });
   } else {
-    runFile('git', ['worktree', 'add', worktreePath, '-b', branchName], { stdio: 'pipe' });
+    base = explicitBase || resolveDefaultBase(projectRoot, runFile);
+    runFile('git', ['worktree', 'add', worktreePath, '-b', branchName, base], { stdio: 'pipe' });
   }
 
   // Step 3: Populate node_modules (link to the shared install, else install).
@@ -329,14 +377,19 @@ async function handleCreate(slug, flags, projectRoot, opts) {
   const linkage = await registerWorktreeLinkage({ projectRoot, worktreePath, branch: branchName, issueId, workFolder, opts });
   const backing = await autoFileBackingIssue({ projectRoot, worktreePath, branch: branchName, issueId, opts });
 
+  // Report the base so the fork point is never silent. `base` is null when an
+  // existing branch was checked out (no fork happened).
+  const baseNote = base ? `based on ${base}` : `existing branch ${branchName}`;
   return {
     success: true,
     worktreePath,
     branch: branchName,
+    base,
     depsLinked: deps.linked,
     depsInstalled: deps.installed,
     linkage,
     backing,
+    output: `Created worktree ${worktreePath} on ${branchName} (${baseNote}).`,
   };
 }
 
@@ -383,8 +436,8 @@ async function handleRemove(slug, projectRoot, opts) {
 }
 
 // Long flags that take a value, in both `--flag value` and `--flag=value` forms.
-const WORKTREE_VALUE_FLAGS = ['--branch', '--issue', '--work-folder'];
-const WORKTREE_USAGE_HINT = 'Usage: forge worktree create <slug> [--branch <name>] [--issue <id>] [--work-folder <path>]';
+const WORKTREE_VALUE_FLAGS = ['--branch', '--issue', '--work-folder', '--base'];
+const WORKTREE_USAGE_HINT = 'Usage: forge worktree create <slug> [--branch <name>] [--base <ref>] [--issue <id>] [--work-folder <path>]';
 
 function parseWorktreeArgs(args, flags) {
   const positional = [];
@@ -429,6 +482,7 @@ module.exports = {
   usage: 'forge worktree <create|remove|list> <slug>',
   flags: {
     '--branch': 'Custom branch name (default: feat/<slug>)',
+    '--base': 'Base ref a new branch forks from (default: the repo default branch, e.g. origin/main)',
     '--issue': 'Kernel issue id to link this worktree to (records issue → worktree)',
     '--work-folder': 'Repo-relative work-folder this issue owns (records worktree → work-folder + drops a .forge-issue marker)',
   },
@@ -486,5 +540,7 @@ module.exports = {
     setupWorktreeDeps,
     runInstall,
     autoFileBackingIssue,
+    refExists,
+    resolveDefaultBase,
   },
 };

--- a/test/commands/worktree-base.test.js
+++ b/test/commands/worktree-base.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const { describe, test, expect, afterEach } = require('bun:test');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+// ---------------------------------------------------------------------------
+// B2 (5f7e3f9b): `forge worktree create` must fork a NEW branch off the repo's
+// DEFAULT branch, not the checkout's current HEAD. Uses REAL git repos so the
+// fork point is genuinely verified (merge-base / log), plus --base override and
+// invalid-base handling.
+// ---------------------------------------------------------------------------
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+// Stub the kernel so no real SQLite driver is opened (Windows EBUSY on cleanup);
+// the real git worktree creation is what these tests exercise.
+const stubOpts = () => ({
+  _kernelDriver: { registerWorktree: () => {}, listWorktrees: () => [] },
+  _kernelBroker: {},
+  _ensureBackingIssue: async () => null,
+});
+
+// `git worktree add` runs in process.cwd(); production always invokes the handler
+// with projectRoot === cwd. Replicate that invariant so the real git commands
+// target the temp repo, then restore.
+async function createIn(root, args) {
+  const mod = require('../../lib/commands/worktree');
+  const prev = process.cwd();
+  process.chdir(root);
+  try {
+    return await mod.handler(args, {}, root, stubOpts());
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+const roots = [];
+
+function initRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'forge-wt-base-'));
+  roots.push(root);
+  git(root, 'init', '-b', 'main');
+  git(root, 'config', 'user.email', 'test@example.com');
+  git(root, 'config', 'user.name', 'Test');
+  fs.writeFileSync(path.join(root, 'base.txt'), 'base\n');
+  git(root, 'add', '.');
+  git(root, 'commit', '-m', 'base commit');
+  return root;
+}
+
+afterEach(() => {
+  while (roots.length) {
+    const root = roots.pop();
+    try { fs.rmSync(root, { recursive: true, force: true }); } catch (_e) { /* best-effort temp cleanup */ }
+  }
+});
+
+describe('forge worktree create — base ref (B2)', () => {
+  test('bases the new branch off the default branch, NOT the current checked-out branch', async () => {
+    const root = initRepo();
+    const defaultHead = git(root, 'rev-parse', 'HEAD').trim();
+
+    // Switch to a WIP branch with a commit absent from the default branch.
+    git(root, 'checkout', '-b', 'feat/wip');
+    fs.writeFileSync(path.join(root, 'wip.txt'), 'wip\n');
+    git(root, 'add', '.');
+    git(root, 'commit', '-m', 'wip-only commit');
+    const wipHead = git(root, 'rev-parse', 'HEAD').trim();
+
+    const result = await createIn(root, ['create', 'myslug']);
+
+    expect(result.success).toBe(true);
+    // No remote → local default branch is the base.
+    expect(result.base).toBe('main');
+    // The new branch forked from the default HEAD, not the WIP HEAD.
+    const newHead = git(root, 'rev-parse', 'feat/myslug').trim();
+    expect(newHead).toBe(defaultHead);
+    expect(newHead).not.toBe(wipHead);
+    // The WIP-only commit must NOT be in the new branch history.
+    const log = git(root, 'log', '--format=%H', 'feat/myslug');
+    expect(log).not.toContain(wipHead);
+  });
+
+  test('--base <ref> overrides the default base', async () => {
+    const root = initRepo();
+    const firstHead = git(root, 'rev-parse', 'HEAD').trim();
+    // Advance the default branch past the first commit.
+    fs.writeFileSync(path.join(root, 'more.txt'), 'more\n');
+    git(root, 'add', '.');
+    git(root, 'commit', '-m', 'second commit');
+    const secondHead = git(root, 'rev-parse', 'HEAD').trim();
+
+    const result = await createIn(root, ['create', 'pinned', '--base', firstHead]);
+
+    expect(result.success).toBe(true);
+    expect(result.base).toBe(firstHead);
+    const newHead = git(root, 'rev-parse', 'feat/pinned').trim();
+    expect(newHead).toBe(firstHead);
+    expect(newHead).not.toBe(secondHead);
+  });
+
+  test('invalid --base errors clearly and creates nothing', async () => {
+    const root = initRepo();
+
+    const result = await createIn(root, ['create', 'bad', '--base', 'no-such-ref-xyz']);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid --base');
+    // Nothing created: no worktree dir and no branch.
+    expect(fs.existsSync(path.join(root, '.worktrees', 'bad'))).toBe(false);
+    expect(git(root, 'branch', '--list', 'feat/bad').trim()).toBe('');
+  });
+
+  test('the base used is reported in the output and the JSON base field', async () => {
+    const root = initRepo();
+
+    const result = await createIn(root, ['create', 'reported']);
+
+    expect(result.success).toBe(true);
+    expect(result.base).toBe('main');
+    expect(typeof result.output).toBe('string');
+    expect(result.output).toContain('based on main');
+    expect(result.output).toContain('feat/reported');
+  });
+});

--- a/test/commands/worktree.test.js
+++ b/test/commands/worktree.test.js
@@ -15,6 +15,7 @@ describe('forge worktree command', () => {
     expect(mod.usage).toBe('forge worktree <create|remove|list> <slug>');
     expect(mod.flags).toEqual({
       '--branch': 'Custom branch name (default: feat/<slug>)',
+      '--base': 'Base ref a new branch forks from (default: the repo default branch, e.g. origin/main)',
       '--issue': 'Kernel issue id to link this worktree to (records issue → worktree)',
       '--work-folder': 'Repo-relative work-folder this issue owns (records worktree → work-folder + drops a .forge-issue marker)',
     });


### PR DESCRIPTION
## Summary

Fixes **B2** (kernel issue `5f7e3f9b`): `forge worktree create <slug>` based the new branch off the checkout's **current** branch/HEAD instead of the repo's default branch. In the field this created `feat/forge-setup` off a WIP branch (`feat/meeting-backend-buddy`), silently inheriting ~5 unrelated commits.

## Fix

- **Default base = the repo default branch**, not current HEAD. Reuses the existing `detectDefaultBranch` helper (`lib/beads-sync-scaffold.js`); prefers `origin/<default>` when the remote ref exists, else the local default branch.
- **New `--base <ref>` flag** overrides the default. Validated up front with `git rev-parse --verify` — an invalid ref errors clearly and creates nothing (no branch, no worktree dir).
- **The base is printed**, so the fork point is never silent: human output `Created worktree <path> on <branch> (based on <base>).` plus a `base` field on the result object.
- `--branch` / `--issue` / `--work-folder` behavior and the kernel linkage are unchanged. An existing branch is still checked out as-is (no base applies).

## Where the base was chosen

- **Before:** `lib/commands/worktree.js` — `git worktree add <path> -b <branch>` (implicit current HEAD).
- **After:** `base = explicitBase || resolveDefaultBase(projectRoot, runFile)` then `git worktree add <path> -b <branch> <base>`.

## Tests (TDD, real git repos)

New `test/commands/worktree-base.test.js`:
- bases the new branch off the default branch, NOT the current checked-out WIP branch (verifies the WIP-only commit is absent from the new branch history)
- `--base <ref>` overrides the default base
- invalid `--base` errors clearly and creates nothing
- the base used is reported in the output and the `base` JSON field

All worktree suites green (`worktree`, `worktree-base`, `worktree-linkage`, `worktree-deps` — 27 pass). Full pre-push suite + ESLint green.

Kernel issue: `5f7e3f9b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)