### PR TITLE
fix(shepherd): required-checks fallback to rollup isRequired — verdict label works from CI (20beb77f)

### DIFF
--- a/.github/workflows/pr-monitor.yml
+++ b/.github/workflows/pr-monitor.yml
@@ -196,21 +196,38 @@ jobs:
             VERDICT=UNKNOWN
           fi
           [ -z "$VERDICT" ] && VERDICT=UNKNOWN
+          # Carry the unreadable-signal list forward so the sticky/label step can
+          # name WHICH signal was unreadable (default [] when pull.json is absent).
+          UNREADABLE=$(jq -c '.evidence.unreadable // []' pull.json 2>/dev/null || echo '[]')
+          [ -z "$UNREADABLE" ] && UNREADABLE='[]'
           echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+          echo "unreadable=$UNREADABLE" >> "$GITHUB_OUTPUT"
           echo "Merge verdict: $VERDICT"
+          # NAME the failure: an UNKNOWN verdict is fail-closed but silent by
+          # default. Emit a WARNING (never a red-X — the no-non-success-check design
+          # is deliberate) that says which signal(s) were unreadable, so a
+          # permanent-UNKNOWN regression can't hide again.
+          if [ "$VERDICT" = "UNKNOWN" ]; then
+            echo "::warning::verdict UNKNOWN — unreadable: $UNREADABLE"
+          fi
 
       - name: Render sticky comment body
         if: steps.resolve.outputs.should_run == 'true'
         env:
           VERDICT: ${{ steps.pullverdict.outputs.verdict }}
+          UNREADABLE: ${{ steps.pullverdict.outputs.unreadable }}
         run: |
           set -euo pipefail
           # Pass the --pull verdict into the renderer so the sticky leads with the
           # SAME verdict as the pr-verdict:* label (render-sticky only displays it).
+          # Also pass the unreadable-signal list so an UNKNOWN verdict on the PR
+          # always says WHICH signal was unreadable (never a bare `unknown`).
           node -e '
             const { renderStickyComment } = require("./lib/pr-monitor/render-sticky");
             const bundle = JSON.parse(require("fs").readFileSync("bundle.json", "utf8"));
-            const { body } = renderStickyComment(bundle, { verdict: process.env.VERDICT });
+            let unreadable = [];
+            try { unreadable = JSON.parse(process.env.UNREADABLE || "[]"); } catch { unreadable = []; }
+            const { body } = renderStickyComment(bundle, { verdict: process.env.VERDICT, unreadable });
             require("fs").writeFileSync("monitor-body.md", body);
           '
           # jq -Rs slurps the raw markdown into a JSON string for the comment API.

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -127,17 +127,59 @@ class PrStateAdapter {
   }
 
   /**
-   * Read the branch-protection required-checks set.
+   * Read the required-checks set for a PR, with a two-source strategy so the
+   * verdict is not permanently UNKNOWN in CI.
    *
-   * Returns `null` when the protection endpoint is unreadable (e.g. 403
-   * insufficient scope, the branch is not protected, or the payload shape is
-   * unexpected) so the caller can escalate rather than guess. Re-throws non-auth
-   * errors.
+   * 1. **Branch protection** (`.../protection/required_status_checks`) — the
+   *    authoritative set, but this REST endpoint needs repo `Administration:read`,
+   *    which GitHub Actions' `GITHUB_TOKEN` can NEVER hold (administration is not a
+   *    grantable `permissions:` scope). So in CI this ALWAYS 403/404s and the set
+   *    was permanently null → verdict UNKNOWN on every PR.
+   * 2. **statusCheckRollup `isRequired`** (GraphQL, on the PR head commit) — the
+   *    fallback. It is readable with the plain PR-read scope the Actions token DOES
+   *    hold (it is what `gh pr checks --required` uses) and it covers BOTH classic
+   *    branch protection AND repository rulesets.
    *
-   * @param {{ owner: string, repo: string, base: string }} ctx
+   * Known limitation of the fallback: the rollup only lists contexts that
+   * PRODUCED a run, so a required context that never ran at all is invisible on
+   * this path — missing-required detection is best-effort when the source is the
+   * rollup. That is strictly better than a permanent UNKNOWN.
+   *
+   * Returns `null` only when BOTH sources are unreadable (existing fail-closed
+   * behaviour). `lastRequiredSource` records which source answered
+   * (`'protection'` | `'rollup'` | `null`) so callers can surface it as evidence.
+   * Re-throws non-auth protection errors (unchanged).
+   *
+   * @param {{ owner: string, repo: string, base: string, pr?: string|number }} ctx
    * @returns {Promise<string[] | null>}
    */
