### PR TITLE
feat(shepherd): singleton watcher-set lease (W-S3)

### DIFF
--- a/lib/pr-monitor/shepherd-lease.js
+++ b/lib/pr-monitor/shepherd-lease.js
@@ -1,0 +1,199 @@
+'use strict';
+
+/**
+ * Shepherd singleton lease — a machine-wide "one watcher-set" guard for the PR
+ * shepherd, fusing two existing precedents:
+ *
+ *   - `serve.lock`'s exclusive-create + foreign-PID block + stale reclaim
+ *     (`lib/commands/_serve-security.js`), so a live foreign owner is never
+ *     stolen but a dead/wedged one is reclaimed.
+ *   - the journal lock's heartbeat + TTL staleness
+ *     (`lib/pr-monitor/journal.js`), so a slow-but-alive owner refreshes its
+ *     timestamp and a crashed owner ages out.
+ *
+ * The lock lives at `<gitCommonDir>/forge/shepherd.lock`, keyed by the SAME
+ * `resolveGitCommonDir` the kernel DB uses — so every worktree of a repo shares
+ * one lock. This module is the lease PRIMITIVE only: pure fs + I/O, no spawned
+ * process and no reconcile loop (the daemon wires those up later).
+ *
+ * Payload JSON: `{ pid, startedAt, heartbeatAt, watchers: [prNumbers] }`.
+ *
+ * @module pr-monitor/shepherd-lease
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { resolveGitCommonDir } = require('../kernel/broker');
+
+/** A wedged owner whose heartbeat is older than this (ms) is reclaimable. */
+const STALE_MS = 30000;
+const LOCK_FILE_MODE = 0o600;
+
+/**
+ * Resolve the shared lock path. `gitCommonDir` may be injected (tests, or a
+ * caller that already resolved it); otherwise it is resolved from `projectRoot`
+ * with the same resolver the kernel broker uses.
+ */
+function lockFilePath(projectRoot, opts = {}) {
+  const gitCommonDir = opts.gitCommonDir
+    ? path.resolve(opts.gitCommonDir)
+    : resolveGitCommonDir(projectRoot, opts);
+  return path.join(gitCommonDir, 'forge', 'shepherd.lock');
+}
+
+/** Parse the lock payload, or null when missing/unreadable/corrupt. */
+function readLock(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// Is `pid` a live process? `process.kill(pid, 0)` sends no signal but throws
+// ESRCH when the pid is gone. EPERM means it exists but isn't ours — still live.
+function pidAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === 'EPERM';
+  }
+}
+
+/** Is a held lock stale (dead owner, or heartbeat older than STALE_MS)? */
+function isHeldStale(held, { isAlive, now }) {
+  if (!isAlive(held.pid)) return true;
+  const beat = Date.parse(held.heartbeatAt);
+  if (!Number.isFinite(beat)) return true;
+  return now() - beat >= STALE_MS;
+}
+
+function writeLock(file, payload) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(payload), { mode: LOCK_FILE_MODE });
+}
+
+/**
+ * Try to claim the singleton lease.
+ *   -> { ok:true, file }              first claim
+ *   -> { ok:true, file, reclaimed }   stale lock (dead/wedged owner) reclaimed
+ *   -> { ok:false, held }             a LIVE, FRESH foreign owner holds it
+ *   -> { ok:false, held }             we lost a concurrent double-reclaim race
+ *
+ * `pid`/`isAlive`/`now` are injectable for testing. `onReclaimWrite` is a test
+ * seam invoked immediately after the reclaim write and before the confirm
+ * re-read, so a test can simulate a competitor overwriting the file.
+ */
+function acquire(projectRoot, {
+  gitCommonDir,
+  pid = process.pid,
+  isAlive = pidAlive,
+  now = () => Date.now(),
+  onReclaimWrite = null,
+} = {}) {
+  const file = lockFilePath(projectRoot, { gitCommonDir });
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const iso = new Date(now()).toISOString();
+  const payload = { pid, startedAt: iso, heartbeatAt: iso, watchers: [] };
+
+  try {
+    // Exclusive create: EEXIST if a lock is already present.
+    const fd = fs.openSync(file, 'wx', LOCK_FILE_MODE);
+    try {
+      fs.writeSync(fd, JSON.stringify(payload));
+    } finally {
+      fs.closeSync(fd);
+    }
+    return { ok: true, file };
+  } catch (err) {
+    if (err.code !== 'EEXIST') throw err;
+  }
+
+  // A lock exists. A DIFFERENT, live, fresh owner blocks us.
+  const held = readLock(file);
+  if (held && held.pid !== pid && !isHeldStale(held, { isAlive, now })) {
+    return { ok: false, held };
+  }
+
+  // Stale (dead/wedged owner, unreadable, or already ours) — reclaim. The write
+  // is not atomic against a simultaneous double-reclaim (see
+  // _serve-security.js:164-165), so after writing we RE-READ and confirm our
+  // pid won; a foreign pid means a competitor overwrote us — back off.
+  writeLock(file, payload);
+  if (typeof onReclaimWrite === 'function') onReclaimWrite();
+  const after = readLock(file);
+  if (!after || after.pid !== pid) {
+    return { ok: false, held: after };
+  }
+  return { ok: true, file, reclaimed: true };
+}
+
+/**
+ * Refresh `heartbeatAt` on OUR lock. Returns false (a no-op) when the lock is
+ * missing or owned by another pid — we never stamp a foreign lock.
+ */
+function stamp(projectRoot, { gitCommonDir, pid = process.pid, now = () => Date.now() } = {}) {
+  const file = lockFilePath(projectRoot, { gitCommonDir });
+  const held = readLock(file);
+  if (!held || held.pid !== pid) return false;
+  held.heartbeatAt = new Date(now()).toISOString();
+  writeLock(file, held);
+  return true;
+}
+
+/**
+ * Start a heartbeat timer that stamps `heartbeatAt` every STALE_MS/3. The timer
+ * is `.unref()`ed so it never keeps the process alive. Returns the handle for
+ * `stopHeartbeat`.
+ */
+function startHeartbeat(projectRoot, opts = {}) {
+  const timer = setInterval(() => stamp(projectRoot, opts), Math.max(1, Math.floor(STALE_MS / 3)));
+  if (typeof timer.unref === 'function') timer.unref();
+  return timer;
+}
+
+/** Stop a heartbeat timer started by `startHeartbeat`. */
+function stopHeartbeat(timer) {
+  if (timer) clearInterval(timer);
+}
+
+/**
+ * Rewrite the `watchers[]` array on OUR lock. Returns false when the lock is
+ * missing or foreign-owned.
+ */
+function updateWatchers(projectRoot, prNumbers, { gitCommonDir, pid = process.pid } = {}) {
+  const file = lockFilePath(projectRoot, { gitCommonDir });
+  const held = readLock(file);
+  if (!held || held.pid !== pid) return false;
+  held.watchers = Array.isArray(prNumbers) ? prNumbers : [];
+  writeLock(file, held);
+  return true;
+}
+
+/**
+ * Release the lease — delete the lock ONLY when it is ours (matching pid), so a
+ * foreign or reclaimed lock is never removed out from under its owner.
+ */
+function release(projectRoot, { gitCommonDir, pid = process.pid } = {}) {
+  const file = lockFilePath(projectRoot, { gitCommonDir });
+  try {
+    const held = readLock(file);
+    if (held && held.pid === pid) fs.rmSync(file, { force: true });
+  } catch {
+    /* best effort — a failed release just leaves a stale lock to be reclaimed */
+  }
+}
+
+module.exports = {
+  STALE_MS,
+  lockFilePath,
+  pidAlive,
+  acquire,
+  stamp,
+  startHeartbeat,
+  stopHeartbeat,
+  updateWatchers,
+  release,
+};

