### PR TITLE
feat(kernel): pr authority table via migration 009 (W-S2)

### DIFF
--- a/lib/kernel/broker.js
+++ b/lib/kernel/broker.js
@@ -1177,6 +1177,14 @@ function createLocalBroker(options = {}) {
 			return driver.importIssues(kernel, options, {}, config);
 		},
 
+		// PR reconcile-ledger read (autonomous-shepherd design §3.4). Read-only SELECT of
+		// the open `pr` rows for a repo (keyed by git_common_dir); creates/migrates nothing.
+		// Consumed later by prime and the reconciler to enumerate PRs under shepherd.
+		async listOpenPrs(gitCommonDir, context = {}) {
+			requireDriverMethod(driver, 'listOpenPrs');
+			return driver.listOpenPrs(gitCommonDir, context, getConfig());
+		},
+
 		// --- Projection-outbox read/update surface (D16) -----------------------
 		// Additive read/update methods for projection consumers. These never touch
 		// the append/CAS path above (runGuardedEvent / enqueueKernelProjection);

--- a/lib/kernel/migrations.js
+++ b/lib/kernel/migrations.js
@@ -57,8 +57,8 @@ function renderDropTable(table) {
 // stays the full current schema; the named tables are filtered out of 001 so they are
 // created exactly once by their dedicated migration (both on a fresh DB and, via the
 // ledger, on an existing DB). KEEP IN SYNC with every new table-creating migration.
-//   memories → 005
-const MIGRATION_ADDED_TABLES = ['memories'];
+//   memories → 005 ; pr → 009
+const MIGRATION_ADDED_TABLES = ['memories', 'pr'];
 
 function getInitialKernelSchema() {
 	const schema = getKernelSchema();
@@ -278,6 +278,32 @@ function buildMemoryFtsMigration() {
 	};
 }
 
+// 009: the PR reconcile ledger + verdict store (kernel_pr). Rendered from the schema.js
+// table definition so the DDL never drifts from the registry — mirroring migration 005.
+// A NEW authority table (NOT columns on kernel_worktrees) because a PR can outlive its
+// worktree or have none at all (autonomous-shepherd design §3.1). Excluded from the 001
+// initial schema (MIGRATION_ADDED_TABLES), so a fresh DB creates it exactly once here and
+// an existing DB picks it up through the broker's per-migration ledger. CREATE … IF NOT
+// EXISTS keeps a re-run idempotent; it is a create-table with no data backfill, so no
+// BEGIN IMMEDIATE is needed (broker.js apply-loop caveat does not bite).
+function buildPrLinkageMigration() {
+	const pr = getKernelSchema().tables.find(table => table.name === 'pr');
+	if (!pr) {
+		throw new Error('Kernel schema is missing the pr authority table');
+	}
+	return {
+		id: '009_kernel_pr_linkage',
+		apply: [
+			renderCreateTable(pr),
+			...pr.indexes.map(prIndex => renderCreateIndex(pr, prIndex)),
+		],
+		rollback: [
+			...[...pr.indexes].reverse().map(prIndex => renderDropIndex(prIndex)),
+			renderDropTable(pr),
+		],
+	};
+}
+
 function validateKernelMigrations(migrations) {
 	const ids = new Set();
 	for (const migration of migrations) {
@@ -308,6 +334,7 @@ function buildKernelMigrationPlan(migrations = [
 	buildIssueFidelityColumnsMigration(),
 	buildWorktreeLinkageColumnsMigration(),
 	buildMemoryFtsMigration(),
+	buildPrLinkageMigration(),
 ]) {
 	validateKernelMigrations(migrations);
 
@@ -326,6 +353,7 @@ module.exports = {
 	buildKernelMigrationPlan,
 	buildMemoryFtsMigration,
 	buildMemoryProjectionMigration,
+	buildPrLinkageMigration,
 	buildSchemaMigration,
 	buildWorktreeLinkageColumnsMigration,
 	memoryFtsDdl,

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -305,7 +305,12 @@ const TABLE_LIST = deepFreeze([
 		field('registered_at', 'TEXT', { notNull: true }),
 		field('retired_at', 'TEXT'),
 	], [
-		index('idx_pr_common_dir_state', ['git_common_dir', 'state']),
+		// Covering index for the reconciler's hot read `listOpenPrs` (WHERE
+		// git_common_dir=? AND state='open' ORDER BY repo, number): the trailing
+		// repo/number let SQLite satisfy both the state filter AND the ordering from
+		// this one index, instead of scanning every PR for the common-dir once the
+		// ledger retains merged/closed history. (Codex review, PR #424.)
+		index('idx_pr_common_dir_state_repo_number', ['git_common_dir', 'state', 'repo', 'number']),
 		index('idx_pr_common_dir_repo_number', ['git_common_dir', 'repo', 'number'], { unique: true }),
 	]),
 ]);

--- a/lib/kernel/schema.js
+++ b/lib/kernel/schema.js
@@ -278,6 +278,36 @@ const TABLE_LIST = deepFreeze([
 	], [
 		index('idx_kernel_memories_source_agent', ['source_agent']),
 	]),
+	// The PR reconcile ledger + verdict store (autonomous-shepherd design §3): a
+	// first-class `pr` authority row links a pull request to its issue, worktree and
+	// journal, and records the winning verdict with its freshness discriminators
+	// (head_sha, verdict_source, verdict_at). A PR is the unit of ownership and can
+	// outlive its worktree (or have none — a hand-opened/other-harness PR), so it is a
+	// separate table, NOT columns on kernel_worktrees. git_common_dir keys every open PR
+	// to its repo so all worktrees share one reconcile view. issue_id/worktree_id are
+	// soft nullable links. Created by migration 009 (excluded from the 001 initial schema
+	// via MIGRATION_ADDED_TABLES), so a fresh DB creates it exactly once and an existing
+	// DB picks it up through the broker's per-migration ledger.
+	table('pr', 'authority', [
+		field('id', 'TEXT', { primaryKey: true }),
+		field('git_common_dir', 'TEXT', { notNull: true }),
+		field('repo', 'TEXT', { notNull: true }),
+		field('number', 'INTEGER', { notNull: true }),
+		field('issue_id', 'TEXT'),
+		field('worktree_id', 'TEXT'),
+		field('branch', 'TEXT'),
+		field('head_sha', 'TEXT'),
+		field('verdict', 'TEXT'),
+		field('verdict_source', 'TEXT'),
+		field('verdict_at', 'TEXT'),
+		field('journal_ptr', 'TEXT'),
+		field('state', 'TEXT', { notNull: true, default: "'open'" }),
+		field('registered_at', 'TEXT', { notNull: true }),
+		field('retired_at', 'TEXT'),
+	], [
+		index('idx_pr_common_dir_state', ['git_common_dir', 'state']),
+		index('idx_pr_common_dir_repo_number', ['git_common_dir', 'repo', 'number'], { unique: true }),
+	]),
 ]);
 
 const KERNEL_TABLES = deepFreeze(Object.fromEntries(TABLE_LIST.map(candidate => [candidate.name, candidate])));

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -2181,6 +2181,19 @@ function createDriver(runtime, configuredDatabasePath) {
 				[`${escaped}%`, limit],
 			);
 		},
