### PR TITLE
fix(shepherd): windowsHide on background/detached child processes (931e7924)

### DIFF
--- a/lib/adapters/greptile-review-adapter.js
+++ b/lib/adapters/greptile-review-adapter.js
@@ -86,7 +86,7 @@ function matchThreadsToCommitsWithGit(threads, projectRoot, opts = {}) {
   }
 
   const exec = opts._exec || ((cmd, args) => {
-    return execFileSync(cmd, args, { encoding: 'utf8' });
+    return execFileSync(cmd, args, { encoding: 'utf8', windowsHide: true });
   });
 
   let sinceCommit = opts.sinceCommit;

--- a/lib/adapters/pr-state-adapter.js
+++ b/lib/adapters/pr-state-adapter.js
@@ -78,9 +78,12 @@ class PrStateAdapter {
     this.id = options.id || 'pr-state-adapter';
     this.kind = 'pr-state';
     this.name = options.name || this.id;
+    // windowsHide keeps the shepherd's per-poll gh/git calls from flashing a
+    // console window on Windows when the watcher runs detached (issue 931e7924).
     const defaultRunner = (cmd, args, opts = {}) => execFileSync(cmd, args, {
       encoding: 'utf8',
       timeout: options.timeout || 30000,
+      windowsHide: true,
       ...(opts.cwd ? { cwd: opts.cwd } : {}),
     });
     this._gh = options.gh || defaultRunner;

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -240,7 +240,7 @@ async function routeMutation(verb, args, projectRoot, deps = {}) {
 function defaultGenerate(projectRoot, dashboardDir) {
   return new Promise((resolve, reject) => {
     const script = path.join(dashboardDir, 'generate-snapshot.mjs');
-    const child = spawn(process.execPath, [script], { cwd: projectRoot, stdio: 'ignore' });
+    const child = spawn(process.execPath, [script], { cwd: projectRoot, stdio: 'ignore', windowsHide: true });
     const timer = setTimeout(() => { child.kill(); reject(new Error('snapshot generation timed out')); }, GEN_TIMEOUT_MS);
     child.on('error', (err) => { clearTimeout(timer); reject(err); });
     child.on('exit', (code) => {
@@ -441,7 +441,10 @@ function browserOpener() {
 function openBrowser(url) {
   try {
     const { file, args } = browserOpener();
-    const child = spawn(file, [...args, url], { detached: true, stdio: 'ignore' });
+    // windowsHide keeps this detached opener from flashing a console window on
+    // Windows (Node defaults windowsHide to false); background/detached spawns
+    // must stay silent (issue 931e7924).
+    const child = spawn(file, [...args, url], { detached: true, stdio: 'ignore', windowsHide: true });
     // spawn() failures (e.g. the opener binary is missing) surface ASYNChronously
     // as an 'error' event, NOT via the try/catch — an unhandled one would crash
     // `forge serve`. Opening a browser is best-effort; swallow it (URL is printed).

--- a/lib/commands/shepherd.js
+++ b/lib/commands/shepherd.js
@@ -43,7 +43,14 @@ const { autoShepherdRailEnabled } = require('./ship');
 
 const DEFAULT_RERUN_BUDGET = 3;
 
-const defaultGhRunner = (cmd, a) => execFileSync(cmd, a, { encoding: 'utf8', timeout: 30000 });
+// windowsHide: true on EVERY spawn here is load-bearing, not cosmetic. The
+// shepherd watcher runs detached in the background and re-polls every ~60s; on
+// Windows a child process spawned WITHOUT windowsHide flashes a visible console
+// window each time (Node's default is windowsHide:false). Background work's
+// preferred home is the harness's managed shell (hidden + reaped); a
+// Forge-spawned detached watcher is the no-session fallback and must be
+// COMPLETELY silent — no console window, ever. See kernel issue 931e7924.
+const defaultGhRunner = (cmd, a) => execFileSync(cmd, a, { encoding: 'utf8', timeout: 30000, windowsHide: true });
 
 /**
  * Resolve owner/repo and base branch for the shepherd pass.
@@ -282,7 +289,7 @@ function wireSignals() {
 function defaultListOpenPrs(exec = execFileSync) {
   try {
     const out = exec('gh', ['pr', 'list', '--state', 'open', '--json', 'number', '-q', '.[].number'], {
-      encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true,
     });
     return String(out)
       .split(/\r?\n/)
@@ -408,7 +415,7 @@ async function handler(args, _flags, projectRoot, deps = {}) {
     return { success: false, error: 'Usage: forge shepherd <pr> [--auto-rebase] [--bundle --json] [--pull --json]' };
   }
 
-  const gh = deps.gh || ((cmd, a) => execFileSync(cmd, a, { encoding: 'utf8', timeout: 30000 }));
+  const gh = deps.gh || ((cmd, a) => execFileSync(cmd, a, { encoding: 'utf8', timeout: 30000, windowsHide: true }));
   const git = deps.git || gh;
   const buildContext = deps.buildContext || defaultBuildContext;
   const runPass = deps.runPass || runShepherdPass;

--- a/lib/pr-monitor/upsert-sticky.js
+++ b/lib/pr-monitor/upsert-sticky.js
@@ -88,7 +88,7 @@ async function upsertStickyComment({ marker }, client) {
 // one annotation here covers every call site. `encoding: 'utf8'` also pipes
 // stderr onto the thrown error, so isAlreadyGone() below can classify failures.
 function runGh(args) {
-  return execFileSync('gh', args, { encoding: 'utf8' }); // NOSONAR S4036 - hardcoded CLI (gh), args array (no shell), developer-tool context
+  return execFileSync('gh', args, { encoding: 'utf8', windowsHide: true }); // NOSONAR S4036 - hardcoded CLI (gh), args array (no shell), developer-tool context. windowsHide: sticky upsert runs in the detached watcher (issue 931e7924).
 }
 
 /**

--- a/lib/pr-monitor/watch-lifecycle.js
+++ b/lib/pr-monitor/watch-lifecycle.js
@@ -35,7 +35,7 @@ function forgeBin() {
 function defaultResolveSlug({ cwd, exec = execFileSync }) {
   try {
     const url = exec('git', ['remote', 'get-url', 'origin'], {
-      cwd, encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'],
+      cwd, encoding: 'utf8', timeout: 3000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true,
     }).trim();
     const match = /[/:][^/]+\/([^/]+?)(?:\.git)?$/.exec(url);
     return match ? match[1] : null;

--- a/test/greptile-review-adapter.test.js
+++ b/test/greptile-review-adapter.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Name-matched regression test for lib/adapters/greptile-review-adapter.js.
+// Guards the windowsHide fix (kernel issue 931e7924): the adapter's default git
+// runner is reachable from the shepherd's review-thread reading, which runs in
+// the detached background watcher on Windows. Without windowsHide:true every
+// git call there flashes a console window. OS window behaviour can't be asserted
+// cross-platform, so this is a structural check of the module's runner source.
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+describe('greptile-review-adapter git runner (issue 931e7924)', () => {
+  test('default exec sets windowsHide on execFileSync', () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'lib', 'adapters', 'greptile-review-adapter.js'),
+      'utf8',
+    );
+    const callRe = /\bexecFileSync\s*\(\s*[^)\s]/g;
+    let match;
+    let sites = 0;
+    while ((match = callRe.exec(source)) !== null) {
+      sites += 1;
+      const slice = source.slice(match.index, match.index + 400);
+      expect(slice).toContain('windowsHide');
+    }
+    expect(sites).toBeGreaterThan(0);
+  });
+});

--- a/test/windows-hide-background-spawns.test.js
+++ b/test/windows-hide-background-spawns.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// Regression guard for kernel issue 931e7924: `forge shepherd watch` runs
+// detached in the background and re-polls every ~60s. On Windows, any
+// child_process spawn/execFileSync WITHOUT `windowsHide: true` flashes a visible
+// console window every poll (Node defaults windowsHide to false), strobing the
+// user's desktop. Background/detached/hook-reachable spawns must be silent.
+//
+// OS-specific window behaviour can't be asserted cross-platform, so this is a
+// STRUCTURAL test: it reads the source of every background-reachable child
+// process call site and asserts each spawn/execFileSync option object carries
+// `windowsHide: true`. If a new call site is added to these modules without it,
+// this test fails and points at the regression.
+
+const { describe, test, expect } = require('bun:test');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+
+/**
+ * Count child_process invocations (execFileSync / spawn / spawnSync) in `source`
+ * and how many carry `windowsHide`. We match the call keyword and require a
+ * `windowsHide` token to appear before the statement's terminating `);` so every
+ * spawning call is covered, not just the file as a whole.
+ */
+function spawnCallsMissingWindowsHide(source) {
+  const missing = [];
+  // Match the child_process call keywords. The trailing `[^)\s]` lookahead skips
+  // bare `spawn()` mentions in prose/comments (empty arg list), which are never
+  // real spawning calls, so comments don't produce false positives.
+  const callRe = /\b(execFileSync|spawnSync|spawn)\s*\(\s*[^)\s]/g;
+  let match;
+  while ((match = callRe.exec(source)) !== null) {
+    const start = match.index;
+    // Grab a window of text covering the call's arguments (options object is the
+    // last arg, always within a few hundred chars for these call sites).
+    const slice = source.slice(start, start + 400);
+    if (!/windowsHide/.test(slice)) {
+      const line = source.slice(0, start).split(/\r?\n/).length;
+      missing.push({ call: match[1], line });
+    }
+  }
+  return missing;
+}
+
+// Every module below is reachable from the detached `forge shepherd watch`
+// background process (or a detached spawn) and MUST keep windowsHide on all its
+// child_process call sites.
+const BACKGROUND_REACHABLE = [
+  'lib/commands/shepherd.js',
+  'lib/adapters/pr-state-adapter.js',
+  'lib/pr-monitor/watch-lifecycle.js',
+  'lib/pr-monitor/upsert-sticky.js',
+  'lib/adapters/greptile-review-adapter.js',
+  'lib/commands/serve.js',
+];
+
+describe('windowsHide on background/detached child processes (issue 931e7924)', () => {
+  for (const rel of BACKGROUND_REACHABLE) {
+    test(`${rel}: every spawn/execFileSync sets windowsHide`, () => {
+      const source = fs.readFileSync(path.join(ROOT, rel), 'utf8');
+      const missing = spawnCallsMissingWindowsHide(source);
+      expect(missing).toEqual([]);
+    });
+  }
+
+  test('the detached shepherd watcher spawn itself is hidden', () => {
+    const source = fs.readFileSync(
+      path.join(ROOT, 'lib/pr-monitor/watch-lifecycle.js'),
+      'utf8',
+    );
+    // The detached spawn that launches `forge shepherd watch` must be silent.
+    expect(/detached:\s*true[\s\S]{0,120}windowsHide:\s*true/.test(source)).toBe(true);
+  });
+});


### PR DESCRIPTION
Background/detached processes (shepherd watch, gh/git children, hook runners) flashed conhost windows on Windows (windowsHide defaults false). Adds windowsHide:true at every background-reachable spawn site + regression test. Containment rule per epic 57fb8889. Rebased on #420 (same subsystem). 🤖 Generated with [Claude Code](https://claude.com/claude-code)