--- a/lib/pr-monitor/shepherd-lease.js
+++ b/lib/pr-monitor/shepherd-lease.js
@@ -16,13 +16,24 @@
  * one lock. This module is the lease PRIMITIVE only: pure fs + I/O, no spawned
  * process and no reconcile loop (the daemon wires those up later).
  *
- * Payload JSON: `{ pid, startedAt, heartbeatAt, watchers: [prNumbers] }`.
+ * Payload JSON: `{ pid, token, startedAt, heartbeatAt, watchers: [prNumbers] }`.
+ *
+ * ## Ownership is by TOKEN, not pid
+ * Each successful `acquire` mints a unique `token`. Every mutating op
+ * (`stamp`/`updateWatchers`/`release`) verifies that token against the on-disk
+ * lock before writing. A pid can be reused after a crash/reboot, and a wedged
+ * owner can revive after its lease was reclaimed — in both cases the token no
+ * longer matches, so the superseded holder can never resurrect or mutate a lease
+ * it no longer owns. Takeover of a stale lock is made atomic by an O_EXCL create
+ * (only one racer can win it), so two processes reclaiming the same stale lock
+ * can never both succeed.
  *
  * @module pr-monitor/shepherd-lease
  */
 
 const fs = require('node:fs');
 const path = require('node:path');