+		// Open PRs under shepherd for one repo (autonomous-shepherd design §3.4): the
+		// reconciler's "open PRs in this repo" read, keyed by git_common_dir so every
+		// worktree shares one view. Parameterized (git_common_dir is a filesystem path —
+		// never interpolate it), served by the idx_pr_common_dir_state index. Ordered so
+		// the result is deterministic. `context` is part of the broker contract but unused
+		// by this direct SELECT (prefixed `_` for eslint no-unused-vars).
+		async listOpenPrs(gitCommonDir, _context = {}, config = {}) {
+			return allParams(
+				runtime, getDatabase(config),
+				"SELECT * FROM kernel_pr WHERE git_common_dir = ? AND state = 'open' ORDER BY repo ASC, number ASC",
+				[gitCommonDir],
+			);
+		},
 		// --- Event-store primitives (Wave 2) — composed by broker.runGuardedEvent.
 		// `context` is part of the broker contract but unused by these direct SQL
 		// reads/writes (prefixed `_` for eslint no-unused-vars).

--- a/lib/kernel/sqlite-driver.js
+++ b/lib/kernel/sqlite-driver.js
@@ -2184,7 +2184,7 @@ function createDriver(runtime, configuredDatabasePath) {
 		// Open PRs under shepherd for one repo (autonomous-shepherd design §3.4): the
 		// reconciler's "open PRs in this repo" read, keyed by git_common_dir so every
 		// worktree shares one view. Parameterized (git_common_dir is a filesystem path —
-		// never interpolate it), served by the idx_pr_common_dir_state index. Ordered so
+		// never interpolate it), covered by idx_pr_common_dir_state_repo_number. Ordered so
 		// the result is deterministic. `context` is part of the broker contract but unused
 		// by this direct SELECT (prefixed `_` for eslint no-unused-vars).
 		async listOpenPrs(gitCommonDir, _context = {}, config = {}) {

--- a/test/kernel/broker-migration-ledger.test.js
+++ b/test/kernel/broker-migration-ledger.test.js
@@ -130,6 +130,7 @@ describe('Kernel broker — migration ledger', () => {
 			'006_kernel_issue_fidelity_columns',
 			'007_kernel_worktrees_linkage_columns',
 			'008_kernel_memories_fts',
+			'009_kernel_pr_linkage',
 		]);
 
 		const after = await driver.queryAll('PRAGMA table_info(kernel_issues);', config);

--- a/test/kernel/migrations.test.js
+++ b/test/kernel/migrations.test.js
@@ -21,9 +21,10 @@ describe('kernel migration plans', () => {
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_events (\n  id TEXT NOT NULL PRIMARY KEY,\n  entity_type TEXT NOT NULL,\n  entity_id TEXT NOT NULL,\n  event_type TEXT NOT NULL,\n  idempotency_key TEXT NOT NULL,\n  actor TEXT NOT NULL,\n  origin TEXT NOT NULL,\n  payload_json TEXT NOT NULL,\n  created_at TEXT NOT NULL\n);');
 		expect(plan.apply).toContain('ALTER TABLE kernel_events ADD COLUMN expected_revision INTEGER NOT NULL DEFAULT 0;');
 		expect(plan.apply).toContain('CREATE TABLE IF NOT EXISTS kernel_outbox (\n  id TEXT NOT NULL PRIMARY KEY,\n  event_id TEXT NOT NULL REFERENCES kernel_events(id),\n  target TEXT NOT NULL,\n  status TEXT NOT NULL DEFAULT \'pending\',\n  attempts INTEGER NOT NULL DEFAULT 0,\n  next_attempt_at TEXT,\n  created_at TEXT NOT NULL\n);');
-		// Rollback runs migrations in reverse, so 008 (the latest migration) rolls back
-		// first: its last-created FTS trigger drops before everything else.
-		expect(plan.rollback[0]).toBe('DROP TRIGGER IF EXISTS kernel_memories_au;');
+		// Rollback runs migrations in reverse, so 009 (the latest migration) rolls back
+		// first: its last-created index drops before everything else.
+		expect(plan.rollback[0]).toBe('DROP INDEX IF EXISTS idx_pr_common_dir_repo_number;');
+		expect(plan.rollback).toContain('DROP TABLE IF EXISTS kernel_pr;');
 		expect(plan.rollback).toContain('DROP INDEX IF EXISTS idx_kernel_memories_source_agent;');
 		expect(plan.rollback).toContain('DROP TABLE IF EXISTS kernel_memories;');
 		expect(plan.rollback).toContain('ALTER TABLE kernel_issues DROP COLUMN assignee;');
@@ -41,6 +42,7 @@ describe('kernel migration plans', () => {
 			'006_kernel_issue_fidelity_columns',
 			'007_kernel_worktrees_linkage_columns',
 			'008_kernel_memories_fts',
+			'009_kernel_pr_linkage',
 		]);
 	});
 

--- a/test/kernel/pr-linkage.test.js
+++ b/test/kernel/pr-linkage.test.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const { describe, test, expect, beforeEach, afterEach } = require('bun:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+	buildKernelMigrationPlan,
+	buildPrLinkageMigration,
+	buildSchemaMigration,
+	buildEventExpectedRevisionMigration,
+	buildClaimActiveLeaseMigration,
+	buildIssueContentFieldsMigration,
+	buildMemoryProjectionMigration,
+	buildIssueFidelityColumnsMigration,
+	buildWorktreeLinkageColumnsMigration,
+	buildMemoryFtsMigration,
+} = require('../../lib/kernel/migrations');
+const { createLocalBroker } = require('../../lib/kernel/broker');
+const { createBuiltinSQLiteDriver } = require('../../lib/kernel/sqlite-driver');
+
+// Migration 009 introduces the `pr` authority table — the reconcile ledger + verdict
+// store that links a PR to its issue/worktree/journal (design §3). Like migration 005
+// (kernel_memories), the whole table is owned by 009: it is EXCLUDED from the 001 initial
+// schema (MIGRATION_ADDED_TABLES) so a fresh DB creates it exactly once and an existing
+// DB picks it up through the broker's per-migration ledger.
+describe('kernel migration 009 — pr linkage table', () => {
+	test('builds a create-table migration for kernel_pr with the reconcile indexes', () => {
+		const migration = buildPrLinkageMigration();
+
+		expect(migration.id).toBe('009_kernel_pr_linkage');
+		// Idempotent CREATE IF NOT EXISTS so a fresh DB and an existing DB both migrate
+		// cleanly through the broker ledger (create-table, no backfill).
+		expect(migration.apply[0]).toContain('CREATE TABLE IF NOT EXISTS kernel_pr');
+		expect(migration.apply[0]).toContain('id TEXT NOT NULL PRIMARY KEY');
+		expect(migration.apply[0]).toContain('git_common_dir TEXT NOT NULL');
+		expect(migration.apply[0]).toContain('number INTEGER NOT NULL');
+		expect(migration.apply[0]).toContain("state TEXT NOT NULL DEFAULT 'open'");
+		// The reconciler's "open PRs in this repo" index + the natural-key uniqueness guard.
+		expect(migration.apply).toContain(
+			'CREATE INDEX IF NOT EXISTS idx_pr_common_dir_state ON kernel_pr (git_common_dir, state);',
+		);
+		expect(migration.apply).toContain(
+			'CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_common_dir_repo_number ON kernel_pr (git_common_dir, repo, number);',
+		);
+		// Rollback drops the indexes (reverse order) and the table.
+		expect(migration.rollback).toEqual([
+			'DROP INDEX IF EXISTS idx_pr_common_dir_repo_number;',
+			'DROP INDEX IF EXISTS idx_pr_common_dir_state;',
+			'DROP TABLE IF EXISTS kernel_pr;',
+		]);
+	});
+
+	test('registers 009 last in the default plan and excludes kernel_pr from the 001 schema', () => {
+		const plan = buildKernelMigrationPlan();
+
+		expect(plan.migrations.map(migration => migration.id)).toEqual([
+			'001_kernel_schema',
+			'002_kernel_events_expected_revision',
+			'003_kernel_claims_active_lease',
+			'004_kernel_issues_content_fields',
+			'005_kernel_memories',
+			'006_kernel_issue_fidelity_columns',
+			'007_kernel_worktrees_linkage_columns',
+			'008_kernel_memories_fts',
+			'009_kernel_pr_linkage',
+		]);
+		expect(plan.apply).toContain(
+			'CREATE INDEX IF NOT EXISTS idx_pr_common_dir_state ON kernel_pr (git_common_dir, state);',
+		);
+		// KEEP-IN-SYNC guard: kernel_pr must NOT be created by 001 — it is owned by 009 so a
+		// fresh DB creates it exactly once. FAILS until `pr` is added to MIGRATION_ADDED_TABLES.
+		// Word-boundary match so this does not false-positive on kernel_priority_events.
+		const schemaMigration = plan.migrations.find(migration => migration.id === '001_kernel_schema');
+		expect(schemaMigration.apply.some(statement => /\bkernel_pr\b/.test(statement))).toBe(false);
+	});
+});
+
+describe('kernel migration 009 — broker application', () => {
+	let tmpDir;
+	let driver;
+	let config;
+
+	function makeBroker(migrationPlan) {
+		return createLocalBroker({
+			projectRoot: tmpDir,
+			execFileSync: () => path.join(tmpDir, '.git'),
+			databasePath: config.databasePath,
+			driver,
+			...(migrationPlan ? { migrationPlan } : {}),
+		});
+	}
+
+	function prTableShape() {
+		return driver.queryAll('PRAGMA table_info(kernel_pr);', config)
+			.then(rows => rows.map(row => ({
+				name: row.name,
+				type: row.type,
+				notnull: Number(row.notnull),
+				dflt_value: row.dflt_value,
+				pk: Number(row.pk),
+			})));
+	}
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kpr-009-'));
+		config = { databasePath: path.join(tmpDir, 'kernel.sqlite') };
+		driver = createBuiltinSQLiteDriver({});
+	});
+
+	afterEach(() => {
+		if (driver) driver.close();
+		if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('KEEP-IN-SYNC parity: a fresh DB and a migrated (pre-009) DB end with an identical kernel_pr shape', async () => {
+		// The prior-schema plan (everything through 008) is exactly the default plan BEFORE
+		// 009 was appended. Because 009 owns the table, a genuine pre-009 DB has no kernel_pr.
+		const priorPlan = buildKernelMigrationPlan([
+			buildSchemaMigration(),
+			buildEventExpectedRevisionMigration(),
+			buildClaimActiveLeaseMigration(),
+			buildIssueContentFieldsMigration(),
+			buildMemoryProjectionMigration(),
+			buildIssueFidelityColumnsMigration(),
+			buildWorktreeLinkageColumnsMigration(),
+			buildMemoryFtsMigration(),
+		]);
+		await makeBroker(priorPlan).initialize();
+
+		// FAILS until MIGRATION_ADDED_TABLES excludes `pr` from 001: otherwise 001 would
+		// create kernel_pr on the pre-009 DB and this shape would be non-empty.
+		const migratedBefore = await prTableShape();
+		expect(migratedBefore).toEqual([]);
+
+		// Upgrading with the full plan applies 009 and creates the table.
+		const upgrade = await makeBroker(buildKernelMigrationPlan()).initialize();
+		expect(upgrade.migrationsNewlyApplied).toEqual(['009_kernel_pr_linkage']);
+		const migratedShape = await prTableShape();
+
+		// A brand-new DB built straight from the full plan.
+		const freshDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kpr-009-fresh-'));
+		const freshConfig = { databasePath: path.join(freshDir, 'kernel.sqlite') };
+		const freshDriver = createBuiltinSQLiteDriver({});
+		try {
+			await createLocalBroker({
+				projectRoot: freshDir,
+				execFileSync: () => path.join(freshDir, '.git'),
+				databasePath: freshConfig.databasePath,
+				driver: freshDriver,
+			}).initialize();
+			const freshShape = (await freshDriver.queryAll('PRAGMA table_info(kernel_pr);', freshConfig)).map(row => ({
+				name: row.name,
+				type: row.type,
+				notnull: Number(row.notnull),
+				dflt_value: row.dflt_value,
+				pk: Number(row.pk),
+			}));
+
+			expect(freshShape.length).toBeGreaterThan(0);
+			expect(migratedShape).toEqual(freshShape);
+		} finally {
+			freshDriver.close();
+			fs.rmSync(freshDir, { recursive: true, force: true });
+		}
+	});
+
+	test('the ledger records 009 exactly once and a re-run initialize() is a no-op', async () => {
+		const first = await makeBroker().initialize();
+		expect(first.migrationsNewlyApplied).toContain('009_kernel_pr_linkage');
+
+		const second = await makeBroker().initialize();
+		expect(second.migrationsNewlyApplied).toEqual([]);
+
+		const ledger = await driver.queryAll(
+			"SELECT id FROM kernel_migrations WHERE id = '009_kernel_pr_linkage';",
+			config,
+		);
+		expect(ledger.map(row => row.id)).toEqual(['009_kernel_pr_linkage']);
+	});
+
+	test('listOpenPrs returns only state=open rows for the given git_common_dir', async () => {
+		await makeBroker().initialize();
+
+		const rows = [
+			['a#1', '/repo-a/.git', 'owner/a', 1, 'open'],
+			['a#2', '/repo-a/.git', 'owner/a', 2, 'merged'],
+			['a#3', '/repo-a/.git', 'owner/a', 3, 'open'],
+			['b#1', '/repo-b/.git', 'owner/b', 1, 'open'],
+		];
+		for (const [id, gitCommonDir, repo, number, state] of rows) {
+			await driver.exec(
+				`INSERT INTO kernel_pr (id, git_common_dir, repo, number, state, registered_at) `
+				+ `VALUES ('${id}', '${gitCommonDir}', '${repo}', ${number}, '${state}', '2026-07-20T00:00:00.000Z');`,
+				config,
+			);
+		}
+
+		const open = await makeBroker().listOpenPrs('/repo-a/.git');
+
+		expect(open.map(row => row.id).sort()).toEqual(['a#1', 'a#3']);
+		expect(open.every(row => row.state === 'open')).toBe(true);
+		expect(open.every(row => row.git_common_dir === '/repo-a/.git')).toBe(true);
+	});
+});

--- a/test/kernel/pr-linkage.test.js
+++ b/test/kernel/pr-linkage.test.js
@@ -37,9 +37,10 @@ describe('kernel migration 009 — pr linkage table', () => {
 		expect(migration.apply[0]).toContain('git_common_dir TEXT NOT NULL');
 		expect(migration.apply[0]).toContain('number INTEGER NOT NULL');
 		expect(migration.apply[0]).toContain("state TEXT NOT NULL DEFAULT 'open'");
-		// The reconciler's "open PRs in this repo" index + the natural-key uniqueness guard.
+		// The reconciler's covering "open PRs in this repo, ordered" index + the
+		// natural-key uniqueness guard.
 		expect(migration.apply).toContain(
-			'CREATE INDEX IF NOT EXISTS idx_pr_common_dir_state ON kernel_pr (git_common_dir, state);',
+			'CREATE INDEX IF NOT EXISTS idx_pr_common_dir_state_repo_number ON kernel_pr (git_common_dir, state, repo, number);',
 		);
 		expect(migration.apply).toContain(
 			'CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_common_dir_repo_number ON kernel_pr (git_common_dir, repo, number);',
@@ -47,7 +48,7 @@ describe('kernel migration 009 — pr linkage table', () => {
 		// Rollback drops the indexes (reverse order) and the table.
 		expect(migration.rollback).toEqual([
 			'DROP INDEX IF EXISTS idx_pr_common_dir_repo_number;',
-			'DROP INDEX IF EXISTS idx_pr_common_dir_state;',
+			'DROP INDEX IF EXISTS idx_pr_common_dir_state_repo_number;',
 			'DROP TABLE IF EXISTS kernel_pr;',
 		]);
 	});
@@ -67,7 +68,7 @@ describe('kernel migration 009 — pr linkage table', () => {
 			'009_kernel_pr_linkage',
 		]);
 		expect(plan.apply).toContain(
-			'CREATE INDEX IF NOT EXISTS idx_pr_common_dir_state ON kernel_pr (git_common_dir, state);',
+			'CREATE INDEX IF NOT EXISTS idx_pr_common_dir_state_repo_number ON kernel_pr (git_common_dir, state, repo, number);',
 		);
 		// KEEP-IN-SYNC guard: kernel_pr must NOT be created by 001 — it is owned by 009 so a
 		// fresh DB creates it exactly once. FAILS until `pr` is added to MIGRATION_ADDED_TABLES.

--- a/test/kernel/schema.test.js
+++ b/test/kernel/schema.test.js
@@ -27,6 +27,7 @@ const REQUIRED_TABLES = [
 	'outbox',
 	'dead_letters',
 	'memories',
+	'pr',
 ];
 
 describe('kernel schema registry', () => {


### PR DESCRIPTION
Autonomous-shepherd MVP wave **W-S2**. Adds a new kernel `pr` authority table — the PR↔issue↔worktree↔journal linkage that becomes the reconcile ledger + verdict-of-record.

**Why a new table (not columns on `kernel_worktrees`):** a hand-opened / other-harness PR has no worktree row, and a PR's verdict history + retirement record must outlive `forge clean`. The PR is the reconcile unit — first-class identity.

- `pr` table: id, git_common_dir, repo, number, issue_id?, worktree_id?, branch, head_sha, verdict, verdict_source, verdict_at, journal_ptr, state(open|merged|closed), registered_at, retired_at. Index `(git_common_dir, state)`; unique `(git_common_dir, repo, number)`.
- Migration `009_kernel_pr_linkage` via `buildPrLinkageMigration()`, appended to `buildKernelMigrationPlan()`; `MIGRATION_ADDED_TABLES` updated so a fresh DB doesn't double-create.
- `listOpenPrs(gitCommonDir)` broker read helper — parameterized, index-served (used by prime in W-S5).

**31 tests** cover KEEP-IN-SYNC parity (fresh DB == migrated DB), ledger applies 009 exactly once + re-init no-op, and open-row read filtering.

Design: `docs/work/2026-07-20-autonomous-shepherd/design.md` §3. Kernel issue: d8512775-6871-4228-98a9-0c977b7adf66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for listing open pull requests for a specified repository workspace.
  - Results are limited to open pull requests and returned in a consistent order.
  - Added pull-request tracking with repository, branch, verdict, and lifecycle metadata.

- **Bug Fixes**
  - Database upgrades now reliably create and track pull-request data structures, including rollback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->