### PR TITLE
feat(skills): skill chain metadata + generic sub-skill registry (W2)

### DIFF
--- a/.agents/skills/claim-safety/SKILL.md
+++ b/.agents/skills/claim-safety/SKILL.md
@@ -14,10 +14,13 @@ description: >
   and NOT for read-only selecting or ranking the next ready issue without claiming (that is
   triage-ready).
 allowed-tools: Read, Bash(forge:*)
-terminal: true
+next: dev
+terminal: false
 ---
 
 # Claim safety — claim, then prove you own the lease
+
+> **Chain:** once you have PROVEN the lease (`forge issue owns <id>` exits 0), continue to `dev` to work the issue (`smith` proceeds into plan/dev after this proof). Usable standalone whenever ownership is in question.
 
 Claiming is not owning. The Forge kernel keys a claim's idempotency on
 `claim.create:<issue_id>:<actor>`, so a **same-key duplicate replay returns

--- a/.agents/skills/claim-safety/SKILL.md
+++ b/.agents/skills/claim-safety/SKILL.md
@@ -14,6 +14,7 @@ description: >
   and NOT for read-only selecting or ranking the next ready issue without claiming (that is
   triage-ready).
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 # Claim safety — claim, then prove you own the lease

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -13,11 +13,15 @@ description: >
   opening the PR (ship), for addressing PR review feedback (review), or for orchestrating
   several stages / taking an issue end-to-end to a merged PR (smith).
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+next: validate
+terminal: false
 ---
 
 Implement each task from the /plan task list using a subagent-driven loop: implementer → spec compliance reviewer → code quality reviewer per task.
 
 # Dev
+
+> **Chain (HARD-GATE):** the ONLY skill you invoke after `dev` is `validate`. Never open a PR straight from `dev`.
 
 This skill reads the task list created by `/plan` and implements each task using a three-stage subagent loop. TDD is enforced inside each implementer subagent.
 

--- a/.agents/skills/hermes-forge/SKILL.md
+++ b/.agents/skills/hermes-forge/SKILL.md
@@ -26,6 +26,7 @@ metadata:
   author: forge
   version: "1.0.0"
   roadmap: forge-2agy.9.7.x
+chainExempt: true
 ---
 
 # Hermes ⇄ Forge consumption contract

--- a/.agents/skills/issue-basics/SKILL.md
+++ b/.agents/skills/issue-basics/SKILL.md
@@ -14,6 +14,7 @@ description: >
   the plan->dev->validate->ship pipeline or open a PR (use smith or stage skills); does NOT
   report the current stage or what's in flight (use status).
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 # Issue basics — the CRUD floor

--- a/.agents/skills/kernel/SKILL.md
+++ b/.agents/skills/kernel/SKILL.md
@@ -60,8 +60,9 @@ status → plan → dev → validate → ship → review → verify
 ### Chain map (each skill declares its successor)
 
 Every skill carries chain metadata in its frontmatter (`next`, `terminal`,
-`subskills`, `handoffs`) plus a HARD-GATE chain line in its body, so each stage
-announces the next one. The linear ladder:
+`subskills`, `handoffs`); each workflow STAGE skill additionally carries a
+HARD-GATE chain line in its body, so each stage announces the next one. The
+linear ladder:
 
 | Skill | `next` | terminal |
 |-------|--------|----------|

--- a/.agents/skills/kernel/SKILL.md
+++ b/.agents/skills/kernel/SKILL.md
@@ -64,14 +64,20 @@ Every skill carries chain metadata in its frontmatter (`next`, `terminal`,
 HARD-GATE chain line in its body, so each stage announces the next one. The
 linear ladder:
 
-| Skill | `next` | terminal |
-|-------|--------|----------|
-| `plan` | `dev` | no (composes `research`) |
-| `dev` | `validate` | no |
-| `validate` | `ship` | no |
-| `ship` | `review` | no (handoff → `shepherd`) |
-| `review` | `verify` | no (handoff → `shepherd`) |
-| `verify` | — | **yes (terminal)** |
+| Skill | `next` | `terminal` |
+|-------|--------|-----------|
+| `plan` | `dev` | `false` |
+| `dev` | `validate` | `false` |
+| `validate` | `ship` | `false` |
+| `ship` | `review` | `false` |
+| `review` | `verify` | `false` |
+| `verify` | `ship` | `false` |
+
+The `next` column is each stage's DEFAULT / critical-path successor (`plan`
+composes `research`; `ship` and `review` also carry a `shepherd` handoff). The
+actual successor after `ship`, `review`, and `verify` is classification-dependent
+— see the note below. `verify`'s `next` (`ship`) is the `docs`-only pre-ship
+reuse; in every other flow nothing follows `verify`.
 
 Feeders into the chain: `triage-ready` → `claim-safety` → `dev` (rank the pick,
 prove the live lease, then work it). `research` is standalone / callable

--- a/.agents/skills/kernel/SKILL.md
+++ b/.agents/skills/kernel/SKILL.md
@@ -14,6 +14,7 @@ description: >
   merged PR under gates → `smith`; token-bounded state for the Hermes harness →
   `hermes-forge`.
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 # Forge kernel surface
@@ -55,6 +56,28 @@ mutating it — a claim returning ok:true does not by itself prove ownership).
 ```
 status → plan → dev → validate → ship → review → verify
 ```