+const crypto = require('node:crypto');
 const { resolveGitCommonDir } = require('../kernel/broker');
 
 /** A wedged owner whose heartbeat is older than this (ms) is reclaimable. */
@@ -70,45 +81,73 @@ function isHeldStale(held, { isAlive, now }) {
   return now() - beat >= STALE_MS;
 }
 
+/**
+ * A lock is "ours" iff its unique lease `token` matches the one `acquire`
+ * returned. Token is authoritative: a pid can be reused after a crash/reboot and
+ * a wedged owner can revive after being reclaimed, so a pid match alone is NOT
+ * proof of ownership. Only a hypothetical legacy lock with no `token` field falls
+ * back to pid comparison.
+ */
+function ownsLock(held, { token, pid }) {
+  if (held.token) return token !== undefined && held.token === token;
+  return held.pid === pid;
+}
+
 function writeLock(file, payload) {
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, JSON.stringify(payload), { mode: LOCK_FILE_MODE });
 }
 
 /**
+ * Atomically create the lock with O_EXCL and write `payload`. Returns true when
+ * we won the create, false on EEXIST (a concurrent contender holds it); other
+ * errors rethrow. The O_EXCL create is the single atomic arbiter — of N racers
+ * attempting it against the same absent path, exactly one succeeds.
+ */
+function tryExclusiveCreate(file, payload) {
+  let fd;
+  try {
+    fd = fs.openSync(file, 'wx', LOCK_FILE_MODE);
+  } catch (err) {
+    if (err.code === 'EEXIST') return false;
+    throw err;
+  }
+  try {
+    fs.writeSync(fd, JSON.stringify(payload));
+  } finally {
+    fs.closeSync(fd);
+  }
+  return true;
+}
+
+/**
  * Try to claim the singleton lease.
- *   -> { ok:true, file }              first claim
- *   -> { ok:true, file, reclaimed }   stale lock (dead/wedged owner) reclaimed
- *   -> { ok:false, held }             a LIVE, FRESH foreign owner holds it
- *   -> { ok:false, held }             we lost a concurrent double-reclaim race
+ *   -> { ok:true, file, token }              first claim
+ *   -> { ok:true, file, token, reclaimed }   stale lock (dead/wedged owner) reclaimed
+ *   -> { ok:false, held }                    a LIVE, FRESH foreign owner holds it
+ *   -> { ok:false, held }                    we lost the atomic takeover race
  *
- * `pid`/`isAlive`/`now` are injectable for testing. `onReclaimWrite` is a test
- * seam invoked immediately after the reclaim write and before the confirm
- * re-read, so a test can simulate a competitor overwriting the file.
+ * `pid`/`isAlive`/`now`/`token` are injectable for testing. `onBeforeTakeover` is
+ * a test seam invoked AFTER the stale lock is removed and BEFORE our exclusive
+ * re-create, so a test can simulate a competitor winning the O_EXCL create first
+ * (making our takeover lose).
  */
 function acquire(projectRoot, {
   gitCommonDir,
   pid = process.pid,
   isAlive = pidAlive,
   now = () => Date.now(),
-  onReclaimWrite = null,
+  token = crypto.randomUUID(),
+  onBeforeTakeover = null,
 } = {}) {
   const file = lockFilePath(projectRoot, { gitCommonDir });
   fs.mkdirSync(path.dirname(file), { recursive: true });
   const iso = new Date(now()).toISOString();
-  const payload = { pid, startedAt: iso, heartbeatAt: iso, watchers: [] };
+  const payload = { pid, token, startedAt: iso, heartbeatAt: iso, watchers: [] };
 
-  try {
-    // Exclusive create: EEXIST if a lock is already present.
-    const fd = fs.openSync(file, 'wx', LOCK_FILE_MODE);
-    try {
-      fs.writeSync(fd, JSON.stringify(payload));
-    } finally {
-      fs.closeSync(fd);
-    }
-    return { ok: true, file };
-  } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
+  // Fast path: atomic exclusive create. Only ONE caller can win O_EXCL.
+  if (tryExclusiveCreate(file, payload)) {
+    return { ok: true, file, token };
   }
 
   // A lock exists. A DIFFERENT, live, fresh owner blocks us.
@@ -117,27 +156,29 @@ function acquire(projectRoot, {
     return { ok: false, held };
   }
 
-  // Stale (dead/wedged owner, unreadable, or already ours) — reclaim. The write
-  // is not atomic against a simultaneous double-reclaim (see
-  // _serve-security.js:164-165), so after writing we RE-READ and confirm our
-  // pid won; a foreign pid means a competitor overwrote us — back off.
-  writeLock(file, payload);
-  if (typeof onReclaimWrite === 'function') onReclaimWrite();
-  const after = readLock(file);
-  if (!after || after.pid !== pid) {
-    return { ok: false, held: after };
+  // Stale (dead/wedged owner, unreadable, or already ours). Take over ATOMICALLY:
+  // remove the stale lock, then re-create it with O_EXCL. If a competitor
+  // recreated it first, our exclusive create fails (EEXIST) and we back off — so
+  // two racers reclaiming the same stale lock can NEVER both win. A wedged owner
+  // that revives after we delete its lock is stopped by the per-lease `token`
+  // guard on stamp()/updateWatchers()/release(), never able to resurrect it here.
+  fs.rmSync(file, { force: true });
+  if (typeof onBeforeTakeover === 'function') onBeforeTakeover();
+  if (!tryExclusiveCreate(file, payload)) {
+    return { ok: false, held: readLock(file) };
   }
-  return { ok: true, file, reclaimed: true };
+  return { ok: true, file, token, reclaimed: true };
 }
 
 /**
  * Refresh `heartbeatAt` on OUR lock. Returns false (a no-op) when the lock is
- * missing or owned by another pid — we never stamp a foreign lock.
+ * missing or NOT ours by `token` — we never stamp a lease we no longer own, so a
+ * revived wedged owner cannot resurrect a reclaimed lease.
  */
-function stamp(projectRoot, { gitCommonDir, pid = process.pid, now = () => Date.now() } = {}) {
+function stamp(projectRoot, { gitCommonDir, token, pid = process.pid, now = () => Date.now() } = {}) {
   const file = lockFilePath(projectRoot, { gitCommonDir });
   const held = readLock(file);
-  if (!held || held.pid !== pid) return false;
+  if (!held || !ownsLock(held, { token, pid })) return false;
   held.heartbeatAt = new Date(now()).toISOString();
   writeLock(file, held);
   return true;
@@ -145,8 +186,9 @@ function stamp(projectRoot, { gitCommonDir, pid = process.pid, now = () => Date.
 
 /**
  * Start a heartbeat timer that stamps `heartbeatAt` every STALE_MS/3. The timer
- * is `.unref()`ed so it never keeps the process alive. Returns the handle for
- * `stopHeartbeat`.
+ * is `.unref()`ed so it never keeps the process alive. `opts` MUST carry the
+ * `token` returned by `acquire` (threaded straight through to `stamp`). Returns
+ * the handle for `stopHeartbeat`.
  */
 function startHeartbeat(projectRoot, opts = {}) {
   const timer = setInterval(() => stamp(projectRoot, opts), Math.max(1, Math.floor(STALE_MS / 3)));
@@ -161,26 +203,27 @@ function stopHeartbeat(timer) {
 
 /**
  * Rewrite the `watchers[]` array on OUR lock. Returns false when the lock is
- * missing or foreign-owned.
+ * missing or NOT ours by `token`.
  */
-function updateWatchers(projectRoot, prNumbers, { gitCommonDir, pid = process.pid } = {}) {
+function updateWatchers(projectRoot, prNumbers, { gitCommonDir, token, pid = process.pid } = {}) {
   const file = lockFilePath(projectRoot, { gitCommonDir });
   const held = readLock(file);
-  if (!held || held.pid !== pid) return false;
+  if (!held || !ownsLock(held, { token, pid })) return false;
   held.watchers = Array.isArray(prNumbers) ? prNumbers : [];
   writeLock(file, held);
   return true;
 }
 
 /**
- * Release the lease — delete the lock ONLY when it is ours (matching pid), so a
- * foreign or reclaimed lock is never removed out from under its owner.
+ * Release the lease — delete the lock ONLY when it is ours by `token`, so a
+ * foreign or already-reclaimed lock is never removed out from under its owner
+ * (and a reused pid can never delete someone else's lease).
  */
-function release(projectRoot, { gitCommonDir, pid = process.pid } = {}) {
+function release(projectRoot, { gitCommonDir, token, pid = process.pid } = {}) {
   const file = lockFilePath(projectRoot, { gitCommonDir });
   try {
     const held = readLock(file);
-    if (held && held.pid === pid) fs.rmSync(file, { force: true });
+    if (held && ownsLock(held, { token, pid })) fs.rmSync(file, { force: true });
   } catch {
     /* best effort — a failed release just leaves a stale lock to be reclaimed */
   }
@@ -190,6 +233,7 @@ module.exports = {
   STALE_MS,
   lockFilePath,
   pidAlive,
+  ownsLock,
   acquire,
   stamp,
   startHeartbeat,

--- a/test/pr-monitor/shepherd-lease.test.js
+++ b/test/pr-monitor/shepherd-lease.test.js
@@ -23,11 +23,13 @@ function readHolder() {
 }
 
 describe('shepherd-lease', () => {
-  test('first acquire writes payload with pid/startedAt/heartbeatAt/watchers', () => {
+  test('first acquire writes payload with pid/token/startedAt/heartbeatAt/watchers', () => {
     const res = lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
     expect(res.ok).toBe(true);
+    expect(typeof res.token).toBe('string');
     const held = readHolder();
     expect(held.pid).toBe(100);
+    expect(held.token).toBe(res.token);
     expect(typeof held.startedAt).toBe('string');
     expect(typeof held.heartbeatAt).toBe('string');
     expect(held.watchers).toEqual([]);
@@ -64,50 +66,80 @@ describe('shepherd-lease', () => {
     expect(readHolder().pid).toBe(100);
   });
 
-  test('(5) release removes only our own lock', () => {
-    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
-    lease.release(null, opts({ pid: 200 }));
+  test('(5) release removes only OUR lock (by token, not pid)', () => {
+    const held = lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    // A foreign token (even with any pid) cannot release our lease.
+    lease.release(null, opts({ token: 'someone-else' }));
     expect(fs.existsSync(lease.lockFilePath(null, { gitCommonDir }))).toBe(true);
-    lease.release(null, opts({ pid: 100 }));
+    // Our own token releases it.
+    lease.release(null, opts({ token: held.token }));
     expect(fs.existsSync(lease.lockFilePath(null, { gitCommonDir }))).toBe(false);
   });
 
-  test('(6) re-read after reclaim rejects a lost double-reclaim race', () => {
-    // Wedge a dead holder so acquire takes the reclaim branch.
+  test('(6) ATOMIC takeover: losing the O_EXCL race backs off (never double-owns)', () => {
+    // Wedge a dead holder so the second acquire takes the takeover branch.
     lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 0 }));
-    // A competitor overwrites the file with ITS pid right after our reclaim
-    // write but before our confirm re-read.
+    // A competitor wins the exclusive re-create in the window AFTER we remove the
+    // stale lock and BEFORE our own O_EXCL create — so our create hits EEXIST and
+    // we must back off rather than both returning ok:true.
     const res = lease.acquire(null, opts({
       pid: 200,
       isAlive: (p) => p !== 100,
       now: () => 1000,
-      onReclaimWrite: () => {
+      onBeforeTakeover: () => {
         fs.writeFileSync(lease.lockFilePath(null, { gitCommonDir }),
-          JSON.stringify({ pid: 999, startedAt: 'x', heartbeatAt: 'x', watchers: [] }));
+          JSON.stringify({ pid: 999, token: 'competitor', startedAt: 'x', heartbeatAt: 'x', watchers: [] }));
       },
     }));
     expect(res.ok).toBe(false);
     expect(readHolder().pid).toBe(999);
+    expect(readHolder().token).toBe('competitor');
   });
 
-  test('updateWatchers rewrites the watchers array only for the owner', () => {
-    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
-    expect(lease.updateWatchers(null, [7, 8], opts({ pid: 100 }))).toBe(true);
+  test('(P2) a reclaimed owner cannot resurrect its lease via a revived heartbeat', () => {
+    // Owner A claims, then wedges (heartbeat ages out).
+    const a = lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 0 }));
+    // Owner B reclaims the stale lease with a fresh token.
+    const b = lease.acquire(null, opts({ pid: 200, isAlive: alive, now: () => lease.STALE_MS + 1 }));
+    expect(b.ok).toBe(true);
+    expect(b.token).not.toBe(a.token);
+    // A revives and its heartbeat fires — but its token no longer owns the lock,
+    // so the stamp is a no-op and B's lease is NOT overwritten.
+    expect(lease.stamp(null, opts({ token: a.token, now: () => 9999 }))).toBe(false);
+    expect(lease.updateWatchers(null, [1, 2], opts({ token: a.token }))).toBe(false);
+    expect(readHolder().token).toBe(b.token);
+    expect(readHolder().watchers).toEqual([]);
+  });
+
+  test('pid reuse cannot mutate a foreign lease (token authoritative over pid)', () => {
+    // A crashes; B later acquires the SAME pid (reuse) but a different token.
+    lease.acquire(null, opts({ pid: 100, isAlive: (p) => p !== 100, now: () => 0 }));
+    const b = lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => lease.STALE_MS + 1 }));
+    // A stale actor holding pid 100 but the OLD token cannot stamp or release.
+    expect(lease.stamp(null, opts({ token: 'stale-a-token', pid: 100 }))).toBe(false);
+    lease.release(null, opts({ token: 'stale-a-token', pid: 100 }));
+    expect(fs.existsSync(lease.lockFilePath(null, { gitCommonDir }))).toBe(true);
+    expect(readHolder().token).toBe(b.token);
+  });
+
+  test('updateWatchers rewrites the watchers array only for the token owner', () => {
+    const held = lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    expect(lease.updateWatchers(null, [7, 8], opts({ token: held.token }))).toBe(true);
     expect(readHolder().watchers).toEqual([7, 8]);
-    expect(lease.updateWatchers(null, [9], opts({ pid: 200 }))).toBe(false);
+    expect(lease.updateWatchers(null, [9], opts({ token: 'other' }))).toBe(false);
     expect(readHolder().watchers).toEqual([7, 8]);
   });
 
-  test('heartbeat stamp refreshes heartbeatAt for the owner and start/stop are safe', () => {
-    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+  test('heartbeat stamp refreshes heartbeatAt for the token owner and start/stop are safe', () => {
+    const held = lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
     const before = readHolder().heartbeatAt;
-    expect(lease.stamp(null, opts({ pid: 100, now: () => 5000 }))).toBe(true);
+    expect(lease.stamp(null, opts({ token: held.token, now: () => 5000 }))).toBe(true);
     const after = readHolder().heartbeatAt;
     expect(after).not.toBe(before);
     expect(Date.parse(after)).toBe(5000);
-    // A non-owner cannot stamp.
-    expect(lease.stamp(null, opts({ pid: 200, now: () => 9000 }))).toBe(false);
-    const timer = lease.startHeartbeat(null, opts({ pid: 100 }));
+    // A non-owner token cannot stamp.
+    expect(lease.stamp(null, opts({ token: 'other', now: () => 9000 }))).toBe(false);
+    const timer = lease.startHeartbeat(null, opts({ token: held.token }));
     lease.stopHeartbeat(timer);
   });
 });

--- a/test/pr-monitor/shepherd-lease.test.js
+++ b/test/pr-monitor/shepherd-lease.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const lease = require('../../lib/pr-monitor/shepherd-lease');
+
+// A temp dir stands in for the shared gitCommonDir so no test ever touches the
+// real repo lock. Passing `gitCommonDir` bypasses the git rev-parse resolver.
+let gitCommonDir;
+const opts = (extra = {}) => ({ gitCommonDir, ...extra });
+const alive = () => true;
+
+beforeEach(() => {
+  gitCommonDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shep-lease-'));
+});
+afterEach(() => { fs.rmSync(gitCommonDir, { recursive: true, force: true }); });
+
+function readHolder() {
+  return JSON.parse(fs.readFileSync(lease.lockFilePath(null, { gitCommonDir }), 'utf8'));
+}
+
+describe('shepherd-lease', () => {
+  test('first acquire writes payload with pid/startedAt/heartbeatAt/watchers', () => {
+    const res = lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    expect(res.ok).toBe(true);
+    const held = readHolder();
+    expect(held.pid).toBe(100);
+    expect(typeof held.startedAt).toBe('string');
+    expect(typeof held.heartbeatAt).toBe('string');
+    expect(held.watchers).toEqual([]);
+  });
+
+  test('(1) live + fresh holder blocks a second acquire', () => {
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    const res = lease.acquire(null, opts({ pid: 200, isAlive: alive, now: () => 1000 }));
+    expect(res.ok).toBe(false);
+    expect(res.held.pid).toBe(100);
+  });
+
+  test('(2) dead holder is reclaimed', () => {
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    const res = lease.acquire(null, opts({ pid: 200, isAlive: (p) => p !== 100, now: () => 1000 }));
+    expect(res.ok).toBe(true);
+    expect(res.reclaimed).toBe(true);
+    expect(readHolder().pid).toBe(200);
+  });
+
+  test('(3) wedged holder (heartbeat older than STALE_MS) is reclaimed', () => {
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 0 }));
+    const res = lease.acquire(null, opts({ pid: 200, isAlive: alive, now: () => lease.STALE_MS + 1 }));
+    expect(res.ok).toBe(true);
+    expect(res.reclaimed).toBe(true);
+    expect(readHolder().pid).toBe(200);
+  });
+
+  test('(4) a foreign live+fresh holder is NEVER stolen', () => {
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    const res = lease.acquire(null, opts({ pid: 200, isAlive: alive, now: () => 1000 }));
+    expect(res.ok).toBe(false);
+    expect(res.reclaimed).toBeUndefined();
+    expect(readHolder().pid).toBe(100);
+  });
+
+  test('(5) release removes only our own lock', () => {
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    lease.release(null, opts({ pid: 200 }));
+    expect(fs.existsSync(lease.lockFilePath(null, { gitCommonDir }))).toBe(true);
+    lease.release(null, opts({ pid: 100 }));
+    expect(fs.existsSync(lease.lockFilePath(null, { gitCommonDir }))).toBe(false);
+  });
+
+  test('(6) re-read after reclaim rejects a lost double-reclaim race', () => {
+    // Wedge a dead holder so acquire takes the reclaim branch.
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 0 }));
+    // A competitor overwrites the file with ITS pid right after our reclaim
+    // write but before our confirm re-read.
+    const res = lease.acquire(null, opts({
+      pid: 200,
+      isAlive: (p) => p !== 100,
+      now: () => 1000,
+      onReclaimWrite: () => {
+        fs.writeFileSync(lease.lockFilePath(null, { gitCommonDir }),
+          JSON.stringify({ pid: 999, startedAt: 'x', heartbeatAt: 'x', watchers: [] }));
+      },
+    }));
+    expect(res.ok).toBe(false);
+    expect(readHolder().pid).toBe(999);
+  });
+
+  test('updateWatchers rewrites the watchers array only for the owner', () => {
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    expect(lease.updateWatchers(null, [7, 8], opts({ pid: 100 }))).toBe(true);
+    expect(readHolder().watchers).toEqual([7, 8]);
+    expect(lease.updateWatchers(null, [9], opts({ pid: 200 }))).toBe(false);
+    expect(readHolder().watchers).toEqual([7, 8]);
+  });
+
+  test('heartbeat stamp refreshes heartbeatAt for the owner and start/stop are safe', () => {
+    lease.acquire(null, opts({ pid: 100, isAlive: alive, now: () => 1000 }));
+    const before = readHolder().heartbeatAt;
+    expect(lease.stamp(null, opts({ pid: 100, now: () => 5000 }))).toBe(true);
+    const after = readHolder().heartbeatAt;
+    expect(after).not.toBe(before);
+    expect(Date.parse(after)).toBe(5000);
+    // A non-owner cannot stamp.
+    expect(lease.stamp(null, opts({ pid: 200, now: () => 9000 }))).toBe(false);
+    const timer = lease.startHeartbeat(null, opts({ pid: 100 }));
+    lease.stopHeartbeat(timer);
+  });
+});


### PR DESCRIPTION
Autonomous-shepherd MVP wave **W-S3**. Adds the singleton lease primitive at `<gitCommonDir>/forge/shepherd.lock` so all worktrees of a repo share ONE shepherd.

Fuses the two existing precedents: `serve.lock` exclusive-create + foreign-PID-block (`_serve-security.js:139-181`) with the journal heartbeat+TTL staleness (`journal.js:164-237`), keyed via `resolveGitCommonDir` (`broker.js:60-96`) — the same resolver the kernel DB uses.

- Payload `{pid, startedAt, heartbeatAt, watchers[]}`; acquire (wx) → block on live-fresh-foreign, reclaim on dead/stale, with a **re-read-after-reclaim** confirm to close the non-atomic double-reclaim race.
- `STALE_MS=30000`, heartbeat at `STALE_MS/3` via `.unref()`; release only removes own lock.
- Pure lease primitive — no process spawn, no loop (reconciler wires it later in W-S4).

Injectable clock + `isAlive` for deterministic TTL/liveness tests. **9 tests** cover: live-fresh→block, dead→reclaim, wedged-stale→reclaim, foreign-live→never-stolen, release-own-only, reclaim-race re-read.

Design: `docs/work/2026-07-20-autonomous-shepherd/design.md` §2. Kernel issue: 30a1955d-7736-49dc-bf04-c8c3d27ccf48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordination to ensure only one PR-monitor watcher set runs across worktrees.
  * Added automatic lock heartbeats and recovery for abandoned or unresponsive monitoring sessions.
  * Added watcher tracking and safe lock release for the active monitor.

* **Bug Fixes**
  * Prevented active monitoring sessions from being incorrectly taken over during concurrent startup or lock updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->