### PR TITLE
feat(skills): static skill-eval scorecard + forge skill scores + CI gate (W3)

### DIFF
--- a/.agents/skills/claim-safety/evals/scorecard.json
+++ b/.agents/skills/claim-safety/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "claim-safety",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 995,
+      "body_lines": 88,
+      "score": 43
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/.agents/skills/dev/evals/scorecard.json
+++ b/.agents/skills/dev/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "dev",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 962,
+      "body_lines": 328,
+      "score": 20
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 76
+}

--- a/.agents/skills/hermes-forge/evals/scorecard.json
+++ b/.agents/skills/hermes-forge/evals/scorecard.json
@@ -24,9 +24,9 @@
     "router_exempt": false,
     "fixtures": "present",
     "fixtures_total": 6,
-    "fixtures_best_hit": 4,
+    "fixtures_best_hit": 2,
     "reachable": true,
-    "keyword_alignment": 0.67
+    "keyword_alignment": 0.33
   },
   "behavioral": {
     "trigger_recall": null,

--- a/.agents/skills/hermes-forge/evals/scorecard.json
+++ b/.agents/skills/hermes-forge/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "hermes-forge",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 157,
+      "score": 36
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 4,
+    "reachable": true,
+    "keyword_alignment": 0.67
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 81
+}

--- a/.agents/skills/issue-basics/evals/scorecard.json
+++ b/.agents/skills/issue-basics/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "issue-basics",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 991,
+      "body_lines": 95,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 63
+}

--- a/.agents/skills/kernel/evals/scorecard.json
+++ b/.agents/skills/kernel/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "kernel",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 187,
+      "score": 33
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 80
+}

--- a/.agents/skills/memory/evals/scorecard.json
+++ b/.agents/skills/memory/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "memory",
+  "fixtures": "no-fixtures",
+  "static": {
+    "token_cost": {
+      "desc_chars": 938,
+      "body_lines": 87,
+      "score": 45
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "no-fixtures",
+    "fixtures_total": 0,
+    "fixtures_best_hit": 0,
+    "reachable": null,
+    "keyword_alignment": null
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 84
+}

--- a/.agents/skills/parallel-deep-research/evals/scorecard.json
+++ b/.agents/skills/parallel-deep-research/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "parallel-deep-research",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 996,
+      "body_lines": 92,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.2
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/.agents/skills/plan/evals/scorecard.json
+++ b/.agents/skills/plan/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "plan",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 958,
+      "body_lines": 530,
+      "score": 3
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 4,
+    "reachable": true,
+    "keyword_alignment": 0.8
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 51
+}

--- a/.agents/skills/research/evals/scorecard.json
+++ b/.agents/skills/research/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "research",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 1014,
+      "body_lines": 179,
+      "score": 33
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.4
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 60
+}

--- a/.agents/skills/review/evals/scorecard.json
+++ b/.agents/skills/review/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "review",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 988,
+      "body_lines": 476,
+      "score": 4
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 3,
+    "reachable": true,
+    "keyword_alignment": 0.6
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 71
+}

--- a/.agents/skills/rollback/evals/scorecard.json
+++ b/.agents/skills/rollback/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "rollback",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 965,
+      "body_lines": 95,
+      "score": 43
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.17
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/.agents/skills/shepherd/evals/scorecard.json
+++ b/.agents/skills/shepherd/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "shepherd",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 991,
+      "body_lines": 51,
+      "score": 47
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.2
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 84
+}

--- a/.agents/skills/ship/evals/scorecard.json
+++ b/.agents/skills/ship/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "ship",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 237,
+      "score": 28
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 3,
+    "reachable": true,
+    "keyword_alignment": 0.6
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 78
+}

--- a/.agents/skills/smith/evals/scorecard.json
+++ b/.agents/skills/smith/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "smith",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 819,
+      "body_lines": 127,
+      "score": 47
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 84
+}

--- a/.agents/skills/sonarcloud-analysis/evals/scorecard.json
+++ b/.agents/skills/sonarcloud-analysis/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "sonarcloud-analysis",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 156,
+      "score": 36
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 81
+}

--- a/.agents/skills/sonarcloud/evals/scorecard.json
+++ b/.agents/skills/sonarcloud/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "sonarcloud",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 977,
+      "body_lines": 147,
+      "score": 38
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 6,
+    "reachable": true,
+    "keyword_alignment": 1
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 61
+}

--- a/.agents/skills/status/evals/scorecard.json
+++ b/.agents/skills/status/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "status",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 954,
+      "body_lines": 88,
+      "score": 45
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 64
+}

--- a/.agents/skills/triage-ready/evals/scorecard.json
+++ b/.agents/skills/triage-ready/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "triage-ready",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 977,
+      "body_lines": 105,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.2
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/.agents/skills/using-forge/evals/scorecard.json
+++ b/.agents/skills/using-forge/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "using-forge",
+  "fixtures": "no-fixtures",
+  "static": {
+    "token_cost": {
+      "desc_chars": 1016,
+      "body_lines": 87,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": false,
+    "router_exempt": false,
+    "fixtures": "no-fixtures",
+    "fixtures_total": 0,
+    "fixtures_best_hit": 0,
+    "reachable": null,
+    "keyword_alignment": null
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 63
+}

--- a/.agents/skills/validate/evals/scorecard.json
+++ b/.agents/skills/validate/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "validate",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 995,
+      "body_lines": 300,
+      "score": 21
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 3,
+    "reachable": true,
+    "keyword_alignment": 0.6
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 56
+}

--- a/.agents/skills/verify/evals/scorecard.json
+++ b/.agents/skills/verify/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "verify",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 890,
+      "body_lines": 287,
+      "score": 28
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 78
+}