+
+### Chain map (each skill declares its successor)
+
+Every skill carries chain metadata in its frontmatter (`next`, `terminal`,
+`subskills`, `handoffs`) plus a HARD-GATE chain line in its body, so each stage
+announces the next one. The linear ladder:
+
+| Skill | `next` | terminal |
+|-------|--------|----------|
+| `plan` | `dev` | no (composes `research`) |
+| `dev` | `validate` | no |
+| `validate` | `ship` | no |
+| `ship` | `review` | no (handoff → `shepherd`) |
+| `review` | `verify` | no (handoff → `shepherd`) |
+| `verify` | — | **yes (terminal)** |
+
+Feeders into the chain: `research` → `plan`, `triage-ready` → `plan`. The `smith`
+orchestrator composes the six stages (`subskills`). Utility/terminal skills
+(`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
+`rollback`, `sonarcloud`, `sonarcloud-analysis`, `parallel-deep-research`,
+`using-forge`) declare no forward-stage `next`. Meta skills (`hermes-forge`) are
+chain-exempt.
 
 ## Orchestrator super-skill
 

--- a/.agents/skills/kernel/SKILL.md
+++ b/.agents/skills/kernel/SKILL.md
@@ -72,14 +72,20 @@ announces the next one. The linear ladder:
 | `review` | `verify` | no (handoff → `shepherd`) |
 | `verify` | — | **yes (terminal)** |
 
-Feeders into the chain: `triage-ready` → `claim-safety` (prove the lease before
-work starts), then plan/dev. `research` is standalone / callable mid-workflow and
-returns to its CALLER (no forced `next`); it is also a `subskill` of `plan`. The
-`smith` orchestrator composes the six stages (`subskills`). Utility/terminal
-skills (`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
+Feeders into the chain: `triage-ready` → `claim-safety` → `dev` (rank the pick,
+prove the live lease, then work it). `research` is standalone / callable
+mid-workflow and returns to its CALLER (no forced `next`); it is also a `subskill`
+of `plan`. The `smith` orchestrator composes the six stages (`subskills`).
+Utility/terminal skills (`status`, `shepherd`, `kernel`, `issue-basics`, `memory`,
 `rollback`, `research`, `sonarcloud`, `sonarcloud-analysis`,
 `parallel-deep-research`, `using-forge`) declare no forward-stage `next`. Meta
 skills (`hermes-forge`) are chain-exempt.
+
+The stage `next` values above are the DEFAULT / critical-path successors. The
+actual successor after `ship`, `review`, and `verify` is
+classification-dependent — the authoritative matrix is `lib/workflow/stages.js`
+(Simple/Hotfix/Refactor end at `ship`; Standard ends at `review`; Critical runs
+through `verify`; the `docs` classification reuses `verify` → `ship`).
 
 ## Orchestrator super-skill
 

--- a/.agents/skills/kernel/SKILL.md
+++ b/.agents/skills/kernel/SKILL.md
@@ -72,12 +72,14 @@ announces the next one. The linear ladder:
 | `review` | `verify` | no (handoff → `shepherd`) |
 | `verify` | — | **yes (terminal)** |
 
-Feeders into the chain: `research` → `plan`, `triage-ready` → `plan`. The `smith`
-orchestrator composes the six stages (`subskills`). Utility/terminal skills
-(`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
-`rollback`, `sonarcloud`, `sonarcloud-analysis`, `parallel-deep-research`,
-`using-forge`) declare no forward-stage `next`. Meta skills (`hermes-forge`) are
-chain-exempt.
+Feeders into the chain: `triage-ready` → `claim-safety` (prove the lease before
+work starts), then plan/dev. `research` is standalone / callable mid-workflow and
+returns to its CALLER (no forced `next`); it is also a `subskill` of `plan`. The
+`smith` orchestrator composes the six stages (`subskills`). Utility/terminal
+skills (`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
+`rollback`, `research`, `sonarcloud`, `sonarcloud-analysis`,
+`parallel-deep-research`, `using-forge`) declare no forward-stage `next`. Meta
+skills (`hermes-forge`) are chain-exempt.
 
 ## Orchestrator super-skill
 

--- a/.agents/skills/memory/SKILL.md
+++ b/.agents/skills/memory/SKILL.md
@@ -13,6 +13,7 @@ description: >
   The local backend is always the offline floor. Not for: issue create/list/close ops
   (issue-basics), workflow status (status), or transient scratch notes.
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
 ---
 
 # Memory

--- a/.agents/skills/parallel-deep-research/SKILL.md
+++ b/.agents/skills/parallel-deep-research/SKILL.md
@@ -17,6 +17,7 @@ compatibility: Requires PARALLEL_API_KEY in .env.local. Uses curl. Takes 3-25 mi
 metadata:
   author: harshanandak
   version: "1.0.0"
+terminal: true
 ---
 
 # Parallel Deep Research

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -13,11 +13,17 @@ description: >
   where work stands or what is stale (status), and NOT for everyday issue create/list/close or
   picking the next ready issue (issue-basics / triage-ready).
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+next: dev
+terminal: false
+subskills:
+  - research
 ---
 
 Plan a feature from scratch: brainstorm design intent, research technical approach, then set up branch, worktree, and a complete task list ready for /dev.
 
 # Plan
+
+> **Chain (HARD-GATE):** the next skill after `plan` is `dev`. `plan` composes the `research` sub-skill for its Phase 2 technical bundle. Do not skip ahead past `dev`.
 
 `/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
 

--- a/.agents/skills/research/SKILL.md
+++ b/.agents/skills/research/SKILL.md
@@ -14,6 +14,8 @@ description: >
   heavyweight EXTERNAL market/competitive report (paid Parallel AI); `plan` for the full plan
   stage (brainstorm + tasks); `dev` or `validate` to implement or scan rather than investigate.
 allowed-tools: Bash, Read, Write, Grep, Glob, WebSearch, WebFetch
+next: plan
+terminal: false
 ---
 
 Investigate anything, from anywhere: verify a claim, search the web, find better options, pull

--- a/.agents/skills/research/SKILL.md
+++ b/.agents/skills/research/SKILL.md
@@ -14,8 +14,7 @@ description: >
   heavyweight EXTERNAL market/competitive report (paid Parallel AI); `plan` for the full plan
   stage (brainstorm + tasks); `dev` or `validate` to implement or scan rather than investigate.
 allowed-tools: Bash, Read, Write, Grep, Glob, WebSearch, WebFetch
-next: plan
-terminal: false
+terminal: true
 ---
 
 Investigate anything, from anywhere: verify a claim, search the web, find better options, pull

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -23,7 +23,7 @@ Process ALL pull request issues including GitHub Actions failures, review-agent 
 
 # Review
 
-> **Chain (HARD-GATE):** after `review` lands the merge, the next skill is `verify` (post-merge health check). While the PR is still open you may hand off to `shepherd` to watch checks toward merge. `review` never merges.
+> **Chain (HARD-GATE):** the successor depends on the change classification (source of truth: lib/workflow/stages.js) — Critical → `verify` (post-merge health check); Standard ENDS at `review`. `verify` is the default/critical-path next. While the PR is still open you may hand off to `shepherd` to watch checks toward merge. `review` never merges.
 
 This skill handles ALL issues that arise after creating a pull request.
 

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -13,11 +13,17 @@ description: >
   closing issues), ship (pushes the branch + opens the PR), validate (PRE-PR local
   type/lint/test/security), and sonarcloud / sonarcloud-analysis (only QUERY SonarCloud data).
 allowed-tools: Bash, Read, Edit, Grep, Glob
+next: verify
+terminal: false
+handoffs:
+  - shepherd
 ---
 
 Process ALL pull request issues including GitHub Actions failures, review-agent inline comments (Greptile, CodeRabbit, Qodo, or human reviewers), SonarCloud analysis, and other CI/CD checks.
 
 # Review
+
+> **Chain (HARD-GATE):** after `review` lands the merge, the next skill is `verify` (post-merge health check). While the PR is still open you may hand off to `shepherd` to watch checks toward merge. `review` never merges.
 
 This skill handles ALL issues that arise after creating a pull request.
 

--- a/.agents/skills/rollback/SKILL.md
+++ b/.agents/skills/rollback/SKILL.md
@@ -13,6 +13,7 @@ description: >
   (shepherd), the post-merge CI health check on master (verify), pushing a branch or opening a
   PR (ship), or ordinary issue status/field edits (issue-basics).
 allowed-tools: Bash, Read, Edit, Grep, Glob
+terminal: true
 ---
 
 Comprehensive rollback system with multiple methods and automatic USER content preservation.

--- a/.agents/skills/shepherd/SKILL.md
+++ b/.agents/skills/shepherd/SKILL.md
@@ -13,6 +13,9 @@ description: >
   `ship`; nor for the post-merge "CI green on master + close issues" check — that is `verify`;
   nor for a general "where am I / what's in flight" report — that is `status`.
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
+handoffs:
+  - review
 ---
 
 Run one bounded monitor pass over a pull request: read CI and check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -24,7 +24,7 @@ Push code and create a pull request with full context and documentation links.
 
 # Ship
 
-> **Chain (HARD-GATE):** the ONLY skill you invoke after `ship` is `review` (or `shepherd` to monitor the PR's checks toward merge). `ship` never merges.
+> **Chain (HARD-GATE):** the successor depends on the change classification (source of truth: lib/workflow/stages.js) — Standard → `review`; Critical → `review` → `verify`; Simple/Hotfix/Refactor/Docs END at `ship`. `review` is the default/critical-path next; `shepherd` may monitor the PR's checks. `ship` never merges.
 
 This skill creates a PR after validation passes.
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -14,11 +14,17 @@ description: >
   (verify); reverting an already-shipped change (rollback). If the PR already exists, this is
   not the skill.
 allowed-tools: Bash, Read, Edit, Grep, Glob
+next: review
+terminal: false
+handoffs:
+  - shepherd
 ---
 
 Push code and create a pull request with full context and documentation links.
 
 # Ship
+
+> **Chain (HARD-GATE):** the ONLY skill you invoke after `ship` is `review` (or `shepherd` to monitor the PR's checks toward merge). `ship` never merges.
 
 This skill creates a PR after validation passes.
 

--- a/.agents/skills/smith/SKILL.md
+++ b/.agents/skills/smith/SKILL.md
@@ -13,6 +13,14 @@ description: >
   skill only when the user explicitly wants just that one step (e.g. "just open the
   PR").
 allowed-tools: Read, Bash(forge:*)
+terminal: true
+subskills:
+  - plan
+  - dev
+  - validate
+  - ship
+  - review
+  - verify
 ---
 
 # Smith — the orchestrator super-skill

--- a/.agents/skills/sonarcloud-analysis/SKILL.md
+++ b/.agents/skills/sonarcloud-analysis/SKILL.md
@@ -18,6 +18,7 @@ tags: [sonarcloud, code-quality, issues, metrics, security]
 context: fork
 tools: [Bash, WebFetch, Read, Grep, Glob]
 model: sonnet
+terminal: true
 ---
 
 <role>

--- a/.agents/skills/sonarcloud/SKILL.md
+++ b/.agents/skills/sonarcloud/SKILL.md
@@ -13,6 +13,7 @@ description: >
   Not for local SAST scans of your own code, nor the Forge issue tracker (`forge issue ...`,
   "open/ready issues") — here those bare words always mean SonarCloud.
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
+terminal: true
 ---
 
 # SonarCloud Query Command

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -12,6 +12,7 @@ description: >
   (issue-basics); the Hermes harness's token-bounded orient/recap contract (hermes-forge); or
   the post-merge CI health check that closes issues after a merge lands (verify).
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
 ---
 
 Check where you are in the project and what work is in progress.

--- a/.agents/skills/triage-ready/SKILL.md
+++ b/.agents/skills/triage-ready/SKILL.md
@@ -14,7 +14,7 @@ description: >
   whole session or routing to stage skills (use kernel), not for driving an issue to a merged
   PR (use smith).
 allowed-tools: Read, Bash(forge:*)
-next: plan
+next: claim-safety
 terminal: false
 ---
 

--- a/.agents/skills/triage-ready/SKILL.md
+++ b/.agents/skills/triage-ready/SKILL.md
@@ -14,6 +14,8 @@ description: >
   whole session or routing to stage skills (use kernel), not for driving an issue to a merged
   PR (use smith).
 allowed-tools: Read, Bash(forge:*)
+next: plan
+terminal: false
 ---
 
 # Triage: what should I work on next

--- a/.agents/skills/using-forge/SKILL.md
+++ b/.agents/skills/using-forge/SKILL.md
@@ -14,6 +14,7 @@ description: >
   deterministic fallback. NOT itself a stage; the kernel skill is the fuller umbrella index
   once oriented.
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 <SUBAGENT-STOP>

--- a/.agents/skills/validate/SKILL.md
+++ b/.agents/skills/validate/SKILL.md
@@ -13,6 +13,8 @@ description: >
   is `/ship`), it does not answer PR review feedback from Greptile / SonarCloud / CodeRabbit
   (that is `/review`), and it is not the post-merge CI health check (that is `/verify`).
 allowed-tools: Bash, Read, Grep, Glob
+next: ship
+terminal: false
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
@@ -23,6 +25,8 @@ allowed-tools: Bash, Read, Grep, Glob
 Run comprehensive validation including type checking, linting, code review, security review, and tests.
 
 # Validate
+
+> **Chain (HARD-GATE):** the ONLY skill you invoke after `validate` is `ship`. Do not open the PR until validation shows fresh passing output in THIS session.
 
 This skill validates all code before creating a pull request.
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -19,7 +19,7 @@ Verify that the merge landed correctly and everything is running properly after 
 
 # Verify
 
-> **Chain (HARD-GATE):** `verify` is the TERMINAL stage — the post-merge health check. No stage follows it; the chain ends here.
+> **Chain (HARD-GATE):** in the default post-merge flow `verify` is the TERMINAL stage — nothing follows it (source of truth: lib/workflow/stages.js). The `docs` classification alone reuses `verify` → `ship` as a pre-ship content check, so `verify` is not universally terminal.
 
 This skill runs AFTER the user has merged the PR. It checks system health — not documentation (that was handled by the pre-merge gate embedded in `/ship` and `/review`).
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -12,11 +12,14 @@ description: >
   rollback to undo an already-shipped change, status to merely report the current stage
   without acting, and issue-basics to close an issue unrelated to a just-merged PR.
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
 ---
 
 Verify that the merge landed correctly and everything is running properly after merge.
 
 # Verify
+
+> **Chain (HARD-GATE):** `verify` is the TERMINAL stage — the post-merge health check. No stage follows it; the chain ends here.
 
 This skill runs AFTER the user has merged the PR. It checks system health — not documentation (that was handled by the pre-merge gate embedded in `/ship` and `/review`).
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -12,14 +12,15 @@ description: >
   rollback to undo an already-shipped change, status to merely report the current stage
   without acting, and issue-basics to close an issue unrelated to a just-merged PR.
 allowed-tools: Bash, Read, Grep, Glob
-terminal: true
+next: ship
+terminal: false
 ---
 
 Verify that the merge landed correctly and everything is running properly after merge.
 
 # Verify
 
-> **Chain (HARD-GATE):** in the default post-merge flow `verify` is the TERMINAL stage — nothing follows it (source of truth: lib/workflow/stages.js). The `docs` classification alone reuses `verify` → `ship` as a pre-ship content check, so `verify` is not universally terminal.
+> **Chain (HARD-GATE):** the successor depends on the change classification (source of truth: lib/workflow/stages.js) — in the post-merge flow (Critical/Standard/Refactor/Simple/Hotfix) NOTHING follows `verify`; the `docs` flow alone reuses `verify` → `ship` as a pre-ship content check. `verify` is therefore not universally terminal — a chain-aware harness MUST gate on classification, not blindly follow `next`.
 
 This skill runs AFTER the user has merged the PR. It checks system health — not documentation (that was handled by the pre-merge gate embedded in `/ship` and `/review`).
 

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -170,29 +170,37 @@ const PLAN_SUBSKILL_IDS = new Set(PLAN_SUBSKILL_DEFINITIONS.map(definition => de
 const SMITH_SUBSKILL_DEFINITIONS = ['plan', 'dev', 'validate', 'ship', 'review', 'verify']
   .map(stage => ({ id: stage, label: `${stage} stage`, owner: 'smith' }));
 
+// Skills that `plan` COMPOSES at the whole-skill level (its SKILL.md `subskills:`
+// frontmatter), distinct from the fine-grained plan.* planning micro-phases in
+// PLAN_SUBSKILL_DEFINITIONS. A composed whole-skill is an advertised sub-skill
+// that must both VALIDATE and RESOLVE, but it is NOT a partialInvocation
+// micro-phase (it maps to no runtime-graph action), so it lives OUTSIDE
+// PLAN_SUBSKILL_IDS (which governs planning.template.only/skip).
+const PLAN_COMPOSED_SUBSKILLS = ['research'];
+const PLAN_COMPOSED_SUBSKILL_DEFINITIONS = PLAN_COMPOSED_SUBSKILLS.map(id => ({
+  id,
+  label: `${id.charAt(0).toUpperCase()}${id.slice(1)} (composed skill)`,
+  kind: 'composed-skill',
+  owner: 'plan',
+}));
+
 // Generic per-skill sub-skill registry, keyed by owning skill id. Generalizes
 // plan's previously hardcoded PLAN_SUBSKILL_DEFINITIONS / validatePlanSubSkillList
 // so any composing skill (plan, smith, ...) declares its sub-skill set through a
-// single mechanism. Add an owner here to give a new skill a validated sub-skill
-// composition without touching the validators.
+// single mechanism. This registry is the SINGLE source for BOTH validation (ids)
+// and resolution (definitions), so getSubSkillDefinitions and validateSubSkillList
+// can never disagree. plan's set = its planning micro-phases + composed whole-skills.
 const SUBSKILL_REGISTRY = {
-  plan: PLAN_SUBSKILL_DEFINITIONS,
+  plan: [...PLAN_SUBSKILL_DEFINITIONS, ...PLAN_COMPOSED_SUBSKILL_DEFINITIONS],
   smith: SMITH_SUBSKILL_DEFINITIONS,
 };
 
-// Skills that `plan` COMPOSES at the whole-skill level (its SKILL.md `subskills:`
-// frontmatter), distinct from the fine-grained plan.* planning micro-phases in
-// PLAN_SUBSKILL_DEFINITIONS (which drive the runtime graph + partialInvocation
-// config). Both axes are valid sub-skills of plan, so the registry's known-id set
-// is their union — this keeps plan's advertised frontmatter subskills resolvable
-// through the SAME generic validator without adding a runtime-graph action for a
-// composed skill. See W2 review fix (research/plan reconciliation).
-const PLAN_COMPOSED_SUBSKILLS = ['research'];
-
-const SUBSKILL_IDS_BY_OWNER = {
-  plan: new Set([...PLAN_SUBSKILL_IDS, ...PLAN_COMPOSED_SUBSKILLS]),
-  smith: new Set(SMITH_SUBSKILL_DEFINITIONS.map(d => d.id)),
-};
+// Validation id sets DERIVED from the registry definitions — guarantees
+// validate-vs-resolve parity for every owner (a subskill that validates also
+// resolves, and vice versa).
+const SUBSKILL_IDS_BY_OWNER = Object.fromEntries(
+  Object.entries(SUBSKILL_REGISTRY).map(([owner, defs]) => [owner, new Set(defs.map(d => d.id))])
+);
 
 function getSubSkillDefinitions(owner) {
   return SUBSKILL_REGISTRY[owner] ? [...SUBSKILL_REGISTRY[owner]] : [];

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -818,21 +818,18 @@ function assertStringList(value, errors, code, message) {
   return valid;
 }
 
-// Generic sub-skill list validator, keyed by owning skill. Replaces the
-// plan-hardcoded validator with an owner-parameterized one; `validatePlanSubSkillList`
-// below is the backward-compatible plan wrapper.
-function validateSubSkillList(owner, value, errors, path) {
-  const knownIds = SUBSKILL_IDS_BY_OWNER[owner] || new Set();
-  const listCode = owner === 'plan' ? 'INVALID_PLAN_SUBSKILL_LIST' : 'INVALID_SUBSKILL_LIST';
-  const unknownCode = owner === 'plan' ? 'UNKNOWN_PLAN_SUBSKILL' : 'UNKNOWN_SUBSKILL';
-  const noun = owner === 'plan' ? 'planning sub-skill' : `${owner} sub-skill`;
+function subSkillCodesForOwner(owner) {
+  return owner === 'plan'
+    ? { listCode: 'INVALID_PLAN_SUBSKILL_LIST', unknownCode: 'UNKNOWN_PLAN_SUBSKILL', noun: 'planning sub-skill' }
+    : { listCode: 'INVALID_SUBSKILL_LIST', unknownCode: 'UNKNOWN_SUBSKILL', noun: `${owner} sub-skill` };
+}
 
-  if (!assertStringList(
-    value,
-    errors,
-    listCode,
-    `${path} must be a list of ${noun} IDs.`
-  )) {
+// Core list validator against an explicit known-id Set. The two callers below
+// deliberately pass DIFFERENT id sets so the two contracts never leak into each
+// other (see validatePlanSubSkillList).
+function validateAgainstKnownIds(knownIds, codes, value, errors, path) {
+  const { listCode, unknownCode, noun } = codes;
+  if (!assertStringList(value, errors, listCode, `${path} must be a list of ${noun} IDs.`)) {
     return undefined;
   }
 
@@ -847,14 +844,25 @@ function validateSubSkillList(owner, value, errors, path) {
       });
     }
   }
-  if (hasUnknown) {
-    return undefined;
-  }
-  return normalized;
+  return hasUnknown ? undefined : normalized;
 }
 
+// Generic COMPOSITION validator, keyed by owning skill — validates a skill's
+// ADVERTISED (SKILL.md frontmatter) subskills. For `plan` the known-id set is the
+// composition union (plan.* micro-phases + composed whole-skills like research).
+function validateSubSkillList(owner, value, errors, path) {
+  const knownIds = SUBSKILL_IDS_BY_OWNER[owner] || new Set();
+  return validateAgainstKnownIds(knownIds, subSkillCodesForOwner(owner), value, errors, path);
+}
+
+// partialInvocation validator (.forge/config.yaml planning.template.only/skip).
+// SEPARATE contract from composition: it MUST accept ONLY the fine-grained plan.*
+// MICRO-PHASE ids (PLAN_SUBSKILL_IDS), never composed whole-skill ids like
+// `research` — a composed skill maps to no runtime-graph action, so `only:
+// [research]` would be silent dead config. Validates against PLAN_SUBSKILL_IDS,
+// NOT the composition union, so it fails closed on composed ids.
 function validatePlanSubSkillList(value, errors, path) {
-  return validateSubSkillList('plan', value, errors, path);
+  return validateAgainstKnownIds(PLAN_SUBSKILL_IDS, subSkillCodesForOwner('plan'), value, errors, path);
 }
 
 function applyPlanningMode(template, nextTemplate, errors) {

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -180,8 +180,17 @@ const SUBSKILL_REGISTRY = {
   smith: SMITH_SUBSKILL_DEFINITIONS,
 };
 
+// Skills that `plan` COMPOSES at the whole-skill level (its SKILL.md `subskills:`
+// frontmatter), distinct from the fine-grained plan.* planning micro-phases in
+// PLAN_SUBSKILL_DEFINITIONS (which drive the runtime graph + partialInvocation
+// config). Both axes are valid sub-skills of plan, so the registry's known-id set
+// is their union — this keeps plan's advertised frontmatter subskills resolvable
+// through the SAME generic validator without adding a runtime-graph action for a
+// composed skill. See W2 review fix (research/plan reconciliation).
+const PLAN_COMPOSED_SUBSKILLS = ['research'];
+
 const SUBSKILL_IDS_BY_OWNER = {
-  plan: PLAN_SUBSKILL_IDS,
+  plan: new Set([...PLAN_SUBSKILL_IDS, ...PLAN_COMPOSED_SUBSKILLS]),
   smith: new Set(SMITH_SUBSKILL_DEFINITIONS.map(d => d.id)),
 };
 

--- a/lib/core/runtime-graph.js
+++ b/lib/core/runtime-graph.js
@@ -161,6 +161,38 @@ const PLAN_SUBSKILL_DEFINITIONS = [
 
 const PLAN_SUBSKILL_IDS = new Set(PLAN_SUBSKILL_DEFINITIONS.map(definition => definition.id));
 
+// The `smith` orchestrator composes the stage skills end-to-end. Its sub-skills
+// are the stage skill NAMES (each a real `skills/<name>/` dir), unlike plan's
+// fine-grained internal planning phases. Both resolve through the ONE generic
+// registry below (keyed by owning skill), so composition is no longer hardcoded
+// to plan. See docs/work kernel-native-skills composition epic (a0776e61) +
+// smith-orchestrator (7da81cbd).
+const SMITH_SUBSKILL_DEFINITIONS = ['plan', 'dev', 'validate', 'ship', 'review', 'verify']
+  .map(stage => ({ id: stage, label: `${stage} stage`, owner: 'smith' }));
+
+// Generic per-skill sub-skill registry, keyed by owning skill id. Generalizes
+// plan's previously hardcoded PLAN_SUBSKILL_DEFINITIONS / validatePlanSubSkillList
+// so any composing skill (plan, smith, ...) declares its sub-skill set through a
+// single mechanism. Add an owner here to give a new skill a validated sub-skill
+// composition without touching the validators.
+const SUBSKILL_REGISTRY = {
+  plan: PLAN_SUBSKILL_DEFINITIONS,
+  smith: SMITH_SUBSKILL_DEFINITIONS,
+};
+
+const SUBSKILL_IDS_BY_OWNER = {
+  plan: PLAN_SUBSKILL_IDS,
+  smith: new Set(SMITH_SUBSKILL_DEFINITIONS.map(d => d.id)),
+};
+
+function getSubSkillDefinitions(owner) {
+  return SUBSKILL_REGISTRY[owner] ? [...SUBSKILL_REGISTRY[owner]] : [];
+}
+
+function getSubSkillIds(owner) {
+  return new Set(SUBSKILL_IDS_BY_OWNER[owner] || []);
+}
+
 function planningSubSkillFromDefinition(definition) {
   return PlanningSubSkill({
     id: definition.id,
@@ -777,12 +809,20 @@ function assertStringList(value, errors, code, message) {
   return valid;
 }
 
-function validatePlanSubSkillList(value, errors, path) {
+// Generic sub-skill list validator, keyed by owning skill. Replaces the
+// plan-hardcoded validator with an owner-parameterized one; `validatePlanSubSkillList`
+// below is the backward-compatible plan wrapper.
+function validateSubSkillList(owner, value, errors, path) {
+  const knownIds = SUBSKILL_IDS_BY_OWNER[owner] || new Set();
+  const listCode = owner === 'plan' ? 'INVALID_PLAN_SUBSKILL_LIST' : 'INVALID_SUBSKILL_LIST';
+  const unknownCode = owner === 'plan' ? 'UNKNOWN_PLAN_SUBSKILL' : 'UNKNOWN_SUBSKILL';
+  const noun = owner === 'plan' ? 'planning sub-skill' : `${owner} sub-skill`;
+
   if (!assertStringList(
     value,
     errors,
-    'INVALID_PLAN_SUBSKILL_LIST',
-    `${path} must be a list of planning sub-skill IDs.`
+    listCode,
+    `${path} must be a list of ${noun} IDs.`
   )) {
     return undefined;
   }
@@ -790,11 +830,11 @@ function validatePlanSubSkillList(value, errors, path) {
   const normalized = value.map(item => item.trim());
   let hasUnknown = false;
   for (const id of normalized) {
-    if (!PLAN_SUBSKILL_IDS.has(id)) {
+    if (!knownIds.has(id)) {
       hasUnknown = true;
       errors.push({
-        code: 'UNKNOWN_PLAN_SUBSKILL',
-        message: `Unknown planning sub-skill '${id}' in ${CONFIG_SOURCE}.`,
+        code: unknownCode,
+        message: `Unknown ${noun} '${id}' in ${CONFIG_SOURCE}.`,
       });
     }
   }
@@ -802,6 +842,10 @@ function validatePlanSubSkillList(value, errors, path) {
     return undefined;
   }
   return normalized;
+}
+
+function validatePlanSubSkillList(value, errors, path) {
+  return validateSubSkillList('plan', value, errors, path);
 }
 
 function applyPlanningMode(template, nextTemplate, errors) {
@@ -968,6 +1012,11 @@ module.exports = {
   PlanningSubSkill,
   Role,
   ROLE_IDS,
+  SUBSKILL_REGISTRY,
+  getSubSkillDefinitions,
+  getSubSkillIds,
+  validateSubSkillList,
+  validatePlanSubSkillList,
   loadRuntimeGraphConfig,
   lintRuntimeGraphConfig,
   resolveRuntimeGraph,

--- a/skills/claim-safety/SKILL.md
+++ b/skills/claim-safety/SKILL.md
@@ -14,10 +14,13 @@ description: >
   and NOT for read-only selecting or ranking the next ready issue without claiming (that is
   triage-ready).
 allowed-tools: Read, Bash(forge:*)
-terminal: true
+next: dev
+terminal: false
 ---
 
 # Claim safety — claim, then prove you own the lease
+
+> **Chain:** once you have PROVEN the lease (`forge issue owns <id>` exits 0), continue to `dev` to work the issue (`smith` proceeds into plan/dev after this proof). Usable standalone whenever ownership is in question.
 
 Claiming is not owning. The Forge kernel keys a claim's idempotency on
 `claim.create:<issue_id>:<actor>`, so a **same-key duplicate replay returns

--- a/skills/claim-safety/SKILL.md
+++ b/skills/claim-safety/SKILL.md
@@ -14,6 +14,7 @@ description: >
   and NOT for read-only selecting or ranking the next ready issue without claiming (that is
   triage-ready).
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 # Claim safety — claim, then prove you own the lease

--- a/skills/dev/SKILL.md
+++ b/skills/dev/SKILL.md
@@ -13,11 +13,15 @@ description: >
   opening the PR (ship), for addressing PR review feedback (review), or for orchestrating
   several stages / taking an issue end-to-end to a merged PR (smith).
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+next: validate
+terminal: false
 ---
 
 Implement each task from the /plan task list using a subagent-driven loop: implementer → spec compliance reviewer → code quality reviewer per task.
 
 # Dev
+
+> **Chain (HARD-GATE):** the ONLY skill you invoke after `dev` is `validate`. Never open a PR straight from `dev`.
 
 This skill reads the task list created by `/plan` and implements each task using a three-stage subagent loop. TDD is enforced inside each implementer subagent.
 

--- a/skills/hermes-forge/SKILL.md
+++ b/skills/hermes-forge/SKILL.md
@@ -26,6 +26,7 @@ metadata:
   author: forge
   version: "1.0.0"
   roadmap: forge-2agy.9.7.x
+chainExempt: true
 ---
 
 # Hermes ⇄ Forge consumption contract

--- a/skills/issue-basics/SKILL.md
+++ b/skills/issue-basics/SKILL.md
@@ -14,6 +14,7 @@ description: >
   the plan->dev->validate->ship pipeline or open a PR (use smith or stage skills); does NOT
   report the current stage or what's in flight (use status).
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 # Issue basics — the CRUD floor

--- a/skills/kernel/SKILL.md
+++ b/skills/kernel/SKILL.md
@@ -60,8 +60,9 @@ status → plan → dev → validate → ship → review → verify
 ### Chain map (each skill declares its successor)
 
 Every skill carries chain metadata in its frontmatter (`next`, `terminal`,
-`subskills`, `handoffs`) plus a HARD-GATE chain line in its body, so each stage
-announces the next one. The linear ladder:
+`subskills`, `handoffs`); each workflow STAGE skill additionally carries a
+HARD-GATE chain line in its body, so each stage announces the next one. The
+linear ladder:
 
 | Skill | `next` | terminal |
 |-------|--------|----------|

--- a/skills/kernel/SKILL.md
+++ b/skills/kernel/SKILL.md
@@ -64,14 +64,20 @@ Every skill carries chain metadata in its frontmatter (`next`, `terminal`,
 HARD-GATE chain line in its body, so each stage announces the next one. The
 linear ladder:
 
-| Skill | `next` | terminal |
-|-------|--------|----------|
-| `plan` | `dev` | no (composes `research`) |
-| `dev` | `validate` | no |
-| `validate` | `ship` | no |
-| `ship` | `review` | no (handoff → `shepherd`) |
-| `review` | `verify` | no (handoff → `shepherd`) |
-| `verify` | — | **yes (terminal)** |
+| Skill | `next` | `terminal` |
+|-------|--------|-----------|
+| `plan` | `dev` | `false` |
+| `dev` | `validate` | `false` |
+| `validate` | `ship` | `false` |
+| `ship` | `review` | `false` |
+| `review` | `verify` | `false` |
+| `verify` | `ship` | `false` |
+
+The `next` column is each stage's DEFAULT / critical-path successor (`plan`
+composes `research`; `ship` and `review` also carry a `shepherd` handoff). The
+actual successor after `ship`, `review`, and `verify` is classification-dependent
+— see the note below. `verify`'s `next` (`ship`) is the `docs`-only pre-ship
+reuse; in every other flow nothing follows `verify`.
 
 Feeders into the chain: `triage-ready` → `claim-safety` → `dev` (rank the pick,
 prove the live lease, then work it). `research` is standalone / callable

--- a/skills/kernel/SKILL.md
+++ b/skills/kernel/SKILL.md
@@ -14,6 +14,7 @@ description: >
   merged PR under gates → `smith`; token-bounded state for the Hermes harness →
   `hermes-forge`.
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 # Forge kernel surface
@@ -55,6 +56,28 @@ mutating it — a claim returning ok:true does not by itself prove ownership).
 ```
 status → plan → dev → validate → ship → review → verify
 ```
+
+### Chain map (each skill declares its successor)
+
+Every skill carries chain metadata in its frontmatter (`next`, `terminal`,
+`subskills`, `handoffs`) plus a HARD-GATE chain line in its body, so each stage
+announces the next one. The linear ladder:
+
+| Skill | `next` | terminal |
+|-------|--------|----------|
+| `plan` | `dev` | no (composes `research`) |
+| `dev` | `validate` | no |
+| `validate` | `ship` | no |
+| `ship` | `review` | no (handoff → `shepherd`) |
+| `review` | `verify` | no (handoff → `shepherd`) |
+| `verify` | — | **yes (terminal)** |
+
+Feeders into the chain: `research` → `plan`, `triage-ready` → `plan`. The `smith`
+orchestrator composes the six stages (`subskills`). Utility/terminal skills
+(`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
+`rollback`, `sonarcloud`, `sonarcloud-analysis`, `parallel-deep-research`,
+`using-forge`) declare no forward-stage `next`. Meta skills (`hermes-forge`) are
+chain-exempt.
 
 ## Orchestrator super-skill
 

--- a/skills/kernel/SKILL.md
+++ b/skills/kernel/SKILL.md
@@ -72,14 +72,20 @@ announces the next one. The linear ladder:
 | `review` | `verify` | no (handoff → `shepherd`) |
 | `verify` | — | **yes (terminal)** |
 
-Feeders into the chain: `triage-ready` → `claim-safety` (prove the lease before
-work starts), then plan/dev. `research` is standalone / callable mid-workflow and
-returns to its CALLER (no forced `next`); it is also a `subskill` of `plan`. The
-`smith` orchestrator composes the six stages (`subskills`). Utility/terminal
-skills (`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
+Feeders into the chain: `triage-ready` → `claim-safety` → `dev` (rank the pick,
+prove the live lease, then work it). `research` is standalone / callable
+mid-workflow and returns to its CALLER (no forced `next`); it is also a `subskill`
+of `plan`. The `smith` orchestrator composes the six stages (`subskills`).
+Utility/terminal skills (`status`, `shepherd`, `kernel`, `issue-basics`, `memory`,
 `rollback`, `research`, `sonarcloud`, `sonarcloud-analysis`,
 `parallel-deep-research`, `using-forge`) declare no forward-stage `next`. Meta
 skills (`hermes-forge`) are chain-exempt.
+
+The stage `next` values above are the DEFAULT / critical-path successors. The
+actual successor after `ship`, `review`, and `verify` is
+classification-dependent — the authoritative matrix is `lib/workflow/stages.js`
+(Simple/Hotfix/Refactor end at `ship`; Standard ends at `review`; Critical runs
+through `verify`; the `docs` classification reuses `verify` → `ship`).
 
 ## Orchestrator super-skill
 

--- a/skills/kernel/SKILL.md
+++ b/skills/kernel/SKILL.md
@@ -72,12 +72,14 @@ announces the next one. The linear ladder:
 | `review` | `verify` | no (handoff → `shepherd`) |
 | `verify` | — | **yes (terminal)** |
 
-Feeders into the chain: `research` → `plan`, `triage-ready` → `plan`. The `smith`
-orchestrator composes the six stages (`subskills`). Utility/terminal skills
-(`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
-`rollback`, `sonarcloud`, `sonarcloud-analysis`, `parallel-deep-research`,
-`using-forge`) declare no forward-stage `next`. Meta skills (`hermes-forge`) are
-chain-exempt.
+Feeders into the chain: `triage-ready` → `claim-safety` (prove the lease before
+work starts), then plan/dev. `research` is standalone / callable mid-workflow and
+returns to its CALLER (no forced `next`); it is also a `subskill` of `plan`. The
+`smith` orchestrator composes the six stages (`subskills`). Utility/terminal
+skills (`status`, `shepherd`, `kernel`, `issue-basics`, `claim-safety`, `memory`,
+`rollback`, `research`, `sonarcloud`, `sonarcloud-analysis`,
+`parallel-deep-research`, `using-forge`) declare no forward-stage `next`. Meta
+skills (`hermes-forge`) are chain-exempt.
 
 ## Orchestrator super-skill
 

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -13,6 +13,7 @@ description: >
   The local backend is always the offline floor. Not for: issue create/list/close ops
   (issue-basics), workflow status (status), or transient scratch notes.
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
 ---
 
 # Memory

--- a/skills/parallel-deep-research/SKILL.md
+++ b/skills/parallel-deep-research/SKILL.md
@@ -17,6 +17,7 @@ compatibility: Requires PARALLEL_API_KEY in .env.local. Uses curl. Takes 3-25 mi
 metadata:
   author: harshanandak
   version: "1.0.0"
+terminal: true
 ---
 
 # Parallel Deep Research

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -13,11 +13,17 @@ description: >
   where work stands or what is stale (status), and NOT for everyday issue create/list/close or
   picking the next ready issue (issue-basics / triage-ready).
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+next: dev
+terminal: false
+subskills:
+  - research
 ---
 
 Plan a feature from scratch: brainstorm design intent, research technical approach, then set up branch, worktree, and a complete task list ready for /dev.
 
 # Plan
+
+> **Chain (HARD-GATE):** the next skill after `plan` is `dev`. `plan` composes the `research` sub-skill for its Phase 2 technical bundle. Do not skip ahead past `dev`.
 
 `/plan` is the default planning super-skill. A full invocation runs the three legacy sections below (intent, research, setup/task list), but v3 treats the internal planning work as callable sub-skills:
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -14,6 +14,8 @@ description: >
   heavyweight EXTERNAL market/competitive report (paid Parallel AI); `plan` for the full plan
   stage (brainstorm + tasks); `dev` or `validate` to implement or scan rather than investigate.
 allowed-tools: Bash, Read, Write, Grep, Glob, WebSearch, WebFetch
+next: plan
+terminal: false
 ---
 
 Investigate anything, from anywhere: verify a claim, search the web, find better options, pull

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -14,8 +14,7 @@ description: >
   heavyweight EXTERNAL market/competitive report (paid Parallel AI); `plan` for the full plan
   stage (brainstorm + tasks); `dev` or `validate` to implement or scan rather than investigate.
 allowed-tools: Bash, Read, Write, Grep, Glob, WebSearch, WebFetch
-next: plan
-terminal: false
+terminal: true
 ---
 
 Investigate anything, from anywhere: verify a claim, search the web, find better options, pull

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -23,7 +23,7 @@ Process ALL pull request issues including GitHub Actions failures, review-agent 
 
 # Review
 
-> **Chain (HARD-GATE):** after `review` lands the merge, the next skill is `verify` (post-merge health check). While the PR is still open you may hand off to `shepherd` to watch checks toward merge. `review` never merges.
+> **Chain (HARD-GATE):** the successor depends on the change classification (source of truth: lib/workflow/stages.js) — Critical → `verify` (post-merge health check); Standard ENDS at `review`. `verify` is the default/critical-path next. While the PR is still open you may hand off to `shepherd` to watch checks toward merge. `review` never merges.
 
 This skill handles ALL issues that arise after creating a pull request.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -13,11 +13,17 @@ description: >
   closing issues), ship (pushes the branch + opens the PR), validate (PRE-PR local
   type/lint/test/security), and sonarcloud / sonarcloud-analysis (only QUERY SonarCloud data).
 allowed-tools: Bash, Read, Edit, Grep, Glob
+next: verify
+terminal: false
+handoffs:
+  - shepherd
 ---
 
 Process ALL pull request issues including GitHub Actions failures, review-agent inline comments (Greptile, CodeRabbit, Qodo, or human reviewers), SonarCloud analysis, and other CI/CD checks.
 
 # Review
+
+> **Chain (HARD-GATE):** after `review` lands the merge, the next skill is `verify` (post-merge health check). While the PR is still open you may hand off to `shepherd` to watch checks toward merge. `review` never merges.
 
 This skill handles ALL issues that arise after creating a pull request.
 

--- a/skills/rollback/SKILL.md
+++ b/skills/rollback/SKILL.md
@@ -13,6 +13,7 @@ description: >
   (shepherd), the post-merge CI health check on master (verify), pushing a branch or opening a
   PR (ship), or ordinary issue status/field edits (issue-basics).
 allowed-tools: Bash, Read, Edit, Grep, Glob
+terminal: true
 ---
 
 Comprehensive rollback system with multiple methods and automatic USER content preservation.

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -13,6 +13,9 @@ description: >
   `ship`; nor for the post-merge "CI green on master + close issues" check — that is `verify`;
   nor for a general "where am I / what's in flight" report — that is `status`.
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
+handoffs:
+  - review
 ---
 
 Run one bounded monitor pass over a pull request: read CI and check state, take at most one idempotent action, then hand off. Never merges and never resolves review threads.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -24,7 +24,7 @@ Push code and create a pull request with full context and documentation links.
 
 # Ship
 
-> **Chain (HARD-GATE):** the ONLY skill you invoke after `ship` is `review` (or `shepherd` to monitor the PR's checks toward merge). `ship` never merges.
+> **Chain (HARD-GATE):** the successor depends on the change classification (source of truth: lib/workflow/stages.js) — Standard → `review`; Critical → `review` → `verify`; Simple/Hotfix/Refactor/Docs END at `ship`. `review` is the default/critical-path next; `shepherd` may monitor the PR's checks. `ship` never merges.
 
 This skill creates a PR after validation passes.
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -14,11 +14,17 @@ description: >
   (verify); reverting an already-shipped change (rollback). If the PR already exists, this is
   not the skill.
 allowed-tools: Bash, Read, Edit, Grep, Glob
+next: review
+terminal: false
+handoffs:
+  - shepherd
 ---
 
 Push code and create a pull request with full context and documentation links.
 
 # Ship
+
+> **Chain (HARD-GATE):** the ONLY skill you invoke after `ship` is `review` (or `shepherd` to monitor the PR's checks toward merge). `ship` never merges.
 
 This skill creates a PR after validation passes.
 

--- a/skills/smith/SKILL.md
+++ b/skills/smith/SKILL.md
@@ -13,6 +13,14 @@ description: >
   skill only when the user explicitly wants just that one step (e.g. "just open the
   PR").
 allowed-tools: Read, Bash(forge:*)
+terminal: true
+subskills:
+  - plan
+  - dev
+  - validate
+  - ship
+  - review
+  - verify
 ---
 
 # Smith — the orchestrator super-skill

--- a/skills/sonarcloud-analysis/SKILL.md
+++ b/skills/sonarcloud-analysis/SKILL.md
@@ -18,6 +18,7 @@ tags: [sonarcloud, code-quality, issues, metrics, security]
 context: fork
 tools: [Bash, WebFetch, Read, Grep, Glob]
 model: sonnet
+terminal: true
 ---
 
 <role>

--- a/skills/sonarcloud/SKILL.md
+++ b/skills/sonarcloud/SKILL.md
@@ -13,6 +13,7 @@ description: >
   Not for local SAST scans of your own code, nor the Forge issue tracker (`forge issue ...`,
   "open/ready issues") — here those bare words always mean SonarCloud.
 allowed-tools: Bash, Read, Grep, Glob, WebFetch
+terminal: true
 ---
 
 # SonarCloud Query Command

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -12,6 +12,7 @@ description: >
   (issue-basics); the Hermes harness's token-bounded orient/recap contract (hermes-forge); or
   the post-merge CI health check that closes issues after a merge lands (verify).
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
 ---
 
 Check where you are in the project and what work is in progress.

--- a/skills/triage-ready/SKILL.md
+++ b/skills/triage-ready/SKILL.md
@@ -14,7 +14,7 @@ description: >
   whole session or routing to stage skills (use kernel), not for driving an issue to a merged
   PR (use smith).
 allowed-tools: Read, Bash(forge:*)
-next: plan
+next: claim-safety
 terminal: false
 ---
 

--- a/skills/triage-ready/SKILL.md
+++ b/skills/triage-ready/SKILL.md
@@ -14,6 +14,8 @@ description: >
   whole session or routing to stage skills (use kernel), not for driving an issue to a merged
   PR (use smith).
 allowed-tools: Read, Bash(forge:*)
+next: plan
+terminal: false
 ---
 
 # Triage: what should I work on next

--- a/skills/using-forge/SKILL.md
+++ b/skills/using-forge/SKILL.md
@@ -14,6 +14,7 @@ description: >
   deterministic fallback. NOT itself a stage; the kernel skill is the fuller umbrella index
   once oriented.
 allowed-tools: Read, Bash(forge:*)
+terminal: true
 ---
 
 <SUBAGENT-STOP>

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -13,6 +13,8 @@ description: >
   is `/ship`), it does not answer PR review feedback from Greptile / SonarCloud / CodeRabbit
   (that is `/review`), and it is not the post-merge CI health check (that is `/verify`).
 allowed-tools: Bash, Read, Grep, Glob
+next: ship
+terminal: false
 ---
 
 > **Note:** Three things share the "validate" name in Forge:
@@ -23,6 +25,8 @@ allowed-tools: Bash, Read, Grep, Glob
 Run comprehensive validation including type checking, linting, code review, security review, and tests.
 
 # Validate
+
+> **Chain (HARD-GATE):** the ONLY skill you invoke after `validate` is `ship`. Do not open the PR until validation shows fresh passing output in THIS session.
 
 This skill validates all code before creating a pull request.
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -19,7 +19,7 @@ Verify that the merge landed correctly and everything is running properly after 
 
 # Verify
 
-> **Chain (HARD-GATE):** `verify` is the TERMINAL stage — the post-merge health check. No stage follows it; the chain ends here.
+> **Chain (HARD-GATE):** in the default post-merge flow `verify` is the TERMINAL stage — nothing follows it (source of truth: lib/workflow/stages.js). The `docs` classification alone reuses `verify` → `ship` as a pre-ship content check, so `verify` is not universally terminal.
 
 This skill runs AFTER the user has merged the PR. It checks system health — not documentation (that was handled by the pre-merge gate embedded in `/ship` and `/review`).
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -12,11 +12,14 @@ description: >
   rollback to undo an already-shipped change, status to merely report the current stage
   without acting, and issue-basics to close an issue unrelated to a just-merged PR.
 allowed-tools: Bash, Read, Grep, Glob
+terminal: true
 ---
 
 Verify that the merge landed correctly and everything is running properly after merge.
 
 # Verify
+
+> **Chain (HARD-GATE):** `verify` is the TERMINAL stage — the post-merge health check. No stage follows it; the chain ends here.
 
 This skill runs AFTER the user has merged the PR. It checks system health — not documentation (that was handled by the pre-merge gate embedded in `/ship` and `/review`).
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -12,14 +12,15 @@ description: >
   rollback to undo an already-shipped change, status to merely report the current stage
   without acting, and issue-basics to close an issue unrelated to a just-merged PR.
 allowed-tools: Bash, Read, Grep, Glob
-terminal: true
+next: ship
+terminal: false
 ---
 
 Verify that the merge landed correctly and everything is running properly after merge.
 
 # Verify
 
-> **Chain (HARD-GATE):** in the default post-merge flow `verify` is the TERMINAL stage — nothing follows it (source of truth: lib/workflow/stages.js). The `docs` classification alone reuses `verify` → `ship` as a pre-ship content check, so `verify` is not universally terminal.
+> **Chain (HARD-GATE):** the successor depends on the change classification (source of truth: lib/workflow/stages.js) — in the post-merge flow (Critical/Standard/Refactor/Simple/Hotfix) NOTHING follows `verify`; the `docs` flow alone reuses `verify` → `ship` as a pre-ship content check. `verify` is therefore not universally terminal — a chain-aware harness MUST gate on classification, not blindly follow `next`.
 
 This skill runs AFTER the user has merged the PR. It checks system health — not documentation (that was handled by the pre-merge gate embedded in `/ship` and `/review`).
 

--- a/test/runtime-graph-config.test.js
+++ b/test/runtime-graph-config.test.js
@@ -312,4 +312,27 @@ planning:
     expect(graph.planning.template.partialInvocation.only).toEqual([]);
     expect(graph.planning.template.partialInvocation.skip).toEqual(['plan.final_lock']);
   });
+
+  // Guards the W2 registry split: `research` is a COMPOSED whole-skill of plan
+  // (its SKILL.md subskills), NOT a partialInvocation micro-phase. partialInvocation
+  // maps ids to runtime-graph plan.* actions, so accepting `research` here would be
+  // silent dead config. It must fail closed.
+  test('rejects a composed whole-skill (research) in planning template partial invocation', () => {
+    const projectRoot = makeProject(`
+planning:
+  template:
+    partialInvocation:
+      only:
+        - research
+`);
+
+    const result = lintRuntimeGraphConfig({ projectRoot });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.map(error => error.code)).toContain('UNKNOWN_PLAN_SUBSKILL');
+
+    const { graph } = resolveRuntimeGraph({ projectRoot, throwOnError: false });
+    // Dead config dropped — never mapped into the runtime graph.
+    expect(graph.planning.template.partialInvocation.only).toEqual([]);
+  });
 });

--- a/test/skills/chain-integrity.test.js
+++ b/test/skills/chain-integrity.test.js
@@ -32,12 +32,17 @@ const STAGE_NEXT = {
   review: 'verify',
   // verify → terminal
 };
+// Feeders point INTO the chain. triage-ready routes through claim-safety (prove
+// the live lease before work starts) — NOT straight to plan, which would bypass
+// lease safety. `research` is intentionally NOT a feeder: it is standalone /
+// callable mid-workflow and returns to its CALLER, so it declares no forced
+// `next` (it is terminal + a subskill of plan).
 const FEEDER_NEXT = {
-  research: 'plan',
-  'triage-ready': 'plan',
+  'triage-ready': 'claim-safety',
 };
 const TERMINAL_SKILLS = [
   'verify',
+  'research',
   'status',
   'shepherd',
   'kernel',
@@ -132,6 +137,35 @@ describe('linear stage chain plan → dev → validate → ship → review → v
     expect(walked).toEqual(STAGE_CHAIN);
     expect(FM[walked[walked.length - 1]].terminal).toBe(true);
   });
+});
+
+// The dual-encoding's BODY half: each stage skill carries a model-facing
+// HARD-GATE chain line (the instruction the agent actually obeys). This must
+// stay in agreement with the frontmatter `next` — a future edit that changes
+// frontmatter but leaves stale body prose is exactly what this catches.
+function chainGateLine(name) {
+  const body = readSkill(name).replace(/^---\r?\n[\s\S]*?\r?\n---/, '');
+  return body.split(/\r?\n/).find((l) => l.includes('Chain (HARD-GATE)'));
+}
+
+describe('stage skills carry the HARD-GATE body chain line (body half of the dual-encoding)', () => {
+  for (const name of STAGE_CHAIN) {
+    test(`${name}: body has a "Chain (HARD-GATE)" line`, () => {
+      expect(typeof chainGateLine(name)).toBe('string');
+    });
+
+    test(`${name}: the successor named in the body agrees with frontmatter next`, () => {
+      const line = chainGateLine(name);
+      const fm = FM[name];
+      if (fm.terminal === true) {
+        // verify — terminal; the body must say so and name no successor.
+        expect(line.toUpperCase()).toContain('TERMINAL');
+      } else {
+        // The frontmatter successor must be named (backtick-quoted) in the body line.
+        expect(line).toContain('`' + fm.next + '`');
+      }
+    });
+  }
 });
 
 describe('feeder skills point into the chain', () => {
@@ -239,4 +273,18 @@ describe('generic sub-skill registry (backward compatible with plan)', () => {
     expect(errors).toEqual([]);
     expect(out).toEqual(['plan', 'dev', 'verify']);
   });
+
+  // Reconciliation: a skill's ADVERTISED frontmatter subskills must resolve
+  // through the same generic registry (frontmatter is the source of truth). This
+  // catches the plan `subskills: [research]` vs registry drift.
+  for (const owner of ['plan', 'smith']) {
+    test(`${owner}: declared frontmatter subskills all resolve through the registry`, () => {
+      const declared = FM[owner].subskills || [];
+      expect(declared.length).toBeGreaterThan(0);
+      const errors = [];
+      const out = validateSubSkillList(owner, declared, errors, `${owner}.frontmatter`);
+      expect(errors).toEqual([]);
+      expect(out).toEqual(declared);
+    });
+  }
 });

--- a/test/skills/chain-integrity.test.js
+++ b/test/skills/chain-integrity.test.js
@@ -12,6 +12,7 @@ const {
   validatePlanSubSkillList,
   SUBSKILL_REGISTRY,
 } = require('../../lib/core/runtime-graph');
+const { WORKFLOW_STAGE_MATRIX } = require('../../lib/workflow/stages');
 
 const repoRoot = path.resolve(__dirname, '../..');
 const skillsDir = path.join(repoRoot, 'skills');
@@ -39,6 +40,9 @@ const STAGE_NEXT = {
 // `next` (it is terminal + a subskill of plan).
 const FEEDER_NEXT = {
   'triage-ready': 'claim-safety',
+  // claim-safety proves the live lease, then work continues into dev (smith
+  // proceeds into plan/dev after the proof) — it does NOT dead-end the flow.
+  'claim-safety': 'dev',
 };
 const TERMINAL_SKILLS = [
   'verify',
@@ -47,7 +51,6 @@ const TERMINAL_SKILLS = [
   'shepherd',
   'kernel',
   'issue-basics',
-  'claim-safety',
   'memory',
   'rollback',
   'sonarcloud',
@@ -166,6 +169,46 @@ describe('stage skills carry the HARD-GATE body chain line (body half of the dua
       }
     });
   }
+});
+
+// The stage chain metadata must AGREE with the change-classification matrix in
+// lib/workflow/stages.js (the runtime source of truth). frontmatter `next` is the
+// DEFAULT / critical-path successor; it must be a successor stages.js actually
+// uses for SOME classification, and no stage may assert a successor stages.js
+// never uses. (ship/review/verify successors are classification-dependent — the
+// body HARD-GATE lines spell that out; frontmatter carries the critical-path.)
+function stagesJsSuccessors(stage) {
+  const successors = new Set();
+  for (const path of Object.values(WORKFLOW_STAGE_MATRIX)) {
+    const i = path.indexOf(stage);
+    if (i !== -1 && i < path.length - 1) successors.add(path[i + 1]);
+  }
+  return successors;
+}
+
+describe('stage chain metadata is consistent with lib/workflow/stages.js', () => {
+  for (const stage of STAGE_CHAIN) {
+    test(`${stage}: frontmatter next is a successor stages.js actually uses (or terminal)`, () => {
+      const next = FM[stage].next;
+      if (next === undefined || next === null) {
+        // Terminal in the critical path — verify. stages.js must also treat it as
+        // terminal for at least one classification (it is, for all but docs).
+        const isTerminalSomewhere = Object.values(WORKFLOW_STAGE_MATRIX)
+          .some((path) => path.at(-1) === stage);
+        expect(isTerminalSomewhere).toBeTruthy();
+        return;
+      }
+      expect([...stagesJsSuccessors(stage)]).toContain(next);
+    });
+  }
+
+  test('no stage declares a successor stages.js never uses for any classification', () => {
+    for (const stage of STAGE_CHAIN) {
+      const next = FM[stage].next;
+      if (!next) continue;
+      expect([...stagesJsSuccessors(stage)]).toContain(next);
+    }
+  });
 });
 
 describe('feeder skills point into the chain', () => {

--- a/test/skills/chain-integrity.test.js
+++ b/test/skills/chain-integrity.test.js
@@ -25,14 +25,20 @@ const skillsDir = path.join(repoRoot, 'skills');
 // the chain rules (hermes-forge is a harness adapter, not a chain/route target).
 // ---------------------------------------------------------------------------
 const STAGE_CHAIN = ['plan', 'dev', 'validate', 'ship', 'review', 'verify'];
+// Each stage's frontmatter `next` (the DEFAULT / critical-path successor). No
+// stage is unconditionally terminal: verify's only stages.js successor is `ship`
+// (the docs-only pre-ship reuse), so verify carries next:ship too. The linear
+// critical ladder is plan→dev→validate→ship→review→verify (CRITICAL_LADDER below).
 const STAGE_NEXT = {
   plan: 'dev',
   dev: 'validate',
   validate: 'ship',
   ship: 'review',
   review: 'verify',
-  // verify → terminal
+  verify: 'ship',
 };
+// The canonical critical-path ladder (WORKFLOW_STAGE_MATRIX.critical order).
+const CRITICAL_LADDER = ['plan', 'dev', 'validate', 'ship', 'review', 'verify'];
 // Feeders point INTO the chain. triage-ready routes through claim-safety (prove
 // the live lease before work starts) — NOT straight to plan, which would bypass
 // lease safety. `research` is intentionally NOT a feeder: it is standalone /
@@ -44,8 +50,10 @@ const FEEDER_NEXT = {
   // proceeds into plan/dev after the proof) — it does NOT dead-end the flow.
   'claim-safety': 'dev',
 };
+// Utility/terminal skills — terminal by their OWN semantics (return to caller),
+// not stages in lib/workflow/stages.js. verify is NOT here: it is a stage and
+// (per the docs flow) not unconditionally terminal.
 const TERMINAL_SKILLS = [
-  'verify',
   'research',
   'status',
   'shepherd',
@@ -123,12 +131,13 @@ describe('linear stage chain plan → dev → validate → ship → review → v
     });
   }
 
-  test('verify is terminal (end of the linear chain)', () => {
-    expect(FM.verify.terminal).toBe(true);
-    expect(FM.verify.next === undefined || FM.verify.next === null).toBeTruthy();
+  test('the critical-path ladder edges match frontmatter next (plan→…→verify)', () => {
+    for (let i = 0; i < CRITICAL_LADDER.length - 1; i++) {
+      expect(FM[CRITICAL_LADDER[i]].next).toBe(CRITICAL_LADDER[i + 1]);
+    }
   });
 
-  test('walking `next` from plan visits every stage in order and terminates at verify', () => {
+  test('walking `next` from plan visits every stage in critical order (docs back-edge stops the walk)', () => {
     const walked = [];
     let cursor = 'plan';
     const seen = new Set();
@@ -137,8 +146,10 @@ describe('linear stage chain plan → dev → validate → ship → review → v
       walked.push(cursor);
       cursor = FM[cursor].next;
     }
+    // plan→dev→validate→ship→review→verify, then verify.next=ship is already seen
+    // (the docs-only back-edge) so the walk terminates cleanly.
     expect(walked).toEqual(STAGE_CHAIN);
-    expect(FM[walked[walked.length - 1]].terminal).toBe(true);
+    expect(FM.verify.next).toBe('ship');
   });
 });
 
@@ -160,13 +171,10 @@ describe('stage skills carry the HARD-GATE body chain line (body half of the dua
     test(`${name}: the successor named in the body agrees with frontmatter next`, () => {
       const line = chainGateLine(name);
       const fm = FM[name];
-      if (fm.terminal === true) {
-        // verify — terminal; the body must say so and name no successor.
-        expect(line.toUpperCase()).toContain('TERMINAL');
-      } else {
-        // The frontmatter successor must be named (backtick-quoted) in the body line.
-        expect(line).toContain('`' + fm.next + '`');
-      }
+      // Every stage carries a frontmatter next; the body HARD-GATE line must name
+      // that successor (backtick-quoted) so prose and metadata never drift.
+      expect(typeof fm.next).toBe('string');
+      expect(line).toContain('`' + fm.next + '`');
     });
   }
 });
@@ -188,14 +196,19 @@ function stagesJsSuccessors(stage) {
 
 describe('stage chain metadata is consistent with lib/workflow/stages.js', () => {
   for (const stage of STAGE_CHAIN) {
-    test(`${stage}: frontmatter next is a successor stages.js actually uses (or terminal)`, () => {
+    // IFF: a stage may advertise terminal:true ONLY IF no classification continues
+    // past it. Every one of the 6 stages has a successor in SOME classification
+    // (verify → ship in docs), so none is unconditionally terminal.
+    test(`${stage}: terminal:true iff stages.js never continues past it`, () => {
+      const continuesSomewhere = stagesJsSuccessors(stage).size > 0;
+      expect(FM[stage].terminal).toBe(!continuesSomewhere);
+    });
+
+    test(`${stage}: frontmatter next is a successor stages.js actually uses`, () => {
       const next = FM[stage].next;
       if (next === undefined || next === null) {
-        // Terminal in the critical path — verify. stages.js must also treat it as
-        // terminal for at least one classification (it is, for all but docs).
-        const isTerminalSomewhere = Object.values(WORKFLOW_STAGE_MATRIX)
-          .some((path) => path.at(-1) === stage);
-        expect(isTerminalSomewhere).toBeTruthy();
+        // Only permitted if the stage truly never continues (no such stage today).
+        expect(stagesJsSuccessors(stage).size).toBe(0);
         return;
       }
       expect([...stagesJsSuccessors(stage)]).toContain(next);
@@ -207,6 +220,14 @@ describe('stage chain metadata is consistent with lib/workflow/stages.js', () =>
       const next = FM[stage].next;
       if (!next) continue;
       expect([...stagesJsSuccessors(stage)]).toContain(next);
+    }
+  });
+
+  test('no stage advertises terminal where some classification continues past it', () => {
+    for (const stage of STAGE_CHAIN) {
+      if (FM[stage].terminal === true) {
+        expect(stagesJsSuccessors(stage).size).toBe(0);
+      }
     }
   });
 });
@@ -344,5 +365,69 @@ describe('generic sub-skill registry (backward compatible with plan)', () => {
     const partial = validatePlanSubSkillList(['research'], partialErrors, 'planning.template.partialInvocation.only');
     expect(partial).toBeUndefined();
     expect(partialErrors.map((e) => e.code)).toContain('UNKNOWN_PLAN_SUBSKILL');
+  });
+
+  // VALIDATE-vs-RESOLVE parity: the id set that validates (getSubSkillIds) must
+  // exactly equal the id set that resolves (getSubSkillDefinitions) for every
+  // owner — a subskill that validates also resolves, and vice versa.
+  for (const owner of ['plan', 'smith']) {
+    test(`${owner}: getSubSkillIds equals the ids of getSubSkillDefinitions (validate == resolve)`, () => {
+      const resolveIds = new Set(getSubSkillDefinitions(owner).map((d) => d.id));
+      const validateIds = getSubSkillIds(owner);
+      expect([...resolveIds].sort()).toEqual([...validateIds].sort());
+    });
+
+    test(`${owner}: every declared frontmatter subskill BOTH validates AND resolves`, () => {
+      const declared = FM[owner].subskills || [];
+      const resolveIds = new Set(getSubSkillDefinitions(owner).map((d) => d.id));
+      for (const sub of declared) {
+        const errors = [];
+        expect(validateSubSkillList(owner, [sub], errors, 'test')).toEqual([sub]);
+        expect(errors).toEqual([]);
+        expect(resolveIds.has(sub)).toBeTruthy();
+      }
+    });
+  }
+
+  test('getSubSkillDefinitions(plan) resolves the composed whole-skill research (not just plan.* phases)', () => {
+    const ids = getSubSkillDefinitions('plan').map((d) => d.id);
+    expect(ids).toContain('research');
+    expect(ids).toContain('plan.intent_capture');
+  });
+});
+
+// KERNEL-MAP vs METADATA: the kernel umbrella publishes a chain-map table. Its
+// rows MUST agree with each skill's actual frontmatter, so the human-facing index
+// can never drift from the machine metadata.
+describe('kernel chain-map table agrees with per-skill frontmatter', () => {
+  function parseKernelChainMap() {
+    const body = readSkill('kernel');
+    const rows = [];
+    for (const line of body.split(/\r?\n/)) {
+      // Rows look like: | `plan` | `dev` | `false` |
+      const m = line.match(/^\|\s*`(\w[\w-]*)`\s*\|\s*(`[\w-]+`|—|-)\s*\|\s*`(true|false)`\s*\|/);
+      if (!m) continue;
+      const skill = m[1];
+      const nextCell = m[2] === '—' || m[2] === '-' ? null : m[2].replace(/`/g, '');
+      const terminal = m[3] === 'true';
+      rows.push({ skill, next: nextCell, terminal });
+    }
+    return rows;
+  }
+
+  test('every stage row is present in the kernel chain-map', () => {
+    const rows = parseKernelChainMap();
+    const mapped = new Set(rows.map((r) => r.skill));
+    for (const stage of STAGE_CHAIN) expect(mapped.has(stage)).toBeTruthy();
+  });
+
+  test('each kernel chain-map row matches the skill frontmatter (next + terminal)', () => {
+    for (const row of parseKernelChainMap()) {
+      const fm = FM[row.skill];
+      expect(fm).toBeTruthy();
+      const fmNext = fm.next === undefined || fm.next === null ? null : fm.next;
+      expect(row.next).toBe(fmNext);
+      expect(row.terminal).toBe(fm.terminal === true);
+    }
   });
 });

--- a/test/skills/chain-integrity.test.js
+++ b/test/skills/chain-integrity.test.js
@@ -287,4 +287,19 @@ describe('generic sub-skill registry (backward compatible with plan)', () => {
       expect(out).toEqual(declared);
     });
   }
+
+  // The two plan contracts must stay SEPARATE: the composed whole-skill `research`
+  // resolves as a frontmatter subskill, but must be REJECTED as a partialInvocation
+  // micro-phase (it maps to no runtime-graph action — silent dead config otherwise).
+  test('research resolves as a plan frontmatter subskill but is rejected as a partial-invocation micro-phase', () => {
+    const composeErrors = [];
+    const composed = validateSubSkillList('plan', ['research'], composeErrors, 'plan.frontmatter');
+    expect(composeErrors).toEqual([]);
+    expect(composed).toEqual(['research']);
+
+    const partialErrors = [];
+    const partial = validatePlanSubSkillList(['research'], partialErrors, 'planning.template.partialInvocation.only');
+    expect(partial).toBeUndefined();
+    expect(partialErrors.map((e) => e.code)).toContain('UNKNOWN_PLAN_SUBSKILL');
+  });
 });

--- a/test/skills/chain-integrity.test.js
+++ b/test/skills/chain-integrity.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const YAML = require('yaml');
+
+const {
+  getSubSkillIds,
+  getSubSkillDefinitions,
+  validateSubSkillList,
+  validatePlanSubSkillList,
+  SUBSKILL_REGISTRY,
+} = require('../../lib/core/runtime-graph');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const skillsDir = path.join(repoRoot, 'skills');
+
+// ---------------------------------------------------------------------------
+// Canonical chain graph (W2). Each stage skill declares the FOLLOWING stage as
+// its `next`; the linear ladder is plan → dev → validate → ship → review →
+// verify, and `verify` is TERMINAL (post-merge health check, nothing after).
+// Utilities are terminal (no forward-stage next). Meta skills are EXEMPT from
+// the chain rules (hermes-forge is a harness adapter, not a chain/route target).
+// ---------------------------------------------------------------------------
+const STAGE_CHAIN = ['plan', 'dev', 'validate', 'ship', 'review', 'verify'];
+const STAGE_NEXT = {
+  plan: 'dev',
+  dev: 'validate',
+  validate: 'ship',
+  ship: 'review',
+  review: 'verify',
+  // verify → terminal
+};
+const FEEDER_NEXT = {
+  research: 'plan',
+  'triage-ready': 'plan',
+};
+const TERMINAL_SKILLS = [
+  'verify',
+  'status',
+  'shepherd',
+  'kernel',
+  'issue-basics',
+  'claim-safety',
+  'memory',
+  'rollback',
+  'sonarcloud',
+  'sonarcloud-analysis',
+  'parallel-deep-research',
+  'using-forge',
+  'smith',
+];
+const EXEMPT_SKILLS = ['hermes-forge'];
+
+function listSkillDirs() {
+  return fs.readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) => fs.existsSync(path.join(skillsDir, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function readSkill(name) {
+  return fs.readFileSync(path.join(skillsDir, name, 'SKILL.md'), 'utf8');
+}
+
+function parseFrontmatter(name) {
+  const content = readSkill(name);
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) throw new Error(`${name}: no YAML frontmatter block`);
+  return YAML.parse(match[1]) || {};
+}
+
+const SKILL_DIRS = listSkillDirs();
+const SKILL_SET = new Set(SKILL_DIRS);
+const FM = Object.fromEntries(SKILL_DIRS.map((name) => [name, parseFrontmatter(name)]));
+
+describe('skill chain metadata (frontmatter dual-encoding)', () => {
+  for (const name of SKILL_DIRS) {
+    test(`${name}: chain frontmatter is well-formed`, () => {
+      const fm = FM[name];
+      if (EXEMPT_SKILLS.includes(name)) {
+        // Meta skill — must opt out of the chain explicitly.
+        expect(fm.chainExempt).toBe(true);
+        return;
+      }
+      // Non-exempt: must carry a `terminal` boolean.
+      expect(typeof fm.terminal).toBe('boolean');
+      // No orphan: a non-terminal skill MUST declare a `next` successor.
+      if (fm.terminal === false) {
+        expect(typeof fm.next).toBe('string');
+        expect(fm.next.trim().length).toBeGreaterThan(0);
+      }
+      // A terminal skill must NOT declare a forward-stage `next`.
+      if (fm.terminal === true) {
+        expect(fm.next === undefined || fm.next === null).toBeTruthy();
+      }
+    });
+
+    test(`${name}: next/handoffs/subskills targets are real skill dirs`, () => {
+      const fm = FM[name];
+      if (fm.next) expect(SKILL_SET.has(fm.next)).toBeTruthy();
+      for (const h of fm.handoffs || []) expect(SKILL_SET.has(h)).toBeTruthy();
+      for (const s of fm.subskills || []) expect(SKILL_SET.has(s)).toBeTruthy();
+    });
+  }
+});
+
+describe('linear stage chain plan → dev → validate → ship → review → verify', () => {
+  for (const [from, to] of Object.entries(STAGE_NEXT)) {
+    test(`${from}.next === ${to}`, () => {
+      expect(FM[from].next).toBe(to);
+      expect(FM[from].terminal).toBe(false);
+    });
+  }
+
+  test('verify is terminal (end of the linear chain)', () => {
+    expect(FM.verify.terminal).toBe(true);
+    expect(FM.verify.next === undefined || FM.verify.next === null).toBeTruthy();
+  });
+
+  test('walking `next` from plan visits every stage in order and terminates at verify', () => {
+    const walked = [];
+    let cursor = 'plan';
+    const seen = new Set();
+    while (cursor && !seen.has(cursor)) {
+      seen.add(cursor);
+      walked.push(cursor);
+      cursor = FM[cursor].next;
+    }
+    expect(walked).toEqual(STAGE_CHAIN);
+    expect(FM[walked[walked.length - 1]].terminal).toBe(true);
+  });
+});
+
+describe('feeder skills point into the chain', () => {
+  for (const [from, to] of Object.entries(FEEDER_NEXT)) {
+    test(`${from}.next === ${to}`, () => {
+      expect(FM[from].next).toBe(to);
+    });
+  }
+
+  test('review can hand off to shepherd, and shepherd points back to review (bidirectional)', () => {
+    expect(FM.review.handoffs || []).toContain('shepherd');
+    expect(FM.shepherd.handoffs || []).toContain('review');
+  });
+});
+
+describe('terminal / utility skills', () => {
+  for (const name of TERMINAL_SKILLS) {
+    test(`${name} is terminal:true`, () => {
+      expect(FM[name].terminal).toBe(true);
+    });
+  }
+});
+
+describe('smith orchestrator composes the whole chain via the generic registry', () => {
+  test('smith declares the 6 stage skills as subskills', () => {
+    expect(FM.smith.subskills).toEqual(STAGE_CHAIN);
+  });
+
+  test('smith subskills resolve through the generic sub-skill registry (keyed by owner)', () => {
+    const registryIds = getSubSkillIds('smith');
+    for (const stage of FM.smith.subskills) {
+      expect(registryIds.has(stage)).toBeTruthy();
+    }
+    // Registry is keyed by owner, not hardcoded to plan.
+    expect(SUBSKILL_REGISTRY).toHaveProperty('smith');
+    expect(SUBSKILL_REGISTRY).toHaveProperty('plan');
+  });
+});
+
+describe('plan references research as a subskill (research/plan inversion)', () => {
+  test('plan declares research as a subskill', () => {
+    expect(FM.plan.subskills || []).toContain('research');
+  });
+
+  test('research owns its own Plan-bundle logic (OWASP + TDD scenarios)', () => {
+    const body = readSkill('research');
+    expect(body).toContain('OWASP');
+    expect(body.toLowerCase()).toContain('tdd scenario');
+    expect(body).toContain('Plan bundle');
+  });
+
+  test('plan delegates the technical bundle to the research skill (does not re-own it)', () => {
+    const body = readSkill('plan');
+    expect(body).toContain('Skill("research")');
+  });
+});
+
+describe('kernel umbrella carries the chain map (index of the chain)', () => {
+  test('kernel references the stage ladder and the smith orchestrator', () => {
+    const body = readSkill('kernel');
+    for (const stage of STAGE_CHAIN) expect(body).toContain(stage);
+    expect(body).toContain('smith');
+  });
+
+  test('all stages are reachable from the kernel index (via smith subskills + next-walk)', () => {
+    // kernel indexes smith; smith composes plan; plan chains to verify.
+    const fromSmith = new Set(FM.smith.subskills);
+    let cursor = 'plan';
+    const seen = new Set();
+    while (cursor && !seen.has(cursor)) {
+      seen.add(cursor);
+      cursor = FM[cursor].next;
+    }
+    for (const stage of STAGE_CHAIN) {
+      expect(fromSmith.has(stage) || seen.has(stage)).toBeTruthy();
+    }
+  });
+});
+
+describe('generic sub-skill registry (backward compatible with plan)', () => {
+  test('plan sub-skill definitions still resolve (backward compatible)', () => {
+    const defs = getSubSkillDefinitions('plan');
+    expect(defs.length).toBeGreaterThan(0);
+    const ids = defs.map((d) => d.id);
+    expect(ids).toContain('plan.intent_capture');
+  });
+
+  test('validatePlanSubSkillList still validates known plan sub-skill ids', () => {
+    const errors = [];
+    const out = validatePlanSubSkillList(['plan.intent_capture', 'plan.final_lock'], errors, 'test');
+    expect(errors).toEqual([]);
+    expect(out).toEqual(['plan.intent_capture', 'plan.final_lock']);
+  });
+
+  test('validateSubSkillList is generic (keyed by owner) and rejects unknown ids', () => {
+    const errors = [];
+    const out = validateSubSkillList('plan', ['plan.nope'], errors, 'test');
+    expect(out).toBeUndefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  test('validateSubSkillList resolves smith stage subskills', () => {
+    const errors = [];
+    const out = validateSubSkillList('smith', ['plan', 'dev', 'verify'], errors, 'test');
+    expect(errors).toEqual([]);
+    expect(out).toEqual(['plan', 'dev', 'verify']);
+  });
+});


### PR DESCRIPTION
## What

Wave 2 (skill composition): make Forge's skills chain like Superpowers. Each skill declares its terminal state and required successor; composing skills declare sub-skills through one generic registry. The agent now flows **plan → dev → validate → ship → review → verify**, each skill announcing its successor.

## Chain graph applied (per-skill next/terminal)

| Skill | `next` | `terminal` | notes |
|-------|--------|-----------|-------|
| plan | dev | false | subskills: [research] |
| dev | validate | false | |
| validate | ship | false | |
| ship | review | false | handoffs: [shepherd] |
| review | verify | false | handoffs: [shepherd] |
| verify | — | **true** | terminal (post-merge health check) |
| research | plan | false | feeder + plan subskill |
| triage-ready | plan | false | feeder |
| smith | — | true | orchestrator, subskills: [plan,dev,validate,ship,review,verify] |
| status, shepherd, kernel, issue-basics, claim-safety, memory, rollback, sonarcloud, sonarcloud-analysis, parallel-deep-research, using-forge | — | true | utilities/terminal |
| hermes-forge | — | — | `chainExempt: true` (meta, excluded) |

## Dual-encoding

- **Frontmatter** keys `next` / `terminal` / `subskills` / `handoffs` — extra keys harnesses ignore. Tolerance confirmed: `allowed-tools` is already a non-name/description key, and the `.agents/skills` mirror is a raw byte-for-byte copy (no frontmatter parsing). No harness loader chokes.
- **Body**: a model-facing HARD-GATE chain line in each stage skill (e.g. "The ONLY skill you invoke after `ship` is `review` (or `shepherd` to monitor the PR)").

## Generic sub-skill registry

`lib/core/runtime-graph.js`: generalized `PLAN_SUBSKILL_DEFINITIONS` / `validatePlanSubSkillList` into a per-owner `SUBSKILL_REGISTRY` + `getSubSkillDefinitions` / `getSubSkillIds` / `validateSubSkillList` keyed by the owning skill (not hardcoded to plan). `smith` resolves its 6 stage subskills through it; plan's existing sub-skills stay backward compatible (`validatePlanSubSkillList` is now a thin wrapper).

## research/plan inversion (issue 4d4e027c)

`research` already owns its Plan-bundle logic (OWASP + DRY + TDD scenarios); `plan` delegates via `Skill("research")` and now declares `subskills: [research]` structurally. Added shepherd↔review handoff pointers.

## Tests

New `test/skills/chain-integrity.test.js` (76 assertions): every `next`/`handoffs`/`subskills` target is a real skill dir; no orphan `terminal:false` with no `next`; linear ladder fully connected and reachable from the kernel index; smith subskills resolve through the registry; plan sub-skills still validate; research owns its logic. Broad suite green (skills + structural + runtime-graph + release + parity + agent/setup ≈ 590 pass); eslint + tdd-check green.

`.agents/skills` mirror regenerated byte-identical (drift gate passes).

Issues: `skill-chain-metadata-hard-92fecf9f`, `generic-sub-skill-registry-4529ccc7`, `4d4e027c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Workflow Improvements**
  * Added consistent stage routing with hard-gate rules to control progression through plan → dev → validate → ship → review → verify.
  * Standardized terminal stage behavior and clarified handoffs between review and shepherd.
  * Updated skill chaining constraints to prevent premature continuation (e.g., PR creation before validation).

* **Validation & Reliability**
  * Added automated configuration integrity checks for stage metadata, handoffs, and reachability.
  * Strengthened validation of composed skill and sub-skill declarations, with fail-closed behavior for invalid planning actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->