-  async readRequiredChecks({ owner, repo, base }) {
+  async readRequiredChecks({ owner, repo, base, pr }) {
+    this.lastRequiredSource = null;
+    const fromProtection = this._readProtectionRequired({ owner, repo, base });
+    if (Array.isArray(fromProtection)) {
+      this.lastRequiredSource = 'protection';
+      return fromProtection;
+    }
+    // Protection unreadable (auth/scope/not-protected/unexpected shape) — fall back
+    // to the rollup `isRequired` set the Actions token CAN read.
+    const fromRollup = this._readRollupRequired({ owner, repo, pr });
+    if (Array.isArray(fromRollup)) {
+      this.lastRequiredSource = 'rollup';
+      return fromRollup;
+    }
+    return null;
+  }
+
+  /**
+   * Branch-protection required set, or `null` when unreadable (auth/scope/
+   * not-protected/unexpected shape). Re-throws non-auth errors so a genuine
+   * outage is not silently masked. Split out so `readRequiredChecks` can fall
+   * back cleanly.
+   *
+   * @param {{ owner: string, repo: string, base: string }} ctx
+   * @returns {string[] | null}
+   */
+  _readProtectionRequired({ owner, repo, base }) {
     const apiPath = `repos/${owner}/${repo}/branches/${encodeURIComponent(base)}/protection/required_status_checks`;
     try {
       const raw = this._gh('gh', ['api', apiPath]);
@@ -150,10 +192,60 @@ class PrStateAdapter {
     } catch (error) {
       const auth = classifyAuthError(error);
       if (auth) {
-        // Unreadable protection (auth/scope/not-protected) — caller escalates.
+        // Unreadable protection (auth/scope/not-protected) — fall back to rollup.
         return null;
       }
       throw error;
+    }
+  }
+
+  /**
+   * Fallback required set from the PR head commit's `statusCheckRollup`, reading
+   * per-context `isRequired(pullRequestNumber:)` via GraphQL. Readable with plain
+   * PR-read scope (unlike branch protection). Returns the deduped names of every
+   * required CheckRun/StatusContext, `[]` when the rollup is readable but nothing
+   * is required, or `null` when the rollup itself is unreadable (fail-closed).
+   *
+   * @param {{ owner: string, repo: string, pr?: string|number }} ctx
+   * @returns {string[] | null}
+   */
+  _readRollupRequired({ owner, repo, pr }) {
+    const prNum = Number.parseInt(String(pr), 10);
+    if (!Number.isInteger(prNum) || prNum <= 0) return null;
+    // pr is inlined as a validated integer (no injection); owner/repo are GitHub
+    // name-charset identifiers. Shape verified against the live GraphQL API.
+    const query = `query { repository(owner: "${owner}", name: "${repo}") { `
+      + `pullRequest(number: ${prNum}) { headRef { target { ... on Commit { `
+      + `statusCheckRollup { contexts(first: 100) { nodes { __typename `
+      + `... on CheckRun { name isRequired(pullRequestNumber: ${prNum}) } `
+      + `... on StatusContext { context isRequired(pullRequestNumber: ${prNum}) } `
+      + `} } } } } } } } }`;
+    try {
+      const raw = this._gh('gh', ['api', 'graphql', '-f', `query=${query}`]);
+      const data = JSON.parse(raw || '{}');
+      const nodes = data
+        && data.data
+        && data.data.repository
+        && data.data.repository.pullRequest
+        && data.data.repository.pullRequest.headRef
+        && data.data.repository.pullRequest.headRef.target
+        && data.data.repository.pullRequest.headRef.target.statusCheckRollup
+        && data.data.repository.pullRequest.headRef.target.statusCheckRollup.contexts
+        && data.data.repository.pullRequest.headRef.target.statusCheckRollup.contexts.nodes;
+      // No rollup at all (e.g. statusCheckRollup null) → cannot determine the set.
+      if (!Array.isArray(nodes)) return null;
+      const required = [];
+      for (const node of nodes) {
+        if (node && node.isRequired === true) {
+          const name = node.name || node.context;
+          if (name) required.push(name);
+        }
+      }
+      // Dedupe matrix duplicates (same context reported by multiple jobs).
+      return [...new Set(required)];
+    } catch {
+      // GraphQL unreadable (auth/network/etc.) — fail closed to null.
+      return null;
     }
   }
 

--- a/lib/pr-bundle.js
+++ b/lib/pr-bundle.js
@@ -145,8 +145,9 @@ async function gatherPrBundle({ pr, owner, repo, base, baseRef, cwd, adapter }) 
   const state = await adapter.readState(pr);
   // NOTE: required-check lookup needs the base BRANCH name (`base`), not the
   // remote ref (`baseRef`); passing the ref builds a bad protection path and
-  // silently yields a null required set.
-  const requiredRaw = await adapter.readRequiredChecks({ owner, repo, base });
+  // silently yields a null required set. `pr` lets the adapter fall back to the
+  // rollup `isRequired` set when branch protection is unreadable in CI.
+  const requiredRaw = await adapter.readRequiredChecks({ owner, repo, base, pr });
   const divergence = await adapter.readDivergence({ baseRef, cwd });
   const comments = await gatherUnresolvedComments(adapter, { owner, repo, pr });
   const conflicts = await gatherConflicts(adapter, { baseRef, cwd });
@@ -171,6 +172,9 @@ async function gatherPrBundle({ pr, owner, repo, base, baseRef, cwd, adapter }) 
       state: String(state.state || 'OPEN').toUpperCase(),
     },
     ci: buildCi(state.checks, requiredSet),
+    // Which source answered the required-checks read (`protection` | `rollup` |
+    // null) — `rollup` is the CI path where branch protection is unreadable.
+    requiredSource: adapter.lastRequiredSource || null,
     branch: {
       ahead: divergence.ahead || 0,
       behind: divergence.behind || 0,

--- a/lib/pr-monitor/render-sticky.js
+++ b/lib/pr-monitor/render-sticky.js
@@ -147,6 +147,10 @@ function renderChecks(bundle, lines) {
  * @param {object} bundle - a `gatherPrBundle` result (lib/pr-bundle.js).
  * @param {object} [opts]
  * @param {Date}   [opts.now] - injected clock for deterministic output.
+ * @param {string} [opts.verdict] - the canonical `--pull` verdict.
+ * @param {string[]} [opts.unreadable] - unreadable signal names (from the `--pull`
+ *   evidence). Surfaced when the verdict is UNKNOWN so the sticky always says WHICH
+ *   signal could not be read, not just a bare `unknown`.
  * @returns {{ marker: string, body: string }}
  */
 function renderStickyComment(bundle = {}, opts = {}) {
@@ -163,6 +167,16 @@ function renderStickyComment(bundle = {}, opts = {}) {
   // by pr-pull). Surface only: it labels state; this monitor **does not merge**
   // and never resolves review threads.
   lines.push(verdictHeadline(opts.verdict));
+  // An `unknown` verdict is useless without the WHY — name the unreadable
+  // signal(s) so a human/agent knows what to fix (e.g. `requiredChecks` when both
+  // branch-protection AND the rollup fallback could not be read).
+  const verdictUpper = String(opts.verdict || '').toUpperCase();
+  const isUnknown = verdictUpper === 'UNKNOWN' || !VERDICT_HEADLINE[verdictUpper];
+  const unreadable = Array.isArray(opts.unreadable) ? opts.unreadable.filter(Boolean) : [];
+  if (isUnknown && unreadable.length > 0) {
+    lines.push('');
+    lines.push(`> Unreadable signal(s): ${unreadable.map((s) => `\`${s}\``).join(', ')}.`);
+  }
   lines.push('');
   lines.push('_Surfaces open review + check state so async feedback never rots. This monitor **does not merge** and never resolves review threads — a human merges in the GitHub UI._');
   lines.push('');

--- a/lib/pr-pull.js
+++ b/lib/pr-pull.js
@@ -1093,7 +1093,9 @@ async function gatherPrSnapshot(ctx) {
   const state = await adapter.readState(pr);
   const requiredSet = await safeRead(
     'requiredChecks',
-    () => adapter.readRequiredChecks({ owner, repo, base }),
+    // `pr` lets the adapter fall back to the rollup `isRequired` set when branch
+    // protection is unreadable (the Actions token can't read protection).
+    () => adapter.readRequiredChecks({ owner, repo, base, pr }),
     { degraded, fallback: null },
   );
 
@@ -1194,6 +1196,11 @@ async function gatherPrSnapshot(ctx) {
     settleWindowMs: ctx.settleWindowMs,
     unreadable,
   });
+
+  // Record which source answered the required-checks read (`protection` |
+  // `rollup` | null) so the source is visible in the verdict evidence — the
+  // rollup source is the CI path where branch protection is unreadable.
+  evidence.requiredSource = adapter.lastRequiredSource || null;
 
   return {
     state, requiredSet, threads, behind, conflicts, issueComments,

--- a/test/pr-monitor/render-sticky.test.js
+++ b/test/pr-monitor/render-sticky.test.js
@@ -38,6 +38,19 @@ describe('renderStickyComment', () => {
     expect(body.startsWith(STICKY_MARKER)).toBe(true);
   });
 
+  test('an UNKNOWN verdict names which signal(s) were unreadable', () => {
+    // A bare `unknown` verdict is useless on the PR — the sticky must say WHICH
+    // signal was unreadable so a human/agent knows what to fix (the fallback's
+    // whole point is that requiredChecks should no longer be permanently unknown).
+    const { body } = renderStickyComment(makeBundle(), {
+      now: NOW,
+      verdict: 'UNKNOWN',
+      unreadable: ['requiredChecks'],
+    });
+    expect(body).toContain('requiredChecks');
+    expect(body).toMatch(/[Uu]nreadable/);
+  });
+
   test('groups unresolved threads BY AUTHOR across all authors (agnostic)', () => {
     const bundle = makeBundle({
       unresolvedComments: [

--- a/test/pr-pull.test.js
+++ b/test/pr-pull.test.js
@@ -227,6 +227,20 @@ describe('classifyRequiredChecks (required-vs-produced)', () => {
     const out = classifyRequiredChecks([green('Lint')], null);
     expect(out.unreadable).toBe(true);
   });
+
+  test('a rollup-sourced required set (isRequired fallback) still flags failing/pending', () => {
+    // The fallback returns the SAME string[] shape as branch protection, so the
+    // required-vs-produced classification is source-agnostic — a set recovered
+    // from statusCheckRollup.isRequired classifies identically to a protection set.
+    const requiredFromRollup = ['Cross-OS Gate', 'Run eslint scanning'];
+    const out = classifyRequiredChecks(
+      [fail('Cross-OS Gate'), running('Run eslint scanning')],
+      requiredFromRollup,
+    );
+    expect(out.failing).toEqual(['Cross-OS Gate']);
+    expect(out.pending).toEqual(['Run eslint scanning']);
+    expect(out.unreadable).toBe(false);
+  });
 });
 
 describe('pendingCheckNames', () => {

--- a/test/pr-state-adapter.test.js
+++ b/test/pr-state-adapter.test.js
@@ -41,6 +41,33 @@ const PR_VIEW_JSON = JSON.stringify({
 
 const REQUIRED_CHECKS_JSON = JSON.stringify({ contexts: ['unit', 'lint'] });
 
+// A statusCheckRollup GraphQL payload with per-context `isRequired` — the shape
+// `gh api graphql` returns and the fallback path reads when branch-protection is
+// unreadable by the Actions token. Includes a StatusContext, a non-required
+// CheckRun, and a matrix duplicate (must dedupe to ['unit', 'deploy/ok']).
+const ROLLUP_REQUIRED_JSON = JSON.stringify({
+  data: {
+    repository: {
+      pullRequest: {
+        headRef: {
+          target: {
+            statusCheckRollup: {
+              contexts: {
+                nodes: [
+                  { __typename: 'CheckRun', name: 'unit', isRequired: true },
+                  { __typename: 'CheckRun', name: 'optional-bench', isRequired: false },
+                  { __typename: 'StatusContext', context: 'deploy/ok', isRequired: true },
+                  { __typename: 'CheckRun', name: 'unit', isRequired: true },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
 describe('PrStateAdapter', () => {
   test('satisfies the pr-state adapter contract', () => {
     const { run } = makeRunner([]);
@@ -114,6 +141,51 @@ describe('PrStateAdapter', () => {
     const result = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master' });
 
     expect(result).toBeNull(); // null = "cannot determine required set"
+  });
+
+  test('readRequiredChecks falls back to rollup isRequired when protection is unreadable (403)', async () => {
+    // The real bug: the Actions GITHUB_TOKEN can NEVER read branch protection
+    // (admin scope), so protection 403s in CI and the required set was permanently
+    // null → verdict UNKNOWN. The rollup `isRequired` fallback is readable with the
+    // plain PR-read scope the Actions token DOES hold.
+    const err = new Error('403');
+    err.stderr = 'HTTP 403: Resource not accessible by integration';
+    const { run } = makeRunner([
+      ['protection/required_status_checks', () => { throw err; }],
+      ['api graphql', ROLLUP_REQUIRED_JSON],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const required = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master', pr: '419' });
+
+    // Only required contexts, deduped across matrix duplicates, from both node types.
+    expect(required).toEqual(['unit', 'deploy/ok']);
+    expect(adapter.lastRequiredSource).toBe('rollup');
+  });
+
+  test('readRequiredChecks stamps requiredSource=protection when protection is readable', async () => {
+    const { run } = makeRunner([
+      ['protection/required_status_checks', REQUIRED_CHECKS_JSON],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const required = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master', pr: '419' });
+
+    // Unchanged behaviour on the readable path — no rollup call, source = protection.
+    expect(required).toEqual(['unit', 'lint']);
+    expect(adapter.lastRequiredSource).toBe('protection');
+  });
+
+  test('readRequiredChecks returns null (fail-closed) when BOTH protection and rollup are unreadable', async () => {
+    const err = new Error('403');
+    err.stderr = 'HTTP 403: Resource not accessible by integration';
+    const { run } = makeRunner([
+      ['protection/required_status_checks', () => { throw err; }],
+      ['api graphql', () => { throw new Error('graphql boom'); }],
+    ]);
+    const adapter = new PrStateAdapter({ gh: run, git: run });
+    const result = await adapter.readRequiredChecks({ owner: 'o', repo: 'r', base: 'master', pr: '419' });
+
+    expect(result).toBeNull();
+    expect(adapter.lastRequiredSource).toBeNull();
   });
 
   test('readDivergence parses git rev-list --left-right --count as { behind, ahead }', async () => {


### PR DESCRIPTION
## Root cause (proven from run 29684610892)

The pr-monitor auto-workflow's `pr-verdict:*` label was **permanently stuck at `pr-verdict:unknown` on every PR**.

`lib/adapters/pr-state-adapter.js` `readRequiredChecks` read the branch-protection REST endpoint `repos/{o}/{r}/branches/{base}/protection/required_status_checks`. That endpoint requires repo **Administration:read** — a scope GitHub Actions' `GITHUB_TOKEN` can **never** hold (administration is not a grantable `permissions:` scope; `pr-monitor.yml` grants only contents/PR/checks/actions). In CI it always 403/404s → `requiredSet=null` → `classifyRequiredChecks` `unreadable:true` → `rankUnknown` → verdict **UNKNOWN**, exit 0, silent. Locally an admin token succeeds, so `--pull` looked fine on a dev machine — a 100%-reproducible permission bug hidden by silent fail-closed.

## The fallback (real fix)

When branch protection is unreadable (auth/scope/not-protected/unexpected shape), `readRequiredChecks` now falls back to the PR **head commit's `statusCheckRollup` `isRequired(pullRequestNumber:)`** via GraphQL — readable with the plain PR-read scope the Actions token **does** hold (it is what `gh pr checks --required` uses), and it covers **both** classic branch protection **and** repository rulesets. Only if **both** sources fail → `null` (existing fail-closed behavior unchanged). `lastRequiredSource` (`protection` | `rollup` | null) is stamped into the verdict `evidence.requiredSource` and the bundle so the source is visible.

GraphQL shape **verified against the live API** (PR #419) before encoding. Known limit noted in-code: the rollup can't see a required context that never produced a run, so missing-required detection is best-effort on that path — strictly better than a permanent UNKNOWN.

## Named-failure hardening

- **`pr-monitor.yml`**: when `VERDICT=UNKNOWN`, emit `::warning::verdict UNKNOWN — unreadable: <list>` (never a red-X — the no-non-success-check design at the top of the job is deliberate) so a permanent-UNKNOWN regression can't hide silently again.
- **`render-sticky.js`**: the unreadable-signal list is threaded through so an `unknown` verdict on the PR always says **which** signal was unreadable.

## Tests (TDD, failing-first)

- Adapter: protection 403 + rollup success → rollup contexts + `requiredSource:'rollup'`; protection success → unchanged + `requiredSource:'protection'`; both fail → `null` (fail-closed).
- `classifyRequiredChecks` with a rollup-sourced set still flags failing/pending (source-agnostic).
- `render-sticky` names the unreadable signal when the verdict is unknown.

Broad suite green: pr-monitor + pr-pull + pr-bundle + adapter/validator + shepherd + release-readiness + structural (508 tests). eslint `--max-warnings 0` clean; tdd-check clean.

## Acceptance criterion

After merge, pr-monitor on the next PR event must print `Merge verdict: <real>` and flip the `pr-verdict:*` label off `unknown`.

Kernel issue: 20beb77f

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback handling for required checks when branch protection data cannot be read.
  * Pull request monitor results now indicate which source provided required-check information.
  * Unknown verdicts can now identify the specific signals that were unreadable.

* **Bug Fixes**
  * Improved required-check evaluation in restricted-access or unavailable-data scenarios.

* **Tests**
  * Added coverage for fallback behavior, unreadable signals, deduplication, and unknown verdict messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->