--- a/lib/commands/skill.js
+++ b/lib/commands/skill.js
@@ -165,7 +165,12 @@ function handleScores(rest, flags, projectRoot) {
   // Compare the recomputed cards against the COMMITTED artifacts (canonical skills/ AND the
   // .agents/skills mirror). A stale/missing committed scorecard is drift, so the gate reported here
   // is FAIL — matching the CI drift test — instead of a hollow PASS over freshly-rebuilt cards.
-  const mirrorDir = path.join(path.dirname(skillsDir), '.agents', 'skills');
+  // Gate the committed .agents/skills mirror only when this checkout actually ships one. A consumer
+  // install has no mirror, so passing it would report false drift; the repo always has it, so a
+  // partial mirror loss (a missing skill card) is still caught. (Total mirror loss is caught by the
+  // CI gate test + the skills-sync structural test.)
+  const mirrorCandidate = path.join(path.dirname(skillsDir), '.agents', 'skills');
+  const mirrorDir = fs.existsSync(mirrorCandidate) ? mirrorCandidate : null;
   const drift = skillEval.detectScorecardDrift({ skillsDir, freshCards: scorecards, mirrorDir });
   const gate = skillEval.evaluateGate(scorecards, { drift });
   if (json) {

--- a/lib/commands/skill.js
+++ b/lib/commands/skill.js
@@ -160,17 +160,16 @@ function handleScores(rest, flags, projectRoot) {
   if (!ctx) {
     return { success: false, error: 'No canonical skills/ directory found (looked in the project and the packaged Forge root).' };
   }
-  const { skillsDir, catalog } = ctx;
+  const { skillsDir, catalog, source } = ctx;
   const scorecards = skillEval.buildAllScorecards(skillsDir, catalog);
   // Compare the recomputed cards against the COMMITTED artifacts (canonical skills/ AND the
   // .agents/skills mirror). A stale/missing committed scorecard is drift, so the gate reported here
   // is FAIL — matching the CI drift test — instead of a hollow PASS over freshly-rebuilt cards.
-  // Gate the committed .agents/skills mirror only when this checkout actually ships one. A consumer
-  // install has no mirror, so passing it would report false drift; the repo always has it, so a
-  // partial mirror loss (a missing skill card) is still caught. (Total mirror loss is caught by the
-  // CI gate test + the skills-sync structural test.)
-  const mirrorCandidate = path.join(path.dirname(skillsDir), '.agents', 'skills');
-  const mirrorDir = fs.existsSync(mirrorCandidate) ? mirrorCandidate : null;
+  // Gate the mirror by CONTEXT, not existence: a SOURCE checkout (source==='project') is EXPECTED
+  // to ship the committed .agents/skills mirror, so pass mirrorDir UNCONDITIONALLY — a deleted or
+  // never-checked-out mirror then REPORTS drift instead of silently passing. From the PACKAGED root
+  // (source==='package', a consumer install) no mirror ships, so omit the check to avoid false drift.
+  const mirrorDir = source === 'project' ? path.join(path.dirname(skillsDir), '.agents', 'skills') : null;
   const drift = skillEval.detectScorecardDrift({ skillsDir, freshCards: scorecards, mirrorDir });
   const gate = skillEval.evaluateGate(scorecards, { drift });
   if (json) {

--- a/lib/commands/skill.js
+++ b/lib/commands/skill.js
@@ -15,9 +15,14 @@
  * @module commands/skill
  */
 
-const { routeSkill, loadSkillCatalog } = require('../using-forge');
+const fs = require('node:fs');
+const path = require('node:path');
+const { routeSkill, loadSkillCatalog, resolveSkillsRoot } = require('../using-forge');
+const skillEval = require('../skill-eval');
 
-const USAGE = 'Usage: forge skill for "<situation>" [--json]';
+const USAGE = 'Usage: forge skill for "<situation>" [--json]\n' +
+  '       forge skill eval [name] --static [--json]\n' +
+  '       forge skill scores [--json]';
 
 /** Extract the situation text (all non-flag args after the verb) and json flag. */
 function parseForArgs(rest, flags) {
@@ -64,29 +69,144 @@ function handleFor(rest, flags) {
   return { success: true, result, output: formatRouting(result) };
 }
 
+/** Resolve the skills SOURCE dir (canonical skills/ under the package/dev root), or null. */
+function resolveSkillsDir(projectRoot) {
+  const root = resolveSkillsRoot(projectRoot);
+  if (!root) return null;
+  const dir = path.join(root, 'skills');
+  return fs.existsSync(dir) ? dir : null;
+}
+
+/** Write a scorecard to skills/<name>/evals/scorecard.json (stable 2-space JSON + trailing NL). */
+function writeScorecard(skillsDir, name, card) {
+  const dir = path.join(skillsDir, name, 'evals');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'scorecard.json'), JSON.stringify(card, null, 2) + '\n');
+}
+
+/**
+ * "forge skill eval [name] --static [--json]" -- compute + persist the DETERMINISTIC scorecard(s).
+ * All skills when no name. --static is the only tier today (behavioral is W5); it is accepted (and
+ * implied) so the flag reads honestly and future tiers can branch here.
+ */
+function handleEval(rest, flags, projectRoot) {
+  const json = flags.json === true || flags['--json'] === true || rest.includes('--json');
+  const positional = rest.filter(a => typeof a === 'string' && !a.startsWith('--'));
+  const name = positional[0];
+  const skillsDir = resolveSkillsDir(projectRoot);
+  if (!skillsDir) {
+    return { success: false, error: 'No canonical skills/ directory found (run from a Forge checkout).' };
+  }
+  const catalog = loadSkillCatalog(projectRoot);
+  const targets = name
+    ? [name]
+    : fs.readdirSync(skillsDir, { withFileTypes: true })
+        .filter(e => e.isDirectory() && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')))
+        .map(e => e.name)
+        .sort();
+
+  const written = [];
+  const cards = {};
+  for (const target of targets) {
+    const card = skillEval.buildScorecard({ skillsDir, name: target, catalog });
+    if (!card) {
+      if (name) return { success: false, error: `Skill '${name}' not found under ${skillsDir}.` };
+      continue;
+    }
+    writeScorecard(skillsDir, target, card);
+    written.push(target);
+    cards[target] = card;
+  }
+
+  if (json) {
+    return { success: true, cards, output: JSON.stringify(name ? cards[name] : cards, null, 2) + '\n' };
+  }
+  const lines = ['Static scorecards written (deterministic tier):'];
+  for (const t of written) lines.push('  ' + t + '  composite=' + cards[t].composite);
+  lines.push('', 'Behavioral tier (recall/precision/chains/outcome/variance) is W5.');
+  return { success: true, cards, output: lines.join('\n') };
+}
+
+/** Render the worst-first league table from a scorecards map. */
+function formatScores(scorecards, gate) {
+  const rows = Object.values(scorecards)
+    .map(c => ({
+      skill: c.skill,
+      composite: c.composite,
+      dq: c.static.description_quality.score,
+      tok: c.static.token_cost.score,
+      caps: c.static.caps.score,
+      fixtures: c.fixtures,
+    }))
+    .sort((a, b) => a.composite - b.composite || a.skill.localeCompare(b.skill));
+
+  const lines = ['Skill scores (static tier — worst first). Composite = 0.5*desc-quality + 0.3*token-cost + 0.2*caps.', ''];
+  lines.push('  COMPOSITE  DESC-Q  TOKEN  CAPS  FIXTURES  SKILL');
+  for (const r of rows) {
+    lines.push(
+      '  ' + String(r.composite).padStart(9) +
+      '  ' + String(r.dq).padStart(6) +
+      '  ' + String(r.tok).padStart(5) +
+      '  ' + String(r.caps).padStart(4) +
+      '  ' + r.fixtures.padEnd(8) +
+      '  ' + r.skill,
+    );
+  }
+  if (gate.warnings.length > 0) {
+    lines.push('', 'Router-reachability warnings (paraphrase gap — W5 judge is the fix, not blocking):');
+    for (const w of gate.warnings) lines.push('  - ' + w.skill + ': ' + w.detail);
+  }
+  lines.push('', gate.passed ? 'CI gate: PASS' : 'CI gate: FAIL (' + gate.failures.length + ')');
+  for (const f of gate.failures) lines.push('  x ' + f.skill + ': ' + f.kind + ' — ' + f.detail);
+  return lines.join('\n');
+}
+
+/** "forge skill scores [--json]" -- the league table over committed/recomputed scorecards. */
+function handleScores(rest, flags, projectRoot) {
+  const json = flags.json === true || flags['--json'] === true || rest.includes('--json');
+  const skillsDir = resolveSkillsDir(projectRoot);
+  if (!skillsDir) {
+    return { success: false, error: 'No canonical skills/ directory found (run from a Forge checkout).' };
+  }
+  const catalog = loadSkillCatalog(projectRoot);
+  const scorecards = skillEval.buildAllScorecards(skillsDir, catalog);
+  const gate = skillEval.evaluateGate(scorecards);
+  if (json) {
+    return { success: true, scorecards, gate, output: JSON.stringify({ scorecards, gate }, null, 2) + '\n' };
+  }
+  return { success: true, scorecards, gate, output: formatScores(scorecards, gate) };
+}
+
 module.exports = {
   name: 'skill',
-  description: 'Route a situation to the best-fit Forge skill (forge skill for "<situation>")',
-  usage: USAGE + '\n       (future: forge skill eval | forge skill scores)',
+  description: 'Route, evaluate, and score Forge skills (forge skill for | eval | scores)',
+  usage: USAGE,
   flags: {
-    '--json': 'Emit the machine-readable routing result',
+    '--json': 'Emit the machine-readable result',
+    '--static': 'Score only the deterministic static tier (the only tier today; behavioral is W5)',
   },
   // flags is the LAST declared param so its `= {}` default is trailing (SonarCloud S1788). The
-  // registry still passes (args, flags, projectRoot, opts) — the extra args are simply ignored,
-  // and the router reads the canonical catalog from the package root, not projectRoot.
-  handler: (args, flags = {}) => {
+  // registry still passes (args, flags, projectRoot, opts) — the router reads the canonical catalog
+  // from the package root; eval/scores read the canonical skills/ source dir.
+  handler: (args, flags = {}, projectRoot) => {
     const verb = args[0];
     if (verb === 'for') {
       return handleFor(args.slice(1), flags);
+    }
+    if (verb === 'eval') {
+      return handleEval(args.slice(1), flags, projectRoot);
+    }
+    if (verb === 'scores') {
+      return handleScores(args.slice(1), flags, projectRoot);
     }
     if (!verb) {
       return { success: false, error: 'Missing verb.\n' + USAGE };
     }
     return {
       success: false,
-      error: "Unknown verb '" + verb + "'. Supported: for.\n" + USAGE,
+      error: "Unknown verb '" + verb + "'. Supported: for, eval, scores.\n" + USAGE,
     };
   },
   // Exposed for unit tests; not part of the CLI surface.
-  _internal: { parseForArgs, formatRouting, handleFor },
+  _internal: { parseForArgs, formatRouting, handleFor, handleEval, handleScores, formatScores },
 };

--- a/lib/commands/skill.js
+++ b/lib/commands/skill.js
@@ -172,10 +172,19 @@ function handleScores(rest, flags, projectRoot) {
   const mirrorDir = source === 'project' ? path.join(path.dirname(skillsDir), '.agents', 'skills') : null;
   const drift = skillEval.detectScorecardDrift({ skillsDir, freshCards: scorecards, mirrorDir });
   const gate = skillEval.evaluateGate(scorecards, { drift });
+  // The gate verdict MUST drive the command's exit status: a failing gate (scorecard drift, caps
+  // violation, invalid fixtures) returns success:false so the registry runner exits non-zero and a
+  // CI job running `forge skill scores` actually FAILS — instead of exiting 0 while the output says
+  // "CI gate: FAIL". The full league table + gate detail still ride along in output/gate for context.
+  const passed = gate.passed === true;
+  const gateError = passed
+    ? undefined
+    : 'Skill CI gate FAILED (' + gate.failures.length + '): ' +
+      gate.failures.map(f => f.skill + ' — ' + f.kind).join('; ');
   if (json) {
-    return { success: true, scorecards, gate, drift, output: JSON.stringify({ scorecards, gate, drift }, null, 2) + '\n' };
+    return { success: passed, error: gateError, scorecards, gate, drift, output: JSON.stringify({ scorecards, gate, drift }, null, 2) + '\n' };
   }
-  return { success: true, scorecards, gate, drift, output: formatScores(scorecards, gate) };
+  return { success: passed, error: gateError, scorecards, gate, drift, output: formatScores(scorecards, gate) };
 }
 
 module.exports = {

--- a/lib/commands/skill.js
+++ b/lib/commands/skill.js
@@ -17,7 +17,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { routeSkill, loadSkillCatalog, resolveSkillsRoot } = require('../using-forge');
+const { routeSkill, loadSkillCatalog } = require('../using-forge');
 const skillEval = require('../skill-eval');
 
 const USAGE = 'Usage: forge skill for "<situation>" [--json]\n' +
@@ -69,14 +69,6 @@ function handleFor(rest, flags) {
   return { success: true, result, output: formatRouting(result) };
 }
 
-/** Resolve the skills SOURCE dir (canonical skills/ under the package/dev root), or null. */
-function resolveSkillsDir(projectRoot) {
-  const root = resolveSkillsRoot(projectRoot);
-  if (!root) return null;
-  const dir = path.join(root, 'skills');
-  return fs.existsSync(dir) ? dir : null;
-}
-
 /** Write a scorecard to skills/<name>/evals/scorecard.json (stable 2-space JSON + trailing NL). */
 function writeScorecard(skillsDir, name, card) {
   const dir = path.join(skillsDir, name, 'evals');
@@ -93,11 +85,11 @@ function handleEval(rest, flags, projectRoot) {
   const json = flags.json === true || flags['--json'] === true || rest.includes('--json');
   const positional = rest.filter(a => typeof a === 'string' && !a.startsWith('--'));
   const name = positional[0];
-  const skillsDir = resolveSkillsDir(projectRoot);
-  if (!skillsDir) {
-    return { success: false, error: 'No canonical skills/ directory found (run from a Forge checkout).' };
+  const ctx = skillEval.resolveSkillsContext(projectRoot);
+  if (!ctx) {
+    return { success: false, error: 'No canonical skills/ directory found (looked in the project and the packaged Forge root).' };
   }
-  const catalog = loadSkillCatalog(projectRoot);
+  const { skillsDir, catalog } = ctx;
   const targets = name
     ? [name]
     : fs.readdirSync(skillsDir, { withFileTypes: true })
@@ -141,14 +133,14 @@ function formatScores(scorecards, gate) {
     .sort((a, b) => a.composite - b.composite || a.skill.localeCompare(b.skill));
 
   const lines = ['Skill scores (static tier — worst first). Composite = 0.5*desc-quality + 0.3*token-cost + 0.2*caps.', ''];
-  lines.push('  COMPOSITE  DESC-Q  TOKEN  CAPS  FIXTURES  SKILL');
+  lines.push('  COMPOSITE  DESC-Q  TOKEN  CAPS  FIXTURES     SKILL');
   for (const r of rows) {
     lines.push(
       '  ' + String(r.composite).padStart(9) +
       '  ' + String(r.dq).padStart(6) +
       '  ' + String(r.tok).padStart(5) +
       '  ' + String(r.caps).padStart(4) +
-      '  ' + r.fixtures.padEnd(8) +
+      '  ' + r.fixtures.padEnd(11) +
       '  ' + r.skill,
     );
   }
@@ -161,20 +153,25 @@ function formatScores(scorecards, gate) {
   return lines.join('\n');
 }
 
-/** "forge skill scores [--json]" -- the league table over committed/recomputed scorecards. */
+/** "forge skill scores [--json]" -- the league table. Gate state is drift-aware so it agrees with CI. */
 function handleScores(rest, flags, projectRoot) {
   const json = flags.json === true || flags['--json'] === true || rest.includes('--json');
-  const skillsDir = resolveSkillsDir(projectRoot);
-  if (!skillsDir) {
-    return { success: false, error: 'No canonical skills/ directory found (run from a Forge checkout).' };
+  const ctx = skillEval.resolveSkillsContext(projectRoot);
+  if (!ctx) {
+    return { success: false, error: 'No canonical skills/ directory found (looked in the project and the packaged Forge root).' };
   }
-  const catalog = loadSkillCatalog(projectRoot);
+  const { skillsDir, catalog } = ctx;
   const scorecards = skillEval.buildAllScorecards(skillsDir, catalog);
-  const gate = skillEval.evaluateGate(scorecards);
+  // Compare the recomputed cards against the COMMITTED artifacts (canonical skills/ AND the
+  // .agents/skills mirror). A stale/missing committed scorecard is drift, so the gate reported here
+  // is FAIL — matching the CI drift test — instead of a hollow PASS over freshly-rebuilt cards.
+  const mirrorDir = path.join(path.dirname(skillsDir), '.agents', 'skills');
+  const drift = skillEval.detectScorecardDrift({ skillsDir, freshCards: scorecards, mirrorDir });
+  const gate = skillEval.evaluateGate(scorecards, { drift });
   if (json) {
-    return { success: true, scorecards, gate, output: JSON.stringify({ scorecards, gate }, null, 2) + '\n' };
+    return { success: true, scorecards, gate, drift, output: JSON.stringify({ scorecards, gate, drift }, null, 2) + '\n' };
   }
-  return { success: true, scorecards, gate, output: formatScores(scorecards, gate) };
+  return { success: true, scorecards, gate, drift, output: formatScores(scorecards, gate) };
 }
 
 module.exports = {

--- a/lib/skill-eval.js
+++ b/lib/skill-eval.js
@@ -1,0 +1,310 @@
+'use strict';
+
+/**
+ * Static skill-eval scorer (W3) -- a DETERMINISTIC, free, CI-gateable scorecard per skill.
+ *
+ * WHY only three scored parameters. A skill's real quality includes how reliably it TRIGGERS on
+ * paraphrased intent, whether its chains fire correctly, and its live-outcome quality. Those are
+ * inherently SEMANTIC: the skills/<name>/evals/evals.json fixtures are natural paraphrases, and
+ * the W1 deterministic router (routeSkill) is a curated-KEYWORD matcher -- so measuring recall
+ * with it scores keyword overlap, not skill quality (mean ~0.32 on real fixtures). Trigger
+ * recall/precision/disambiguation therefore belong to the W5 BEHAVIORAL tier (LLM judge) and
+ * appear here ONLY as typed placeholders. The static composite is built from the parameters that
+ * ARE deterministic and free to measure:
+ *
+ *   - token_cost         description chars + body lines, normalized (lower is better).
+ *   - caps               compliance with the desc<=1024 / body<=500 progressive-disclosure budget.
+ *   - description_quality has explicit trigger phrases + disambiguation cues (the PR #292 pattern).
+ *
+ * Alongside the composite we run a ROUTER-REACHABILITY LINT (independent of the quality score): a
+ * fixtured skill with NO curated INTENT_RULES rule and not router-exempt can NEVER be reached via
+ * `forge skill for` -- a real defect the gate blocks. A skill that HAS a rule but whose paraphrase
+ * fixtures don't hit its keywords is only a warning (that gap is exactly what the W5 judge fixes).
+ *
+ * Everything here is pure fs + pure JS: no LLM, no network, no subprocess -> reproducible in CI on
+ * every platform. Follow-up rationale is recorded in kernel issue skill-eval-static.
+ *
+ * @module skill-eval
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { INTENT_RULES, routeSkill, resolveSkillsRoot } = require('./using-forge');
+
+// Progressive-disclosure budget -- mirrors test/skills/context-cost.test.js (single source of the
+// numbers; kept in sync by the shared gate philosophy, not a runtime import to avoid test-dep).
+const DESC_CAP = 1024; // Anthropic Agent Skills description limit (hard)
+const BODY_CAP = 500; // body-line budget (loads on every trigger)
+
+// Skills whose body legitimately exceeds BODY_CAP (documented in context-cost). `plan` keeps its
+// HARD-GATEs in the body by design. Mirror it here so caps scoring agrees with the context gate.
+const BODY_OVER_ALLOWLIST = new Set(['plan']);
+
+// Skills intentionally NOT deterministic route targets (harness-internal, never user-invoked).
+// Empty today: hermes-forge is a legitimate Hermes-session trigger target and instead carries a
+// curated INTENT_RULES rule. The mechanism is retained (mirrors the chain-exempt pattern) so a
+// future internal adapter can be classified honestly rather than forced to fake a route.
+const ROUTER_EXEMPT = new Set([]);
+
+// Documented composite weighting over the deterministic static params. description_quality leads
+// (it is the actionable, skill-authored signal); token_cost next; caps compliance last (it is also
+// a hard gate, so it contributes little marginal ranking signal). Weights sum to 1.
+const WEIGHTS = Object.freeze({ description_quality: 0.5, token_cost: 0.3, caps: 0.2 });
+
+// Gate floor for description_quality. 60 == adequate length + at least one of {trigger,
+// disambiguation} cue; every canonical skill meets it today, and a regression that strips a
+// skill's trigger phrasing AND contrast cues, or shrinks it below the length band, trips it.
+const DESC_QUALITY_FLOOR = 60;
+
+// Deterministic description-quality cues (lowercased substring checks -- no regex backtracking).
+const TRIGGER_CUES = ['use when', 'use this', 'use it when', 'use whenever', 'when the user', 'when you', 'triggers:', 'trigger:'];
+const DISAMBIGUATION_CUES = ['not ', "don't", 'do not', 'never', 'unlike', 'instead of', 'rather than', ' vs ', 'vs.', 'as opposed to', 'not for', 'skip'];
+
+const RULE_SKILLS = new Set(INTENT_RULES.map(r => r.skill));
+
+/** True when `name` has a curated INTENT_RULES rule (i.e. the deterministic router can target it). */
+function hasCuratedRule(name) {
+  return RULE_SKILLS.has(name);
+}
+
+/** Clamp a ratio into [0, 1]. */
+function clamp01(x) {
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+/**
+ * token_cost: normalized cost of a skill's permanent (description) + on-trigger (body) footprint.
+ * Lower cost -> higher score. Each axis is measured against its cap and averaged 50/50.
+ * @param {{descLen:number, bodyLines:number}} m
+ */
+function scoreTokenCost({ descLen, bodyLines }) {
+  const descRatio = clamp01(descLen / DESC_CAP);
+  const bodyRatio = clamp01(bodyLines / BODY_CAP);
+  const score = Math.round(100 * (1 - (descRatio * 0.5 + bodyRatio * 0.5)));
+  return { desc_chars: descLen, body_lines: bodyLines, score };
+}
+
+/**
+ * caps: hard compliance with the progressive-disclosure budget. Description over the cap always
+ * fails; body over the cap fails UNLESS the skill is allowlisted (mirrors the context-cost gate).
+ * @param {{descLen:number, bodyLines:number, allowlisted:boolean}} m
+ */
+function scoreCaps({ descLen, bodyLines, allowlisted }) {
+  const descWithin = descLen <= DESC_CAP;
+  const bodyWithin = bodyLines <= BODY_CAP || allowlisted === true;
+  return { desc_within: descWithin, body_within: bodyWithin, score: descWithin && bodyWithin ? 100 : 0 };
+}
+
+/** Case-insensitive "does haystack contain any of these substrings". */
+function containsAny(haystack, needles) {
+  const lower = String(haystack).toLowerCase();
+  return needles.some(n => lower.includes(n));
+}
+
+/**
+ * description_quality: the PR #292 description pattern, scored deterministically.
+ *   - trigger cues present   (explicit "use when / when the user / triggers:") -> 40
+ *   - disambiguation cues     (contrast markers: "NOT the X skill", "unlike", ...) -> 40
+ *   - adequate length         (>=120 chars and within the cap)                    -> 20
+ * @param {string} description
+ */
+function scoreDescriptionQuality(description) {
+  const desc = String(description || '');
+  const hasTrigger = containsAny(desc, TRIGGER_CUES);
+  const hasDisambiguation = containsAny(desc, DISAMBIGUATION_CUES);
+  const adequate = desc.length >= 120 && desc.length <= DESC_CAP;
+  const score = (hasTrigger ? 40 : 0) + (hasDisambiguation ? 40 : 0) + (adequate ? 20 : 0);
+  return { has_trigger_cues: hasTrigger, has_disambiguation_cues: hasDisambiguation, adequate_length: adequate, score };
+}
+
+/** Weighted composite over the three deterministic static params -> integer 0..100. */
+function composite({ tokenCost, caps, descQuality }) {
+  const value =
+    WEIGHTS.description_quality * descQuality.score +
+    WEIGHTS.token_cost * tokenCost.score +
+    WEIGHTS.caps * caps.score;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+/** The W5 behavioral-tier params, typed as null placeholders so consumers can rely on the shape. */
+function behavioralPlaceholders() {
+  return {
+    trigger_recall: null,
+    trigger_precision: null,
+    disambiguation: null,
+    chain_correctness: null,
+    outcome_quality: null,
+    variance: null,
+    note: 'behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic',
+  };
+}
+
+/**
+ * Router-reachability lint (B): run a skill's should_trigger fixtures through the deterministic
+ * router and report whether >=1 places this skill as best-match. This measures the W1 router's
+ * COVERAGE (a fixable gap), NOT skill quality, so it is separate from the composite.
+ *
+ * @param {{name:string, fixtures:Array|null, catalog:Array, hasRule:boolean, exempt:boolean}} args
+ */
+function routerReachability({ name, fixtures, catalog, hasRule, exempt }) {
+  const base = { has_curated_rule: hasRule === true, router_exempt: exempt === true };
+  const positives = Array.isArray(fixtures) ? fixtures.filter(f => f && f.should_trigger === true) : null;
+  if (!positives || positives.length === 0) {
+    return { ...base, fixtures: 'no-fixtures', fixtures_total: 0, fixtures_best_hit: 0, reachable: null, keyword_alignment: null };
+  }
+  let hit = 0;
+  for (const f of positives) {
+    const r = routeSkill(f.query, { catalog });
+    if (r.best === name) hit += 1;
+  }
+  return {
+    ...base,
+    fixtures: 'present',
+    fixtures_total: positives.length,
+    fixtures_best_hit: hit,
+    reachable: hit > 0,
+    keyword_alignment: Math.round((hit / positives.length) * 100) / 100,
+  };
+}
+
+/** Strip a leading UTF-8 BOM without embedding the literal char. */
+function stripBom(value) {
+  const s = String(value);
+  return s.charCodeAt(0) === 0xFEFF ? s.slice(1) : s;
+}
+
+/**
+ * Parse a skill's SKILL.md source into { name, description, descLen, bodyLines }. Mirrors the
+ * context-cost parser so caps/token measurements agree with that gate. Returns null when absent.
+ * @param {string} skillsDir absolute path to the skills/ directory
+ * @param {string} name skill folder name
+ */
+function parseSkillSource(skillsDir, name) {
+  const file = path.join(skillsDir, name, 'SKILL.md');
+  if (!fs.existsSync(file)) return null;
+  const text = stripBom(fs.readFileSync(file, 'utf8'));
+  const lines = text.split(/\r?\n/);
+  if (lines[0].trim() !== '---') return { name, description: '', descLen: 0, bodyLines: lines.length };
+  let fmEnd = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') { fmEnd = i; break; }
+  }
+  if (fmEnd === -1) return { name, description: '', descLen: 0, bodyLines: 0 };
+  const fm = lines.slice(1, fmEnd).join('\n');
+  const m = fm.match(/description:\s*([\s\S]*?)(?:\n[A-Za-z_-]+:|$)/);
+  const description = m ? m[1].replace(/^>\s*/, '').replace(/\s+/g, ' ').trim() : '';
+  const bodyLines = lines.length - (fmEnd + 1);
+  return { name, description, descLen: description.length, bodyLines };
+}
+
+/** Load a skill's evals.json fixtures, or null when the skill has none. */
+function loadFixtures(skillsDir, name) {
+  const file = path.join(skillsDir, name, 'evals', 'evals.json');
+  if (!fs.existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(stripBom(fs.readFileSync(file, 'utf8')));
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a full deterministic scorecard for one skill. `catalog` is the router catalog (injectable);
+ * a skill missing its SKILL.md yields null.
+ * @param {{skillsDir:string, name:string, catalog:Array}} args
+ */
+function buildScorecard({ skillsDir, name, catalog }) {
+  const src = parseSkillSource(skillsDir, name);
+  if (!src) return null;
+  const allowlisted = BODY_OVER_ALLOWLIST.has(name);
+  const tokenCost = scoreTokenCost({ descLen: src.descLen, bodyLines: src.bodyLines });
+  const caps = scoreCaps({ descLen: src.descLen, bodyLines: src.bodyLines, allowlisted });
+  const descQuality = scoreDescriptionQuality(src.description);
+  const fixtures = loadFixtures(skillsDir, name);
+  const reachability = routerReachability({
+    name,
+    fixtures,
+    catalog: catalog || [],
+    hasRule: hasCuratedRule(name),
+    exempt: ROUTER_EXEMPT.has(name),
+  });
+  return {
+    skill: name,
+    fixtures: reachability.fixtures === 'no-fixtures' ? 'no-fixtures' : 'present',
+    static: { token_cost: tokenCost, caps, description_quality: descQuality },
+    router_reachability: reachability,
+    behavioral: behavioralPlaceholders(),
+    composite: composite({ tokenCost, caps, descQuality }),
+  };
+}
+
+/** Build scorecards for every skill under `skillsDir`, keyed by name (sorted, deterministic). */
+function buildAllScorecards(skillsDir, catalog) {
+  const cat = catalog || [];
+  const names = fs
+    .readdirSync(skillsDir, { withFileTypes: true })
+    .filter(e => e.isDirectory() && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')))
+    .map(e => e.name)
+    .sort();
+  const out = {};
+  for (const name of names) {
+    const card = buildScorecard({ skillsDir, name, catalog: cat });
+    if (card) out[name] = card;
+  }
+  return out;
+}
+
+/**
+ * The CI GATE. Given scorecards keyed by name, returns { passed, failures, warnings }.
+ * HARD failures (block CI):
+ *   - caps: a description over the char cap or a non-allowlisted body over the line cap.
+ *   - description_quality: below DESC_QUALITY_FLOOR.
+ *   - router_unreachable: a FIXTURED skill with NO curated rule and NOT router-exempt (the router
+ *     can never reach it via `forge skill for`).
+ * WARNINGS (surface in `forge skill scores`, never block): a fixtured skill that HAS a rule but
+ * whose paraphrase fixtures don't hit its keywords (reachable:false) -- the W5 judge is the real fix.
+ */
+function evaluateGate(scorecards) {
+  const failures = [];
+  const warnings = [];
+  for (const [name, card] of Object.entries(scorecards)) {
+    if (card.static.caps.score !== 100) {
+      failures.push({ skill: name, kind: 'caps', detail: `desc_within=${card.static.caps.desc_within} body_within=${card.static.caps.body_within}` });
+    }
+    if (card.static.description_quality.score < DESC_QUALITY_FLOOR) {
+      failures.push({ skill: name, kind: 'description_quality', detail: `score ${card.static.description_quality.score} < floor ${DESC_QUALITY_FLOOR}` });
+    }
+    const rr = card.router_reachability;
+    if (rr.fixtures === 'present' && !rr.has_curated_rule && !rr.router_exempt) {
+      failures.push({ skill: name, kind: 'router_unreachable', detail: 'fixtured skill has no curated INTENT_RULES rule and is not router-exempt' });
+    } else if (rr.fixtures === 'present' && rr.has_curated_rule && rr.reachable === false) {
+      warnings.push({ skill: name, kind: 'router_keyword_gap', detail: 'has a rule but no fixture reaches it (paraphrase gap — W5)' });
+    }
+  }
+  return { passed: failures.length === 0, failures, warnings };
+}
+
+module.exports = {
+  DESC_CAP,
+  BODY_CAP,
+  BODY_OVER_ALLOWLIST,
+  ROUTER_EXEMPT,
+  WEIGHTS,
+  DESC_QUALITY_FLOOR,
+  hasCuratedRule,
+  scoreTokenCost,
+  scoreCaps,
+  scoreDescriptionQuality,
+  composite,
+  behavioralPlaceholders,
+  routerReachability,
+  parseSkillSource,
+  loadFixtures,
+  buildScorecard,
+  buildAllScorecards,
+  evaluateGate,
+  resolveSkillsRoot,
+};

--- a/lib/skill-eval.js
+++ b/lib/skill-eval.js
@@ -200,13 +200,15 @@ function parseSkillSource(skillsDir, name) {
 }
 
 /**
- * Load a skill's evals.json fixtures as a typed STATE, distinguishing:
- *   - 'absent'  no evals.json file      -> honest "no-fixtures" (gate unaffected).
- *   - 'valid'   file parses to an array -> the fixtures.
- *   - 'invalid' file exists but is unreadable / not JSON / not an array -> a BROKEN fixture file.
- * The 'invalid' state must NOT masquerade as 'absent': a malformed file silently disabling the
- * router-reachability lint would let a real defect pass CI, so buildScorecard/evaluateGate treat
- * 'invalid' as a gate failure with the parse error surfaced.
+ * Load a skill's evals.json fixtures as a typed STATE. ONLY a genuinely ABSENT file is
+ * "no-fixtures"; every other broken shape is 'invalid' so it can never silently disable the
+ * router-reachability lint and pass CI:
+ *   - 'absent'  no evals.json file.
+ *   - 'valid'   file parses to an ARRAY, EVERY entry has a non-empty string `query` and a boolean
+ *               `should_trigger`, AND there is >=1 positive (should_trigger:true) fixture.
+ *   - 'invalid' file exists but is unreadable / not JSON / not an array / has a wrong-shape entry
+ *               (e.g. `shouldTrigger` instead of `should_trigger`, missing `query`) / has zero
+ *               positive fixtures. The `error` names the first bad entry and why.
  * @returns {{status:'absent'|'valid'|'invalid', fixtures:Array|null, error:string|null}}
  */
 function loadFixtures(skillsDir, name) {
@@ -226,6 +228,21 @@ function loadFixtures(skillsDir, name) {
   }
   if (!Array.isArray(parsed)) {
     return { status: 'invalid', fixtures: null, error: 'evals.json is not a JSON array of fixtures' };
+  }
+  for (let i = 0; i < parsed.length; i += 1) {
+    const entry = parsed[i];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return { status: 'invalid', fixtures: null, error: `fixture #${i} is not an object` };
+    }
+    if (typeof entry.query !== 'string' || entry.query.trim() === '') {
+      return { status: 'invalid', fixtures: null, error: `fixture #${i} has no non-empty string "query"` };
+    }
+    if (typeof entry.should_trigger !== 'boolean') {
+      return { status: 'invalid', fixtures: null, error: `fixture #${i} has no boolean "should_trigger" (check for a mis-spelled key)` };
+    }
+  }
+  if (!parsed.some(e => e.should_trigger === true)) {
+    return { status: 'invalid', fixtures: null, error: 'no positive (should_trigger:true) fixtures — the reachability lint would be a no-op' };
   }
   return { status: 'valid', fixtures: parsed, error: null };
 }

--- a/lib/skill-eval.js
+++ b/lib/skill-eval.js
@@ -199,16 +199,35 @@ function parseSkillSource(skillsDir, name) {
   return { name, description, descLen: description.length, bodyLines };
 }
 
-/** Load a skill's evals.json fixtures, or null when the skill has none. */
+/**
+ * Load a skill's evals.json fixtures as a typed STATE, distinguishing:
+ *   - 'absent'  no evals.json file      -> honest "no-fixtures" (gate unaffected).
+ *   - 'valid'   file parses to an array -> the fixtures.
+ *   - 'invalid' file exists but is unreadable / not JSON / not an array -> a BROKEN fixture file.
+ * The 'invalid' state must NOT masquerade as 'absent': a malformed file silently disabling the
+ * router-reachability lint would let a real defect pass CI, so buildScorecard/evaluateGate treat
+ * 'invalid' as a gate failure with the parse error surfaced.
+ * @returns {{status:'absent'|'valid'|'invalid', fixtures:Array|null, error:string|null}}
+ */
 function loadFixtures(skillsDir, name) {
   const file = path.join(skillsDir, name, 'evals', 'evals.json');
-  if (!fs.existsSync(file)) return null;
+  if (!fs.existsSync(file)) return { status: 'absent', fixtures: null, error: null };
+  let raw;
   try {
-    const parsed = JSON.parse(stripBom(fs.readFileSync(file, 'utf8')));
-    return Array.isArray(parsed) ? parsed : null;
-  } catch {
-    return null;
+    raw = stripBom(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    return { status: 'invalid', fixtures: null, error: `unreadable evals.json: ${err.message}` };
   }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { status: 'invalid', fixtures: null, error: `malformed evals.json: ${err.message}` };
+  }
+  if (!Array.isArray(parsed)) {
+    return { status: 'invalid', fixtures: null, error: 'evals.json is not a JSON array of fixtures' };
+  }
+  return { status: 'valid', fixtures: parsed, error: null };
 }
 
 /**
@@ -223,17 +242,32 @@ function buildScorecard({ skillsDir, name, catalog }) {
   const tokenCost = scoreTokenCost({ descLen: src.descLen, bodyLines: src.bodyLines });
   const caps = scoreCaps({ descLen: src.descLen, bodyLines: src.bodyLines, allowlisted });
   const descQuality = scoreDescriptionQuality(src.description);
-  const fixtures = loadFixtures(skillsDir, name);
-  const reachability = routerReachability({
-    name,
-    fixtures,
-    catalog: catalog || [],
-    hasRule: hasCuratedRule(name),
-    exempt: ROUTER_EXEMPT.has(name),
-  });
+  const fx = loadFixtures(skillsDir, name);
+  let reachability;
+  if (fx.status === 'invalid') {
+    // A broken fixture file is NOT "no-fixtures": mark it explicitly so the gate can fail it.
+    reachability = {
+      has_curated_rule: hasCuratedRule(name),
+      router_exempt: ROUTER_EXEMPT.has(name),
+      fixtures: 'invalid',
+      error: fx.error,
+      fixtures_total: 0,
+      fixtures_best_hit: 0,
+      reachable: null,
+      keyword_alignment: null,
+    };
+  } else {
+    reachability = routerReachability({
+      name,
+      fixtures: fx.fixtures,
+      catalog: catalog || [],
+      hasRule: hasCuratedRule(name),
+      exempt: ROUTER_EXEMPT.has(name),
+    });
+  }
   return {
     skill: name,
-    fixtures: reachability.fixtures === 'no-fixtures' ? 'no-fixtures' : 'present',
+    fixtures: reachability.fixtures, // 'present' | 'no-fixtures' | 'invalid'
     static: { token_cost: tokenCost, caps, description_quality: descQuality },
     router_reachability: reachability,
     behavioral: behavioralPlaceholders(),
@@ -377,7 +411,10 @@ function evaluateGate(scorecards, options = {}) {
       failures.push({ skill: name, kind: 'description_quality', detail: `score ${card.static.description_quality.score} < floor ${DESC_QUALITY_FLOOR}` });
     }
     const rr = card.router_reachability;
-    if (rr.fixtures === 'present' && !rr.has_curated_rule && !rr.router_exempt) {
+    if (rr.fixtures === 'invalid') {
+      // A broken evals.json must FAIL, not silently disable the reachability lint.
+      failures.push({ skill: name, kind: 'invalid_fixtures', detail: rr.error || 'evals.json is malformed or not a JSON array' });
+    } else if (rr.fixtures === 'present' && !rr.has_curated_rule && !rr.router_exempt) {
       failures.push({ skill: name, kind: 'router_unreachable', detail: 'fixtured skill has no curated INTENT_RULES rule and is not router-exempt' });
     } else if (rr.fixtures === 'present' && rr.has_curated_rule && rr.reachable === false) {
       warnings.push({ skill: name, kind: 'router_keyword_gap', detail: 'has a rule but no fixture reaches it (paraphrase gap — W5)' });

--- a/lib/skill-eval.js
+++ b/lib/skill-eval.js
@@ -345,17 +345,22 @@ function dirHasAnySkill(dir) {
 }
 
 /**
- * Resolve BOTH the skills SOURCE dir and its aligned router catalog from the same root, so eval
- * and scores never read the catalog from a different root than the scorecards. Returns null when
- * no skills/ is resolvable.
+ * Resolve the skills SOURCE dir, its aligned router catalog, AND which root was selected, so eval
+ * and scores never read the catalog from a different root than the scorecards. `source` is:
+ *   - 'project'  the consumer/dev SOURCE checkout's own skills/ was selected (projectRoot/skills).
+ *                A committed .agents/skills MIRROR is expected here, so mirror drift MUST be gated.
+ *   - 'package'  fell back to the PACKAGED skills root (installed consumer with no root skills/).
+ *                No mirror ships with the package, so a mirror check would be false drift.
+ * Returns null when no skills/ is resolvable.
  * @param {string} [projectRoot]
- * @returns {{ skillsDir: string, catalog: {name:string,description:string}[] } | null}
+ * @returns {{ skillsDir: string, catalog: {name:string,description:string}[], source: 'project'|'package' } | null}
  */
 function resolveSkillsContext(projectRoot) {
   const skillsDir = resolveSkillsDir(projectRoot);
   if (!skillsDir) return null;
+  const source = projectRoot && skillsDir === path.join(projectRoot, 'skills') ? 'project' : 'package';
   // loadSkillCatalog(override) reads override/skills — pass the parent of the resolved skills dir.
-  return { skillsDir, catalog: loadSkillCatalog(path.dirname(skillsDir)) };
+  return { skillsDir, catalog: loadSkillCatalog(path.dirname(skillsDir)), source };
 }
 
 /** Read a committed scorecard.json under `<baseDir>/<name>/evals/`, or null when absent/unparseable. */

--- a/lib/skill-eval.js
+++ b/lib/skill-eval.js
@@ -29,7 +29,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { INTENT_RULES, routeSkill, resolveSkillsRoot } = require('./using-forge');
+const { INTENT_RULES, routeSkill, resolveSkillsRoot, loadSkillCatalog } = require('./using-forge');
 
 // Progressive-disclosure budget -- mirrors test/skills/context-cost.test.js (single source of the
 // numbers; kept in sync by the shared gate philosophy, not a runtime import to avoid test-dep).
@@ -258,6 +258,82 @@ function buildAllScorecards(skillsDir, catalog) {
 }
 
 /**
+ * Resolve the canonical skills/ SOURCE dir, preferring the consumer/dev checkout's own skills/
+ * and FALLING BACK to the packaged skills root (resolveSkillsRoot() with no override wraps
+ * getPackageRoot). This is the SHARED resolver every `forge skill` verb must use so an installed
+ * consumer project (which has no root skills/) reads Forge's PACKAGED skills instead of failing
+ * with "no skills dir" — mirrors what `forge skill for` already does. Never throws -> null only
+ * when no skills/ exists on either root. Keep this the single resolver so no future verb regresses.
+ * @param {string} [projectRoot]
+ * @returns {string|null}
+ */
+function resolveSkillsDir(projectRoot) {
+  const roots = [];
+  if (projectRoot) roots.push(projectRoot);
+  const pkg = resolveSkillsRoot();
+  if (pkg && pkg !== projectRoot) roots.push(pkg);
+  for (const root of roots) {
+    const dir = path.join(root, 'skills');
+    if (fs.existsSync(dir)) return dir;
+  }
+  return null;
+}
+
+/**
+ * Resolve BOTH the skills SOURCE dir and its aligned router catalog from the same root, so eval
+ * and scores never read the catalog from a different root than the scorecards. Returns null when
+ * no skills/ is resolvable.
+ * @param {string} [projectRoot]
+ * @returns {{ skillsDir: string, catalog: {name:string,description:string}[] } | null}
+ */
+function resolveSkillsContext(projectRoot) {
+  const skillsDir = resolveSkillsDir(projectRoot);
+  if (!skillsDir) return null;
+  // loadSkillCatalog(override) reads override/skills — pass the parent of the resolved skills dir.
+  return { skillsDir, catalog: loadSkillCatalog(path.dirname(skillsDir)) };
+}
+
+/** Read a committed scorecard.json under `<baseDir>/<name>/evals/`, or null when absent/unparseable. */
+function loadCommittedScorecard(baseDir, name) {
+  const file = path.join(baseDir, name, 'evals', 'scorecard.json');
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(stripBom(fs.readFileSync(file, 'utf8')));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detect scorecard DRIFT: for each fresh scorecard, the committed artifact under the canonical
+ * skills/ dir (and, when present, the .agents/skills MIRROR) must byte-match the recomputed card.
+ * Returns [{ skill, where, reason }] — empty when everything is fresh. This is what lets both the
+ * CI gate and `forge skill scores` refuse to report PASS while a committed artifact is stale.
+ * @param {{skillsDir:string, freshCards:object, mirrorDir?:string|null}} args
+ */
+function detectScorecardDrift({ skillsDir, freshCards, mirrorDir }) {
+  const drift = [];
+  for (const [name, fresh] of Object.entries(freshCards)) {
+    const expected = JSON.stringify(fresh);
+    const canonical = loadCommittedScorecard(skillsDir, name);
+    if (canonical === null) {
+      drift.push({ skill: name, where: 'canonical', reason: 'missing scorecard.json — run `forge skill eval --static`' });
+    } else if (JSON.stringify(canonical) !== expected) {
+      drift.push({ skill: name, where: 'canonical', reason: 'scorecard.json out of date — run `forge skill eval --static`' });
+    }
+    if (mirrorDir && fs.existsSync(mirrorDir)) {
+      const mirror = loadCommittedScorecard(mirrorDir, name);
+      if (mirror === null) {
+        drift.push({ skill: name, where: 'mirror', reason: 'missing .agents/skills scorecard.json — regenerate the mirror' });
+      } else if (JSON.stringify(mirror) !== expected) {
+        drift.push({ skill: name, where: 'mirror', reason: '.agents/skills scorecard.json out of date — regenerate the mirror' });
+      }
+    }
+  }
+  return drift;
+}
+
+/**
  * The CI GATE. Given scorecards keyed by name, returns { passed, failures, warnings }.
  * HARD failures (block CI):
  *   - caps: a description over the char cap or a non-allowlisted body over the line cap.
@@ -267,9 +343,15 @@ function buildAllScorecards(skillsDir, catalog) {
  * WARNINGS (surface in `forge skill scores`, never block): a fixtured skill that HAS a rule but
  * whose paraphrase fixtures don't hit its keywords (reachable:false) -- the W5 judge is the real fix.
  */
-function evaluateGate(scorecards) {
+function evaluateGate(scorecards, options = {}) {
   const failures = [];
   const warnings = [];
+  // Committed-artifact drift is a hard failure: a stale scorecard.json (canonical or mirror) means
+  // the published scores disagree with the source, so the gate must not report PASS.
+  const drift = Array.isArray(options.drift) ? options.drift : [];
+  for (const d of drift) {
+    failures.push({ skill: d.skill, kind: 'scorecard_drift', detail: `${d.where}: ${d.reason}` });
+  }
   for (const [name, card] of Object.entries(scorecards)) {
     if (card.static.caps.score !== 100) {
       failures.push({ skill: name, kind: 'caps', detail: `desc_within=${card.static.caps.desc_within} body_within=${card.static.caps.body_within}` });
@@ -307,4 +389,8 @@ module.exports = {
   buildAllScorecards,
   evaluateGate,
   resolveSkillsRoot,
+  resolveSkillsDir,
+  resolveSkillsContext,
+  loadCommittedScorecard,
+  detectScorecardDrift,
 };

--- a/lib/skill-eval.js
+++ b/lib/skill-eval.js
@@ -274,9 +274,23 @@ function resolveSkillsDir(projectRoot) {
   if (pkg && pkg !== projectRoot) roots.push(pkg);
   for (const root of roots) {
     const dir = path.join(root, 'skills');
-    if (fs.existsSync(dir)) return dir;
+    // Require at least one <name>/SKILL.md: a consumer project may have an unrelated or empty
+    // skills/ dir, which would otherwise be selected and yield ZERO scorecards (a hollow PASS).
+    // An empty/skill-less dir falls through to the packaged skills root.
+    if (dirHasAnySkill(dir)) return dir;
   }
   return null;
+}
+
+/** True when `dir` contains at least one `<name>/SKILL.md` (a real skills source, not an empty dir). */
+function dirHasAnySkill(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  return entries.some(e => e.isDirectory() && fs.existsSync(path.join(dir, e.name, 'SKILL.md')));
 }
 
 /**
@@ -321,7 +335,10 @@ function detectScorecardDrift({ skillsDir, freshCards, mirrorDir }) {
     } else if (JSON.stringify(canonical) !== expected) {
       drift.push({ skill: name, where: 'canonical', reason: 'scorecard.json out of date — run `forge skill eval --static`' });
     }
-    if (mirrorDir && fs.existsSync(mirrorDir)) {
+    // No existsSync(mirrorDir) guard: a TOTALLY missing mirror is the worst case and must report
+    // drift per skill (loadCommittedScorecard already returns null safely for missing files). The
+    // caller passes mirrorDir only when a mirror is expected in this checkout (null skips it).
+    if (mirrorDir) {
       const mirror = loadCommittedScorecard(mirrorDir, name);
       if (mirror === null) {
         drift.push({ skill: name, where: 'mirror', reason: 'missing .agents/skills scorecard.json — regenerate the mirror' });

--- a/lib/using-forge.js
+++ b/lib/using-forge.js
@@ -188,6 +188,7 @@ const INTENT_RULES = Object.freeze([
   { skill: 'sonarcloud-analysis', weight: 1, keywords: ['sonarcloud analysis', 'sonar analysis', 'sonarcloud report', 'analyze with sonar'] },
   { skill: 'rollback', weight: 2, keywords: ['revert', 'roll back', 'rollback', 'undo the merge', 'undo a change'] },
   { skill: 'kernel', weight: 1, keywords: ['how does forge', 'which command', 'which skill', 'how is forge set up', 'new here', 'orient'] },
+  { skill: 'hermes-forge', weight: 2, keywords: ['hermes', 'hermes session', 'forge orient', 'orient me', 'orient came back', 'orient envelope', 'cite the source', 'where does that decision come from'] },
 ]);
 
 /** Normalize a situation string for matching: lowercase, collapse whitespace, strip punctuation. */

--- a/lib/using-forge.js
+++ b/lib/using-forge.js
@@ -188,7 +188,7 @@ const INTENT_RULES = Object.freeze([
   { skill: 'sonarcloud-analysis', weight: 1, keywords: ['sonarcloud analysis', 'sonar analysis', 'sonarcloud report', 'analyze with sonar'] },
   { skill: 'rollback', weight: 2, keywords: ['revert', 'roll back', 'rollback', 'undo the merge', 'undo a change'] },
   { skill: 'kernel', weight: 1, keywords: ['how does forge', 'which command', 'which skill', 'how is forge set up', 'new here', 'orient'] },
-  { skill: 'hermes-forge', weight: 2, keywords: ['hermes', 'hermes session', 'forge orient', 'orient me', 'orient came back', 'orient envelope', 'cite the source', 'where does that decision come from'] },
+  { skill: 'hermes-forge', weight: 2, keywords: ['hermes', 'hermes session', 'hermes harness'] },
 ]);
 
 /** Normalize a situation string for matching: lowercase, collapse whitespace, strip punctuation. */

--- a/skills/claim-safety/evals/scorecard.json
+++ b/skills/claim-safety/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "claim-safety",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 995,
+      "body_lines": 88,
+      "score": 43
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/skills/dev/evals/scorecard.json
+++ b/skills/dev/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "dev",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 962,
+      "body_lines": 328,
+      "score": 20
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 76
+}

--- a/skills/hermes-forge/evals/scorecard.json
+++ b/skills/hermes-forge/evals/scorecard.json
@@ -24,9 +24,9 @@
     "router_exempt": false,
     "fixtures": "present",
     "fixtures_total": 6,
-    "fixtures_best_hit": 4,
+    "fixtures_best_hit": 2,
     "reachable": true,
-    "keyword_alignment": 0.67
+    "keyword_alignment": 0.33
   },
   "behavioral": {
     "trigger_recall": null,

--- a/skills/hermes-forge/evals/scorecard.json
+++ b/skills/hermes-forge/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "hermes-forge",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 157,
+      "score": 36
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 4,
+    "reachable": true,
+    "keyword_alignment": 0.67
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 81
+}

--- a/skills/issue-basics/evals/scorecard.json
+++ b/skills/issue-basics/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "issue-basics",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 991,
+      "body_lines": 95,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 63
+}

--- a/skills/kernel/evals/scorecard.json
+++ b/skills/kernel/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "kernel",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 187,
+      "score": 33
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 80
+}

--- a/skills/memory/evals/scorecard.json
+++ b/skills/memory/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "memory",
+  "fixtures": "no-fixtures",
+  "static": {
+    "token_cost": {
+      "desc_chars": 938,
+      "body_lines": 87,
+      "score": 45
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "no-fixtures",
+    "fixtures_total": 0,
+    "fixtures_best_hit": 0,
+    "reachable": null,
+    "keyword_alignment": null
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 84
+}

--- a/skills/parallel-deep-research/evals/scorecard.json
+++ b/skills/parallel-deep-research/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "parallel-deep-research",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 996,
+      "body_lines": 92,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.2
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/skills/plan/evals/scorecard.json
+++ b/skills/plan/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "plan",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 958,
+      "body_lines": 530,
+      "score": 3
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 4,
+    "reachable": true,
+    "keyword_alignment": 0.8
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 51
+}

--- a/skills/research/evals/scorecard.json
+++ b/skills/research/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "research",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 1014,
+      "body_lines": 179,
+      "score": 33
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.4
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 60
+}

--- a/skills/review/evals/scorecard.json
+++ b/skills/review/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "review",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 988,
+      "body_lines": 476,
+      "score": 4
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 3,
+    "reachable": true,
+    "keyword_alignment": 0.6
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 71
+}

--- a/skills/rollback/evals/scorecard.json
+++ b/skills/rollback/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "rollback",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 965,
+      "body_lines": 95,
+      "score": 43
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.17
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/skills/shepherd/evals/scorecard.json
+++ b/skills/shepherd/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "shepherd",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 991,
+      "body_lines": 51,
+      "score": 47
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.2
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 84
+}

--- a/skills/ship/evals/scorecard.json
+++ b/skills/ship/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "ship",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 237,
+      "score": 28
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 3,
+    "reachable": true,
+    "keyword_alignment": 0.6
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 78
+}

--- a/skills/smith/evals/scorecard.json
+++ b/skills/smith/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "smith",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 819,
+      "body_lines": 127,
+      "score": 47
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 84
+}

--- a/skills/sonarcloud-analysis/evals/scorecard.json
+++ b/skills/sonarcloud-analysis/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "sonarcloud-analysis",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 993,
+      "body_lines": 156,
+      "score": 36
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 0,
+    "reachable": false,
+    "keyword_alignment": 0
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 81
+}

--- a/skills/sonarcloud/evals/scorecard.json
+++ b/skills/sonarcloud/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "sonarcloud",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 977,
+      "body_lines": 147,
+      "score": 38
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 6,
+    "reachable": true,
+    "keyword_alignment": 1
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 61
+}

--- a/skills/status/evals/scorecard.json
+++ b/skills/status/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "status",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 954,
+      "body_lines": 88,
+      "score": 45
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 64
+}

--- a/skills/triage-ready/evals/scorecard.json
+++ b/skills/triage-ready/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "triage-ready",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 977,
+      "body_lines": 105,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 1,
+    "reachable": true,
+    "keyword_alignment": 0.2
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 83
+}

--- a/skills/using-forge/evals/scorecard.json
+++ b/skills/using-forge/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "using-forge",
+  "fixtures": "no-fixtures",
+  "static": {
+    "token_cost": {
+      "desc_chars": 1016,
+      "body_lines": 87,
+      "score": 42
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": false,
+    "router_exempt": false,
+    "fixtures": "no-fixtures",
+    "fixtures_total": 0,
+    "fixtures_best_hit": 0,
+    "reachable": null,
+    "keyword_alignment": null
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 63
+}

--- a/skills/validate/evals/scorecard.json
+++ b/skills/validate/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "validate",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 995,
+      "body_lines": 300,
+      "score": 21
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": false,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 60
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 5,
+    "fixtures_best_hit": 3,
+    "reachable": true,
+    "keyword_alignment": 0.6
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 56
+}

--- a/skills/verify/evals/scorecard.json
+++ b/skills/verify/evals/scorecard.json
@@ -1,0 +1,41 @@
+{
+  "skill": "verify",
+  "fixtures": "present",
+  "static": {
+    "token_cost": {
+      "desc_chars": 890,
+      "body_lines": 287,
+      "score": 28
+    },
+    "caps": {
+      "desc_within": true,
+      "body_within": true,
+      "score": 100
+    },
+    "description_quality": {
+      "has_trigger_cues": true,
+      "has_disambiguation_cues": true,
+      "adequate_length": true,
+      "score": 100
+    }
+  },
+  "router_reachability": {
+    "has_curated_rule": true,
+    "router_exempt": false,
+    "fixtures": "present",
+    "fixtures_total": 6,
+    "fixtures_best_hit": 2,
+    "reachable": true,
+    "keyword_alignment": 0.33
+  },
+  "behavioral": {
+    "trigger_recall": null,
+    "trigger_precision": null,
+    "disambiguation": null,
+    "chain_correctness": null,
+    "outcome_quality": null,
+    "variance": null,
+    "note": "behavioral — W5 (LLM judge): semantic recall/precision/chain/outcome/variance, not deterministic"
+  },
+  "composite": 78
+}

--- a/test/commands/skill.test.js
+++ b/test/commands/skill.test.js
@@ -112,6 +112,46 @@ describe('forge skill scores', () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  // Gate-contract: a FAILING gate MUST surface as a FAILING command result (success:false) so the
+  // registry runner exits non-zero and CI running `forge skill scores` actually fails — instead of
+  // exiting 0 while the output reads "CI gate: FAIL". The full table still rides along in output.
+  test('a failing gate returns success:false with an error naming the failures (both text and --json)', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-scores-failgate-'));
+    try {
+      const sdir = path.join(root, 'skills', 'demo');
+      fs.mkdirSync(sdir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sdir, 'SKILL.md'),
+        '---\nname: demo\ndescription: Use this when exercising the failing-gate command contract. This is NOT a real ' +
+          'skill and unlike ship it never runs; it only needs an adequately long, cue-bearing description string.\n---\nbody\n'
+      );
+      // Seed a fresh canonical scorecard; the missing .agents mirror in this SOURCE checkout is the drift.
+      expect(skillCommand.handler(['eval', 'demo', '--json'], {}, root).success).toBe(true);
+
+      const jsonRes = skillCommand.handler(['scores', '--json'], {}, root);
+      expect(jsonRes.gate.passed).toBe(false);
+      expect(jsonRes.success).toBe(false);
+      expect(typeof jsonRes.error).toBe('string');
+      expect(jsonRes.error).toContain('gate');
+      // The league table / gate detail still ride along for context even on failure.
+      expect(jsonRes.output).toContain('scorecards');
+
+      const textRes = skillCommand.handler(['scores'], {}, root);
+      expect(textRes.success).toBe(false);
+      expect(textRes.output).toContain('CI gate: FAIL');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // Healthy path: a clean dev checkout (gate passes) keeps success:true and carries no error.
+  test('a passing gate keeps success:true and sets no error', () => {
+    const res = skillCommand.handler(['scores', '--json'], {}, repoRoot);
+    expect(res.gate.passed).toBe(true);
+    expect(res.success).toBe(true);
+    expect(res.error).toBeUndefined();
+  });
 });
 
 // ── forge skill eval (writes scorecard.json) ──────────────────────────────────

--- a/test/commands/skill.test.js
+++ b/test/commands/skill.test.js
@@ -1,8 +1,13 @@
 'use strict';
 
 const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 const skillCommand = require('../../lib/commands/skill');
+
+const repoRoot = path.resolve(__dirname, '../..');
 
 // The `forge skill` noun routes a situation to the best-fit Forge skill via the deterministic
 // router (lib/using-forge). The catalog is read from the Forge PACKAGE root (getPackageRoot),
@@ -36,15 +41,117 @@ describe('forge skill command', () => {
     expect(res.error).toContain('Usage: forge skill for');
   });
 
-  test('unknown verb errors and lists supported verbs', () => {
+  test('unknown verb error advertises every supported verb (for, eval, scores)', () => {
     const res = skillCommand.handler(['bogus'], {});
     expect(res.success).toBe(false);
-    expect(res.error).toContain('Supported: for');
+    // Tightened: the old `toContain('Supported: for')` passed trivially once the list grew.
+    expect(res.error).toContain('eval');
+    expect(res.error).toContain('scores');
   });
 
   test('exports the standard command interface', () => {
     expect(skillCommand.name).toBe('skill');
     expect(typeof skillCommand.description).toBe('string');
     expect(typeof skillCommand.handler).toBe('function');
+  });
+});
+
+// ── forge skill scores (read-only) ────────────────────────────────────────────
+describe('forge skill scores', () => {
+  test('--json against the dev checkout returns scorecards + a gate + drift', () => {
+    const res = skillCommand.handler(['scores', '--json'], {}, repoRoot);
+    expect(res.success).toBe(true);
+    const parsed = JSON.parse(res.output);
+    expect(Object.keys(parsed.scorecards).length).toBeGreaterThan(0);
+    expect(typeof parsed.gate.passed).toBe('boolean');
+    expect(Array.isArray(parsed.drift)).toBe(true);
+  });
+
+  test('text mode renders the league-table header and a gate verdict line', () => {
+    const res = skillCommand.handler(['scores'], {}, repoRoot);
+    expect(res.success).toBe(true);
+    expect(res.output).toContain('COMPOSITE');
+    expect(res.output).toMatch(/CI gate: (PASS|FAIL)/);
+  });
+
+  // Finding A (consumer-repo resolution): a real installed project has no root skills/, and the
+  // command MUST fall back to the packaged Forge skills instead of erroring.
+  test('falls back to the packaged skills root when cwd has no skills/', () => {
+    const consumer = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-scores-consumer-'));
+    try {
+      const res = skillCommand.handler(['scores', '--json'], {}, consumer);
+      expect(res.success).toBe(true);
+      expect(Object.keys(JSON.parse(res.output).scorecards).length).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(consumer, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── forge skill eval (writes scorecard.json) ──────────────────────────────────
+describe('forge skill eval', () => {
+  test('--json writes and returns a scorecard for a temp skill (no repo mutation)', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-cmd-'));
+    try {
+      const sdir = path.join(root, 'skills', 'demo');
+      fs.mkdirSync(sdir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sdir, 'SKILL.md'),
+        '---\nname: demo\ndescription: Use this when demoing. This is NOT a real skill and unlike ship it never runs. ' +
+          'It exists only to exercise the eval writer with an adequately long description string.\n---\nbody line 1\nbody line 2\n'
+      );
+      const res = skillCommand.handler(['eval', 'demo', '--json'], {}, root);
+      expect(res.success).toBe(true);
+      const parsed = JSON.parse(res.output);
+      expect(parsed.skill).toBe('demo');
+      expect(Number.isInteger(parsed.composite)).toBe(true);
+      expect(fs.existsSync(path.join(sdir, 'evals', 'scorecard.json'))).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("a named skill that does not exist returns a 'not found' error", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-missing-'));
+    try {
+      fs.mkdirSync(path.join(root, 'skills'), { recursive: true });
+      const res = skillCommand.handler(['eval', 'does-not-exist', '--json'], {}, root);
+      expect(res.success).toBe(false);
+      expect(res.error).toContain('not found');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── formatScores rendering (unit) ─────────────────────────────────────────────
+describe('formatScores', () => {
+  const card = (skill, composite, fixtures) => ({
+    skill,
+    composite,
+    fixtures,
+    static: {
+      description_quality: { score: 100 },
+      token_cost: { score: 80 },
+      caps: { score: 100 },
+    },
+  });
+
+  test('renders worst-first rows, warnings, and a PASS verdict', () => {
+    const scorecards = { plan: card('plan', 51, 'present'), memory: card('memory', 84, 'no-fixtures') };
+    const gate = { passed: true, failures: [], warnings: [{ skill: 'kernel', detail: 'paraphrase gap' }] };
+    const out = skillCommand._internal.formatScores(scorecards, gate);
+    expect(out.indexOf('plan')).toBeLessThan(out.indexOf('memory')); // worst first
+    expect(out).toContain('no-fixtures');
+    expect(out).toContain('paraphrase gap');
+    expect(out).toContain('CI gate: PASS');
+  });
+
+  test('renders a FAIL verdict with the failing skill + kind', () => {
+    const scorecards = { ship: card('ship', 78, 'present') };
+    const gate = { passed: false, failures: [{ skill: 'ship', kind: 'scorecard_drift', detail: 'mirror: stale' }], warnings: [] };
+    const out = skillCommand._internal.formatScores(scorecards, gate);
+    expect(out).toContain('CI gate: FAIL');
+    expect(out).toContain('scorecard_drift');
   });
 });

--- a/test/commands/skill.test.js
+++ b/test/commands/skill.test.js
@@ -76,14 +76,40 @@ describe('forge skill scores', () => {
 
   // Finding A (consumer-repo resolution): a real installed project has no root skills/, and the
   // command MUST fall back to the packaged Forge skills instead of erroring.
-  test('falls back to the packaged skills root when cwd has no skills/', () => {
+  test('falls back to the packaged skills root when cwd has no skills/ (no mirror check)', () => {
     const consumer = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-scores-consumer-'));
     try {
       const res = skillCommand.handler(['scores', '--json'], {}, consumer);
       expect(res.success).toBe(true);
-      expect(Object.keys(JSON.parse(res.output).scorecards).length).toBeGreaterThan(0);
+      const parsed = JSON.parse(res.output);
+      expect(Object.keys(parsed.scorecards).length).toBeGreaterThan(0);
+      // Packaged-root path: no mirror ships, so the mirror check is omitted -> no mirror drift.
+      expect(parsed.drift.every(d => d.where !== 'mirror')).toBe(true);
     } finally {
       fs.rmSync(consumer, { recursive: true, force: true });
+    }
+  });
+
+  // Finding: mirror drift must be gated by CONTEXT (which root was resolved), not by whether the
+  // mirror dir happens to exist — otherwise a deleted mirror in a SOURCE checkout silently passes.
+  test('a SOURCE checkout with a DELETED .agents mirror REPORTS drift (gate FAILS)', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-scores-source-'));
+    try {
+      const sdir = path.join(root, 'skills', 'demo');
+      fs.mkdirSync(sdir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sdir, 'SKILL.md'),
+        '---\nname: demo\ndescription: Use this when exercising the source-checkout mirror gate. This is NOT a real ' +
+          'skill and unlike ship it never runs; it only needs an adequately long, cue-bearing description string.\n---\nbody\n'
+      );
+      // Seed a FRESH canonical scorecard so the ONLY drift is the missing mirror. No .agents/skills exists here.
+      expect(skillCommand.handler(['eval', 'demo', '--json'], {}, root).success).toBe(true);
+      const res = skillCommand.handler(['scores', '--json'], {}, root);
+      const parsed = JSON.parse(res.output);
+      expect(parsed.drift.some(d => d.where === 'mirror')).toBe(true);
+      expect(parsed.gate.passed).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/test/skill-eval.test.js
+++ b/test/skill-eval.test.js
@@ -31,6 +31,9 @@ const {
   buildAllScorecards,
   evaluateGate,
   parseSkillSource,
+  resolveSkillsDir,
+  resolveSkillsContext,
+  detectScorecardDrift,
 } = require('../lib/skill-eval');
 
 const { loadSkillCatalog } = require('../lib/using-forge');
@@ -284,27 +287,62 @@ function buildSeed(overrides = {}) {
   return base;
 }
 
-// ── committed-artifact drift ──────────────────────────────────────────────────
+// ── committed-artifact drift (canonical AND the .agents/skills mirror) ─────────
 describe('committed scorecards stay fresh', () => {
   const catalog = loadSkillCatalog(repoRoot);
+  const mirrorDir = path.join(repoRoot, '.agents', 'skills');
+  const freshCards = buildAllScorecards(skillsDir, catalog);
 
-  test('each skill has a committed scorecard.json equal to the recomputed one', () => {
-    const drifted = [];
-    const names = fs
-      .readdirSync(skillsDir, { withFileTypes: true })
-      .filter(e => e.isDirectory() && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')))
-      .map(e => e.name);
-    for (const name of names) {
-      const cardPath = path.join(skillsDir, name, 'evals', 'scorecard.json');
-      if (!fs.existsSync(cardPath)) { drifted.push(`${name}: missing scorecard.json`); continue; }
-      const committed = JSON.parse(fs.readFileSync(cardPath, 'utf8'));
-      const recomputed = buildScorecard({ skillsDir, name, catalog });
-      if (JSON.stringify(committed) !== JSON.stringify(recomputed)) {
-        drifted.push(`${name}: scorecard.json out of date — run \`forge skill eval --static\``);
-      }
+  test('canonical AND mirror scorecard.json each equal the recomputed card', () => {
+    const drift = detectScorecardDrift({ skillsDir, freshCards, mirrorDir });
+    if (drift.length) {
+      throw new Error('Scorecard drift:\n' + drift.map(d => `  ${d.skill} [${d.where}]: ${d.reason}`).join('\n'));
     }
-    if (drifted.length) throw new Error('Scorecard drift:\n' + drifted.map(d => '  ' + d).join('\n'));
-    expect(drifted).toEqual([]);
+    expect(drift).toEqual([]);
+  });
+
+  test('detectScorecardDrift flags a mirror that is missing a card', () => {
+    // Point the mirror at an empty temp dir: every skill should be reported as mirror-missing,
+    // proving the mirror is gated (not just the canonical tree).
+    const emptyMirror = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-mirror-'));
+    const drift = detectScorecardDrift({ skillsDir, freshCards, mirrorDir: emptyMirror });
+    expect(drift.some(d => d.where === 'mirror')).toBe(true);
+    fs.rmSync(emptyMirror, { recursive: true, force: true });
+  });
+});
+
+// ── shared consumer-repo resolver (finding A: un-regressable) ──────────────────
+describe('resolveSkillsDir / resolveSkillsContext', () => {
+  test('a dev checkout resolves its own skills/ dir', () => {
+    expect(resolveSkillsDir(repoRoot)).toBe(skillsDir);
+  });
+
+  test('a consumer project with NO skills/ falls back to the packaged skills root', () => {
+    const noSkills = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-consumer-'));
+    const resolved = resolveSkillsDir(noSkills);
+    // Must NOT be null and must NOT be the (skill-less) consumer dir — it falls back to the package.
+    expect(resolved).not.toBeNull();
+    expect(resolved.startsWith(noSkills)).toBe(false);
+    const ctx = resolveSkillsContext(noSkills);
+    expect(ctx).not.toBeNull();
+    expect(ctx.catalog.length).toBeGreaterThan(0);
+    fs.rmSync(noSkills, { recursive: true, force: true });
+  });
+});
+
+// ── evaluateGate is drift-aware (finding B) ───────────────────────────────────
+describe('evaluateGate drift-awareness', () => {
+  const catalog = loadSkillCatalog(repoRoot);
+  const freshCards = buildAllScorecards(skillsDir, catalog);
+
+  test('a drift entry makes the gate FAIL even when every card is otherwise clean', () => {
+    const result = evaluateGate(freshCards, { drift: [{ skill: 'ship', where: 'mirror', reason: 'stale' }] });
+    expect(result.passed).toBe(false);
+    expect(result.failures.some(f => f.kind === 'scorecard_drift' && f.skill === 'ship')).toBe(true);
+  });
+
+  test('no drift + clean cards still PASS', () => {
+    expect(evaluateGate(freshCards, { drift: [] }).passed).toBe(true);
   });
 });
 

--- a/test/skill-eval.test.js
+++ b/test/skill-eval.test.js
@@ -365,6 +365,64 @@ describe('evaluateGate drift-awareness', () => {
   });
 });
 
+// ── invalid vs absent fixtures (a broken evals.json must FAIL the gate) ───────
+describe('invalid fixtures', () => {
+  const DESC = 'Use this when you want to exercise the fixture-state gate path. This is NOT a real skill and ' +
+    'unlike ship it never runs; it exists only to give the scorer an adequately long, cue-bearing description.';
+
+  function tempSkill(evalsContent) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-fx-'));
+    const sdir = path.join(root, 'skills', 'demo');
+    fs.mkdirSync(sdir, { recursive: true });
+    fs.writeFileSync(path.join(sdir, 'SKILL.md'), `---\nname: demo\ndescription: ${DESC}\n---\nbody line 1\nbody line 2\n`);
+    if (evalsContent !== undefined) {
+      fs.mkdirSync(path.join(sdir, 'evals'), { recursive: true });
+      fs.writeFileSync(path.join(sdir, 'evals', 'evals.json'), evalsContent);
+    }
+    return { root, skillsDir: path.join(root, 'skills') };
+  }
+
+  test('ABSENT evals.json -> no-fixtures, gate unaffected (passes)', () => {
+    const { root, skillsDir: sd } = tempSkill(undefined);
+    try {
+      const card = buildScorecard({ skillsDir: sd, name: 'demo', catalog: [] });
+      expect(card.fixtures).toBe('no-fixtures');
+      const gate = evaluateGate({ demo: card });
+      expect(gate.passed).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('MALFORMED evals.json -> fixtures:invalid, gate FAILS naming the skill + reason', () => {
+    const { root, skillsDir: sd } = tempSkill('{ this is not valid json');
+    try {
+      const card = buildScorecard({ skillsDir: sd, name: 'demo', catalog: [] });
+      expect(card.fixtures).toBe('invalid');
+      expect(String(card.router_reachability.error)).toContain('malformed');
+      const gate = evaluateGate({ demo: card });
+      expect(gate.passed).toBe(false);
+      const fail = gate.failures.find(f => f.skill === 'demo' && f.kind === 'invalid_fixtures');
+      expect(fail).toBeTruthy();
+      expect(fail.detail.length).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('valid JSON that is NOT an array -> fixtures:invalid, gate FAILS', () => {
+    const { root, skillsDir: sd } = tempSkill('{"query":"x","should_trigger":true}');
+    try {
+      const card = buildScorecard({ skillsDir: sd, name: 'demo', catalog: [] });
+      expect(card.fixtures).toBe('invalid');
+      expect(String(card.router_reachability.error)).toContain('not a JSON array');
+      expect(evaluateGate({ demo: card }).passed).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 // ── parseSkillSource matches the context-cost parser ──────────────────────────
 describe('parseSkillSource', () => {
   test('parses a temp SKILL.md into description + body-line count', () => {

--- a/test/skill-eval.test.js
+++ b/test/skill-eval.test.js
@@ -421,6 +421,44 @@ describe('invalid fixtures', () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test('WRONG-KEY entry (shouldTrigger instead of should_trigger) -> invalid, gate FAILS', () => {
+    const { root, skillsDir: sd } = tempSkill('[{"query":"open a pr","shouldTrigger":true}]');
+    try {
+      const card = buildScorecard({ skillsDir: sd, name: 'demo', catalog: [] });
+      expect(card.fixtures).toBe('invalid');
+      expect(String(card.router_reachability.error)).toContain('should_trigger');
+      const gate = evaluateGate({ demo: card });
+      expect(gate.passed).toBe(false);
+      expect(gate.failures.some(f => f.skill === 'demo' && f.kind === 'invalid_fixtures')).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a well-shaped array with ONLY negatives (no positive) -> invalid, gate FAILS', () => {
+    const { root, skillsDir: sd } = tempSkill('[{"query":"a","should_trigger":false},{"query":"b","should_trigger":false}]');
+    try {
+      const card = buildScorecard({ skillsDir: sd, name: 'demo', catalog: [] });
+      expect(card.fixtures).toBe('invalid');
+      expect(String(card.router_reachability.error)).toContain('no positive');
+      expect(evaluateGate({ demo: card }).passed).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('an entry with a missing/empty query -> invalid, gate FAILS', () => {
+    const { root, skillsDir: sd } = tempSkill('[{"query":"   ","should_trigger":true}]');
+    try {
+      const card = buildScorecard({ skillsDir: sd, name: 'demo', catalog: [] });
+      expect(card.fixtures).toBe('invalid');
+      expect(String(card.router_reachability.error)).toContain('query');
+      expect(evaluateGate({ demo: card }).passed).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── parseSkillSource matches the context-cost parser ──────────────────────────

--- a/test/skill-eval.test.js
+++ b/test/skill-eval.test.js
@@ -339,6 +339,16 @@ describe('resolveSkillsDir / resolveSkillsContext', () => {
     fs.rmSync(noSkills, { recursive: true, force: true });
   });
 
+  test('resolveSkillsContext reports source: project for a checkout, package for the fallback', () => {
+    expect(resolveSkillsContext(repoRoot).source).toBe('project');
+    const consumer = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-src-'));
+    try {
+      expect(resolveSkillsContext(consumer).source).toBe('package');
+    } finally {
+      fs.rmSync(consumer, { recursive: true, force: true });
+    }
+  });
+
   test('a project with an EMPTY skills/ dir (no */SKILL.md) also falls back to the package', () => {
     const emptySkills = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-empty-'));
     fs.mkdirSync(path.join(emptySkills, 'skills', 'not-a-skill'), { recursive: true }); // dir, but no SKILL.md

--- a/test/skill-eval.test.js
+++ b/test/skill-eval.test.js
@@ -309,6 +309,16 @@ describe('committed scorecards stay fresh', () => {
     expect(drift.some(d => d.where === 'mirror')).toBe(true);
     fs.rmSync(emptyMirror, { recursive: true, force: true });
   });
+
+  test('a TOTALLY absent mirror dir still reports drift (no existsSync guard hides total loss)', () => {
+    // A path that does not exist at all — the worst case (mirror deleted / fresh checkout). The
+    // guard-free check must report mirror drift for every skill, not silently pass.
+    const gone = path.join(os.tmpdir(), 'skill-eval-nonexistent-mirror-' + Date.now());
+    expect(fs.existsSync(gone)).toBe(false);
+    const drift = detectScorecardDrift({ skillsDir, freshCards, mirrorDir: gone });
+    const mirrorDrift = drift.filter(d => d.where === 'mirror');
+    expect(mirrorDrift.length).toBe(Object.keys(freshCards).length);
+  });
 });
 
 // ── shared consumer-repo resolver (finding A: un-regressable) ──────────────────
@@ -327,6 +337,15 @@ describe('resolveSkillsDir / resolveSkillsContext', () => {
     expect(ctx).not.toBeNull();
     expect(ctx.catalog.length).toBeGreaterThan(0);
     fs.rmSync(noSkills, { recursive: true, force: true });
+  });
+
+  test('a project with an EMPTY skills/ dir (no */SKILL.md) also falls back to the package', () => {
+    const emptySkills = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-empty-'));
+    fs.mkdirSync(path.join(emptySkills, 'skills', 'not-a-skill'), { recursive: true }); // dir, but no SKILL.md
+    const resolved = resolveSkillsDir(emptySkills);
+    expect(resolved).not.toBeNull();
+    expect(resolved.startsWith(emptySkills)).toBe(false); // did NOT select the skill-less dir
+    fs.rmSync(emptySkills, { recursive: true, force: true });
   });
 });
 

--- a/test/skill-eval.test.js
+++ b/test/skill-eval.test.js
@@ -1,0 +1,327 @@
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// ─── static skill-eval scorer (W3) ────────────────────────────────────────────
+//
+// The STATIC tier is DETERMINISTIC and free: it scores only the parameters that
+// can be measured without an LLM or network — token cost, cap compliance, and a
+// description-quality heuristic (the PR #292 pattern). TRUE trigger recall/
+// precision is inherently SEMANTIC (the evals.json fixtures are paraphrases), so
+// it belongs to the W5 behavioral tier and lives here only as a typed placeholder.
+//
+// This file is BOTH the unit spec for the scorer and the CI GATE: it recomputes
+// scorecards from the canonical skills/ source and fails on a cap violation, a
+// description-quality regression, a committed-scorecard drift, or a fixtured skill
+// the deterministic router can NEVER reach (no curated rule + not router-exempt).
+
+const {
+  DESC_CAP,
+  BODY_CAP,
+  WEIGHTS,
+  DESC_QUALITY_FLOOR,
+  scoreTokenCost,
+  scoreCaps,
+  scoreDescriptionQuality,
+  composite,
+  routerReachability,
+  behavioralPlaceholders,
+  buildScorecard,
+  buildAllScorecards,
+  evaluateGate,
+  parseSkillSource,
+} = require('../lib/skill-eval');
+
+const { loadSkillCatalog } = require('../lib/using-forge');
+
+const repoRoot = path.resolve(__dirname, '..');
+const skillsDir = path.join(repoRoot, 'skills');
+
+// ── token cost ────────────────────────────────────────────────────────────────
+describe('scoreTokenCost', () => {
+  test('a zero-cost skill scores 100 (lower cost is better)', () => {
+    expect(scoreTokenCost({ descLen: 0, bodyLines: 0 }).score).toBe(100);
+  });
+
+  test('a skill at both caps scores 0', () => {
+    expect(scoreTokenCost({ descLen: DESC_CAP, bodyLines: BODY_CAP }).score).toBe(0);
+  });
+
+  test('half-budget on both axes scores 50', () => {
+    expect(scoreTokenCost({ descLen: DESC_CAP / 2, bodyLines: BODY_CAP / 2 }).score).toBe(50);
+  });
+
+  test('over-cap inputs clamp (never negative)', () => {
+    expect(scoreTokenCost({ descLen: DESC_CAP * 4, bodyLines: BODY_CAP * 4 }).score).toBe(0);
+  });
+
+  test('echoes the raw measurements', () => {
+    const r = scoreTokenCost({ descLen: 300, bodyLines: 120 });
+    expect(r.desc_chars).toBe(300);
+    expect(r.body_lines).toBe(120);
+  });
+});
+
+// ── caps ────────────────────────────────────────────────────────────────────
+describe('scoreCaps', () => {
+  test('within both caps scores 100', () => {
+    const r = scoreCaps({ descLen: 500, bodyLines: 200, allowlisted: false });
+    expect(r.score).toBe(100);
+    expect(r.desc_within).toBe(true);
+    expect(r.body_within).toBe(true);
+  });
+
+  test('description over the cap fails (score 0)', () => {
+    expect(scoreCaps({ descLen: DESC_CAP + 1, bodyLines: 10, allowlisted: false }).score).toBe(0);
+  });
+
+  test('body over the cap fails when NOT allowlisted', () => {
+    const r = scoreCaps({ descLen: 100, bodyLines: BODY_CAP + 1, allowlisted: false });
+    expect(r.score).toBe(0);
+    expect(r.body_within).toBe(false);
+  });
+
+  test('body over the cap PASSES when allowlisted (e.g. plan)', () => {
+    expect(scoreCaps({ descLen: 100, bodyLines: BODY_CAP + 30, allowlisted: true }).score).toBe(100);
+  });
+});
+
+// ── description quality (PR #292 pattern) ─────────────────────────────────────
+describe('scoreDescriptionQuality', () => {
+  test('trigger phrases + disambiguation cues + adequate length scores 100', () => {
+    const desc =
+      'Use this when the user wants to open a pull request. This is NOT the review skill and unlike ship it never merges. '.repeat(2);
+    const r = scoreDescriptionQuality(desc);
+    expect(r.has_trigger_cues).toBe(true);
+    expect(r.has_disambiguation_cues).toBe(true);
+    expect(r.adequate_length).toBe(true);
+    expect(r.score).toBe(100);
+  });
+
+  test('missing trigger cues drops the score below 100', () => {
+    const desc = 'This skill opens pull requests. It is not the review skill. '.repeat(3);
+    const r = scoreDescriptionQuality(desc);
+    expect(r.has_trigger_cues).toBe(false);
+    expect(r.score).toBeLessThan(100);
+  });
+
+  test('a too-short description loses the adequate-length points', () => {
+    const r = scoreDescriptionQuality('Use when shipping.');
+    expect(r.adequate_length).toBe(false);
+  });
+});
+
+// ── composite ─────────────────────────────────────────────────────────────────
+describe('composite', () => {
+  test('applies the documented weighting', () => {
+    const value = composite({
+      tokenCost: { score: 80 },
+      caps: { score: 100 },
+      descQuality: { score: 100 },
+    });
+    // 0.5*100 + 0.3*80 + 0.2*100 = 94
+    expect(value).toBe(94);
+  });
+
+  test('weights sum to 1', () => {
+    const sum = WEIGHTS.description_quality + WEIGHTS.token_cost + WEIGHTS.caps;
+    expect(Math.round(sum * 1000) / 1000).toBe(1);
+  });
+
+  test('is an integer in 0..100', () => {
+    const value = composite({ tokenCost: { score: 33 }, caps: { score: 0 }, descQuality: { score: 61 } });
+    expect(Number.isInteger(value)).toBe(true);
+    expect(value).toBeGreaterThanOrEqual(0);
+    expect(value).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── behavioral placeholders (W5) ──────────────────────────────────────────────
+describe('behavioralPlaceholders', () => {
+  test('all behavioral params are typed null and labeled W5', () => {
+    const b = behavioralPlaceholders();
+    for (const key of ['trigger_recall', 'trigger_precision', 'disambiguation', 'chain_correctness', 'outcome_quality', 'variance']) {
+      expect(b[key]).toBeNull();
+    }
+    expect(String(b.note).toLowerCase()).toContain('w5');
+  });
+});
+
+// ── router reachability lint (B) — deterministic, uses routeSkill ─────────────
+describe('routerReachability', () => {
+  const catalog = [
+    { name: 'ship', description: 'open a pr' },
+    { name: 'dev', description: 'fix a bug' },
+    { name: 'adapter-x', description: 'internal adapter' },
+  ];
+
+  test('a fixtured skill with a curated rule and a matching fixture is reachable', () => {
+    const r = routerReachability({
+      name: 'ship',
+      fixtures: [{ query: 'open a pr for this branch', should_trigger: true }],
+      catalog,
+      hasRule: true,
+      exempt: false,
+    });
+    expect(r.has_curated_rule).toBe(true);
+    expect(r.reachable).toBe(true);
+    expect(r.fixtures_best_hit).toBeGreaterThanOrEqual(1);
+  });
+
+  test('a fixtured skill with NO rule and NOT exempt is a hard defect (unreachable)', () => {
+    const r = routerReachability({
+      name: 'adapter-x',
+      fixtures: [{ query: 'do the adapter thing', should_trigger: true }],
+      catalog,
+      hasRule: false,
+      exempt: false,
+    });
+    expect(r.has_curated_rule).toBe(false);
+    expect(r.router_exempt).toBe(false);
+    expect(r.reachable).toBe(false);
+  });
+
+  test('a skill without fixtures is marked no-fixtures, not crashed', () => {
+    const r = routerReachability({ name: 'memory', fixtures: null, catalog, hasRule: true, exempt: false });
+    expect(r.fixtures).toBe('no-fixtures');
+    expect(r.has_curated_rule).toBe(true);
+  });
+});
+
+// ── scorecard shape ──────────────────────────────────────────────────────────
+describe('buildScorecard', () => {
+  const catalog = loadSkillCatalog(repoRoot);
+
+  test('a real fixtured skill produces a complete, typed scorecard', () => {
+    const card = buildScorecard({ skillsDir, name: 'ship', catalog });
+    expect(card.skill).toBe('ship');
+    expect(card.fixtures).toBe('present');
+    expect(card.static.token_cost.score).toBeGreaterThanOrEqual(0);
+    expect(card.static.caps.score).toBe(100);
+    expect(card.static.description_quality.score).toBeGreaterThanOrEqual(DESC_QUALITY_FLOOR);
+    expect(Number.isInteger(card.composite)).toBe(true);
+    // behavioral tier is a placeholder, never fabricated
+    expect(card.behavioral.trigger_recall).toBeNull();
+  });
+
+  test('a skill WITHOUT fixtures still scores the deterministic params (no crash)', () => {
+    const card = buildScorecard({ skillsDir, name: 'using-forge', catalog });
+    expect(card.fixtures).toBe('no-fixtures');
+    expect(Number.isInteger(card.composite)).toBe(true);
+    expect(card.static.description_quality.score).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── the CI gate ────────────────────────────────────────────────────────────────
+describe('evaluateGate (CI gate)', () => {
+  const catalog = loadSkillCatalog(repoRoot);
+  const scorecards = buildAllScorecards(skillsDir, catalog);
+
+  test('every skill in the canonical library PASSES the gate today', () => {
+    const result = evaluateGate(scorecards);
+    if (!result.passed) {
+      throw new Error('Static skill-eval gate failures:\n' + result.failures.map(f => `  ${f.skill}: ${f.kind} — ${f.detail}`).join('\n'));
+    }
+    expect(result.passed).toBe(true);
+  });
+
+  test('the gate FAILS on a seeded description over the char cap', () => {
+    const seeded = { ...scorecards };
+    seeded.__seed_cap = buildSeed({ caps: { score: 0, desc_within: false, body_within: true } });
+    const result = evaluateGate(seeded);
+    expect(result.passed).toBe(false);
+    expect(result.failures.some(f => f.skill === '__seed_cap' && f.kind === 'caps')).toBe(true);
+  });
+
+  test('the gate FAILS on a seeded description-quality regression', () => {
+    const seeded = { ...scorecards };
+    seeded.__seed_dq = buildSeed({ description_quality: { score: DESC_QUALITY_FLOOR - 20 } });
+    const result = evaluateGate(seeded);
+    expect(result.passed).toBe(false);
+    expect(result.failures.some(f => f.skill === '__seed_dq' && f.kind === 'description_quality')).toBe(true);
+  });
+
+  test('the gate FAILS on a fixtured skill the router can never reach', () => {
+    const seeded = { ...scorecards };
+    seeded.__seed_unreachable = buildSeed({
+      router_reachability: { has_curated_rule: false, router_exempt: false, fixtures: 'present', reachable: false },
+    });
+    const result = evaluateGate(seeded);
+    expect(result.passed).toBe(false);
+    expect(result.failures.some(f => f.skill === '__seed_unreachable' && f.kind === 'router_unreachable')).toBe(true);
+  });
+
+  test('a fixtured skill with a rule but zero keyword-covered fixtures is a WARNING, not a hard fail', () => {
+    const seeded = { ...scorecards };
+    seeded.__seed_softmiss = buildSeed({
+      router_reachability: { has_curated_rule: true, router_exempt: false, fixtures: 'present', reachable: false },
+    });
+    const result = evaluateGate(seeded);
+    // reachable:false with a rule present is the paraphrase-vs-keyword gap (W5's job): a warning only.
+    expect(result.failures.some(f => f.skill === '__seed_softmiss' && f.kind === 'router_unreachable')).toBe(false);
+    expect(result.warnings.some(w => w.skill === '__seed_softmiss')).toBe(true);
+  });
+});
+
+// A minimal, fully-passing scorecard, with a targeted field override for seeding regressions.
+function buildSeed(overrides = {}) {
+  const base = {
+    skill: 'seed',
+    fixtures: 'present',
+    static: {
+      token_cost: { desc_chars: 100, body_lines: 50, score: 90 },
+      caps: { desc_within: true, body_within: true, score: 100 },
+      description_quality: { has_trigger_cues: true, has_disambiguation_cues: true, adequate_length: true, score: 100 },
+    },
+    router_reachability: { has_curated_rule: true, router_exempt: false, fixtures: 'present', reachable: true, fixtures_total: 1, fixtures_best_hit: 1 },
+    behavioral: behavioralPlaceholders(),
+    composite: 95,
+  };
+  if (overrides.caps) base.static.caps = { ...base.static.caps, ...overrides.caps };
+  if (overrides.description_quality) base.static.description_quality = { ...base.static.description_quality, ...overrides.description_quality };
+  if (overrides.router_reachability) base.router_reachability = { ...base.router_reachability, ...overrides.router_reachability };
+  return base;
+}
+
+// ── committed-artifact drift ──────────────────────────────────────────────────
+describe('committed scorecards stay fresh', () => {
+  const catalog = loadSkillCatalog(repoRoot);
+
+  test('each skill has a committed scorecard.json equal to the recomputed one', () => {
+    const drifted = [];
+    const names = fs
+      .readdirSync(skillsDir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')))
+      .map(e => e.name);
+    for (const name of names) {
+      const cardPath = path.join(skillsDir, name, 'evals', 'scorecard.json');
+      if (!fs.existsSync(cardPath)) { drifted.push(`${name}: missing scorecard.json`); continue; }
+      const committed = JSON.parse(fs.readFileSync(cardPath, 'utf8'));
+      const recomputed = buildScorecard({ skillsDir, name, catalog });
+      if (JSON.stringify(committed) !== JSON.stringify(recomputed)) {
+        drifted.push(`${name}: scorecard.json out of date — run \`forge skill eval --static\``);
+      }
+    }
+    if (drifted.length) throw new Error('Scorecard drift:\n' + drifted.map(d => '  ' + d).join('\n'));
+    expect(drifted).toEqual([]);
+  });
+});
+
+// ── parseSkillSource matches the context-cost parser ──────────────────────────
+describe('parseSkillSource', () => {
+  test('parses a temp SKILL.md into description + body-line count', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-eval-'));
+    const sdir = path.join(dir, 'skills', 'demo');
+    fs.mkdirSync(sdir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sdir, 'SKILL.md'),
+      '---\nname: demo\ndescription: Use when demoing. NOT real.\n---\nbody line 1\nbody line 2\n'
+    );
+    const parsed = parseSkillSource(path.join(dir, 'skills'), 'demo');
+    expect(parsed.name).toBe('demo');
+    expect(parsed.description).toContain('Use when demoing');
+    expect(parsed.bodyLines).toBeGreaterThanOrEqual(2);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/test/structural/skills-sync-drift.test.js
+++ b/test/structural/skills-sync-drift.test.js
@@ -93,5 +93,5 @@ describe('all harness skill dirs render from canonical source', () => {
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
-  });
+  }, 20000); // 20s budget: regenerates 5 harness mirrors × every skill dir — slow on Windows I/O.
 });

--- a/test/using-forge.test.js
+++ b/test/using-forge.test.js
@@ -78,6 +78,15 @@ describe('using-forge router (forge skill for)', () => {
     expect(routeSkill('please review this commit', { catalog }).unknown).toBe(true);
   });
 
+  test('hermes-forge is Hermes-SCOPED: generic orientation stays with kernel/status, not hermes-forge', () => {
+    // hermes-forge keywords are Hermes-specific only, so a normal user's generic orientation
+    // request must NOT route to the Hermes-scoped skill (kernel owns general "orient").
+    expect(routeSkill('orient me', { catalog }).best).not.toBe('hermes-forge');
+    expect(routeSkill('orient me on this project', { catalog }).best).not.toBe('hermes-forge');
+    // A genuinely Hermes-specific phrase still reaches hermes-forge.
+    expect(routeSkill('starting a Hermes session on this Forge repo', { catalog }).best).toBe('hermes-forge');
+  });
+
   test('every routable catalog skill has a curated route (no silent drops as skills are added)', () => {
     // Meta skills are intentionally not route targets: the dispatch skill itself and the harness adapter.
     const META = new Set(['using-forge', 'hermes-forge']);

--- a/test/using-forge.test.js
+++ b/test/using-forge.test.js
@@ -80,9 +80,15 @@ describe('using-forge router (forge skill for)', () => {
 
   test('hermes-forge is Hermes-SCOPED: generic orientation stays with kernel/status, not hermes-forge', () => {
     // hermes-forge keywords are Hermes-specific only, so a normal user's generic orientation
-    // request must NOT route to the Hermes-scoped skill (kernel owns general "orient").
-    expect(routeSkill('orient me', { catalog }).best).not.toBe('hermes-forge');
-    expect(routeSkill('orient me on this project', { catalog }).best).not.toBe('hermes-forge');
+    // request must NOT route to the Hermes-scoped skill (kernel owns general "orient"). Assert the
+    // POSITIVE target (kernel) and a KNOWN route — a bare `not.toBe('hermes-forge')` passes vacuously
+    // when routing returns no match at all, so it would not catch a regression to unknown.
+    const orient = routeSkill('orient me', { catalog });
+    expect(orient.unknown).toBe(false);
+    expect(orient.best).toBe('kernel');
+    const orientProject = routeSkill('orient me on this project', { catalog });
+    expect(orientProject.unknown).toBe(false);
+    expect(orientProject.best).toBe('kernel');
     // A genuinely Hermes-specific phrase still reaches hermes-forge.
     expect(routeSkill('starting a Hermes session on this Forge repo', { catalog }).best).toBe('hermes-forge');
   });


### PR DESCRIPTION
## What

Wave 3 of the skills-system initiative: a **DETERMINISTIC, free, CI-gateable** static skill-eval tier that scores every skill by parameter so low performers surface and can be improved. Kernel issue `forge-skill-eval-static-cd00189d`.

New surface under the existing `forge skill` noun (no new top-level verbs):
- `forge skill eval [name] --static [--json]` — computes + writes `skills/<name>/evals/scorecard.json` (all skills if no name).
- `forge skill scores [--json]` — worst-first league table + CI-gate state.

## Parameters + composite (deterministic only)

- **token_cost** — description chars + body lines, normalized against the caps (lower is better).
- **caps** — compliance with the desc≤1024 / body≤500 progressive-disclosure budget (`plan` body allowlisted, mirroring the context-cost gate).
- **description_quality** — the PR #292 pattern: explicit trigger phrases + disambiguation cues + adequate length.

**composite = 0.5·description_quality + 0.3·token_cost + 0.2·caps** → integer 0–100.

## Behavioral tier is W5 (design fork, decided)

TRUE trigger recall/precision is inherently **semantic**: `evals.json` fixtures are natural paraphrases, and the W1 router is a curated-**keyword** matcher. Measured mean recall **0.32** over 19 fixtured skills (5 at 0.0) — so a static recall metric would score keyword overlap, not skill quality. `trigger_recall`, `trigger_precision`, `disambiguation`, `chain_correctness`, `outcome_quality`, `variance` are therefore **typed null placeholders labeled "behavioral — W5 (LLM judge)"**. Rationale recorded in kernel issue `71955c70`.

## CI gate (how scores become enforceable)

`test/skill-eval.test.js` recomputes scorecards from source and **hard-fails** on:
- a description over the 1024 cap or a non-allowlisted body over 500 (**caps**);
- **description_quality** below the floor (60);
- a **router-unreachable** fixtured skill — no curated `INTENT_RULES` rule and not router-exempt (a real defect: unreachable via `forge skill for`);
- committed-scorecard **drift** (artifact must be regenerated).

Seeded-regression tests prove each failure path fires. A skill that *has* a rule but whose paraphrase fixtures miss its keywords is a **warning only** (that gap is what the W5 judge fixes), surfaced in `forge skill scores`.

## Also

- Added a curated `INTENT_RULES` rule so the deterministic router can reach **hermes-forge** (it has real Hermes-session trigger fixtures); the `ROUTER_EXEMPT` mechanism is retained for future internal adapters.
- Regenerated the committed `.agents/skills` mirror.

## Current worst-3 (improvement targets)

`plan` (51), `validate` (56), `research` (60) — all driven by higher token cost / missing explicit trigger phrasing, not caps violations.

## Verification

- Broad suite green: **1363 pass / 0 fail / 31 skip** across 114 files (skills + structural + using-forge + release-readiness + commands + registry + dispatch-parity).
- eslint `--max-warnings 0` clean; tdd-check + protected-state pass.
- 2 of 21 skills lack fixtures (`memory`, `using-forge`) — scored on the deterministic params, trigger metrics marked `no-fixtures` (no fabrication); fixture data-fill tracked in `skill-eval-data-fill-af9dac5d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `forge skill eval` to generate deterministic per-skill scorecards (with `--json`).
  - Added `forge skill scores` to rebuild scorecards, show worst-first rankings, and report a CI-gate PASS/FAIL (with optional `--json`).
  - Added `--static` to score only the deterministic tier.
  - Improved routing so Hermes-specific requests can match the `hermes-forge` skill.
- **Documentation**
  - Added evaluation scorecards (static metrics plus LLM-judge behavioral placeholders) for many skills.
- **Tests**
  - Expanded automated coverage for scoring, gates, drift detection, CLI behavior, and harness sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->